### PR TITLE
feat: add ArFrame.to_numpy for numeric frames

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor_task.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_task.yml
@@ -1,0 +1,51 @@
+name: Refactor task
+description: Propose a code refactor to improve maintainability, performance, or clarity.
+title: "Refactor: "
+labels: ["type: refactor", "status: needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Refactoring helps keep Arnio's codebase healthy. Please describe the area you want to improve.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Current situation
+      description: What is the current state of the code that needs refactoring?
+      placeholder: "The logic in src/cleaning.cpp for strip_whitespace is repeated..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: How do you propose to refactor the code?
+      placeholder: "Extract the common logic into a separate utility function..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefit
+    attributes:
+      label: Expected benefit
+      description: Why is this refactor important? (e.g., performance, readability, reduced duplication)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: risk
+    attributes:
+      label: Risk assessment
+      options:
+        - label: This change is backwards-compatible.
+          required: true
+        - label: This change does not alter the public API.
+          required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other information or related issues.

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -1,0 +1,211 @@
+# Issue Triage Guide
+
+This document explains how Arnio maintainers triage incoming issues. It defines each label category, provides real-world examples, and outlines the standard triage workflow. Contributors are also welcome to read this to understand how their issues get categorized.
+
+---
+
+## Why Triage?
+
+Every issue that lands in our backlog gets categorized along key dimensions:
+
+1. **Priority** — how urgent it is
+2. **Difficulty** — how much expertise it needs
+3. **Size** — how much effort it'll take
+4. **Status** — where it sits in the workflow
+5. **Type** — what kind of change it is
+6. **Area** — which part of the codebase it touches
+
+This makes the backlog navigable: a beginner GSSoC contributor can filter for `difficulty: beginner` + `size: s` + `status: ready` and instantly find an entry point. Maintainers can spot `priority: critical` + `status: blocked` issues that need unblocking.
+
+---
+
+## Label Categories
+
+### Priority
+
+How urgent is this issue?
+
+| Label | Meaning | Example |
+|:---|:---|:---|
+| `priority: critical` | Production-breaking bug, security issue, or release blocker. Drop everything. | A regression that crashes `read_csv()` on valid input |
+| `priority: high` | Important and time-sensitive. Should be picked up this week. | A documented public API returns wrong results for common case |
+| `priority: medium` | Solid improvement, not urgent. Pick up this milestone. | Add new pipeline step or improve an existing one |
+| `priority: low` | Nice-to-have. May sit in backlog for a while. | Tweak terminology in an internal log message |
+
+---
+
+### Difficulty
+
+How much expertise does this need?
+
+| Label | Meaning | Who should pick it up |
+|:---|:---|:---|
+| `difficulty: beginner` | Self-contained, well-scoped, no prior repo context required. Touching one or two files. | First-time contributors, students new to open source |
+| `difficulty: intermediate` | Requires reading existing code, following established patterns, writing tests. | Contributors comfortable with Python and the codebase |
+| `difficulty: advanced` | Architecture-level work, C++ optimization, performance-critical paths. | Contributors with C++ experience or deep familiarity |
+
+---
+
+### Size
+
+How much effort will this take?
+
+| Label | Estimate | Typical scope |
+|:---|:---|:---|
+| `size: xs` | < 30 minutes | Single docstring, tiny fix, comment update |
+| `size: s` | < 2 hours | Single function, doc fix, small test addition |
+| `size: m` | Half a day | New pipeline step + tests, small refactor |
+| `size: l` | 1–2 days | New module, multi-file feature, schema validation |
+
+---
+
+### Type
+
+What kind of change is this?
+
+| Label | Use for |
+|:---|:---|
+| `type: bug` | Fixing incorrect behavior |
+| `type: feature` | Adding new capability |
+| `type: docs` | Documentation only |
+| `type: tests` | Test suite improvements |
+| `type: refactor` | Code restructuring with no behavior change |
+| `type: performance` | Speed or memory improvements |
+| `type: security` | Security fix or hardening |
+| `type: ci` | GitHub Actions, build pipeline, release tooling |
+| `type: discussion` | Needs community input before implementation |
+
+---
+
+### Area
+
+Which part of the codebase does this touch?
+
+| Label | Covers |
+|:---|:---|
+| `area: csv-parser` | CSV reading, RFC 4180 compliance, BOM handling |
+| `area: cpp-core` | C++ runtime — types, columns, frames, cleaning engine |
+| `area: python-api` | Python API in `arnio/` — IO, pipeline, conversion |
+| `area: pipeline` | Step registry, pipeline executor, custom steps |
+| `area: cleaning` | Cleaning primitives — drop_nulls, fill_nulls, dedup, etc. |
+| `area: pandas-interop` | pandas bridge, zero-copy conversion, buffer protocol |
+| `area: quality` | Data quality engine, profiling, validation, suggestions |
+| `area: schema` | Schema definition, type casting, validation |
+| `area: docs` | README, architecture docs, guides, examples |
+| `area: website` | arnio.vercel.app, landing page, tutorials |
+| `area: ci-packaging` | GitHub Actions, PyPI wheels, releases |
+| `area: benchmarks` | Performance testing, reproduction scripts |
+| `area: examples` | Usage examples, notebooks, tutorials |
+| `area: developer-experience` | Error messages, CLI tooling, dev setup |
+| `area: release` | Version bumping, changelogs, deployment |
+
+---
+
+### Workflow Status
+
+Where is the issue in the lifecycle?
+
+| Label | Meaning |
+|:---|:---|
+| `status: needs triage` | New issue, not yet categorized or scoped |
+| `status: ready` | Triaged, scoped, ready for a contributor to pick up |
+| `status: claimed` | Assigned and being actively worked on |
+| `status: blocked` | Cannot proceed — waiting on a decision, dependency, or upstream change |
+| `status: needs maintainer` | Requires maintainer decision or code review |
+
+---
+
+### GSSoC Labels
+
+For [GSSoC 2026](https://gssoc.girlscript.tech/) participants:
+
+| Label | Meaning |
+|:---|:---|
+| `gssoc` | Issue is eligible for GSSoC contribution credit |
+| `gssoc: good first issue` | Strongly recommended starting point for new GSSoC contributors |
+| `gssoc: level 1` | Beginner-tier scoring |
+| `gssoc: level 2` | Intermediate-tier scoring |
+| `gssoc: level 3` | Advanced-tier scoring |
+
+See [GSSOC_GUIDE.md](../GSSOC_GUIDE.md) for full scoring details.
+
+---
+
+## Triage Workflow
+
+When a new issue arrives, work through these steps in order:
+
+### 1. Read and reproduce
+
+- For bugs: try to reproduce locally. If the report lacks information, apply `status: needs triage` and ask for: OS, Python version, arnio version, minimal reproduction.
+- For feature requests: confirm the proposed behavior fits the project scope. If unclear, apply `status: needs triage` and start a discussion.
+
+### 2. Categorize
+
+Apply labels from each required category:
+
+- ✅ `priority: *` (required)
+- ✅ `difficulty: *` (required)
+- ✅ `size: *` (required)
+- ✅ `status: *` (required — start with `status: needs triage`)
+- ✅ `type: *` (required)
+- ✅ `area: *` (one or more, required)
+- 🟡 `gssoc: *` (only if appropriate for GSSoC contributors)
+
+### 3. Scope the issue
+
+A well-triaged issue includes:
+
+- **Context** — why this matters
+- **Suggested files** — pointers to where the work lives
+- **Scope** — what's in and out of scope
+- **Acceptance criteria** — checkboxes the contributor can tick off
+
+If any of these are missing, keep the issue at `status: needs triage`.
+
+### 4. Set status and assign
+
+- Move to `status: ready` once the issue is fully scoped and ready for pickup
+- Move to `status: claimed` when a contributor is assigned
+- Move to `status: blocked` if external dependencies appear during work
+- Use `status: needs maintainer` if you need another maintainer's input
+
+---
+
+## Worked Example
+
+**Incoming issue title:** "drop_duplicates is slow on large datasets"
+
+**Triage decision:**
+
+| Label | Value | Reasoning |
+|:---|:---|:---|
+| Priority | `priority: high` | Performance is a roadmap focus for v1.2 |
+| Difficulty | `difficulty: advanced` | Requires C++ work in the cleaning engine |
+| Size | `size: l` | Hash-based comparison replacement is multi-file |
+| Status | `status: ready` | Reproducible, well-scoped, fix path is clear |
+| Type | `type: performance` | Performance improvement |
+| Area | `area: cpp-core` | Lives in `cpp/src/cleaning.cpp` |
+| GSSoC | `gssoc: level 3` | Advanced-tier scoring if a GSSoC contributor picks it up |
+
+---
+
+## Quick Reference for Maintainers
+
+When in doubt, default to:
+
+- **Priority** → `priority: medium`
+- **Difficulty** → match the actual code complexity, not the issue description length
+- **Size** → estimate as a maintainer would do it, not as a beginner would
+- **Status** → start at `status: needs triage` if anything is unclear; promote to `status: ready` once scoped
+- **Type** → `type: discussion` if direction is unclear
+
+For consistency, every issue should reach `status: ready` before being advertised as a good first issue or GSSoC pickup.
+
+---
+
+## Questions?
+
+- Open a [Discussion](https://github.com/im-anishraj/arnio/discussions) for triage process questions
+- Tag `@im-anishraj` on the issue for category disputes
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor-side workflow

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,12 @@
 - [ ] `make lint`
 - [ ] Other:
 
+## Screenshots / Media
+<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->
+
+## Performance Impact
+<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->
+
 ## Contributor checklist
 - [ ] I read the contributing guide.
 - [ ] I kept the PR focused on one issue or one logical change.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,49 @@ A `Column` represents a single 1D array of homogeneous data.
 A `Frame` is an ordered collection of `Column` objects, representing a 2D dataset.
 - The `Frame` maintains an index mapping column names to their respective `Column` objects for `O(1)` access.
 
-## 4. Pipeline Execution
+## 4. Pandas Dtype Compatibility
+
+Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model. Some advanced pandas dtypes are currently handled through conversion or have limited support depending on the workflow.
+
+This section describes the current implementation status for each dtype category.
+
+### Fully Supported
+
+The following dtypes are natively supported and map efficiently to strongly typed C++ vectors:
+
+- `int64`
+- `float64`
+- `bool`
+- `string`
+
+These allow efficient parsing, cleaning operations, and zero-copy or near zero-copy conversion back to pandas where possible.
+
+### Limited Support
+
+The following dtypes are not natively supported but may work through conversion or partial compatibility layers depending on the workflow:
+
+- `category`
+- mixed `object` columns
+- nullable pandas dtypes such as `Int64` and `boolean`
+
+Categorical columns may be converted to string/object representations during processing. Mixed object columns can reduce type inference reliability. Nullable pandas dtypes are partially supported through pandas extension dtypes and existing null-mask handling.
+
+### Unsupported
+
+The following dtypes are currently unsupported in the native runtime:
+
+- `datetime64[ns]`
+- `timedelta64[ns]`
+
+These require additional parsing and inference support in the C++ runtime and are not yet available.
+
+### User-facing Behavior
+
+When unsupported or partially supported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
+
+For best performance and compatibility, users are encouraged to prefer strongly typed columns such as `int64`, `float64`, `bool`, and `string`.
+
+## 5. Pipeline Execution
 
 The `pipeline()` function in Python accepts a list of declarative steps. 
 
@@ -53,6 +95,6 @@ The `pipeline()` function in Python accepts a list of declarative steps.
 2. **C++ Execution**: For natively supported operations, the Python wrapper calls the C++ function directly, passing the `Frame` pointer. The operation modifies the data or returns a new `Frame` entirely within C++.
 3. **Python Fallback**: If a step is registered via pure Python (`ar.register_step()`), the `Frame` is temporarily converted to a pandas DataFrame, the Python function executes, and the result is converted back. *(Note: This incurs a conversion penalty and is intended for prototyping or operations not yet supported in C++).*
 
-## 5. Converting to Pandas
+## 6. Converting to Pandas
 
 The `to_pandas()` function is the most critical boundary. It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory directly to pandas, avoiding expensive element-by-element copies where possible (zero-copy for numerics and booleans). String columns currently require instantiation of Python `str` objects.

--- a/README.md
+++ b/README.md
@@ -346,7 +346,27 @@ Works with:
 ---
 
 <br>
+## Converting to NumPy
 
+Use `to_numpy()` for a direct, pandas-free export of numeric/bool frames:
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+
+# Basic conversion — dtype preserved
+arr = frame.to_numpy()
+# int columns  → int64
+# float columns → float64
+# bool columns  → bool
+
+# Handle null values with fill_value
+arr = frame.to_numpy(fill_value=0)
+
+# Raises TypeError for string/mixed columns
+# Raises ValueError for nulls without fill_value
+```
 ## 🧠 Data quality engine
 
 Arnio now includes built-in dataset understanding before you analyze in pandas.

--- a/README.md
+++ b/README.md
@@ -402,6 +402,62 @@ clean, report = ar.auto_clean(frame, mode="strict", return_report=True)
 This is the layer pandas does not try to own: profiling, data contracts, row-level validation issues, and safe cleaning suggestions for messy incoming datasets.
 
 <br>
+
+### Beginner-friendly auto-clean tutorial
+
+Use this workflow when you receive a small messy dataset and want to inspect what Arnio will change before applying it.
+
+```python
+import arnio as ar
+import pandas as pd
+
+raw = pd.DataFrame(
+    {
+        "order_id": [1001, 1002, 1002, 1003, 1004],
+        "customer": [" Ishan ", " Prasoon ", " Prasoon ", " Pranay ", " Dhruv "],
+        "city": [" Paris ", "London", "London", " New York ", " Tokyo "],
+    }
+)
+
+frame = ar.from_pandas(raw)
+
+report = ar.profile(frame)
+summary = report.summary()
+print(summary)
+
+suggestions = ar.suggest_cleaning(frame)
+print(suggestions)
+# [('strip_whitespace', {'subset': ['customer', 'city']}), ('drop_duplicates', {'keep': 'first'})]
+
+safe = ar.auto_clean(frame)
+strict = ar.auto_clean(frame, mode="strict")
+```
+
+Messy input:
+
+| order_id | customer | city |
+|:--|:--|:--|
+| 1001 | ` Ishan ` | ` Paris ` |
+| 1002 | ` Prasoon ` | `London` |
+| 1002 | ` Prasoon ` | `London` |
+| 1003 | ` Pranay ` | ` New York ` |
+| 1004 | ` Dhruv ` | ` Tokyo ` |
+
+Expected cleaned output with `mode="strict"`:
+
+| order_id | customer | city |
+|:--|:--|:--|
+| 1001 | Ishan | Paris |
+| 1002 | Prasoon | London |
+| 1003 | Pranay | New York |
+| 1004 | Dhruv | Tokyo |
+
+`mode="safe"` only trims whitespace. Use `mode="strict"` when you also want deterministic built-in cleanup such as exact duplicate removal.
+
+See [examples/auto_clean_tutorial.py](examples/auto_clean_tutorial.py) for a runnable version of this walkthrough.
+
+<br>
+
 ## Data Quality Reports
 
 Arnio provides detailed profiling for datasets via `ar.profile()`. To generate the report shown in these examples, the following code was used:
@@ -631,7 +687,7 @@ arnio/
 │   └── exceptions.py        # ArnioError, UnknownStepError, CsvReadError, TypeCastError
 ├── tests/                   # pytest suite — CSV, cleaning, pipeline, conversions
 ├── benchmarks/              # Reproducible arnio vs pandas benchmark
-├── examples/                # basic_usage.py, custom_step.py
+├── examples/                # basic_usage.py, auto_clean_tutorial.py, custom_step.py
 └── website/                 # Project website — arnio.vercel.app
 ```
 

--- a/README.md
+++ b/README.md
@@ -346,11 +346,10 @@ Works with:
 ---
 
 <br>
-## Converting to NumPy
 
+## 🔢 Converting to NumPy
 
 Use `to_numpy()` for a direct, pandas-free export of numeric/bool frames:
-
 ```python
 import arnio as ar
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Works with:
 <br>
 ## Converting to NumPy
 
+
 Use `to_numpy()` for a direct, pandas-free export of numeric/bool frames:
 
 ```python
@@ -367,6 +368,39 @@ arr = frame.to_numpy(fill_value=0)
 # Raises TypeError for string/mixed columns
 # Raises ValueError for nulls without fill_value
 ```
+
+## 📊 Pandas Dtype Support Matrix
+
+This table helps users understand which pandas dtypes and workflows are fully supported, partially supported, unsupported, or planned.
+
+If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
+
+| Pandas Dtype | Support Status | Notes |
+|---|---|---|
+| `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
+| `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
+| `bool` | ✅ Supported | Native supported boolean type |
+| `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
+| `datetime64[ns]` | ❌ Unsupported | No native datetime parsing or conversion support yet |
+| `category` | ⚠️ Limited | Converted to string/object during processing |
+| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may coerce to string and reduce type inference reliability |
+| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited | Supported through pandas extension dtypes with null-mask handling |
+| `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
+
+### Notes
+
+- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
+- String columns require Python string object creation during `to_pandas()` conversion.
+- Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
+- Unsupported dtypes should raise clear user-facing errors instead of silent failures.
+
+<br>
+
+---
+
+<br>
+
+
 ## 🧠 Data quality engine
 
 Arnio now includes built-in dataset understanding before you analyze in pandas.

--- a/README.md
+++ b/README.md
@@ -355,11 +355,12 @@ import arnio as ar
 
 frame = ar.read_csv("data.csv")
 
-# Basic conversion — dtype preserved
+# Basic conversion
 arr = frame.to_numpy()
-# int columns  → int64
-# float columns → float64
-# bool columns  → bool
+# All-int frame → int64
+# All-float frame → float64
+# All-bool frame → bool
+# Mixed int/float/bool → NumPy promotes to a common dtype (e.g. float64)
 
 # Handle null values with fill_value
 arr = frame.to_numpy(fill_value=0)

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -73,15 +73,17 @@ class ArFrame:
         ----------
         fill_value : scalar, optional
             Value used to replace null entries. Must be compatible with
-            the column dtype (e.g. 0 for int, 0.0 for float, False for
-            bool). If ``None`` and any null values are present,
+            the column dtype — use int/float for numeric columns, bool
+            for bool columns. If ``None`` and any null values are present,
             ``ValueError`` is raised.
 
         Returns
         -------
         numpy.ndarray
             2D array of shape ``(n_rows, n_cols)`` in column order.
-            An empty frame returns an array of shape ``(0, 0)``.
+            dtype is preserved: int columns return int64, float columns
+            return float64, bool columns return bool.
+            A zero-row frame returns shape ``(0, n_cols)``.
 
         Raises
         ------
@@ -103,9 +105,9 @@ class ArFrame:
 
         n_rows, n_cols = self.shape
 
-        # Empty frame — return immediately
-        if n_cols == 0 or n_rows == 0:
-            return np.empty((0, 0))
+        # Zero-column frame
+        if n_cols == 0:
+            return np.empty((n_rows, 0))
 
         # Validate dtypes and collect columns
         columns = []
@@ -119,21 +121,19 @@ class ArFrame:
                     f"Column '{col.name()}' has unsupported dtype '{dtype}'."
                 )
 
-            # Check for nulls
             mask = col.get_null_mask()
             has_nulls = mask.any()
 
-            if has_nulls:
-                if fill_value is None:
-                    raise ValueError(
-                        f"Column '{col.name()}' contains null values. "
-                        f"Provide fill_value=... to substitute nulls, "
-                        f"e.g. frame.to_numpy(fill_value=0)."
-                    )
+            if has_nulls and fill_value is None:
+                raise ValueError(
+                    f"Column '{col.name()}' contains null values. "
+                    f"Provide fill_value=... to substitute nulls, "
+                    f"e.g. frame.to_numpy(fill_value=0)."
+                )
 
-            # Extract raw array — no pandas routing
+            # Extract with correct dtype — no forced float conversion
             if dtype == _DType.INT64:
-                arr = col.to_numpy_int().astype(float)
+                arr = col.to_numpy_int().copy()
                 if has_nulls:
                     arr[mask] = fill_value
             elif dtype == _DType.FLOAT64:
@@ -141,13 +141,16 @@ class ArFrame:
                 if has_nulls:
                     arr[mask] = fill_value
             else:  # BOOL
-                arr = col.to_numpy_bool().astype(float)
+                arr = col.to_numpy_bool().copy()
                 if has_nulls:
                     arr[mask] = fill_value
 
             columns.append(arr)
 
-        # Stack columns into 2D array: shape (n_rows, n_cols)
+        # Zero-row frame — return correct shape (0, n_cols)
+        if n_rows == 0:
+            return np.empty((0, n_cols))
+
         return np.column_stack(columns)
 
     # --- Dunder methods ---

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -81,8 +81,10 @@ class ArFrame:
         -------
         numpy.ndarray
             2D array of shape ``(n_rows, n_cols)`` in column order.
-            dtype is preserved: int columns return int64, float columns
-            return float64, bool columns return bool.
+            dtype is preserved when all columns share the same type
+            (e.g. all int64, all float64, or all bool). When columns
+            have mixed types (e.g. int and float together), NumPy
+            promotes to a common dtype (typically float64).
             A zero-row frame returns shape ``(0, n_cols)``.
 
         Raises

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -5,6 +5,8 @@ ArFrame — the core data container wrapping the C++ Frame.
 
 from __future__ import annotations
 
+import numpy as np
+
 from ._core import _DType, _Frame
 
 
@@ -63,7 +65,7 @@ class ArFrame:
         """
         return self._frame.memory_usage()
 
-    def to_numpy(self, fill_value: object = None) -> "np.ndarray":
+    def to_numpy(self, fill_value: object = None) -> np.ndarray:
         """Convert a numeric/bool-only ArFrame to a 2D NumPy array.
 
         Provides a direct export path without routing through pandas,
@@ -101,7 +103,6 @@ class ArFrame:
         >>> arr = frame.to_numpy()
         >>> arr = frame.to_numpy(fill_value=0)
         """
-        import numpy as np
 
         SUPPORTED_DTYPES = {_DType.INT64, _DType.FLOAT64, _DType.BOOL}
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -5,7 +5,7 @@ ArFrame — the core data container wrapping the C++ Frame.
 
 from __future__ import annotations
 
-from ._core import _Frame
+from ._core import _DType, _Frame
 
 
 class ArFrame:
@@ -62,6 +62,93 @@ class ArFrame:
             Memory usage in bytes.
         """
         return self._frame.memory_usage()
+
+    def to_numpy(self, fill_value: object = None) -> "np.ndarray":
+        """Convert a numeric/bool-only ArFrame to a 2D NumPy array.
+
+        Provides a direct export path without routing through pandas,
+        suitable for numeric workflows requiring fast array conversion.
+
+        Parameters
+        ----------
+        fill_value : scalar, optional
+            Value used to replace null entries. Must be compatible with
+            the column dtype (e.g. 0 for int, 0.0 for float, False for
+            bool). If ``None`` and any null values are present,
+            ``ValueError`` is raised.
+
+        Returns
+        -------
+        numpy.ndarray
+            2D array of shape ``(n_rows, n_cols)`` in column order.
+            An empty frame returns an array of shape ``(0, 0)``.
+
+        Raises
+        ------
+        TypeError
+            If any column has a non-numeric, non-bool dtype (e.g. string).
+        ValueError
+            If any column contains null values and ``fill_value`` is not
+            provided.
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> arr = frame.to_numpy()
+        >>> arr = frame.to_numpy(fill_value=0)
+        """
+        import numpy as np
+
+        SUPPORTED_DTYPES = {_DType.INT64, _DType.FLOAT64, _DType.BOOL}
+
+        n_rows, n_cols = self.shape
+
+        # Empty frame — return immediately
+        if n_cols == 0 or n_rows == 0:
+            return np.empty((0, 0))
+
+        # Validate dtypes and collect columns
+        columns = []
+        for i in range(n_cols):
+            col = self._frame.column_by_index(i)
+            dtype = col.dtype()
+
+            if dtype not in SUPPORTED_DTYPES:
+                raise TypeError(
+                    f"to_numpy() requires all columns to be numeric or bool. "
+                    f"Column '{col.name()}' has unsupported dtype '{dtype}'."
+                )
+
+            # Check for nulls
+            mask = col.get_null_mask()
+            has_nulls = mask.any()
+
+            if has_nulls:
+                if fill_value is None:
+                    raise ValueError(
+                        f"Column '{col.name()}' contains null values. "
+                        f"Provide fill_value=... to substitute nulls, "
+                        f"e.g. frame.to_numpy(fill_value=0)."
+                    )
+
+            # Extract raw array — no pandas routing
+            if dtype == _DType.INT64:
+                arr = col.to_numpy_int().astype(float)
+                if has_nulls:
+                    arr[mask] = fill_value
+            elif dtype == _DType.FLOAT64:
+                arr = col.to_numpy_float().copy()
+                if has_nulls:
+                    arr[mask] = fill_value
+            else:  # BOOL
+                arr = col.to_numpy_bool().astype(float)
+                if has_nulls:
+                    arr[mask] = fill_value
+
+            columns.append(arr)
+
+        # Stack columns into 2D array: shape (n_rows, n_cols)
+        return np.column_stack(columns)
 
     # --- Dunder methods ---
 

--- a/examples/auto_clean_tutorial.py
+++ b/examples/auto_clean_tutorial.py
@@ -1,0 +1,48 @@
+"""
+Beginner-friendly data quality walkthrough for Arnio.
+
+This example shows a small messy input, the profiling signals Arnio reports,
+the suggested cleaning steps, and the difference between safe and strict
+auto-cleaning.
+"""
+
+import pandas as pd
+
+import arnio as ar
+
+
+def main():
+    raw = pd.DataFrame(
+        {
+            "order_id": [1001, 1002, 1002, 1003, 1004],
+            "customer": [" Ishan ", " Prasoon ", " Prasoon ", " Pranay ", " Dhruv "],
+            "city": [" Paris ", "London", "London", " New York ", " Tokyo "],
+        }
+    )
+
+    frame = ar.from_pandas(raw)
+
+    print("--- Messy Input ---")
+    print(raw)
+
+    report = ar.profile(frame)
+    summary = report.summary()
+    suggestions = ar.suggest_cleaning(frame)
+
+    print("\n--- Profiling Summary ---")
+    print(summary)
+
+    print("\n--- Suggested Cleaning Steps ---")
+    print(suggestions)
+
+    safe = ar.auto_clean(frame)
+    print("\n--- auto_clean(mode='safe') ---")
+    print(ar.to_pandas(safe))
+
+    strict = ar.auto_clean(frame, mode="strict")
+    print("\n--- auto_clean(mode='strict') ---")
+    print(ar.to_pandas(strict))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,0 +1,142 @@
+"""Tests for ArFrame.to_numpy()."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+class TestToNumpy:
+
+    # --- Happy path ---
+
+    def test_integer_frame(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+        result = frame.to_numpy()
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3, 2)
+        assert result[0, 0] == 1.0
+        assert result[2, 1] == 6.0
+
+    def test_float_frame(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.5, 2.5], "y": [3.5, 4.5]}))
+        result = frame.to_numpy()
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 2)
+        assert result[0, 0] == 1.5
+
+    def test_bool_frame(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"p": [True, False, True], "q": [False, True, False]})
+        )
+        result = frame.to_numpy()
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3, 2)
+
+    def test_mixed_numeric_frame(self):
+        """Int and float columns together should work fine."""
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, 2, 3], "b": [1.1, 2.2, 3.3]})
+        )
+        result = frame.to_numpy()
+        assert result.shape == (3, 2)
+
+    def test_returns_correct_values(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [10, 20], "b": [30, 40]}))
+        result = frame.to_numpy()
+        assert result[0, 0] == 10.0
+        assert result[0, 1] == 30.0
+        assert result[1, 0] == 20.0
+        assert result[1, 1] == 40.0
+
+    def test_column_order_preserved(self):
+        """Columns should appear in the same order as frame.columns."""
+        frame = ar.from_pandas(pd.DataFrame({"z": [1, 2], "a": [3, 4]}))
+        result = frame.to_numpy()
+        assert result[0, 0] == 1.0  # z comes first
+        assert result[0, 1] == 3.0  # a comes second
+
+    def test_result_is_2d(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+        result = frame.to_numpy()
+        assert result.ndim == 2
+
+    # --- Null handling ---
+
+    def test_nulls_without_fill_value_raises(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, None, 3], "b": [4, 5, 6]}, dtype=object)
+        )
+        with pytest.raises(ValueError, match="null values"):
+            frame.to_numpy()
+
+    def test_nulls_with_fill_value(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, None, 3], "b": [4, 5, 6]}, dtype=object)
+        )
+        result = frame.to_numpy(fill_value=0)
+        assert result[1, 0] == 0.0
+
+    def test_fill_value_does_not_affect_non_null(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, None, 3]}, dtype=object)
+        )
+        result = frame.to_numpy(fill_value=99)
+        assert result[0, 0] == 1.0
+        assert result[2, 0] == 3.0
+
+    # --- TypeError cases ---
+
+    def test_string_column_raises(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"name": ["Alice", "Bob"], "age": [25, 30]})
+        )
+        with pytest.raises(TypeError, match="to_numpy()"):
+            frame.to_numpy()
+
+    def test_all_string_frame_raises(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": ["x", "y"], "b": ["p", "q"]})
+        )
+        with pytest.raises(TypeError, match="to_numpy()"):
+            frame.to_numpy()
+
+    def test_mixed_dtype_frame_raises(self):
+        """Any string column in an otherwise numeric frame should raise."""
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, 2], "b": [1.5, 2.5], "c": ["x", "y"]})
+        )
+        with pytest.raises(TypeError):
+            frame.to_numpy()
+
+    def test_error_message_contains_column_name(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"score": [1, 2], "label": ["a", "b"]})
+        )
+        with pytest.raises(TypeError, match="label"):
+            frame.to_numpy()
+
+    # --- Edge cases ---
+
+    def test_empty_frame(self):
+        frame = ar.from_pandas(pd.DataFrame({}))
+        result = frame.to_numpy()
+        assert isinstance(result, np.ndarray)
+        assert result.size == 0
+
+    def test_single_column(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+        result = frame.to_numpy()
+        assert result.shape == (3, 1)
+
+    def test_single_row(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [42], "b": [99]}))
+        result = frame.to_numpy()
+        assert result.shape == (1, 2)
+
+    def test_single_cell(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [7]}))
+        result = frame.to_numpy()
+        assert result.shape == (1, 1)
+        assert result[0, 0] == 7.0

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -16,14 +16,16 @@ class TestToNumpy:
         result = frame.to_numpy()
         assert isinstance(result, np.ndarray)
         assert result.shape == (3, 2)
-        assert result[0, 0] == 1.0
-        assert result[2, 1] == 6.0
+        assert result.dtype == np.int64
+        assert result[0, 0] == 1
+        assert result[2, 1] == 6
 
     def test_float_frame(self):
         frame = ar.from_pandas(pd.DataFrame({"x": [1.5, 2.5], "y": [3.5, 4.5]}))
         result = frame.to_numpy()
         assert isinstance(result, np.ndarray)
         assert result.shape == (2, 2)
+        assert result.dtype == np.float64
         assert result[0, 0] == 1.5
 
     def test_bool_frame(self):
@@ -33,6 +35,7 @@ class TestToNumpy:
         result = frame.to_numpy()
         assert isinstance(result, np.ndarray)
         assert result.shape == (3, 2)
+        assert result.dtype == np.bool_
 
     def test_mixed_numeric_frame(self):
         """Int and float columns together should work fine."""
@@ -45,17 +48,17 @@ class TestToNumpy:
     def test_returns_correct_values(self):
         frame = ar.from_pandas(pd.DataFrame({"a": [10, 20], "b": [30, 40]}))
         result = frame.to_numpy()
-        assert result[0, 0] == 10.0
-        assert result[0, 1] == 30.0
-        assert result[1, 0] == 20.0
-        assert result[1, 1] == 40.0
+        assert result[0, 0] == 10
+        assert result[0, 1] == 30
+        assert result[1, 0] == 20
+        assert result[1, 1] == 40
 
     def test_column_order_preserved(self):
         """Columns should appear in the same order as frame.columns."""
         frame = ar.from_pandas(pd.DataFrame({"z": [1, 2], "a": [3, 4]}))
         result = frame.to_numpy()
-        assert result[0, 0] == 1.0  # z comes first
-        assert result[0, 1] == 3.0  # a comes second
+        assert result[0, 0] == 1  # z comes first
+        assert result[0, 1] == 3  # a comes second
 
     def test_result_is_2d(self):
         frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
@@ -76,15 +79,15 @@ class TestToNumpy:
             pd.DataFrame({"a": [1, None, 3], "b": [4, 5, 6]}, dtype=object)
         )
         result = frame.to_numpy(fill_value=0)
-        assert result[1, 0] == 0.0
+        assert result[1, 0] == 0
 
     def test_fill_value_does_not_affect_non_null(self):
         frame = ar.from_pandas(
             pd.DataFrame({"a": [1, None, 3]}, dtype=object)
         )
         result = frame.to_numpy(fill_value=99)
-        assert result[0, 0] == 1.0
-        assert result[2, 0] == 3.0
+        assert result[0, 0] == 1
+        assert result[2, 0] == 3
 
     # --- TypeError cases ---
 
@@ -120,10 +123,19 @@ class TestToNumpy:
     # --- Edge cases ---
 
     def test_empty_frame(self):
+        """Zero columns → shape (0, 0)."""
         frame = ar.from_pandas(pd.DataFrame({}))
         result = frame.to_numpy()
         assert isinstance(result, np.ndarray)
-        assert result.size == 0
+        assert result.shape == (0, 0)
+
+    def test_zero_row_frame(self):
+        """Zero rows but n cols → shape (0, n_cols)."""
+        df = pd.DataFrame({"a": pd.Series([], dtype=int),
+                           "b": pd.Series([], dtype=float)})
+        frame = ar.from_pandas(df)
+        result = frame.to_numpy()
+        assert result.shape == (0, 2)
 
     def test_single_column(self):
         frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
@@ -139,4 +151,4 @@ class TestToNumpy:
         frame = ar.from_pandas(pd.DataFrame({"a": [7]}))
         result = frame.to_numpy()
         assert result.shape == (1, 1)
-        assert result[0, 0] == 7.0
+        assert result[0, 0] == 7

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -38,12 +38,13 @@ class TestToNumpy:
         assert result.dtype == np.bool_
 
     def test_mixed_numeric_frame(self):
-        """Int and float columns together should work fine."""
+        """Int and float columns together — NumPy promotes to float64."""
         frame = ar.from_pandas(
             pd.DataFrame({"a": [1, 2, 3], "b": [1.1, 2.2, 3.3]})
         )
         result = frame.to_numpy()
         assert result.shape == (3, 2)
+        assert result.dtype == np.float64  # int promoted to float64
 
     def test_returns_correct_values(self):
         frame = ar.from_pandas(pd.DataFrame({"a": [10, 20], "b": [30, 40]}))
@@ -82,9 +83,7 @@ class TestToNumpy:
         assert result[1, 0] == 0
 
     def test_fill_value_does_not_affect_non_null(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"a": [1, None, 3]}, dtype=object)
-        )
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, None, 3]}, dtype=object))
         result = frame.to_numpy(fill_value=99)
         assert result[0, 0] == 1
         assert result[2, 0] == 3
@@ -99,9 +98,7 @@ class TestToNumpy:
             frame.to_numpy()
 
     def test_all_string_frame_raises(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"a": ["x", "y"], "b": ["p", "q"]})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"a": ["x", "y"], "b": ["p", "q"]}))
         with pytest.raises(TypeError, match="to_numpy()"):
             frame.to_numpy()
 
@@ -114,9 +111,7 @@ class TestToNumpy:
             frame.to_numpy()
 
     def test_error_message_contains_column_name(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"score": [1, 2], "label": ["a", "b"]})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"score": [1, 2], "label": ["a", "b"]}))
         with pytest.raises(TypeError, match="label"):
             frame.to_numpy()
 
@@ -131,8 +126,9 @@ class TestToNumpy:
 
     def test_zero_row_frame(self):
         """Zero rows but n cols → shape (0, n_cols)."""
-        df = pd.DataFrame({"a": pd.Series([], dtype=int),
-                           "b": pd.Series([], dtype=float)})
+        df = pd.DataFrame(
+            {"a": pd.Series([], dtype=int), "b": pd.Series([], dtype=float)}
+        )
         frame = ar.from_pandas(df)
         result = frame.to_numpy()
         assert result.shape == (0, 2)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -39,9 +39,7 @@ class TestToNumpy:
 
     def test_mixed_numeric_frame(self):
         """Int and float columns together — NumPy promotes to float64."""
-        frame = ar.from_pandas(
-            pd.DataFrame({"a": [1, 2, 3], "b": [1.1, 2.2, 3.3]})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [1.1, 2.2, 3.3]}))
         result = frame.to_numpy()
         assert result.shape == (3, 2)
         assert result.dtype == np.float64  # int promoted to float64


### PR DESCRIPTION
## Summary
Adds `to_numpy()` method to `ArFrame` for numeric/bool-only frames.

## Changes
- `arnio/frame.py` — added `to_numpy(fill_value=None)` method
- `tests/test_frame.py` — full test coverage (17 tests)

## Behavior
- Numeric/bool frames → returns 2D NumPy array directly (no pandas)
- String/mixed columns → raises `TypeError` with column name in message
- Null values → raises `ValueError` unless `fill_value` is provided
- Empty frames → returns array of shape (0, 0)

Fixes #233