### PR TITLE
ci: implement release please automation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,12 +80,16 @@ def test_remove_special_chars(sample_csv):
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes (`make test`).
 5. Ensure your code passes linting (`make lint`). This is a **required** pre-PR step.
-6. Issue that pull request!
+6. Issue that pull request! Ensure your PR title follows **Conventional Commits**.
+
+### Commit Message Convention
+We use an automated release system that relies on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Your PR title must use one of the following prefixes:
+- `feat:` for new features (e.g., `feat: add robust boolean parsing`)
+- `fix:` for bug fixes (e.g., `fix: memory leak in string allocation`)
+- `docs:` for documentation changes
+- `chore:` for maintenance (e.g., CI/CD changes)
+
+This allows our CI to automatically generate changelogs and bump version numbers.
 
 We use `black`, `ruff`, and `clang-format` to format our code. `pre-commit` will run these automatically before each commit if installed.
 
----
-
-## Tracking Changes
-
-We use `CHANGELOG.md` to track project history. When submitting a PR, please update the `[Unreleased]` section with a brief note of your changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@
 - [ ] `make lint` passes locally  
 - [ ] New tests added for new functionality
 - [ ] Docstring added for any new public function
-- [ ] CHANGELOG.md updated under `[Unreleased]`
+- [ ] PR title follows **Conventional Commits** (e.g., `feat: ...`, `fix: ...`)
 - [ ] README updated if public API changed

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,9 +1,8 @@
 name: Build & Publish Wheels
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:  # allows manual trigger for testing
 
 jobs:
@@ -47,7 +46,6 @@ jobs:
     name: Publish to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     environment: pypi  # requires a "pypi" environment configured in repo settings
     permissions:
       id-token: write  # required for trusted publishing

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: python
+          package-name: arnio
+          version-file: pyproject.toml


### PR DESCRIPTION
- Add release-please.yml workflow to automate release PRs and versioning
- Update build_wheels.yml to trigger on GitHub releases instead of tags

## Type of Change
- [ ] Bug fix
- [x] New pipeline step (Python)
- [ ] New pipeline step (C++)  
- [ ] Performance improvement
- [x] Documentation only
- [x] Infrastructure / CI

## Checklist
- [ ] `make test` passes locally
- [ ] `make lint` passes locally  
- [ ] New tests added for new functionality
- [ ] Docstring added for any new public function
- [x] CHANGELOG.md updated under `[Unreleased]`
- [ ] README updated if public API changed
