### PR TITLE
feat: add parse numeric strings cleaning step

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,13 @@ Most operations below run natively in C++. The current `filter_rows` and `parse_
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
 
+`parse_numeric_strings` removes common currency symbols (`$`, `€`, `£`, `¥`,
+`₹`), thousands separators, and surrounding whitespace before parsing. Values
+wrapped in parentheses are treated as negatives, so `(300)` becomes `-300`.
+Percent values are divided by 100, so `45%` becomes `0.45`. With
+`errors="coerce"`, invalid non-empty values become nulls; with
+`errors="raise"`, the first invalid values are reported in a `ValueError`.
+
 Or compose them all into a **pipeline**:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Small differences are expected across CPUs, operating systems, compilers, Python
 
 ## 🧰 Cleaning primitives
 
-Most operations below run natively in C++. The current `filter_rows` step uses the Python pipeline backend and may be optimized in C++ later.
+Most operations below run natively in C++. The current `filter_rows` and `parse_numeric_strings` steps use the Python pipeline backend and may be optimized in C++ later.
 
 | Primitive | What it does | Example |
 |:---|:---|:---|
@@ -297,6 +297,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `drop_duplicates` | Deduplicate rows (first/last/none) | `ar.drop_duplicates(frame, keep="first")` |
 | `strip_whitespace` | Trim leading/trailing spaces from strings | `ar.strip_whitespace(frame)` |
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
+| `parse_numeric_strings` | Convert messy numeric strings such as `$1,234` or `45%` | `ar.parse_numeric_strings(frame, subset=["revenue"])` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
@@ -308,6 +309,7 @@ clean = ar.pipeline(frame, [
     ("strip_whitespace",),
     ("normalize_case", {"case_type": "lower"}),
     ("fill_nulls", {"value": "unknown", "subset": ["city"]}),
+    ("parse_numeric_strings", {"subset": ["revenue"]}),
     ("drop_duplicates", {"keep": "first"}),
 ])
 ```

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -19,6 +19,7 @@ from .cleaning import (
     fill_nulls,
     filter_rows,
     normalize_case,
+    parse_numeric_strings,
     rename_columns,
     strip_whitespace,
 )
@@ -61,6 +62,7 @@ __all__ = [
     "drop_duplicates",
     "strip_whitespace",
     "normalize_case",
+    "parse_numeric_strings",
     "rename_columns",
     "cast_types",
     "clean",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -229,6 +229,74 @@ def cast_types(
     return ArFrame(result)
 
 
+def parse_numeric_strings(
+    frame: ArFrame,
+    *,
+    subset: list[str] | None = None,
+    errors: str = "coerce",
+) -> ArFrame:
+    """Convert messy number-like strings into numeric columns.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    subset : list[str], optional
+        Column names to parse. If None, applies to all object/string columns.
+    errors : {"coerce", "raise"}, default "coerce"
+        How to handle non-empty values that cannot be parsed. ``"coerce"``
+        converts invalid values to nulls. ``"raise"`` raises ``ValueError``.
+
+    Returns
+    -------
+    ArFrame
+        New frame with selected columns parsed as numeric data.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("sales.csv")
+    >>> clean = ar.parse_numeric_strings(frame, subset=["revenue", "margin"])
+    """
+    if errors not in {"coerce", "raise"}:
+        raise ValueError("errors must be either 'coerce' or 'raise'")
+
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame)
+    columns = subset or list(df.select_dtypes(include=["object", "string"]).columns)
+
+    missing = [column for column in columns if column not in df.columns]
+    if missing:
+        raise KeyError(f"Unknown columns for numeric parsing: {missing}")
+
+    result = df.copy()
+    for column in columns:
+        text = result[column].astype("string").str.strip()
+        empty = text.isna() | text.eq("")
+        percent = text.str.endswith("%", na=False)
+        normalized = (
+            text.str.replace(r"^\((.*)\)$", r"-\1", regex=True)
+            .str.replace(r"[%,$€£¥₹]", "", regex=True)
+            .str.replace(",", "", regex=False)
+            .str.replace(r"\s+", "", regex=True)
+        )
+        parsed = pd.to_numeric(normalized, errors="coerce").astype("Float64")
+        parsed = parsed.mask(percent, parsed / 100)
+
+        invalid = parsed.isna() & ~empty
+        if errors == "raise" and invalid.any():
+            values = result.loc[invalid, column].astype(str).head(3).tolist()
+            raise ValueError(
+                f"Column {column!r} contains non-numeric values: {values}"
+            )
+
+        result[column] = parsed
+
+    return from_pandas(result)
+
+
 def clean(
     frame: ArFrame,
     *,

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -288,9 +288,7 @@ def parse_numeric_strings(
         invalid = parsed.isna() & ~empty
         if errors == "raise" and invalid.any():
             values = result.loc[invalid, column].astype(str).head(3).tolist()
-            raise ValueError(
-                f"Column {column!r} contains non-numeric values: {values}"
-            )
+            raise ValueError(f"Column {column!r} contains non-numeric values: {values}")
 
         result[column] = parsed
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -17,6 +17,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "drop_duplicates": cleaning.drop_duplicates,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,
+    "parse_numeric_strings": cleaning.parse_numeric_strings,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
 }

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -131,6 +131,53 @@ class TestCastTypes:
             ar.cast_types(frame, {"age": "decimal"})
 
 
+class TestParseNumericStrings:
+    def test_parse_currency_percent_and_parentheses(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "revenue": ["$1,234.50", "€2 500", "(300)"],
+                    "margin": ["45%", "12.5%", ""],
+                    "label": ["a", "b", "c"],
+                }
+            )
+        )
+
+        result = ar.parse_numeric_strings(frame, subset=["revenue", "margin"])
+        df = ar.to_pandas(result)
+
+        assert list(df["revenue"]) == [1234.5, 2500.0, -300.0]
+        assert list(df["margin"].dropna()) == [0.45, 0.125]
+        assert list(df["label"]) == ["a", "b", "c"]
+
+    def test_parse_all_string_columns_by_default(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"amount": ["1", "2.5"], "count": [1, 2]}))
+
+        result = ar.parse_numeric_strings(frame)
+        df = ar.to_pandas(result)
+
+        assert list(df["amount"]) == [1, 2.5]
+        assert list(df["count"]) == [1, 2]
+
+    def test_parse_invalid_values_can_raise(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"amount": ["$10", "n/a"]}))
+
+        with pytest.raises(ValueError, match="contains non-numeric values"):
+            ar.parse_numeric_strings(frame, errors="raise")
+
+    def test_parse_rejects_unknown_error_mode(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(ValueError, match="errors must be"):
+            ar.parse_numeric_strings(frame, errors="ignore")
+
+
 class TestCleanAPI:
     def test_clean_defaults(self, csv_with_whitespace):
         frame = ar.read_csv(csv_with_whitespace)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -171,6 +171,25 @@ class TestParseNumericStrings:
         with pytest.raises(ValueError, match="contains non-numeric values"):
             ar.parse_numeric_strings(frame, errors="raise")
 
+    def test_parse_invalid_values_coerce_to_null(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"amount": ["$10", "n/a", "25%"]}))
+
+        result = ar.parse_numeric_strings(frame, errors="coerce")
+        df = ar.to_pandas(result)
+
+        assert list(df["amount"].dropna()) == [10.0, 0.25]
+        assert df["amount"].isna().iloc[1]
+
+    def test_parse_rejects_unknown_subset_column(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"amount": ["$10"]}))
+
+        with pytest.raises(KeyError, match="Unknown columns"):
+            ar.parse_numeric_strings(frame, subset=["missing"])
+
     def test_parse_rejects_unknown_error_mode(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -75,6 +75,19 @@ class TestPipeline:
         assert result.dtypes["years"] == "float64"
         assert "age" not in result.columns
 
+    def test_pipeline_parse_numeric_strings(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"amount": ["$1,000", "25%"]}))
+        result = ar.pipeline(
+            frame,
+            [
+                ("parse_numeric_strings", {"subset": ["amount"]}),
+            ],
+        )
+
+        assert list(ar.to_pandas(result)["amount"]) == [1000.0, 0.25]
+
     def test_empty_pipeline(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])


### PR DESCRIPTION
## Summary
- add a public parse_numeric_strings cleaning helper for currency, thousands separators, whitespace, parentheses negatives, and percent strings
- register parse_numeric_strings in the pipeline and export it from arnio
- document the primitive and cover direct and pipeline usage with tests

Fixes #149

## Tests
- .venv/bin/python -m pytest tests/test_cleaning.py tests/test_pipeline.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check arnio/cleaning.py arnio/pipeline.py arnio/__init__.py tests/test_cleaning.py tests/test_pipeline.py