### PR TITLE
feat: add column existence validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | Primitive | What it does | Example |
 |:---|:---|:---|
 | `drop_nulls` | Remove rows with null/empty values | `ar.drop_nulls(frame, subset=["age"])` |
+| `validate_columns_exist` | Fail early when required columns are missing | `ar.validate_columns_exist(frame, ["age"])` |
 | `filter_rows` | Filter rows using comparison operators | `ar.filter_rows(frame, column="age", op=">", value=18)` |
 | `fill_nulls` | Replace nulls with a scalar | `ar.fill_nulls(frame, 0, subset=["revenue"])` |
 | `drop_duplicates` | Deduplicate rows (first/last/none) | `ar.drop_duplicates(frame, keep="first")` |
@@ -305,6 +306,7 @@ Or compose them all into a **pipeline**:
 
 ```python
 clean = ar.pipeline(frame, [
+    ("validate_columns_exist", {"columns": ["name", "city", "revenue"]}),
     ("strip_whitespace",),
     ("normalize_case", {"case_type": "lower"}),
     ("fill_nulls", {"value": "unknown", "subset": ["city"]}),

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -21,6 +21,7 @@ from .cleaning import (
     normalize_case,
     rename_columns,
     strip_whitespace,
+    validate_columns_exist,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
@@ -57,6 +58,7 @@ __all__ = [
     # Cleaning
     "drop_nulls",
     "fill_nulls",
+    "validate_columns_exist",
     "filter_rows",
     "drop_duplicates",
     "strip_whitespace",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -66,7 +66,7 @@ def _validate_column_sequence(
     *,
     argument_name: str,
 ) -> list[str]:
-    if isinstance(columns, str | bytes):
+    if isinstance(columns, (str, bytes)):
         raise TypeError(
             f"{argument_name} must be a sequence of column names, not a string"
         )

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -20,6 +20,43 @@ from .exceptions import TypeCastError
 from .frame import ArFrame
 
 
+def validate_columns_exist(
+    frame: ArFrame,
+    columns: list[str] | tuple[str, ...],
+    *,
+    operation: str | None = None,
+) -> ArFrame:
+    """Validate that all requested columns exist in a frame.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    columns : list[str] or tuple[str, ...]
+        Column names that must exist.
+    operation : str, optional
+        Operation name to include in the error message.
+
+    Returns
+    -------
+    ArFrame
+        The original frame, unchanged. This makes the helper pipeline-friendly.
+
+    Raises
+    ------
+    KeyError
+        If any requested column is missing.
+    """
+    missing = [column for column in columns if column not in frame.columns]
+    if missing:
+        available = ", ".join(frame.columns) or "<none>"
+        context = f" for {operation}" if operation else ""
+        raise KeyError(
+            f"Missing columns{context}: {missing}. Available columns: {available}"
+        )
+    return frame
+
+
 def drop_nulls(
     frame: ArFrame,
     *,
@@ -45,6 +82,8 @@ def drop_nulls(
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.drop_nulls(frame, subset=["age", "name"])
     """
+    if subset is not None:
+        validate_columns_exist(frame, subset, operation="drop_nulls")
     result = _drop_nulls(frame._frame, subset=subset)
     return ArFrame(result)
 
@@ -76,6 +115,8 @@ def fill_nulls(
     >>> frame = ar.read_csv("data.csv")
     >>> filled = ar.fill_nulls(frame, 0, subset=["age"])
     """
+    if subset is not None:
+        validate_columns_exist(frame, subset, operation="fill_nulls")
     result = _fill_nulls(frame._frame, value, subset=subset)
     return ArFrame(result)
 
@@ -108,6 +149,8 @@ def drop_duplicates(
     >>> frame = ar.read_csv("data.csv")
     >>> unique = ar.drop_duplicates(frame, subset=["name"], keep="first")
     """
+    if subset is not None:
+        validate_columns_exist(frame, subset, operation="drop_duplicates")
     keep_arg = "none" if keep is False else keep
     result = _drop_duplicates(frame._frame, subset=subset, keep=keep_arg)
     return ArFrame(result)
@@ -137,6 +180,8 @@ def strip_whitespace(
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.strip_whitespace(frame, subset=["name"])
     """
+    if subset is not None:
+        validate_columns_exist(frame, subset, operation="strip_whitespace")
     result = _strip_whitespace(frame._frame, subset=subset)
     return ArFrame(result)
 
@@ -168,6 +213,8 @@ def normalize_case(
     >>> frame = ar.read_csv("data.csv")
     >>> lower = ar.normalize_case(frame, case_type="lower")
     """
+    if subset is not None:
+        validate_columns_exist(frame, subset, operation="normalize_case")
     result = _normalize_case(frame._frame, subset=subset, case_type=case_type)
     return ArFrame(result)
 
@@ -195,6 +242,7 @@ def rename_columns(
     >>> frame = ar.read_csv("data.csv")
     >>> renamed = ar.rename_columns(frame, {"old_name": "new_name"})
     """
+    validate_columns_exist(frame, list(mapping), operation="rename_columns")
     result = _rename_columns(frame._frame, mapping)
     return ArFrame(result)
 
@@ -222,6 +270,7 @@ def cast_types(
     >>> frame = ar.read_csv("data.csv")
     >>> casted = ar.cast_types(frame, {"age": "int64", "score": "float64"})
     """
+    validate_columns_exist(frame, list(mapping), operation="cast_types")
     try:
         result = _cast_types(frame._frame, mapping)
     except ValueError as e:

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -5,6 +5,7 @@ Data cleaning functions.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from ._core import (
@@ -22,7 +23,7 @@ from .frame import ArFrame
 
 def validate_columns_exist(
     frame: ArFrame,
-    columns: list[str] | tuple[str, ...],
+    columns: Sequence[str],
     *,
     operation: str | None = None,
 ) -> ArFrame:
@@ -32,7 +33,7 @@ def validate_columns_exist(
     ----------
     frame : ArFrame
         Input data frame.
-    columns : list[str] or tuple[str, ...]
+    columns : sequence of str
         Column names that must exist.
     operation : str, optional
         Operation name to include in the error message.
@@ -44,10 +45,13 @@ def validate_columns_exist(
 
     Raises
     ------
+    TypeError
+        If columns is a string/bytes value or contains non-string items.
     KeyError
         If any requested column is missing.
     """
-    missing = [column for column in columns if column not in frame.columns]
+    requested_columns = _validate_column_sequence(columns, argument_name="columns")
+    missing = [column for column in requested_columns if column not in frame.columns]
     if missing:
         available = ", ".join(frame.columns) or "<none>"
         context = f" for {operation}" if operation else ""
@@ -55,6 +59,26 @@ def validate_columns_exist(
             f"Missing columns{context}: {missing}. Available columns: {available}"
         )
     return frame
+
+
+def _validate_column_sequence(
+    columns: Sequence[str],
+    *,
+    argument_name: str,
+) -> list[str]:
+    if isinstance(columns, str | bytes):
+        raise TypeError(
+            f"{argument_name} must be a sequence of column names, not a string"
+        )
+    if not isinstance(columns, Sequence):
+        raise TypeError(f"{argument_name} must be a sequence of column names")
+
+    normalized = list(columns)
+    invalid_columns = [column for column in normalized if not isinstance(column, str)]
+    if invalid_columns:
+        raise TypeError(f"{argument_name} must contain only string column names")
+
+    return normalized
 
 
 def drop_nulls(
@@ -83,7 +107,11 @@ def drop_nulls(
     >>> clean = ar.drop_nulls(frame, subset=["age", "name"])
     """
     if subset is not None:
-        validate_columns_exist(frame, subset, operation="drop_nulls")
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="drop_nulls",
+        )
     result = _drop_nulls(frame._frame, subset=subset)
     return ArFrame(result)
 
@@ -116,7 +144,11 @@ def fill_nulls(
     >>> filled = ar.fill_nulls(frame, 0, subset=["age"])
     """
     if subset is not None:
-        validate_columns_exist(frame, subset, operation="fill_nulls")
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="fill_nulls",
+        )
     result = _fill_nulls(frame._frame, value, subset=subset)
     return ArFrame(result)
 
@@ -150,7 +182,11 @@ def drop_duplicates(
     >>> unique = ar.drop_duplicates(frame, subset=["name"], keep="first")
     """
     if subset is not None:
-        validate_columns_exist(frame, subset, operation="drop_duplicates")
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="drop_duplicates",
+        )
     keep_arg = "none" if keep is False else keep
     result = _drop_duplicates(frame._frame, subset=subset, keep=keep_arg)
     return ArFrame(result)
@@ -181,7 +217,11 @@ def strip_whitespace(
     >>> clean = ar.strip_whitespace(frame, subset=["name"])
     """
     if subset is not None:
-        validate_columns_exist(frame, subset, operation="strip_whitespace")
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="strip_whitespace",
+        )
     result = _strip_whitespace(frame._frame, subset=subset)
     return ArFrame(result)
 
@@ -214,7 +254,11 @@ def normalize_case(
     >>> lower = ar.normalize_case(frame, case_type="lower")
     """
     if subset is not None:
-        validate_columns_exist(frame, subset, operation="normalize_case")
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="normalize_case",
+        )
     result = _normalize_case(frame._frame, subset=subset, case_type=case_type)
     return ArFrame(result)
 
@@ -242,7 +286,11 @@ def rename_columns(
     >>> frame = ar.read_csv("data.csv")
     >>> renamed = ar.rename_columns(frame, {"old_name": "new_name"})
     """
-    validate_columns_exist(frame, list(mapping), operation="rename_columns")
+    validate_columns_exist(
+        frame,
+        _validate_column_sequence(list(mapping), argument_name="mapping keys"),
+        operation="rename_columns",
+    )
     result = _rename_columns(frame._frame, mapping)
     return ArFrame(result)
 
@@ -270,7 +318,11 @@ def cast_types(
     >>> frame = ar.read_csv("data.csv")
     >>> casted = ar.cast_types(frame, {"age": "int64", "score": "float64"})
     """
-    validate_columns_exist(frame, list(mapping), operation="cast_types")
+    validate_columns_exist(
+        frame,
+        _validate_column_sequence(list(mapping), argument_name="mapping keys"),
+        operation="cast_types",
+    )
     try:
         result = _cast_types(frame._frame, mapping)
     except ValueError as e:

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -14,6 +14,7 @@ from .frame import ArFrame
 _STEP_REGISTRY: dict[str, Callable] = {
     "drop_nulls": cleaning.drop_nulls,
     "fill_nulls": cleaning.fill_nulls,
+    "validate_columns_exist": cleaning.validate_columns_exist,
     "drop_duplicates": cleaning.drop_duplicates,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -40,6 +40,33 @@ class TestFillNulls:
             ar.fill_nulls(frame, "bad", subset=["x"])
 
 
+class TestValidateColumnsExist:
+    def test_returns_original_frame_when_columns_exist(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.validate_columns_exist(frame, ["name", "age"])
+
+        assert result is frame
+
+    def test_raises_clear_error_for_missing_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for test_op"):
+            ar.validate_columns_exist(frame, ["missing"], operation="test_op")
+
+    def test_drop_nulls_rejects_missing_subset_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for drop_nulls"):
+            ar.drop_nulls(frame, subset=["missing"])
+
+    def test_rename_rejects_missing_mapping_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for rename_columns"):
+            ar.rename_columns(frame, {"missing": "new_name"})
+
+
 class TestDropDuplicates:
     def test_drop_dupes_first(self, csv_with_duplicates):
         frame = ar.read_csv(csv_with_duplicates)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -48,11 +48,36 @@ class TestValidateColumnsExist:
 
         assert result is frame
 
+    def test_allows_empty_column_list(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.validate_columns_exist(frame, [])
+
+        assert result is frame
+
     def test_raises_clear_error_for_missing_columns(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
         with pytest.raises(KeyError, match="Missing columns for test_op"):
             ar.validate_columns_exist(frame, ["missing"], operation="test_op")
+
+    def test_rejects_string_columns_argument(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="not a string"):
+            ar.validate_columns_exist(frame, "name")
+
+    def test_rejects_non_string_column_items(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="only string column names"):
+            ar.validate_columns_exist(frame, ["name", 1])
+
+    def test_drop_nulls_rejects_string_subset(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="subset must be a sequence"):
+            ar.drop_nulls(frame, subset="name")
 
     def test_drop_nulls_rejects_missing_subset_column(self, sample_csv):
         frame = ar.read_csv(sample_csv)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -87,6 +87,34 @@ class TestPipeline:
 
         assert result.shape == frame.shape
 
+    def test_pipeline_validate_columns_exist_allows_empty_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = ar.pipeline(frame, [("validate_columns_exist", {"columns": []})])
+
+        assert result is frame
+
+    def test_pipeline_validate_columns_exist_rejects_missing_columns(self, sample_csv):
+        import pytest
+
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns"):
+            ar.pipeline(
+                frame,
+                [("validate_columns_exist", {"columns": ["missing"]})],
+            )
+
+    def test_pipeline_subset_step_rejects_missing_columns(self, sample_csv):
+        import pytest
+
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for strip_whitespace"):
+            ar.pipeline(
+                frame,
+                [("strip_whitespace", {"subset": ["missing"]})],
+            )
+
     def test_empty_pipeline(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -75,6 +75,18 @@ class TestPipeline:
         assert result.dtypes["years"] == "float64"
         assert "age" not in result.columns
 
+    def test_pipeline_validate_columns_exist(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = ar.pipeline(
+            frame,
+            [
+                ("validate_columns_exist", {"columns": ["name", "age"]}),
+                ("strip_whitespace", {"subset": ["name"]}),
+            ],
+        )
+
+        assert result.shape == frame.shape
+
     def test_empty_pipeline(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])


### PR DESCRIPTION
## Summary
- add a public validate_columns_exist helper that returns the unchanged frame when required columns exist
- call the helper from subset and mapping-based cleaning wrappers so missing columns fail early with clearer KeyError messages
- register/export the helper and document it in the cleaning primitive table

Fixes #156

## Tests
- .venv/bin/python -m pytest tests/test_cleaning.py tests/test_pipeline.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check arnio/cleaning.py arnio/pipeline.py arnio/__init__.py tests/test_cleaning.py tests/test_pipeline.py
- git diff --check