### PR TITLE
Add combine columns pipeline step

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -5,6 +5,7 @@ Data cleaning functions.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 from ._core import (
@@ -198,6 +199,72 @@ def rename_columns(
     result = _rename_columns(frame._frame, mapping)
     return ArFrame(result)
 
+
+
+def combine_columns(
+    frame: ArFrame,
+    columns: list[str],
+    output_column: str,
+    *,
+    separator: str = "",
+    drop_original: bool = False,
+) -> ArFrame:
+    """Build a string column by joining multiple existing columns.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    columns : list[str]
+        Existing columns to combine in order.
+    output_column : str
+        Name of the new combined column.
+    separator : str, default ""
+        String inserted between non-null values.
+    drop_original : bool, default False
+        Whether to remove the source columns after creating the new column.
+
+    Returns
+    -------
+    ArFrame
+        New frame with the combined string column.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("people.csv")
+    >>> combined = combine_columns(frame, ["first", "last"], "full_name", separator=" ")
+    """
+    if not isinstance(columns, Iterable) or isinstance(columns, (str, bytes)):
+        raise ValueError("columns must be a non-empty list of column names")
+
+    columns = list(columns)
+    if not columns:
+        raise ValueError("columns must be a non-empty list of column names")
+
+    if not output_column:
+        raise ValueError("output_column must be a non-empty string")
+
+    from .convert import from_pandas, to_pandas
+    import pandas as pd
+
+    df = to_pandas(frame)
+    missing = [column for column in columns if column not in df.columns]
+    if missing:
+        raise KeyError(f"Missing columns: {missing}")
+
+    def combine_row(row):
+        values = []
+        for column in columns:
+            value = row[column]
+            if value is not None and not pd.isna(value):
+                values.append(str(value))
+        return separator.join(values)
+
+    df[output_column] = df.apply(combine_row, axis=1)
+    if drop_original:
+        df = df.drop(columns=columns)
+
+    return from_pandas(df)
 
 def cast_types(
     frame: ArFrame,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -19,6 +19,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
+    "combine_columns": cleaning.combine_columns,
 }
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -103,3 +103,61 @@ class TestPipeline:
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "Expected a dict" in str(e)
+
+    def test_combine_columns_step(self, tmp_path):
+        path = tmp_path / "names.csv"
+        path.write_text("first,last,age\nAda,Lovelace,36\nGrace,Hopper,85\n")
+        frame = ar.read_csv(path)
+
+        result = ar.pipeline(
+            frame,
+            [
+                (
+                    "combine_columns",
+                    {
+                        "columns": ["first", "last"],
+                        "output_column": "full_name",
+                        "separator": " ",
+                    },
+                ),
+            ],
+        )
+
+        df = ar.to_pandas(result)
+        assert df["full_name"].tolist() == ["Ada Lovelace", "Grace Hopper"]
+        assert "first" in result.columns
+
+    def test_combine_columns_step_can_drop_original_columns(self, tmp_path):
+        path = tmp_path / "names.csv"
+        path.write_text("first,last\nAda,Lovelace\n")
+        frame = ar.read_csv(path)
+
+        result = ar.pipeline(
+            frame,
+            [
+                (
+                    "combine_columns",
+                    {
+                        "columns": ["first", "last"],
+                        "output_column": "full_name",
+                        "separator": " ",
+                        "drop_original": True,
+                    },
+                ),
+            ],
+        )
+
+        assert result.columns == ["full_name"]
+        assert ar.to_pandas(result)["full_name"].iloc[0] == "Ada Lovelace"
+
+    def test_combine_columns_rejects_empty_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        try:
+            ar.pipeline(
+                frame,
+                [("combine_columns", {"columns": [], "output_column": "combined"})],
+            )
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "non-empty" in str(e)


### PR DESCRIPTION
Adds a focused `combine_columns` cleaning step for pipeline use, allowing callers to join multiple existing columns into a new string column with a configurable separator and optional removal of the source columns. The change includes validation for empty column lists and missing source columns, registers the step in the built-in pipeline registry, and adds pipeline tests for the normal path, dropping originals, and invalid input. Fixes #142.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `combine_columns` step for merging multiple columns into a single output column with optional separator
  * Supports selective dropping of original source columns
  * Includes input validation and handles missing values gracefully

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/im-anishraj/arnio/pull/291)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->