### PR TITLE
ci: fix PyPI publish trigger using reusable workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,8 +1,11 @@
 name: Build & Publish Wheels
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
   workflow_dispatch:  # allows manual trigger for testing
 
 jobs:
@@ -11,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
       - name: Build sdist
         run: pipx run build --sdist
       - uses: actions/upload-artifact@v4
@@ -29,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,19 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: python
+
+  build-and-publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/build_wheels.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
- Convert build_wheels.yml to a workflow_call
- Call build_wheels from release-please upon successful release to bypass GITHUB_TOKEN trigger limitations

## Type of Change
- [x] Bug fix
- [x] New pipeline step (Python)
- [ ] New pipeline step (C++)  
- [ ] Performance improvement
- [ ] Documentation only
- [ ] Infrastructure / CI

## Checklist
- [ ] `make test` passes locally
- [ ] `make lint` passes locally  
- [ ] New tests added for new functionality
- [ ] Docstring added for any new public function
- [ ] PR title follows **Conventional Commits** (e.g., `feat: ...`, `fix: ...`)
- [ ] README updated if public API changed
