### PR TITLE
Expand CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
This updates the CI matrix so the existing test job also runs on macOS while continuing to cover Python 3.9 through 3.13. That matches the supported Python versions declared in the project metadata and adds coverage for the platform already targeted by the wheel build configuration.

Verification: parsed `.github/workflows/ci.yml` with PyYAML to confirm the matrix includes `macos-latest` and Python 3.9 through 3.13, then ran `git diff --check`.
