### PR TITLE
Add split column pipeline step

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -229,6 +229,68 @@ def cast_types(
     return ArFrame(result)
 
 
+def split_column(
+    frame: ArFrame,
+    column: str,
+    into: list[str],
+    *,
+    sep: str = ",",
+    regex: bool = False,
+    maxsplit: int = -1,
+    drop: bool = False,
+) -> ArFrame:
+    """Split one string column into multiple output columns.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    column : str
+        Name of the source column to split.
+    into : list[str]
+        Names of the output columns.
+    sep : str, default ","
+        Delimiter or regex pattern to split on.
+    regex : bool, default False
+        Whether ``sep`` should be treated as a regular expression.
+    maxsplit : int, default -1
+        Maximum number of splits. ``-1`` means no explicit limit.
+    drop : bool, default False
+        Whether to drop the original source column.
+
+    Returns
+    -------
+    ArFrame
+        New frame with the split output columns added.
+    """
+    if column not in frame.columns:
+        raise ValueError(f"Unknown source column: {column!r}")
+    if not into:
+        raise ValueError("into must contain at least one output column")
+    if len(set(into)) != len(into):
+        raise ValueError("Output column names in into must be unique")
+
+    existing = set(frame.columns) - ({column} if drop else set())
+    collisions = existing.intersection(into)
+    if collisions:
+        names = ", ".join(sorted(collisions))
+        raise ValueError(f"Output column already exists: {names}")
+
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame)
+    source = df[column].astype("string")
+    parts = source.str.split(sep, n=maxsplit, expand=True, regex=regex)
+    parts = parts.reindex(columns=range(len(into)))
+
+    if drop:
+        df = df.drop(columns=[column])
+    for index, name in enumerate(into):
+        df[name] = parts[index].astype("string")
+
+    return from_pandas(df)
+
+
 def clean(
     frame: ArFrame,
     *,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -19,6 +19,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
+    "split_column": cleaning.split_column,
 }
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -75,6 +75,46 @@ class TestPipeline:
         assert result.dtypes["years"] == "float64"
         assert "age" not in result.columns
 
+
+    def test_split_column_step(self, tmp_path):
+        path = tmp_path / "names.csv"
+        path.write_text("name\nAda Lovelace\nGrace Hopper\n")
+        frame = ar.read_csv(path)
+
+        result = ar.pipeline(
+            frame,
+            [
+                (
+                    "split_column",
+                    {
+                        "column": "name",
+                        "into": ["first", "last"],
+                        "sep": " ",
+                        "drop": True,
+                    },
+                ),
+            ],
+        )
+
+        df = ar.to_pandas(result)
+        assert "name" not in df.columns
+        assert df["first"].tolist() == ["Ada", "Grace"]
+        assert df["last"].tolist() == ["Lovelace", "Hopper"]
+
+    def test_split_column_rejects_existing_output_column(self, tmp_path):
+        path = tmp_path / "names.csv"
+        path.write_text("name,first\nAda Lovelace,Ada\n")
+        frame = ar.read_csv(path)
+
+        try:
+            ar.pipeline(
+                frame,
+                [("split_column", {"column": "name", "into": ["first"], "sep": " "})],
+            )
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "Output column already exists" in str(e)
+
     def test_empty_pipeline(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])


### PR DESCRIPTION
Adds a `split_column` cleaning step that can split one source string column into named output columns using either a delimiter or regex pattern, with validation for missing columns and output-name collisions. The step is registered for pipelines and covered with tests for the normal split/drop path and an invalid existing-output-column case.

Fixes #141

Tests: `python3 -m pytest tests/test_pipeline.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `split_column` function to split column values into multiple columns with customizable separators and splitting options.
  * Integrated `split_column` into the pipeline system for seamless use in data processing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/im-anishraj/arnio/pull/290)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->