### PR TITLE
docs: Add comprehensive API reference documentation with MkDocs

### DIFF
--- a/docs/api/cleaning.md
+++ b/docs/api/cleaning.md
@@ -1,0 +1,199 @@
+# Cleaning — `arnio.cleaning`
+
+Data cleaning operations for `ArFrame` objects. All functions return a **new** `ArFrame` (immutable pattern).
+
+## `clean`
+
+```python
+arnio.clean(frame, *, strip_whitespace=True, drop_nulls=False, drop_duplicates=False) -> ArFrame
+```
+
+Convenience function to apply common cleaning operations in one call. Operations are applied in order:
+
+1. `strip_whitespace` (if enabled)
+2. `drop_nulls` (if enabled)
+3. `drop_duplicates` (if enabled)
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `strip_whitespace` | `bool` | `True` | Trim leading/trailing whitespace from string columns. |
+| `drop_nulls` | `bool` | `False` | Remove rows containing null/empty values. |
+| `drop_duplicates` | `bool` | `False` | Remove duplicate rows. |
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("messy.csv")
+cleaned = ar.clean(frame, strip_whitespace=True, drop_nulls=True, drop_duplicates=True)
+```
+
+---
+
+## `drop_nulls`
+
+```python
+arnio.drop_nulls(frame, *, subset=None) -> ArFrame
+```
+
+Remove rows containing null/empty values.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to check. If `None`, checks all columns. A row is dropped if ANY column in the subset contains a null. |
+
+```python
+clean = ar.drop_nulls(frame, subset=["age", "name"])
+```
+
+---
+
+## `fill_nulls`
+
+```python
+arnio.fill_nulls(frame, value, *, subset=None) -> ArFrame
+```
+
+Replace null/empty values with a given fill value.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `value` | `Any` | *required* | Value to replace nulls with. |
+| `subset` | `list[str] \| None` | `None` | Columns to fill. If `None`, fills all columns. |
+
+```python
+filled = ar.fill_nulls(frame, 0, subset=["age"])
+filled = ar.fill_nulls(frame, "unknown", subset=["name"])
+```
+
+---
+
+## `drop_duplicates`
+
+```python
+arnio.drop_duplicates(frame, *, subset=None, keep="first") -> ArFrame
+```
+
+Remove duplicate rows.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to consider. If `None`, uses all columns. |
+| `keep` | `str \| bool` | `"first"` | Which duplicate to keep: `"first"`, `"last"`, `"none"`, or `False` (drop all). |
+
+```python
+unique = ar.drop_duplicates(frame, subset=["email"], keep="first")
+# Drop ALL duplicates (keep neither)
+strict = ar.drop_duplicates(frame, subset=["id"], keep=False)
+```
+
+---
+
+## `strip_whitespace`
+
+```python
+arnio.strip_whitespace(frame, *, subset=None) -> ArFrame
+```
+
+Trim leading and trailing whitespace from string columns.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to strip. If `None`, applies to all string columns. |
+
+```python
+clean = ar.strip_whitespace(frame, subset=["name", "email"])
+```
+
+---
+
+## `normalize_case`
+
+```python
+arnio.normalize_case(frame, *, subset=None, case_type="lower") -> ArFrame
+```
+
+Normalize string columns to a specified case.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to normalize. If `None`, applies to all string columns. |
+| `case_type` | `str` | `"lower"` | Case to normalize to: `"lower"`, `"upper"`, or `"title"`. |
+
+```python
+lower = ar.normalize_case(frame, case_type="lower")
+title = ar.normalize_case(frame, subset=["name"], case_type="title")
+```
+
+---
+
+## `rename_columns`
+
+```python
+arnio.rename_columns(frame, mapping) -> ArFrame
+```
+
+Rename columns via a `{old_name: new_name}` dictionary.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `mapping` | `dict[str, str]` | *required* | Dictionary mapping old column names to new names. |
+
+```python
+renamed = ar.rename_columns(frame, {"Old Name": "new_name", "User ID": "user_id"})
+```
+
+---
+
+## `cast_types`
+
+```python
+arnio.cast_types(frame, mapping) -> ArFrame
+```
+
+Cast columns to specified types.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `mapping` | `dict[str, str]` | *required* | Dictionary mapping column names to target types: `"int64"`, `"float64"`, `"bool"`, `"string"`. |
+
+### Raises
+
+- `TypeCastError` — If a cast fails (e.g., non-numeric value in an int column).
+
+```python
+casted = ar.cast_types(frame, {"age": "int64", "score": "float64", "active": "bool"})
+```
+
+---
+
+## `filter_rows`
+
+```python
+arnio.filter_rows(frame, column, op, value) -> ArFrame
+```
+
+Filter rows based on a column condition. Supports comparison operators.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame (or pandas DataFrame). |
+| `column` | `str` | *required* | Column name to filter on. |
+| `op` | `str` | *required* | Comparison operator: `>`, `<`, `>=`, `<=`, `==`, `!=`. |
+| `value` | `Any` | *required* | Value to compare against. |
+
+```python
+adults = ar.filter_rows(frame, "age", ">=", 18)
+high_score = ar.filter_rows(frame, "score", ">", 90)
+```

--- a/docs/api/convert.md
+++ b/docs/api/convert.md
@@ -1,0 +1,92 @@
+# Conversion — `arnio.convert`
+
+Functions for converting between `ArFrame` and pandas `DataFrame`.
+
+## `to_pandas`
+
+```python
+arnio.to_pandas(frame) -> pd.DataFrame
+```
+
+Convert an `ArFrame` to a pandas `DataFrame` with proper dtypes and null handling.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input ArFrame to convert. |
+
+### Returns
+
+`pd.DataFrame` — Equivalent pandas DataFrame. Null values are represented using pandas nullable dtypes (`Int64Dtype`, `BooleanDtype`, `StringDtype`).
+
+### Type Mapping
+
+| Arnio (C++) | pandas |
+|-------------|--------|
+| `int64` | `pd.Int64Dtype()` (nullable integer) |
+| `float64` | `float64` with `NaN` for nulls |
+| `bool` | `pd.BooleanDtype()` (nullable boolean) |
+| `string` | `pd.StringDtype()` (nullable string) |
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+df = ar.to_pandas(frame)
+print(df.dtypes)
+```
+
+---
+
+## `from_pandas`
+
+```python
+arnio.from_pandas(df) -> ArFrame
+```
+
+Convert a pandas `DataFrame` to an `ArFrame` with inferred types.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `df` | `pd.DataFrame` | *required* | Input pandas DataFrame. |
+
+### Returns
+
+`ArFrame` — Equivalent ArFrame with inferred types.
+
+### Raises
+
+- `TypeError` — If the DataFrame contains unsupported nested/complex types (list, dict, tuple, set, ndarray).
+
+### Type Coercion Rules
+
+- Mixed `int` + `float` columns → `float`
+- Mixed `bool` + other types → `string`
+- Mixed `string` + other types → `string`
+- `NaN`/`NA` → `None`
+
+### Edge Cases & Limitations
+
+- **Nested types** (lists, dicts, arrays) are not supported and will raise `TypeError`.
+- **Mixed-type columns** are coerced to the most general type (usually `string`).
+- **Boolean values** mixed with non-boolean types are converted to strings.
+
+### Example
+
+```python
+import pandas as pd
+import arnio as ar
+
+df = pd.DataFrame({
+    "name": ["Alice", "Bob", "Charlie"],
+    "age": [25, 30, 35],
+    "score": [95.5, 87.3, 92.1],
+})
+
+frame = ar.from_pandas(df)
+```

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,0 +1,86 @@
+# Exceptions — `arnio.exceptions`
+
+Custom exception classes for Arnio.
+
+## Exception Hierarchy
+
+```
+ArnioError (base)
+├── CsvReadError
+├── TypeCastError
+└── UnknownStepError
+```
+
+## `ArnioError`
+
+Base exception for all Arnio errors.
+
+```python
+class ArnioError(Exception)
+```
+
+---
+
+## `CsvReadError`
+
+Raised when CSV reading fails (e.g., NUL bytes, unsupported format, decoding errors).
+
+```python
+class CsvReadError(ArnioError)
+```
+
+### Example
+
+```python
+import arnio as ar
+from arnio import CsvReadError
+
+try:
+    frame = ar.read_csv("corrupted.csv")
+except CsvReadError as e:
+    print(f"CSV read failed: {e}")
+```
+
+---
+
+## `TypeCastError`
+
+Raised when a type cast operation fails (e.g., non-numeric value in an int column).
+
+```python
+class TypeCastError(ArnioError)
+```
+
+### Example
+
+```python
+import arnio as ar
+from arnio import TypeCastError
+
+try:
+    frame = ar.cast_types(frame, {"age": "int64"})
+except TypeCastError as e:
+    print(f"Cast failed: {e}")
+```
+
+---
+
+## `UnknownStepError`
+
+Raised when a pipeline step name is not found in the registry.
+
+```python
+class UnknownStepError(ArnioError)
+```
+
+### Example
+
+```python
+import arnio as ar
+from arnio import UnknownStepError
+
+try:
+    ar.pipeline(frame, [("unknown_step",)])
+except UnknownStepError as e:
+    print(f"Unknown step: {e}")
+```

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,0 +1,106 @@
+# I/O — `arnio.io`
+
+CSV reading functions powered by the C++ backend.
+
+## `read_csv`
+
+```python
+arnio.read_csv(
+    path,
+    *,
+    delimiter=",",
+    has_header=True,
+    usecols=None,
+    nrows=None,
+    encoding="utf-8",
+) -> ArFrame
+```
+
+Read a CSV file into an `ArFrame` via the C++ backend.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | `str \| PathLike` | *required* | Path to the CSV file. Supports `.csv`, `.txt`, and `.tsv` extensions. |
+| `delimiter` | `str` | `","` | Field delimiter character. |
+| `has_header` | `bool` | `True` | Whether the file has a header row. |
+| `usecols` | `list[str] \| None` | `None` | Columns to read. If `None`, reads all columns. |
+| `nrows` | `int \| None` | `None` | Number of rows to read. If `None`, reads all rows. |
+| `encoding` | `str` | `"utf-8"` | File encoding. Non-UTF-8 inputs are automatically transcoded. |
+
+### Returns
+
+`ArFrame` — Data frame containing the CSV data.
+
+### Raises
+
+- `ValueError` — If file format is unsupported.
+- `CsvReadError` — If CSV input contains NUL bytes or is corrupted.
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv", delimiter=",", has_header=True)
+
+# Read specific columns only
+frame = ar.read_csv("data.csv", usecols=["name", "age"])
+
+# Read first 100 rows
+frame = ar.read_csv("data.csv", nrows=100)
+
+# Handle non-UTF-8 encoding
+frame = ar.read_csv("data.csv", encoding="latin-1")
+```
+
+---
+
+## `scan_csv`
+
+```python
+arnio.scan_csv(
+    path,
+    *,
+    delimiter=",",
+    encoding="utf-8",
+) -> dict[str, str]
+```
+
+Return schema (column names + inferred types) **without loading data**. Useful for inspecting large files before committing to a full read.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | `str \| PathLike` | *required* | Path to the CSV file. |
+| `delimiter` | `str` | `","` | Field delimiter character. |
+| `encoding` | `str` | `"utf-8"` | File encoding. |
+
+### Returns
+
+`dict[str, str]` — Dictionary mapping column names to inferred type strings (e.g., `"int64"`, `"float64"`, `"string"`).
+
+### Raises
+
+- `ValueError` — If file format is unsupported.
+- `CsvReadError` — If CSV input contains NUL bytes.
+
+### Example
+
+```python
+import arnio as ar
+
+schema = ar.scan_csv("large_data.csv")
+# {'name': 'string', 'age': 'int64', 'score': 'float64'}
+
+# Check types before loading
+for col, dtype in schema.items():
+    print(f"{col}: {dtype}")
+```
+
+### When to Use `scan_csv` vs `read_csv`
+
+- Use `scan_csv` when you need to inspect schema without the memory cost of loading data.
+- Use `read_csv` when you need the actual data for processing.

--- a/docs/api/pipeline.md
+++ b/docs/api/pipeline.md
@@ -1,0 +1,110 @@
+# Pipeline — `arnio.pipeline`
+
+Chained cleaning pipeline for composing multiple operations.
+
+## `pipeline`
+
+```python
+arnio.pipeline(frame, steps) -> ArFrame
+```
+
+Apply a list of cleaning steps sequentially. Each step is a tuple of `(step_name,)` or `(step_name, kwargs_dict)`.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `steps` | `list[tuple]` | *required* | List of steps. Each step is `(name,)` or `(name, kwargs)`. |
+
+### Returns
+
+`ArFrame` — Data frame with all steps applied sequentially.
+
+### Raises
+
+- `ValueError` — If step format is invalid.
+- `UnknownStepError` — If step name is not registered.
+
+### Built-in Steps
+
+| Step Name | Parameters | Description |
+|-----------|------------|-------------|
+| `drop_nulls` | `subset: list[str]` | Remove null rows |
+| `fill_nulls` | `value, subset: list[str]` | Fill null values |
+| `drop_duplicates` | `subset: list[str], keep: str` | Remove duplicates |
+| `strip_whitespace` | `subset: list[str]` | Trim whitespace |
+| `normalize_case` | `subset: list[str], case_type: str` | Normalize case |
+| `rename_columns` | `mapping: dict` | Rename columns |
+| `cast_types` | `mapping: dict` | Cast column types |
+| `filter_rows` | `column, op, value` | Filter rows |
+
+### Step Format
+
+For `rename_columns` and `cast_types`, the kwargs dict is passed directly as the mapping:
+
+```python
+("rename_columns", {"old_name": "new_name"})
+("cast_types", {"age": "int64"})
+```
+
+For all other steps, use standard keyword arguments:
+
+```python
+("drop_nulls", {"subset": ["age"]})
+("strip_whitespace",)  # no kwargs needed
+```
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+
+cleaned = ar.pipeline(frame, [
+    ("strip_whitespace",),
+    ("drop_nulls", {"subset": ["email"]}),
+    ("normalize_case", {"subset": ["name"], "case_type": "title"}),
+    ("drop_duplicates", {"subset": ["email"], "keep": "first"}),
+    ("cast_types", {"age": "int64", "score": "float64"}),
+])
+```
+
+---
+
+## `register_step`
+
+```python
+arnio.register_step(name, fn)
+```
+
+Register a custom Python pipeline step.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | `str` | *required* | Name of the step for use in pipelines. |
+| `fn` | `Callable` | *required* | Function to call. Should accept `(df, **kwargs)` and return a modified DataFrame. |
+
+### Example
+
+```python
+import arnio as ar
+
+def remove_outliers(df, column="value", threshold=3.0):
+    mean = df[column].mean()
+    std = df[column].std()
+    return df[(df[column] - mean).abs() <= threshold * std]
+
+ar.register_step("remove_outliers", remove_outliers)
+
+cleaned = ar.pipeline(frame, [
+    ("strip_whitespace",),
+    ("remove_outliers", {"column": "price", "threshold": 2.5}),
+])
+```
+
+!!! note
+    Custom Python steps convert the frame to pandas internally, so they are slower than built-in C++-backed steps.

--- a/docs/api/quality.md
+++ b/docs/api/quality.md
@@ -1,0 +1,142 @@
+# Data Quality — `arnio.quality`
+
+Data quality profiling, cleaning suggestions, and automatic cleaning.
+
+## `profile`
+
+```python
+arnio.profile(frame, *, sample_size=5) -> DataQualityReport
+```
+
+Profile data quality for an `ArFrame`. Returns a comprehensive report with null counts, uniqueness, basic stats, semantic hints, and safe cleaning suggestions.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input frame to inspect. |
+| `sample_size` | `int` | `5` | Number of non-null sample values per column. |
+
+### Returns
+
+`DataQualityReport` — Full quality report.
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("raw.csv")
+report = ar.profile(frame)
+
+# Access summary
+print(report.summary())
+
+# Check specific columns
+for name, col in report.columns.items():
+    print(f"{name}: {col.null_count} nulls, {col.unique_count} unique")
+    if col.warnings:
+        print(f"  Warnings: {col.warnings}")
+```
+
+---
+
+## `suggest_cleaning`
+
+```python
+arnio.suggest_cleaning(frame_or_report) -> list[tuple[str, dict]]
+```
+
+Suggest safe built-in cleaning steps. Returns pipeline-compatible step tuples.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame_or_report` | `ArFrame \| DataQualityReport` | *required* | Frame to profile or existing report. |
+
+### Returns
+
+`list[tuple[str, dict]]` — Pipeline-compatible cleaning suggestions.
+
+### Example
+
+```python
+suggestions = ar.suggest_cleaning(frame)
+# [("strip_whitespace", {"subset": ["name"]}), ("drop_duplicates", {"keep": "first"})]
+
+# Apply suggestions directly
+clean = ar.pipeline(frame, suggestions)
+```
+
+---
+
+## `auto_clean`
+
+```python
+arnio.auto_clean(frame, *, mode="safe", return_report=False) -> ArFrame | tuple[ArFrame, DataQualityReport]
+```
+
+Apply built-in automatic cleaning based on data quality profiling.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input frame. |
+| `mode` | `str` | `"safe"` | `"safe"` applies only low-risk cleanup (whitespace). `"strict"` also applies casts and duplicate removal. |
+| `return_report` | `bool` | `False` | Whether to return the pre-cleaning quality report. |
+
+### Returns
+
+- `ArFrame` if `return_report=False`
+- `tuple[ArFrame, DataQualityReport]` if `return_report=True`
+
+### Example
+
+```python
+import arnio as ar
+
+# Safe mode (default) - only whitespace trimming
+clean = ar.auto_clean(frame)
+
+# Strict mode - full auto-cleaning
+clean, report = ar.auto_clean(frame, mode="strict", return_report=True)
+print(f"Cleaned {report.issue_count} issues")
+```
+
+---
+
+## `DataQualityReport`
+
+| Property/Method | Type | Description |
+|----------------|------|-------------|
+| `row_count` | `int` | Total rows. |
+| `column_count` | `int` | Total columns. |
+| `memory_usage` | `int` | Memory usage in bytes. |
+| `duplicate_rows` | `int` | Number of duplicate rows. |
+| `duplicate_ratio` | `float` | Ratio of duplicates. |
+| `columns` | `dict[str, ColumnProfile]` | Per-column profiles. |
+| `suggestions` | `list[tuple]` | Suggested cleaning steps. |
+| `to_dict()` | `dict` | JSON-friendly representation. |
+| `summary()` | `dict` | Compact summary. |
+| `to_pandas()` | `pd.DataFrame` | One row per column. |
+
+## `ColumnProfile`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | Column name. |
+| `dtype` | `str` | Detected dtype. |
+| `semantic_type` | `str` | Semantic category: `"email"`, `"url"`, `"numeric"`, `"categorical"`, etc. |
+| `row_count` | `int` | Total rows. |
+| `null_count` | `int` | Null count. |
+| `null_ratio` | `float` | Null ratio (0.0–1.0). |
+| `unique_count` | `int` | Unique value count. |
+| `unique_ratio` | `float` | Unique ratio. |
+| `empty_string_count` | `int` | Empty string count. |
+| `whitespace_count` | `int` | Leading/trailing whitespace count. |
+| `suggested_dtype` | `str \| None` | Suggested alternative dtype. |
+| `min` / `max` / `mean` | `Any` | Basic stats (numeric columns). |
+| `sample_values` | `list` | Sample non-null values. |
+| `warnings` | `list[str]` | Warnings like `"contains_nulls"`, `"leading_or_trailing_whitespace"`. |

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -1,0 +1,160 @@
+# Schema Validation — `arnio.schema`
+
+Production data contracts and validation for `ArFrame` objects.
+
+## `validate`
+
+```python
+arnio.validate(frame, schema) -> ValidationResult
+```
+
+Validate an `ArFrame` against a schema.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input frame. |
+| `schema` | `Schema \| dict[str, Field]` | *required* | Validation contract. |
+
+### Returns
+
+`ValidationResult` — Contains all issues and bad row indexes.
+
+### Example
+
+```python
+import arnio as ar
+
+schema = ar.Schema({
+    "email": ar.Email(nullable=False, unique=True),
+    "age": ar.Int64(min=0, max=150),
+    "name": ar.String(nullable=False, min_length=1),
+})
+
+result = ar.validate(frame, schema)
+if not result.passed:
+    print(f"Found {result.issue_count} issues")
+    for issue in result.issues:
+        print(f"  {issue.column}: {issue.message}")
+```
+
+---
+
+## `Schema`
+
+```python
+Schema(fields, strict=False)
+```
+
+Named column validation contract.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `fields` | `dict[str, Field]` | *required* | Column validation rules. |
+| `strict` | `bool` | `False` | If `True`, rejects unexpected columns. |
+
+---
+
+## `Field`
+
+```python
+Field(
+    dtype=None, nullable=True, min=None, max=None,
+    pattern=None, semantic=None, allowed=None,
+    unique=False, min_length=None, max_length=None,
+)
+```
+
+Validation rules for one column.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `dtype` | `str \| None` | `None` | Expected dtype: `"int64"`, `"float64"`, `"bool"`, `"string"`. |
+| `nullable` | `bool` | `True` | Whether null values are allowed. |
+| `min` | `int \| float \| None` | `None` | Minimum value (numeric columns). |
+| `max` | `int \| float \| None` | `None` | Maximum value (numeric columns). |
+| `pattern` | `str \| None` | `None` | Regex pattern the values must match. |
+| `semantic` | `str \| None` | `None` | Semantic type: `"email"`, `"url"`, `"phone"`. |
+| `allowed` | `set \| None` | `None` | Set of allowed values. |
+| `unique` | `bool` | `False` | Whether all values must be unique. |
+| `min_length` | `int \| None` | `None` | Minimum string length. |
+| `max_length` | `int \| None` | `None` | Maximum string length. |
+
+---
+
+## Type Helper Functions
+
+### `Int64`
+
+```python
+Int64(*, nullable=True, min=None, max=None, unique=False) -> Field
+```
+
+Create an `int64` schema field with optional range and uniqueness constraints.
+
+### `Float64`
+
+```python
+Float64(*, nullable=True, min=None, max=None, unique=False) -> Field
+```
+
+Create a `float64` schema field.
+
+### `String`
+
+```python
+String(*, nullable=True, pattern=None, allowed=None, unique=False,
+       min_length=None, max_length=None) -> Field
+```
+
+Create a `string` schema field.
+
+### `Bool`
+
+```python
+Bool(*, nullable=True) -> Field
+```
+
+Create a `bool` schema field.
+
+### `Email`
+
+```python
+Email(*, nullable=True, unique=False) -> Field
+```
+
+Create an email-address schema field (validates against email regex).
+
+### `URL`
+
+```python
+URL(*, nullable=True, unique=False) -> Field
+```
+
+Create a URL schema field (validates against `http(s)://` pattern).
+
+---
+
+## `ValidationResult`
+
+| Property/Method | Type | Description |
+|----------------|------|-------------|
+| `passed` | `bool` | Whether validation passed with zero issues. |
+| `row_count` | `int` | Total rows in the validated frame. |
+| `issue_count` | `int` | Number of validation issues found. |
+| `issues` | `list[ValidationIssue]` | All validation issues. |
+| `bad_rows` | `list[int]` | Row indexes with issues. |
+| `to_dict()` | `dict` | JSON-friendly representation. |
+| `summary()` | `dict` | Compact summary grouped by rule and column. |
+| `to_pandas()` | `pd.DataFrame` | Issues as a pandas DataFrame. |
+
+## `ValidationIssue`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `column` | `str \| None` | Column name (None for frame-level issues). |
+| `rule` | `str` | Rule that failed (e.g., `"nullable"`, `"dtype"`, `"unique"`). |
+| `message` | `str` | Human-readable description. |
+| `row_index` | `int \| None` | Row index of the failing value. |
+| `value` | `Any` | The failing value. |

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,0 +1,45 @@
+# DType System — `arnio.schema`
+
+Arnio uses a simple type system for column dtypes.
+
+## Built-in DTypes
+
+| DType | Python Type | Description |
+|-------|-------------|-------------|
+| `int64` | `int` | 64-bit signed integer |
+| `float64` | `float` | 64-bit floating point |
+| `bool` | `bool` | Boolean |
+| `string` | `str` | UTF-8 string |
+
+## Type Inference
+
+When reading CSV files, Arnio automatically infers column types:
+
+- **Integer-looking values** → `int64`
+- **Float-looking values** → `float64`
+- **`true`/`false`/`1`/`0`** → `bool`
+- **Everything else** → `string`
+
+## Type Casting
+
+Use `cast_types` to explicitly convert between types:
+
+```python
+frame = ar.cast_types(frame, {
+    "age": "int64",
+    "score": "float64",
+    "active": "bool",
+    "notes": "string",
+})
+```
+
+## Nullable Handling
+
+All types support null values. When converting to pandas, nullable dtypes are used:
+
+| Arnio | pandas |
+|-------|--------|
+| `int64` | `pd.Int64Dtype()` |
+| `float64` | `float64` with `NaN` |
+| `bool` | `pd.BooleanDtype()` |
+| `string` | `pd.StringDtype()` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+# Arnio API Reference
+
+Your CSV hits C++ before Python even wakes up.
+
+**Arnio** is a compiled C++ data cleaning engine that slots in _before_ pandas. It parses, infers types, strips whitespace, deduplicates, and normalizes — all natively, in columnar memory — then hands you a pristine `DataFrame`.
+
+## Installation
+
+```bash
+pip install arnio
+```
+
+## Quick Start
+
+```python
+import arnio as ar
+
+# Read a CSV file
+frame = ar.read_csv("data.csv")
+
+# Profile data quality
+report = ar.profile(frame)
+print(report.summary())
+
+# Clean automatically
+clean = ar.auto_clean(frame)
+
+# Convert to pandas
+import pandas as pd
+df = ar.to_pandas(clean)
+```
+
+## Module Overview
+
+| Module | Description |
+|--------|-------------|
+| [`arnio.io`](api/io.md) | CSV reading and schema scanning |
+| [`arnio.cleaning`](api/cleaning.md) | Data cleaning operations |
+| [`arnio.convert`](api/convert.md) | Pandas ↔ ArFrame conversion |
+| [`arnio.pipeline`](api/pipeline.md) | Chained cleaning pipelines |
+| [`arnio.schema`](api/schema.md) | Data contracts and validation |
+| [`arnio.quality`](api/quality.md) | Data quality profiling and auto-cleaning |
+| [`arnio.exceptions`](api/exceptions.md) | Custom exception classes |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,28 @@
+site_name: Arnio API Reference
+site_description: API reference documentation for Arnio – Fast CSV processing and data cleaning
+theme:
+  name: material
+  palette:
+    primary: indigo
+  features:
+    - navigation.instant
+    - navigation.sections
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - API Reference:
+    - I/O: api/io.md
+    - Cleaning: api/cleaning.md
+    - Conversion: api/convert.md
+    - Pipeline: api/pipeline.md
+    - Schema Validation: api/schema.md
+    - Data Quality: api/quality.md
+    - Exceptions: api/exceptions.md
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - admonition
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary
Resolves #38 - Creates complete API reference documentation using MkDocs with Material theme.

## What's Included

### Configuration
- mkdocs.yml with Material theme, navigation, and markdown extensions

### Documentation Pages (10 files, 1000+ lines)
- **index.md** - Module overview, installation, quick start, module table
- **api/io.md** - ead_csv, scan_csv with full parameter tables, returns, examples
- **api/cleaning.md** - All 9 cleaning functions with signatures, params, examples
- **api/convert.md** - 	o_pandas, rom_pandas with type mapping table, edge cases
- **api/pipeline.md** - pipeline, egister_step with built-in steps table and step format docs
- **api/schema.md** - Schema, Field, alidate, type helpers (Int64, Float64, String, Bool, Email, URL)
- **api/quality.md** - profile, suggest_cleaning, uto_clean, DataQualityReport, ColumnProfile
- **api/exceptions.md** - Exception hierarchy with examples
- **api/types.md** - DType system reference

### Coverage
- Complete function signatures with parameter descriptions
- Type information for all parameters and return values
- Usage examples for every function
- Pipeline step format explanation
- Type mapping tables (Arnio ? pandas)
- Edge cases and limitations for rom_pandas

Closes #38