### PR TITLE
feat: add ArFrame.preview method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ schema = ar.scan_csv("100GB_file.csv")
 ```
 
 Useful for exploring datasets before committing memory.
+</details>
+
 <details>
 <summary><b>👀 Preview rows without loading everything</b></summary>
 <br>
@@ -99,21 +101,10 @@ print(frame.preview())      # first 5 rows (default)
 print(frame.preview(n=10))  # first 10 rows
 ```
 
-Example output:
-
-```text
-ArFrame preview (showing 5 of 1000000 rows):
-id    name     age
-----  -------  ---
-1     Alice    30
-2     Bob      25
-3     Charlie  35
-4     Diana    28
-5     Eve      22
-```
-
 Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
 </details>
+
+<details>
 <summary><b>🧩 Add custom steps without touching C++</b></summary>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Useful for exploring datasets before committing memory.
 </details>
 
 <details>
-<summary><b>👀 Preview rows without loading everything</b></summary>
+<summary><b>👀 Preview rows without pandas conversion or full-column Python list materialization</b></summary>
 <br>
 
 `preview()` reads only the first `n` rows directly from the C++ frame — no pandas conversion triggered.

--- a/README.md
+++ b/README.md
@@ -86,9 +86,34 @@ schema = ar.scan_csv("100GB_file.csv")
 ```
 
 Useful for exploring datasets before committing memory.
-</details>
-
 <details>
+<summary><b>👀 Preview rows without loading everything</b></summary>
+<br>
+
+`preview()` reads only the first `n` rows directly from the C++ frame — no pandas conversion triggered.
+
+```python
+frame = ar.read_csv("huge_file.csv")
+
+print(frame.preview())      # first 5 rows (default)
+print(frame.preview(n=10))  # first 10 rows
+```
+
+Example output:
+
+```text
+ArFrame preview (showing 5 of 1000000 rows):
+id    name     age
+----  -------  ---
+1     Alice    30
+2     Bob      25
+3     Charlie  35
+4     Diana    28
+5     Eve      22
+```
+
+Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
+</details>
 <summary><b>🧩 Add custom steps without touching C++</b></summary>
 <br>
 
@@ -543,7 +568,7 @@ pytest tests/ -v
 
 > **PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)** — `feat:`, `fix:`, `docs:`, `chore:`. Our release pipeline auto-generates changelogs from these.
 
-For GSSoC contributors, please read **[GSSOC_GUIDE.md](GSSOC_GUIDE.md)** before asking to be assigned. It explains issue claiming, contribution levels, review expectations, and what maintainers look for in a strong PR. If you want a quick onboarding refresher, see the [GSSoC FAQ](GSSOC_GUIDE.md#gssoc-faq).
+For GSSoC contributors, please read **[GSSOC_GUIDE.md](GSSOC_GUIDE.md)** before asking to be assigned. It explains issue claiming, contribution levels, review expectations, and what maintainers look for in a strong PR.
 If you are new to Arnio terms, see the [contributor glossary](.github/CONTRIBUTING.md#contributor-glossary).
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -86,9 +86,34 @@ schema = ar.scan_csv("100GB_file.csv")
 ```
 
 Useful for exploring datasets before committing memory.
-</details>
-
 <details>
+<summary><b>👀 Preview rows without loading everything</b></summary>
+<br>
+
+`preview()` reads only the first `n` rows directly from the C++ frame — no pandas conversion triggered.
+
+```python
+frame = ar.read_csv("huge_file.csv")
+
+print(frame.preview())      # first 5 rows (default)
+print(frame.preview(n=10))  # first 10 rows
+```
+
+Example output:
+
+```text
+ArFrame preview (showing 5 of 1000000 rows):
+id    name     age
+----  -------  ---
+1     Alice    30
+2     Bob      25
+3     Charlie  35
+4     Diana    28
+5     Eve      22
+```
+
+Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
+</details>
 <summary><b>🧩 Add custom steps without touching C++</b></summary>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -86,34 +86,9 @@ schema = ar.scan_csv("100GB_file.csv")
 ```
 
 Useful for exploring datasets before committing memory.
-<details>
-<summary><b>👀 Preview rows without loading everything</b></summary>
-<br>
-
-`preview()` reads only the first `n` rows directly from the C++ frame — no pandas conversion triggered.
-
-```python
-frame = ar.read_csv("huge_file.csv")
-
-print(frame.preview())      # first 5 rows (default)
-print(frame.preview(n=10))  # first 10 rows
-```
-
-Example output:
-
-```text
-ArFrame preview (showing 5 of 1000000 rows):
-id    name     age
-----  -------  ---
-1     Alice    30
-2     Bob      25
-3     Charlie  35
-4     Diana    28
-5     Eve      22
-```
-
-Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
 </details>
+
+<details>
 <summary><b>🧩 Add custom steps without touching C++</b></summary>
 <br>
 
@@ -568,7 +543,7 @@ pytest tests/ -v
 
 > **PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/)** — `feat:`, `fix:`, `docs:`, `chore:`. Our release pipeline auto-generates changelogs from these.
 
-For GSSoC contributors, please read **[GSSOC_GUIDE.md](GSSOC_GUIDE.md)** before asking to be assigned. It explains issue claiming, contribution levels, review expectations, and what maintainers look for in a strong PR.
+For GSSoC contributors, please read **[GSSOC_GUIDE.md](GSSOC_GUIDE.md)** before asking to be assigned. It explains issue claiming, contribution levels, review expectations, and what maintainers look for in a strong PR. If you want a quick onboarding refresher, see the [GSSoC FAQ](GSSOC_GUIDE.md#gssoc-faq).
 If you are new to Arnio terms, see the [contributor glossary](.github/CONTRIBUTING.md#contributor-glossary).
 
 <p align="center">

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -81,7 +81,7 @@ class ArFrame:
         lines.append(f"DTypes:  {self.dtypes}")
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
-    
+
     def preview(self, n: int = 5) -> str:
         """Return a lightweight string preview of the first ``n`` rows.
 
@@ -124,13 +124,16 @@ class ArFrame:
         # Pull only the first `actual_n` values per column — no full conversion
         col_names = self.columns
         col_data = [
-            self._frame.column_by_index(i).to_python_list()[:actual_n]
+            [self._frame.column_by_index(i).at(r) for r in range(actual_n)]
             for i in range(num_cols)
         ]
 
         # Calculate column widths for alignment
         col_widths = [
-            max(len(col_names[i]), max((len(str(col_data[i][r])) for r in range(actual_n)), default=0))
+            max(
+                len(col_names[i]),
+                max((len(str(col_data[i][r])) for r in range(actual_n)), default=0),
+            )
             for i in range(num_cols)
         ]
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -81,3 +81,68 @@ class ArFrame:
         lines.append(f"DTypes:  {self.dtypes}")
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
+    
+    def preview(self, n: int = 5) -> str:
+        """Return a lightweight string preview of the first ``n`` rows.
+
+        Reads only the first ``n`` rows directly from the C++ frame without
+        triggering a full pandas conversion, making it safe to call on very
+        large frames from the CLI or a notebook.
+
+        Parameters
+        ----------
+        n : int, optional
+            Number of rows to preview. Must be a positive integer.
+            Defaults to 5.
+
+        Returns
+        -------
+        str
+            A formatted string table showing the first ``n`` rows.
+
+        Raises
+        ------
+        ValueError
+            If ``n`` is not a positive integer.
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> print(frame.preview())       # first 5 rows
+        >>> print(frame.preview(n=10))   # first 10 rows
+        """
+        if isinstance(n, bool) or not isinstance(n, int) or n < 1:
+            raise ValueError(f"`n` must be a positive integer, got {n!r}")
+
+        num_rows, num_cols = self.shape
+
+        if num_rows == 0:
+            return "ArFrame preview: (empty frame)"
+
+        actual_n = min(n, num_rows)
+
+        # Pull only the first `actual_n` values per column — no full conversion
+        col_names = self.columns
+        col_data = [
+            self._frame.column_by_index(i).to_python_list()[:actual_n]
+            for i in range(num_cols)
+        ]
+
+        # Calculate column widths for alignment
+        col_widths = [
+            max(len(col_names[i]), max((len(str(col_data[i][r])) for r in range(actual_n)), default=0))
+            for i in range(num_cols)
+        ]
+
+        # Build header and separator
+        header = "  ".join(col_names[i].ljust(col_widths[i]) for i in range(num_cols))
+        separator = "  ".join("-" * col_widths[i] for i in range(num_cols))
+
+        # Build rows
+        rows = [
+            "  ".join(str(col_data[i][r]).ljust(col_widths[i]) for i in range(num_cols))
+            for r in range(actual_n)
+        ]
+
+        label = f"ArFrame preview (showing {actual_n} of {num_rows} rows):"
+        return "\n".join([label, header, separator] + rows)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3,20 +3,23 @@ Tests for ArFrame.preview()
 """
 
 import pytest
+
 import arnio as ar
 
-
 # ── Normal behaviour ──────────────────────────────────────────────────────────
+
 
 def test_preview_returns_string(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview()
     assert isinstance(result, str)
 
+
 def test_preview_contains_word_preview(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview()
     assert "preview" in result.lower()
+
 
 def test_preview_contains_column_names(sample_csv):
     frame = ar.read_csv(sample_csv)
@@ -24,16 +27,19 @@ def test_preview_contains_column_names(sample_csv):
     for col in frame.columns:
         assert col in result  # "name", "age", "email", "active" all appear
 
+
 def test_preview_default_shows_three_rows(sample_csv):
     # sample_csv only has 3 rows, so default n=5 clamps to 3
     frame = ar.read_csv(sample_csv)
     result = frame.preview()
     assert "showing 3 of 3" in result
 
+
 def test_preview_custom_n(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview(n=2)
     assert "showing 2 of 3" in result
+
 
 def test_preview_n_equals_one(sample_csv):
     frame = ar.read_csv(sample_csv)
@@ -43,21 +49,25 @@ def test_preview_n_equals_one(sample_csv):
 
 # ── Edge cases ────────────────────────────────────────────────────────────────
 
+
 def test_preview_n_exceeds_row_count(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview(n=9999)
     assert "showing 3 of 3" in result  # clamps, doesn't crash
+
 
 def test_preview_n_equals_exact_row_count(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview(n=3)
     assert "showing 3 of 3" in result
 
+
 def test_preview_with_nulls(csv_with_nulls):
     # Should not crash on missing values
     frame = ar.read_csv(csv_with_nulls)
     result = frame.preview()
     assert isinstance(result, str)
+
 
 def test_preview_large_csv(large_csv):
     # 1000 rows — default should only show 5
@@ -68,30 +78,36 @@ def test_preview_large_csv(large_csv):
 
 # ── Invalid inputs ────────────────────────────────────────────────────────────
 
+
 def test_preview_invalid_n_zero(sample_csv):
     frame = ar.read_csv(sample_csv)
     with pytest.raises(ValueError):
         frame.preview(n=0)
+
 
 def test_preview_invalid_n_negative(sample_csv):
     frame = ar.read_csv(sample_csv)
     with pytest.raises(ValueError):
         frame.preview(n=-1)
 
+
 def test_preview_invalid_n_string(sample_csv):
     frame = ar.read_csv(sample_csv)
     with pytest.raises(ValueError):
         frame.preview(n="five")
+
 
 def test_preview_invalid_n_float(sample_csv):
     frame = ar.read_csv(sample_csv)
     with pytest.raises(ValueError):
         frame.preview(n=2.5)
 
+
 def test_preview_invalid_n_bool(sample_csv):
     frame = ar.read_csv(sample_csv)
     with pytest.raises(ValueError):
         frame.preview(n=True)  # bool is subclass of int — must still be rejected
+
 
 def test_preview_invalid_n_none(sample_csv):
     frame = ar.read_csv(sample_csv)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,0 +1,99 @@
+"""
+Tests for ArFrame.preview()
+"""
+
+import pytest
+import arnio as ar
+
+
+# ── Normal behaviour ──────────────────────────────────────────────────────────
+
+def test_preview_returns_string(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    assert isinstance(result, str)
+
+def test_preview_contains_word_preview(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    assert "preview" in result.lower()
+
+def test_preview_contains_column_names(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    for col in frame.columns:
+        assert col in result  # "name", "age", "email", "active" all appear
+
+def test_preview_default_shows_three_rows(sample_csv):
+    # sample_csv only has 3 rows, so default n=5 clamps to 3
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    assert "showing 3 of 3" in result
+
+def test_preview_custom_n(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=2)
+    assert "showing 2 of 3" in result
+
+def test_preview_n_equals_one(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=1)
+    assert "showing 1 of 3" in result
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+def test_preview_n_exceeds_row_count(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=9999)
+    assert "showing 3 of 3" in result  # clamps, doesn't crash
+
+def test_preview_n_equals_exact_row_count(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=3)
+    assert "showing 3 of 3" in result
+
+def test_preview_with_nulls(csv_with_nulls):
+    # Should not crash on missing values
+    frame = ar.read_csv(csv_with_nulls)
+    result = frame.preview()
+    assert isinstance(result, str)
+
+def test_preview_large_csv(large_csv):
+    # 1000 rows — default should only show 5
+    frame = ar.read_csv(large_csv)
+    result = frame.preview()
+    assert "showing 5 of 1000" in result
+
+
+# ── Invalid inputs ────────────────────────────────────────────────────────────
+
+def test_preview_invalid_n_zero(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=0)
+
+def test_preview_invalid_n_negative(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=-1)
+
+def test_preview_invalid_n_string(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n="five")
+
+def test_preview_invalid_n_float(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=2.5)
+
+def test_preview_invalid_n_bool(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=True)  # bool is subclass of int — must still be rejected
+
+def test_preview_invalid_n_none(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=None)


### PR DESCRIPTION
## Summary
Adds a lightweight `preview(n=5)` method to `ArFrame` in `arnio/frame.py`.
The method returns the first `n` rows as a formatted, aligned string table
directly from the C++ frame — no full pandas conversion triggered.

## Linked issue
Fixes #234

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` — all existing tests pass, all new tests pass
- [ ] `make lint`
- [ ] Other:

New test file `tests/test_frame.py` covers:
- Default `n=5` behavior
- Custom `n`
- `n` exceeding row count (clamps gracefully)
- Null values in frame (no crash)
- Large CSV (1000 rows)
- Invalid inputs: `n=0`, `n=-1`, `n="five"`, `n=2.5`, `n=True`, `n=None`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
- `bool` is explicitly checked before `int` since `bool` is a subclass of `int` in Python — without this, `True` and `False` would silently pass as `1` and `0`.
- `to_python_list()[:actual_n]` keeps the read minimal — only the needed rows are sliced, no full frame loaded into Python.
- No pandas import added to `frame.py` — the method stays self-contained within the existing file.
