### PR TITLE
fix: make custom pipeline step registry thread-safe

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -5,8 +5,8 @@ Chained cleaning pipeline.
 
 from __future__ import annotations
 
+from threading import Lock
 from typing import Callable
-from threading import Lock 
 
 from . import cleaning
 from .frame import ArFrame

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -6,6 +6,7 @@ Chained cleaning pipeline.
 from __future__ import annotations
 
 from typing import Callable
+from threading import Lock 
 
 from . import cleaning
 from .frame import ArFrame
@@ -27,6 +28,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
 
 
 _PYTHON_STEP_REGISTRY: dict[str, Callable] = {}
+_REGISTRY_LOCK = Lock()
 
 
 def register_step(name: str, fn: Callable):
@@ -45,7 +47,9 @@ def register_step(name: str, fn: Callable):
     ...     return df.dropna(thresh=threshold)
     >>> ar.register_step("custom_clean", custom_clean)
     """
-    _PYTHON_STEP_REGISTRY[name] = fn
+    with _REGISTRY_LOCK:
+
+        _PYTHON_STEP_REGISTRY[name] = fn
 
 
 def pipeline(
@@ -89,6 +93,9 @@ def pipeline(
     from .convert import from_pandas, to_pandas
     from .exceptions import UnknownStepError
 
+    with _REGISTRY_LOCK:
+        python_step_registry = dict(_PYTHON_STEP_REGISTRY)
+
     result = frame
     for step in steps:
         if len(step) == 1:
@@ -112,13 +119,13 @@ def pipeline(
                 result = fn(result, kwargs)
             else:
                 result = fn(result, **kwargs)
-        elif name in _PYTHON_STEP_REGISTRY:
+        elif name in python_step_registry:
             # Pure Python step - slower but contributor-friendly
             df = to_pandas(result)
-            df = _PYTHON_STEP_REGISTRY[name](df, **kwargs)
+            df = python_step_registry[name](df, **kwargs)
             result = from_pandas(df)
         else:
-            available = list(_STEP_REGISTRY.keys()) + list(_PYTHON_STEP_REGISTRY.keys())
+            available = list(_STEP_REGISTRY.keys()) + list(python_step_registry.keys())
             raise UnknownStepError(name, available)
 
     return result

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,12 +1,15 @@
 """Tests for the pipeline function."""
 
-import arnio as ar
-from concurrent.futures import ThreadPoolExecutor
 import importlib
 import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+
+import arnio as ar
+
 pipeline_module = importlib.import_module("arnio.pipeline")
+
 
 @pytest.fixture(autouse=True)
 def restore_python_step_registry():
@@ -24,6 +27,7 @@ def restore_python_step_registry():
     with pipeline_module._REGISTRY_LOCK:
         pipeline_module._PYTHON_STEP_REGISTRY.clear()
         pipeline_module._PYTHON_STEP_REGISTRY.update(original_registry)
+
 
 class TestPipeline:
     def test_single_step(self, csv_with_nulls):
@@ -187,7 +191,7 @@ class TestPipeline:
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])
         assert result.shape == frame.shape
-    
+
     def test_register_python_step(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
@@ -207,7 +211,7 @@ class TestPipeline:
         df = ar.to_pandas(result)
         assert "marker" in df.columns
         assert set(df["marker"]) == {"done"}
-    
+
     def test_concurrent_step_registration(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
@@ -233,7 +237,7 @@ class TestPipeline:
         for name in step_names:
             assert name in df.columns
             assert set(df[name]) == {name}
-    
+
     def test_pipeline_uses_stable_registry_snapshot_during_execution(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,7 +1,29 @@
 """Tests for the pipeline function."""
 
 import arnio as ar
+from concurrent.futures import ThreadPoolExecutor
+import importlib
+import threading
 
+import pytest
+pipeline_module = importlib.import_module("arnio.pipeline")
+
+@pytest.fixture(autouse=True)
+def restore_python_step_registry():
+    """Restore custom pipeline steps after each test.
+
+    Tests may register temporary custom steps. This fixture prevents those
+    registrations from leaking into other tests while preserving any steps
+    that were already registered before the test started.
+    """
+    with pipeline_module._REGISTRY_LOCK:
+        original_registry = dict(pipeline_module._PYTHON_STEP_REGISTRY)
+
+    yield
+
+    with pipeline_module._REGISTRY_LOCK:
+        pipeline_module._PYTHON_STEP_REGISTRY.clear()
+        pipeline_module._PYTHON_STEP_REGISTRY.update(original_registry)
 
 class TestPipeline:
     def test_single_step(self, csv_with_nulls):
@@ -165,6 +187,98 @@ class TestPipeline:
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])
         assert result.shape == frame.shape
+    
+    def test_register_python_step(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        def add_marker(df, value="ok"):
+            df["marker"] = value
+            return df
+
+        ar.register_step("test_add_marker", add_marker)
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("test_add_marker", {"value": "done"}),
+            ],
+        )
+
+        df = ar.to_pandas(result)
+        assert "marker" in df.columns
+        assert set(df["marker"]) == {"done"}
+    
+    def test_concurrent_step_registration(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        def make_step(column_name):
+            def step(df):
+                df[column_name] = column_name
+                return df
+
+            return step
+
+        step_count = 25
+        step_names = [f"concurrent_step_{i}" for i in range(step_count)]
+
+        def register(name):
+            ar.register_step(name, make_step(name))
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            list(executor.map(register, step_names))
+
+        result = ar.pipeline(frame, [(name,) for name in step_names])
+        df = ar.to_pandas(result)
+
+        for name in step_names:
+            assert name in df.columns
+            assert set(df[name]) == {name}
+    
+    def test_pipeline_uses_stable_registry_snapshot_during_execution(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        started = threading.Event()
+        continue_step = threading.Event()
+
+        def blocking_step(df):
+            started.set()
+            continue_step.wait(timeout=5)
+            df["blocking_step_done"] = True
+            return df
+
+        def late_step(df):
+            df["late_step_done"] = True
+            return df
+
+        ar.register_step("blocking_snapshot_step", blocking_step)
+
+        errors = []
+
+        def run_pipeline():
+            try:
+                ar.pipeline(
+                    frame,
+                    [
+                        ("blocking_snapshot_step",),
+                        ("late_snapshot_step",),
+                    ],
+                )
+            except Exception as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=run_pipeline)
+        thread.start()
+
+        assert started.wait(timeout=5)
+
+        ar.register_step("late_snapshot_step", late_step)
+
+        continue_step.set()
+        thread.join(timeout=5)
+
+        assert len(errors) == 1
+        assert isinstance(errors[0], ar.UnknownStepError)
+        assert "late_snapshot_step" in str(errors[0])
 
     def test_invalid_step_name(self, sample_csv):
         frame = ar.read_csv(sample_csv)


### PR DESCRIPTION
## Summary
Made custom pipeline step registration safer for concurrent use.

Custom Python steps were stored in the shared `_PYTHON_STEP_REGISTRY` without synchronization. This PR adds a lock around registration and takes a stable registry snapshot when `pipeline()` starts, so concurrent registration cannot affect an already-running pipeline or produce inconsistent unknown-step error reporting.

The public API remains unchanged.

## Linked issue
Fixes #285 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `python -m pytest tests/test_pipeline.py -v` — passed
  - `python -m pytest -v` — passed

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Each `pipeline()` call now uses the custom steps that were registered when that pipeline run started. Steps registered after a pipeline has already started are available to future pipeline runs, but do not affect the currently running pipeline.

The new tests restore the custom step registry after each test, so temporary test registrations do not leak into other tests while preserving any pre-existing registered steps.