### PR TITLE
Add coalesce columns cleaning step

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -306,3 +306,19 @@ def filter_rows(frame, column, op, value):
     filtered = df[getattr(df[column], ops[op])(value)]
 
     return from_pandas(filtered) if is_arframe else filtered
+
+def coalesce_columns(frame: ArFrame, columns: list[str], output_column: str) -> ArFrame:
+    """Create a column from the first non-null value across fallback columns."""
+    if not columns:
+        raise ValueError("coalesce_columns requires at least one source column")
+
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame)
+    missing = [column for column in columns if column not in df.columns]
+    if missing:
+        raise KeyError(f"Missing columns for coalesce_columns: {missing}")
+
+    result = df.copy()
+    result[output_column] = result[columns].bfill(axis=1).iloc[:, 0]
+    return from_pandas(result)

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -19,6 +19,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
+    "coalesce_columns": cleaning.coalesce_columns,
 }
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -190,3 +190,22 @@ def test_filter_rows_direct_api():
     result_df = ar.to_pandas(result)
 
     assert list(result_df["age"]) == [30, 40]
+
+
+def test_pipeline_coalesce_columns():
+    import pandas as pd
+
+    import arnio as ar
+
+    frame = ar.from_pandas(
+        pd.DataFrame({"primary": [None, "a", None], "backup": ["x", "b", None]})
+    )
+
+    result = ar.pipeline(
+        frame, [("coalesce_columns", {"columns": ["primary", "backup"], "output_column": "resolved"})]
+    )
+
+    resolved = ar.to_pandas(result)["resolved"]
+    assert resolved.iloc[0] == "x"
+    assert resolved.iloc[1] == "a"
+    assert resolved.isna().iloc[2]


### PR DESCRIPTION
This adds a focused `coalesce_columns` pipeline step for fallback-column datasets. The step validates the requested source columns, copies the input frame, fills the output column from the first non-null source value, and includes a targeted pipeline regression test for the new behavior. Fixes #140.

Verification: `python3 -m pytest tests/test_pipeline.py -q`; `python3 -m pytest tests/test_cleaning.py -q`; `git diff --check`.