### PR TITLE
docs: align pandas dtype support matrix with implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,45 +47,39 @@ A `Frame` is an ordered collection of `Column` objects, representing a 2D datase
 
 ## 4. Pandas Dtype Compatibility
 
-Arnio supports the most common pandas dtypes directly through its native C++ columnar model, while some advanced or mixed dtypes may require conversion or are currently unsupported.
-
+Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model. Some advanced pandas dtypes are currently handled through conversion, have limited support, or are planned for future improvements.
 This section helps users understand which dtype workflows are fully supported, partially supported, unsupported, or planned.
 
 ### Fully Supported
-
-The following dtypes are fully supported and map efficiently to strongly typed C++ vectors:
-
+The following dtypes are natively supported and map efficiently to strongly typed C++ vectors:
 - `int64`
 - `float64`
+- `bool`
 - `string`
-- `datetime64[ns]`
-
 These allow efficient parsing, cleaning operations, and zero-copy or near zero-copy conversion back to pandas where possible.
 
-### Partially Supported
-
-The following dtypes are partially supported and may require preprocessing depending on the workflow:
-
-- `object`
-- `boolean`
+### Limited / Converted Support
+The following dtypes are not natively supported but may work through conversion or preprocessing depending on the workflow:
+- `datetime64[ns]`
 - `category`
+- mixed `object` columns
+These may require conversion before pipeline execution. Mixed object columns can reduce type inference reliability, and categorical workflows may require normalization before cleaning operations.
 
-These may work depending on column consistency and operation type. Mixed `object` columns, categorical operations, and some boolean workflows may require explicit conversion before pipeline execution.
+### Planned Support
+The following pandas-specific nullable dtypes require additional handling for null semantics and conversion consistency:
+- nullable integer types such as `Int64`
+- nullable boolean dtype such as `boolean`
+Support improvements for these dtypes are planned for future releases.
 
-### Currently Unsupported / Planned
-
-The following dtypes are currently unsupported or planned for future improvements:
-
+### Currently Unsupported
+The following dtype is currently unsupported:
 - `timedelta64[ns]`
-- Nullable integer types such as `Int64`
 
-These require additional handling for null semantics, type inference improvements, and conversion consistency.
+This requires additional parsing and inference support in the C++ runtime and is not yet available.
 
 ### User-facing Behavior
-
-When unsupported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
-
-Users are encouraged to prefer strongly typed columns such as `int64`, `float64`, and `string` for best performance and compatibility.
+When unsupported or partially supported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
+For best performance and compatibility, users are encouraged to prefer strongly typed columns such as `int64`, `float64`, `bool`, and `string`.
 
 ## 5. Pipeline Execution
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,49 @@ A `Column` represents a single 1D array of homogeneous data.
 A `Frame` is an ordered collection of `Column` objects, representing a 2D dataset.
 - The `Frame` maintains an index mapping column names to their respective `Column` objects for `O(1)` access.
 
-## 4. Pipeline Execution
+## 4. Pandas Dtype Compatibility
+
+Arnio supports the most common pandas dtypes directly through its native C++ columnar model, while some advanced or mixed dtypes may require conversion or are currently unsupported.
+
+This section helps users understand which dtype workflows are fully supported, partially supported, unsupported, or planned.
+
+### Fully Supported
+
+The following dtypes are fully supported and map efficiently to strongly typed C++ vectors:
+
+- `int64`
+- `float64`
+- `string`
+- `datetime64[ns]`
+
+These allow efficient parsing, cleaning operations, and zero-copy or near zero-copy conversion back to pandas where possible.
+
+### Partially Supported
+
+The following dtypes are partially supported and may require preprocessing depending on the workflow:
+
+- `object`
+- `boolean`
+- `category`
+
+These may work depending on column consistency and operation type. Mixed `object` columns, categorical operations, and some boolean workflows may require explicit conversion before pipeline execution.
+
+### Currently Unsupported / Planned
+
+The following dtypes are currently unsupported or planned for future improvements:
+
+- `timedelta64[ns]`
+- Nullable integer types such as `Int64`
+
+These require additional handling for null semantics, type inference improvements, and conversion consistency.
+
+### User-facing Behavior
+
+When unsupported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
+
+Users are encouraged to prefer strongly typed columns such as `int64`, `float64`, and `string` for best performance and compatibility.
+
+## 5. Pipeline Execution
 
 The `pipeline()` function in Python accepts a list of declarative steps. 
 
@@ -53,6 +95,6 @@ The `pipeline()` function in Python accepts a list of declarative steps.
 2. **C++ Execution**: For natively supported operations, the Python wrapper calls the C++ function directly, passing the `Frame` pointer. The operation modifies the data or returns a new `Frame` entirely within C++.
 3. **Python Fallback**: If a step is registered via pure Python (`ar.register_step()`), the `Frame` is temporarily converted to a pandas DataFrame, the Python function executes, and the result is converted back. *(Note: This incurs a conversion penalty and is intended for prototyping or operations not yet supported in C++).*
 
-## 5. Converting to Pandas
+## 6. Converting to Pandas
 
 The `to_pandas()` function is the most critical boundary. It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory directly to pandas, avoiding expensive element-by-element copies where possible (zero-copy for numerics and booleans). String columns currently require instantiation of Python `str` objects.

--- a/README.md
+++ b/README.md
@@ -316,6 +316,37 @@ clean = ar.pipeline(frame, [
 
 <br>
 
+## 📊 Pandas Dtype Support Matrix
+
+This table helps users understand which pandas dtypes and workflows are fully supported, partially supported, unsupported, or planned.
+
+If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
+
+| Pandas Dtype | Support Status | Notes |
+|---|---|---|
+| `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
+| `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
+| `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
+| `datetime64[ns]` | ✅ Supported | Standard datetime workflows are supported |
+| `object` | ⚠️ Partial | Supported with limitations depending on mixed values |
+| `boolean` | ⚠️ Partial | Some workflows may require explicit conversion |
+| `category` | ⚠️ Partial | Limited compatibility in some operations |
+| `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
+| `Int64` (nullable integer) | 📋 Planned | Support improvements planned for future releases |
+
+### Notes
+
+- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
+- String columns require Python string object creation during `to_pandas()` conversion.
+- Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
+- Unsupported dtypes should raise clear user-facing errors instead of silent failures.
+
+<br>
+
+---
+
+<br>
+
 ## 🧠 Data quality engine
 
 Arnio now includes built-in dataset understanding before you analyze in pandas.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ clean = ar.pipeline(frame, [
 
 ## 📊 Pandas Dtype Support Matrix
 
+## 📊 Pandas Dtype Support Matrix
+
 This table helps users understand which pandas dtypes and workflows are fully supported, partially supported, unsupported, or planned.
 
 If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
@@ -326,13 +328,13 @@ If a dtype is partially supported, users may need conversion before processing. 
 |---|---|---|
 | `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
 | `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
+| `bool` | ✅ Supported | Native supported boolean type |
 | `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
-| `datetime64[ns]` | ✅ Supported | Standard datetime workflows are supported |
-| `object` | ⚠️ Partial | Supported with limitations depending on mixed values |
-| `boolean` | ⚠️ Partial | Some workflows may require explicit conversion |
-| `category` | ⚠️ Partial | Limited compatibility in some operations |
+| `datetime64[ns]` | ⚠️ Limited | Usually converted before processing, not natively supported |
+| `category` | ⚠️ Limited | May require conversion before pipeline execution |
+| `object` (mixed columns) | ⚠️ Limited | Mixed object columns reduce type inference reliability |
+| nullable pandas dtypes (`Int64`, `boolean`) | 📋 Planned | Additional null semantics handling is planned |
 | `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
-| `Int64` (nullable integer) | 📋 Planned | Support improvements planned for future releases |
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,6 @@ clean = ar.pipeline(frame, [
 
 ## 📊 Pandas Dtype Support Matrix
 
-## 📊 Pandas Dtype Support Matrix
-
 This table helps users understand which pandas dtypes and workflows are fully supported, partially supported, unsupported, or planned.
 
 If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
@@ -330,10 +328,10 @@ If a dtype is partially supported, users may need conversion before processing. 
 | `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
 | `bool` | ✅ Supported | Native supported boolean type |
 | `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
-| `datetime64[ns]` | ⚠️ Limited | Usually converted before processing, not natively supported |
-| `category` | ⚠️ Limited | May require conversion before pipeline execution |
-| `object` (mixed columns) | ⚠️ Limited | Mixed object columns reduce type inference reliability |
-| nullable pandas dtypes (`Int64`, `boolean`) | 📋 Planned | Additional null semantics handling is planned |
+| `datetime64[ns]` | ❌ Unsupported | No native datetime parsing or conversion support yet |
+| `category` | ⚠️ Limited | Converted to string/object during processing |
+| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may coerce to string and reduce type inference reliability |
+| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited | Supported through pandas extension dtypes with null-mask handling |
 | `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
 
 ### Notes


### PR DESCRIPTION
## Linked issue
Fixes #278 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [ ] Other:

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
