### PR TITLE
docs: fix non-sequential roadmap versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,10 +303,10 @@ clean = ar.pipeline(frame, [
 
 | Version | Focus | Status |
 |:---:|:---|:---:|
-| **v0.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
-| **v0.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
-| **v0.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
 | **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
+| **v1.1** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
+| **v1.2** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
+| **v1.3** | Parallel column processing · SIMD string operations | 💭 Exploring |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -304,9 +304,10 @@ clean = ar.pipeline(frame, [
 | Version | Focus | Status |
 |:---:|:---|:---:|
 | **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
-| **v1.1** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
-| **v1.2** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
-| **v1.3** | Parallel column processing · SIMD string operations | 💭 Exploring |
+| **v1.1** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
+| **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
+| **v1.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
+| **v1.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -303,10 +303,10 @@ clean = ar.pipeline(frame, [
 
 | Version | Focus | Status |
 |:---:|:---|:---:|
-| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
 | **v0.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
 | **v0.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
 | **v0.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
+| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
 
 <br>
 


### PR DESCRIPTION
## What changed
Fixed the roadmap version ordering in the README.
The roadmap previously showed versions in a non-sequential order:
`v1.0 → v0.2 → v0.3 → v0.4`
Updated it to follow proper progression and improve readability.
## Type of Change
* [x] Documentation only
## Checklist
* [x] PR title follows Conventional Commits
* [x] README updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap in the README: replaced the previous intermediate version rows with v1.1, v1.2, and v1.3 while keeping the v1.0 entry and overall table layout unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/im-anishraj/arnio/pull/107)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->