### PR TITLE
Add parse_bool_strings pipeline step

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pandas as pd
+
 from ._core import (
     _cast_types,
     _drop_duplicates,
@@ -197,6 +199,46 @@ def rename_columns(
     """
     result = _rename_columns(frame._frame, mapping)
     return ArFrame(result)
+
+
+def parse_bool_strings(
+    frame: ArFrame,
+    *,
+    subset: list[str] | None = None,
+) -> ArFrame:
+    """Normalize common boolean-like strings to bool values.
+
+    Values such as ``yes``/``no``, ``y``/``n``, ``1``/``0``, and
+    ``true``/``false`` are matched case-insensitively after trimming whitespace.
+    Non-matching values are left unchanged so mixed columns can be reviewed or
+    handled by a later validation step.
+    """
+    from .convert import from_pandas, to_pandas
+
+    truthy = {"true", "t", "yes", "y", "1"}
+    falsy = {"false", "f", "no", "n", "0"}
+    df = to_pandas(frame).copy()
+    columns = subset if subset is not None else list(df.columns)
+
+    for column in columns:
+        if column not in df.columns:
+            raise KeyError(f"Column not found: {column}")
+
+        def parse_value(value: Any) -> Any:
+            if pd.isna(value):
+                return value
+            if isinstance(value, bool):
+                return value
+            normalized = str(value).strip().lower()
+            if normalized in truthy:
+                return True
+            if normalized in falsy:
+                return False
+            return value
+
+        df[column] = df[column].map(parse_value)
+
+    return from_pandas(df)
 
 
 def cast_types(

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -17,6 +17,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "drop_duplicates": cleaning.drop_duplicates,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,
+    "parse_bool_strings": cleaning.parse_bool_strings,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
 }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -75,6 +75,30 @@ class TestPipeline:
         assert result.dtypes["years"] == "float64"
         assert "age" not in result.columns
 
+
+    def test_parse_bool_strings_step(self, tmp_path):
+        path = tmp_path / "flags.csv"
+        path.write_text("enabled,archived\nyes,0\n No ,1\nTRUE,false\ny,N\n")
+        frame = ar.read_csv(path)
+
+        result = ar.pipeline(frame, [("parse_bool_strings",)])
+        df = ar.to_pandas(result)
+
+        assert df["enabled"].tolist() == [True, False, True, True]
+        assert df["archived"].tolist() == [False, True, False, False]
+
+    def test_parse_bool_strings_subset_and_invalid_values(self, tmp_path):
+        path = tmp_path / "flags.csv"
+        path.write_text("enabled,label\nyes,no\n0,maybe\n")
+        frame = ar.read_csv(path)
+
+        result = ar.pipeline(frame, [("parse_bool_strings", {"subset": ["enabled"]})])
+        df = ar.to_pandas(result)
+
+        assert df["enabled"].tolist() == [True, False]
+        assert df["label"].tolist() == ["no", "maybe"]
+
+
     def test_empty_pipeline(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])


### PR DESCRIPTION
Adds a focused `parse_bool_strings` cleaning step for the pipeline so common values like yes/no, y/n, 1/0, and true/false are normalized consistently while unmatched values are preserved for later review. The change also registers the step in the built-in pipeline registry and covers full-pipeline usage, subset handling, and invalid-value preservation with targeted tests.

Fixes #150

Tested with `python3 -m pytest tests/test_cleaning.py tests/test_pipeline.py -q`.
