### PR TITLE
Handle NUL byte CSV input with CsvReadError

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -106,8 +106,8 @@ def read_csv(
     try:
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
-                raise ValueError(
-                    f"File appears to be binary: {path}. Only text-based CSV files are supported."
+                raise CsvReadError(
+                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
@@ -182,8 +182,8 @@ def scan_csv(
     try:
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
-                raise ValueError(
-                    f"File appears to be binary: {path}. Only text-based CSV files are supported."
+                raise CsvReadError(
+                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -86,7 +86,10 @@ def read_csv(
     Raises
     ------
     ValueError
-        If file format is unsupported or file appears binary.
+        If file format is unsupported.
+
+    CsvReadError
+        If CSV input contains NUL bytes and appears binary or corrupted.
 
     Examples
     --------
@@ -107,7 +110,7 @@ def read_csv(
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
                 raise CsvReadError(
-                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
+                    "CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
@@ -159,8 +162,11 @@ def scan_csv(
 
     Raises
     ------
-    ValueError
-        If file format is unsupported or file appears binary.
+        ValueError
+        If file format is unsupported.
+
+    CsvReadError
+        If CSV input contains NUL bytes and appears binary or corrupted.
 
     Examples
     --------
@@ -183,7 +189,7 @@ def scan_csv(
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
                 raise CsvReadError(
-                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
+                    "CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -162,7 +162,7 @@ def scan_csv(
 
     Raises
     ------
-        ValueError
+    ValueError
         If file format is unsupported.
 
     CsvReadError

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -175,7 +175,7 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, encoding="latin-1")
 
         assert schema == {"name": "string"}
-        
+
     def test_scan_binary_file_rejection(self, tmp_path):
         file_path = str(tmp_path / "data.csv")
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -75,13 +75,14 @@ class TestReadCsv:
             ar.read_csv(file_path)
 
     def test_binary_file_rejection(self, tmp_path):
-        import pytest
-
         file_path = str(tmp_path / "data.csv")
         with open(file_path, "wb") as f:
             f.write(b"col1,col2\n\0binary\0,data\n")
 
-        with pytest.raises(ValueError, match="File appears to be binary"):
+        with pytest.raises(
+            ar.CsvReadError,
+            match="CSV input contains NUL bytes and appears to be binary or corrupted",
+        ):
             ar.read_csv(file_path)
 
     def test_read_with_nulls(self, csv_with_nulls):
@@ -174,3 +175,15 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, encoding="latin-1")
 
         assert schema == {"name": "string"}
+        
+    def test_scan_binary_file_rejection(self, tmp_path):
+        file_path = str(tmp_path / "data.csv")
+
+        with open(file_path, "wb") as f:
+            f.write(b"col1,col2\n\0binary\0,data\n")
+
+        with pytest.raises(
+            ar.CsvReadError,
+            match="CSV input contains NUL bytes and appears to be binary or corrupted",
+        ):
+            ar.scan_csv(file_path)


### PR DESCRIPTION
## Summary

Implemented stricter handling for corrupted or binary-like CSV input containing NUL (`\0`) bytes.

### Changes made

* Updated `read_csv()` to raise `CsvReadError` for NUL-byte input
* Updated `scan_csv()` to follow the same behavior
* Added regression test coverage for `scan_csv()` binary file rejection
* Updated existing tests to validate the new exception contract and error message

This ensures corrupted/binary CSV input fails with a clear and consistent Python-facing error instead of undefined parser behavior.

## Linked issue

Fixes #284

## Type of change

* [x] Bug fix
* [x] Tests

## Area

* [x] CSV parser / I/O

## Testing

```bash
pytest tests/test_csv.py -v
```

Result:

* 23 tests passed successfully
