### PR TITLE
ci: fix PyPI release publishing

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -67,3 +67,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false


### PR DESCRIPTION
## Summary
- Disable PyPI artifact attestations in the reusable wheel publishing workflow
- Keeps Trusted Publishing auth, but avoids the Release Please caller workflow identity mismatch that caused the v1.0.2 publish failure

## Verification
- git diff --check
- Pre-commit hooks for this workflow-only change skipped non-applicable formatters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PyPI publish workflow configuration for package deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/im-anishraj/arnio/pull/112)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->