### PR TITLE
Add ArFrame from records constructor

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -16,6 +16,27 @@ class ArFrame:
     def __init__(self, cpp_frame: _Frame) -> None:
         self._frame = cpp_frame
 
+    @classmethod
+    def from_records(cls, records: list[dict[str, object]]) -> "ArFrame":
+        """Build an ArFrame from a list of row dictionaries."""
+        if not isinstance(records, list):
+            raise TypeError("records must be a list of dictionaries")
+
+        columns: dict[str, list[object]] = {}
+        for row_index, record in enumerate(records):
+            if not isinstance(record, dict):
+                raise TypeError("records must be a list of dictionaries")
+
+            for key in record:
+                name = str(key)
+                if name not in columns:
+                    columns[name] = [None] * row_index
+
+            for name, values in columns.items():
+                values.append(record.get(name))
+
+        return cls(_Frame.from_dict(columns))
+
     # --- Properties ---
 
     @property

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,6 @@
 """Tests for pandas conversion."""
 
+import pytest
 import pandas as pd
 
 import arnio as ar
@@ -48,6 +49,32 @@ class TestToPandas:
         ]
 
 
+class TestFromRecords:
+    def test_from_records_preserves_columns_and_values(self):
+        frame = ar.ArFrame.from_records(
+            [
+                {"name": "Alice", "score": 95},
+                {"score": 88, "active": True},
+            ]
+        )
+
+        assert frame.shape == (2, 3)
+        assert frame.columns == ["name", "score", "active"]
+        assert frame._frame.column_by_name("name").to_python_list() == ["Alice", None]
+        assert frame._frame.column_by_name("score").to_python_list() == [95, 88]
+        assert frame._frame.column_by_name("active").to_python_list() == [None, True]
+
+    def test_from_records_empty(self):
+        frame = ar.ArFrame.from_records([])
+
+        assert frame.shape == (0, 0)
+        assert frame.columns == []
+
+    def test_from_records_requires_dictionaries(self):
+        with pytest.raises(TypeError, match="list of dictionaries"):
+            ar.ArFrame.from_records([("name", "Alice")])
+
+
 class TestFromPandas:
     def test_basic_roundtrip(self, sample_csv):
         frame = ar.read_csv(sample_csv)
@@ -84,8 +111,6 @@ class TestFromPandas:
         assert list(df2["score"]) == [95.5, 87.0]
 
     def test_from_pandas_nested_data(self):
-        import pytest
-
         df_list = pd.DataFrame({"a": [[1, 2], [3, 4]]})
         with pytest.raises(TypeError, match="Unsupported nested/complex type"):
             ar.from_pandas(df_list)


### PR DESCRIPTION
## Summary
Adds `ArFrame.from_records(...)` for building small frames directly from a list of dictionaries without writing an intermediate CSV file. The constructor preserves first-seen column order, fills missing keys with `None`, and includes tests for normal, empty, and invalid-record inputs.

## Linked issue
Fixes #225

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `python3 -m compileall arnio tests/test_convert.py`; `python3 -m pytest tests/test_convert.py -q`; `git diff --check`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The method is intentionally limited to list-of-dictionary records so the initial contract stays small and predictable.
