### PR TITLE
docs: add contributor glossary

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,6 +33,19 @@ Or run the commands manually — each `make` target is just one or two commands 
 
 ---
 
+## Contributor Glossary
+
+- **ArFrame**: Arnio's internal table object. It stores data in a C++-backed, column-oriented format before you convert it to a pandas DataFrame.
+- **pipeline step**: One cleaning action inside `ar.pipeline(...)`, such as `strip_whitespace` or `drop_duplicates`. Steps run in order to transform a frame.
+- **schema**: A set of rules that describes what valid data should look like, such as required columns, expected types, allowed values, or limits.
+- **quality report**: A summary of data health for a frame. It highlights things like nulls, duplicates, whitespace problems, semantic hints, and suggested cleanup steps.
+- **zero-copy**: A fast conversion style where Arnio can expose existing C++ memory to pandas without duplicating the data first, especially for numeric and boolean columns.
+- **C++ core**: The compiled engine underneath the Python API that performs the heavy CSV reading and cleaning work.
+- **pandas bridge**: The conversion path between Arnio data structures and pandas DataFrames, used when exporting results or running pure-Python custom steps.
+- **validation result**: The object returned after checking a frame against a schema. It tells you whether validation passed and lists any issues that were found.
+
+---
+
 ## Adding a Pure Python Pipeline Step (No C++ Required)
 
 Most new features do not require touching C++! You can write a pure Python step and register it with Arnio. This is how 90% of GSSoC contributors will contribute.

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ pytest tests/ -v
 > **PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)** — `feat:`, `fix:`, `docs:`, `chore:`. Our release pipeline auto-generates changelogs from these.
 
 For GSSoC contributors, please read **[GSSOC_GUIDE.md](GSSOC_GUIDE.md)** before asking to be assigned. It explains issue claiming, contribution levels, review expectations, and what maintainers look for in a strong PR.
+If you are new to Arnio terms, see the [contributor glossary](.github/CONTRIBUTING.md#contributor-glossary).
 
 <p align="center">
 <a href=".github/CONTRIBUTING.md"><b>📖 Full Contributing Guide</b></a>&ensp;·&ensp;


### PR DESCRIPTION
## Summary

Added a contributor glossary in `.github/CONTRIBUTING.md` to define common Arnio terms for new contributors, including ArFrame, pipeline step, schema, quality report, zero-copy, C++ core, pandas bridge, and validation result.

Also added a small README reference linking to the glossary.

AI assistance was used to help draft and review the documentation wording. The final changes were reviewed locally before submission.

## Linked issue

Fixes #283

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [x] `make lint`
- [x] Other: `git diff --check`

`git diff --check` passed with no output.

`make lint` passed:
- `ruff check .` — All checks passed
- `black --check .` — 23 files would be left unchanged

`make test` was not run because this PR is docs-only and does not change source code or behavior.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Docs-only PR focused on the contributor glossary requested in #283. No source code or behavior changes were made.