### PR TITLE
test: add stable column order regression tests

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -108,3 +108,56 @@ class TestFromPandas:
         assert frame._frame.column_by_name("created_at").to_python_list() == [
             str(timestamp)
         ]
+
+    def test_from_pandas_preserves_column_order(self):
+        df = pd.DataFrame(
+            {
+                "name": ["Alice"],
+                "age": [20],
+                "city": ["Delhi"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert list(result.columns) == ["name", "age", "city"]
+
+    def test_cleaning_preserves_column_order(self):
+        df = pd.DataFrame(
+            {
+                "name": [" Alice "],
+                "age": [20],
+                "city": ["Delhi"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+
+        result = ar.strip_whitespace(frame)
+        result_df = ar.to_pandas(result)
+
+        assert list(result_df.columns) == ["name", "age", "city"]
+
+    def test_pipeline_preserves_column_order(self):
+        df = pd.DataFrame(
+            {
+                "name": [" Alice "],
+                "age": [20],
+                "city": ["Delhi"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("strip_whitespace",),
+                ("normalize_case", {"case_type": "lower"}),
+            ],
+        )
+
+        result_df = ar.to_pandas(result)
+
+        assert list(result_df.columns) == ["name", "age", "city"]


### PR DESCRIPTION
## Summary

Adds focused regression tests to verify stable column ordering across:

* `from_pandas`
* `to_pandas`
* cleaning operations
* pipeline operations

The tests confirm that user-visible column order is preserved consistently across conversions and transformations.

## Linked issue

Fixes #230

## Type of change

* [ ] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash
python -m pytest tests/test_convert.py -q
python -m pytest tests -q
python -m ruff check arnio tests
python -m black --check arnio tests
```

All tests and checks passed locally.

## Screenshots / Media

N/A

## Performance Impact

N/A

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

No implementation changes were needed because the current behavior already preserves stable column ordering correctly.
