### PR TITLE
docs: add gssoc faq

### DIFF
--- a/GSSOC_GUIDE.md
+++ b/GSSOC_GUIDE.md
@@ -10,6 +10,41 @@ Arnio is a GSSoC 2026 project focused on fast, reliable data preparation before 
 4. Wait for maintainer assignment before starting scored GSSoC work.
 5. Keep one issue to one PR unless a maintainer asks otherwise.
 
+## GSSoC FAQ
+
+**How do I set up the project locally?**
+Clone the repo, install dev dependencies with `pip install -e ".[dev]"`, install pre-commit hooks, and run `pytest tests/ -v`. On Windows, install Visual Studio Build Tools with the "Desktop development with C++" workload first.
+
+**How does issue assignment work?**
+For GSSoC-scored work, maintainers expect contributors to comment with a short implementation approach and wait for assignment before starting.
+
+**How do I claim an issue?**
+Read the issue carefully, search for existing PRs, then comment with a short plan so maintainers can review and assign the work.
+
+**Can I start working before I am assigned?**
+For scored GSSoC work, no. Wait for maintainer assignment before you start so work is not duplicated.
+
+**Should one PR cover more than one issue?**
+Usually no. Keep one issue to one PR unless a maintainer explicitly asks otherwise.
+
+**What should I expect during PR review?**
+Maintainers may ask for tests, doc updates, edge cases, or a narrower scope. Respond politely and clearly during review.
+
+**What testing or linting should I run before opening a PR?**
+Run tests before requesting review. A good local checklist is `pytest tests/ -v`, and if you are using the full contributor workflow, also run `make test` and `make lint`.
+
+**What contribution etiquette should I follow?**
+Keep your PR focused, avoid editing unrelated files, and keep formatting-only changes separate from feature work.
+
+**Can I open a PR if someone already has the issue or PR in progress?**
+Do not open duplicate PRs for the same issue. Unassigned duplicate PRs do not count as accepted GSSoC work.
+
+**Where should I ask questions if I get stuck?**
+Use GitHub Discussions for onboarding and general questions, and use issue comments for task-specific updates.
+
+**What information should I include when asking for help?**
+Share what you tried, the exact command or code, the error output, and your operating system and Python version.
+
 ## Good First Contributions
 
 Start with issues labeled:

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ pytest tests/ -v
 
 > **PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)** — `feat:`, `fix:`, `docs:`, `chore:`. Our release pipeline auto-generates changelogs from these.
 
-For GSSoC contributors, please read **[GSSOC_GUIDE.md](GSSOC_GUIDE.md)** before asking to be assigned. It explains issue claiming, contribution levels, review expectations, and what maintainers look for in a strong PR.
+For GSSoC contributors, please read **[GSSOC_GUIDE.md](GSSOC_GUIDE.md)** before asking to be assigned. It explains issue claiming, contribution levels, review expectations, and what maintainers look for in a strong PR. If you want a quick onboarding refresher, see the [GSSoC FAQ](GSSOC_GUIDE.md#gssoc-faq).
 
 <p align="center">
 <a href=".github/CONTRIBUTING.md"><b>📖 Full Contributing Guide</b></a>&ensp;·&ensp;


### PR DESCRIPTION
## Summary

Added a concise GSSoC FAQ section to `GSSOC_GUIDE.md` to help new contributors with common onboarding questions, including setup, issue assignment, claiming issues, PR review expectations, testing/linting, duplicate PR guidance, and where to ask for help.

Also updated the README’s GSSoC contributor sentence with a small link to the new FAQ.

AI assistance was used to help draft and review the documentation wording. The final changes were reviewed locally before submission.

## Linked issue

Fixes #281

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [x] `make lint`
- [x] Other: `git diff --check`

`git diff --check` passed with no output.

`make lint` passed:
- `ruff check .` — All checks passed
- `black --check .` — 23 files would be left unchanged

`make test` was not run because this PR is docs-only and does not change source code or behavior.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes, or no behavior changes were made.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Docs-only PR focused on the GSSoC FAQ/discussion starter requested in #281. No source code or behavior changes were made.

This PR is separate from #308 / #283 and does not include contributor glossary changes.