### PR TITLE
Preserve nulls in to_python_list

### DIFF
--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -87,16 +87,40 @@ PYBIND11_MODULE(_arnio_cpp, m) {
                  py::list result;
                  if (col.dtype() == DType::STRING) {
                      const auto& vec = std::get<std::vector<std::string>>(col.data());
-                     for (const auto& s : vec) result.append(py::str(s));
+                     for (size_t i = 0; i < vec.size(); ++i) {
+                         if (col.is_null(i)) {
+                             result.append(py::none());
+                         } else {
+                             result.append(py::str(vec[i]));
+                         }
+                     }
                  } else if (col.dtype() == DType::BOOL) {
                      const auto& vec = std::get<std::vector<bool>>(col.data());
-                     for (auto b : vec) result.append(py::bool_(static_cast<bool>(b)));
+                     for (size_t i = 0; i < vec.size(); ++i) {
+                         if (col.is_null(i)) {
+                             result.append(py::none());
+                         } else {
+                             result.append(py::bool_(static_cast<bool>(vec[i])));
+                         }
+                     }
                  } else if (col.dtype() == DType::INT64) {
                      const auto& vec = std::get<std::vector<int64_t>>(col.data());
-                     for (auto v : vec) result.append(py::int_(v));
+                     for (size_t i = 0; i < vec.size(); ++i) {
+                         if (col.is_null(i)) {
+                             result.append(py::none());
+                         } else {
+                             result.append(py::int_(vec[i]));
+                         }
+                     }
                  } else if (col.dtype() == DType::FLOAT64) {
                      const auto& vec = std::get<std::vector<double>>(col.data());
-                     for (auto v : vec) result.append(py::float_(v));
+                     for (size_t i = 0; i < vec.size(); ++i) {
+                         if (col.is_null(i)) {
+                             result.append(py::none());
+                         } else {
+                             result.append(py::float_(vec[i]));
+                         }
+                     }
                  } else {
                      for (size_t i = 0; i < col.size(); ++i) result.append(py::none());
                  }

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -22,6 +22,30 @@ class TestToPandas:
         df = ar.to_pandas(frame)
         assert df.isna().any().any()  # Should have some NaN/NA values
 
+    def test_to_python_list_with_nulls(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", None, "Charlie"],
+                    "score": [95, None, 88],
+                    "active": [True, None, False],
+                },
+                dtype=object,
+            )
+        )
+
+        assert frame._frame.column_by_name("name").to_python_list() == [
+            "Alice",
+            None,
+            "Charlie",
+        ]
+        assert frame._frame.column_by_name("score").to_python_list() == [95, None, 88]
+        assert frame._frame.column_by_name("active").to_python_list() == [
+            True,
+            None,
+            False,
+        ]
+
 
 class TestFromPandas:
     def test_basic_roundtrip(self, sample_csv):


### PR DESCRIPTION
## Summary
- return Python None from Column.to_python_list() when an element is marked null
- cover string, integer, and bool columns with null entries

Fixes #31.

## Tests
- python3 -m pytest tests/test_convert.py::TestToPandas::test_to_python_list_with_nulls -q
- python3 -m pytest tests/test_convert.py -q
- python3 -m pytest tests -q