### PR TITLE
Strip UTF-8 BOM from CSV headers

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -16,6 +16,13 @@ inline void trim_in_place(std::string& s) {
                 .base(),
             s.end());
 }
+
+inline void strip_utf8_bom(std::string& s) {
+    if (s.size() >= 3 && static_cast<unsigned char>(s[0]) == 0xEF &&
+        static_cast<unsigned char>(s[1]) == 0xBB && static_cast<unsigned char>(s[2]) == 0xBF) {
+        s.erase(0, 3);
+    }
+}
 }  // namespace
 
 CsvReader::CsvReader(const CsvConfig& config) : config_(config) {}
@@ -141,6 +148,7 @@ Frame CsvReader::read(const std::string& path) const {
 
     // Read header
     if (config_.has_header && std::getline(file, line)) {
+        strip_utf8_bom(line);
         header = parse_line(line);
         for (auto& h : header) {
             trim_in_place(h);
@@ -226,6 +234,7 @@ std::unordered_map<std::string, std::string> CsvReader::scan_schema(const std::s
     std::vector<std::string> header;
 
     if (std::getline(file, line)) {
+        strip_utf8_bom(line);
         header = parse_line(line);
         for (auto& h : header) {
             trim_in_place(h);

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -77,6 +77,18 @@ class TestReadCsv:
         with pytest.raises(ValueError, match="File appears to be binary"):
             ar.read_csv(file_path)
 
+    def test_utf8_bom_handling(self, tmp_path):
+        csv_path = tmp_path / "bom.csv"
+        csv_path.write_bytes(b"\xef\xbb\xbfname,age\nAlice,30\nBob,25\n")
+
+        frame = ar.read_csv(str(csv_path), usecols=["name"])
+        assert frame.columns == ["name"]
+        assert frame.shape == (2, 1)
+
+        schema = ar.scan_csv(str(csv_path))
+        assert "name" in schema
+        assert "\ufeffname" not in schema
+
 
 class TestScanCsv:
     def test_scan_schema(self, sample_csv):


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM bytes before parsing CSV headers
- apply the same header normalization in scan_csv
- add coverage for BOM-prefixed CSV files with usecols and schema scanning

Fixes #24.

## Tests
- python3 -m pytest tests/test_csv.py::TestReadCsv::test_utf8_bom_handling -q
- python3 -m pytest tests/test_csv.py -q
- python3 -m pytest tests -q