### PR TITLE
feat: add ValidationResult.to_markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,10 @@ schema = ar.Schema({
 result = ar.validate(frame, schema)
 if not result.passed:
     print(result.to_pandas())
+    print(result.to_markdown(max_issues=10))
 ```
+
+`ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
 
 For low-risk automatic cleanup:
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -116,6 +116,10 @@ class ValidationResult:
             Maximum number of issues to include in the table. When omitted, all
             issues are shown.
         """
+        if max_issues is not None and (
+            not isinstance(max_issues, int) or isinstance(max_issues, bool)
+        ):
+            raise TypeError("max_issues must be an integer or None")
         if max_issues is not None and max_issues < 0:
             raise ValueError("max_issues must be non-negative")
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -107,6 +107,61 @@ class ValidationResult:
         """Return issues as a pandas DataFrame."""
         return pd.DataFrame([issue.to_dict() for issue in self.issues])
 
+    def to_markdown(self, *, max_issues: int | None = None) -> str:
+        """Return a GitHub-friendly Markdown validation report.
+
+        Parameters
+        ----------
+        max_issues : int, optional
+            Maximum number of issues to include in the table. When omitted, all
+            issues are shown.
+        """
+        if max_issues is not None and max_issues < 0:
+            raise ValueError("max_issues must be non-negative")
+
+        status = "passed" if self.passed else "failed"
+        lines = [
+            "## Validation Report",
+            "",
+            f"- Status: **{status}**",
+            f"- Rows checked: {self.row_count}",
+            f"- Issues found: {self.issue_count}",
+            f"- Bad rows: {len(self.bad_rows)}",
+        ]
+
+        if self.passed:
+            return "\n".join(lines)
+
+        visible_issues = self.issues if max_issues is None else self.issues[:max_issues]
+        if not visible_issues:
+            lines.extend(["", "_Issue table omitted by `max_issues=0`._"])
+            return "\n".join(lines)
+
+        lines.extend(
+            [
+                "",
+                "| Column | Rule | Row | Value | Message |",
+                "| --- | --- | ---: | --- | --- |",
+            ]
+        )
+        for issue in visible_issues:
+            lines.append(
+                "| "
+                f"{_markdown_cell(issue.column)} | "
+                f"{_markdown_cell(issue.rule)} | "
+                f"{_markdown_cell(issue.row_index)} | "
+                f"{_markdown_cell(_clean_scalar(issue.value))} | "
+                f"{_markdown_cell(issue.message)} |"
+            )
+
+        hidden_count = self.issue_count - len(visible_issues)
+        if hidden_count > 0:
+            lines.extend(
+                ["", f"_Showing {len(visible_issues)} of {self.issue_count} issues._"]
+            )
+
+        return "\n".join(lines)
+
 
 def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationResult:
     """Validate an ArFrame against a schema.
@@ -401,6 +456,13 @@ def _clean_scalar(value: Any) -> Any:
     if hasattr(value, "item"):
         return value.item()
     return value
+
+
+def _markdown_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).replace("\n", "<br>").replace("|", "\\|")
+    return text
 
 
 _SEMANTIC_PATTERNS = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -144,6 +144,18 @@ def test_validation_result_to_markdown_rejects_negative_max_issues(sample_csv):
         raise AssertionError("Expected max_issues validation to raise")
 
 
+def test_validation_result_to_markdown_rejects_non_integer_max_issues(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64(min=31)})
+
+    for invalid in ("1", 1.5, True):
+        try:
+            result.to_markdown(max_issues=invalid)  # type: ignore[arg-type]
+        except TypeError as exc:
+            assert "max_issues must be an integer or None" in str(exc)
+        else:
+            raise AssertionError(f"Expected max_issues={invalid!r} to raise")
+
+
 def test_custom_pattern_validation(tmp_path):
     path = tmp_path / "codes.csv"
     path.write_text("code\nAA-123\nbad\n")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -71,6 +71,79 @@ def test_validation_result_to_pandas(sample_csv):
     assert list(df["row_index"]) == [0, 1]
 
 
+def test_validation_result_to_markdown_for_success(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64()})
+
+    markdown = result.to_markdown()
+
+    assert "## Validation Report" in markdown
+    assert "- Status: **passed**" in markdown
+    assert "- Issues found: 0" in markdown
+    assert "| Column | Rule | Row | Value | Message |" not in markdown
+
+
+def test_validation_result_to_markdown_includes_issue_table(sample_csv):
+    result = ar.validate(
+        ar.read_csv(sample_csv),
+        {"age": ar.Int64(min=31), "missing": ar.String()},
+    )
+
+    markdown = result.to_markdown()
+
+    assert "- Status: **failed**" in markdown
+    assert "- Issues found: 3" in markdown
+    assert "| Column | Rule | Row | Value | Message |" in markdown
+    assert "| age | min | 0 |" in markdown
+    assert (
+        "| missing | required_column |  |  | Missing required column: missing |"
+        in markdown
+    )
+
+
+def test_validation_result_to_markdown_limits_visible_issues(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64(min=31)})
+
+    markdown = result.to_markdown(max_issues=1)
+
+    assert "| age | min | 0 |" in markdown
+    assert "| age | min | 1 |" not in markdown
+    assert "_Showing 1 of 2 issues._" in markdown
+
+
+def test_validation_result_to_markdown_escapes_table_cells():
+    result = ar.ValidationResult(
+        row_count=1,
+        issue_count=1,
+        issues=[
+            ar.ValidationIssue(
+                column="notes|raw",
+                rule="pattern",
+                row_index=0,
+                value="left|right\nnext",
+                message="Expected one|two\nlines",
+            )
+        ],
+        bad_rows=[0],
+    )
+
+    markdown = result.to_markdown()
+
+    assert "notes\\|raw" in markdown
+    assert "left\\|right<br>next" in markdown
+    assert "Expected one\\|two<br>lines" in markdown
+
+
+def test_validation_result_to_markdown_rejects_negative_max_issues(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64(min=31)})
+
+    try:
+        result.to_markdown(max_issues=-1)
+    except ValueError as exc:
+        assert "max_issues" in str(exc)
+    else:
+        raise AssertionError("Expected max_issues validation to raise")
+
+
 def test_custom_pattern_validation(tmp_path):
     path = tmp_path / "codes.csv"
     path.write_text("code\nAA-123\nbad\n")


### PR DESCRIPTION
## Summary
- Add `ValidationResult.to_markdown()` for GitHub/CI-friendly validation reports.
- Render pass/fail status, checked row counts, issue totals, bad row counts, and a Markdown issue table for failed validations.
- Support `max_issues` to keep long reports readable, including validation for negative limits.
- Escape Markdown table cells for pipes and newlines so values/messages paste cleanly.

## Testing
- `pytest tests/test_schema.py -q` (`10 passed`)
- `pytest -q` (`92 passed`)
- `ruff check arnio/schema.py tests/test_schema.py`
- `black --check arnio/schema.py tests/test_schema.py`
- `git diff --check`

Fixes #212