### PR TITLE
feat: add safe_divide_columns cleaning step

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
+| `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 
 Or compose them all into a **pipeline**:
 
@@ -342,6 +343,21 @@ Works with:
 - booleans
 
 <br>
+### 🔢 Safe column division
+
+Divide one column by another while handling division by zero and null denominators explicitly:
+
+```python
+result = ar.safe_divide_columns(
+    frame,
+    numerator="revenue",
+    denominator="cost",
+    output_column="ratio",
+    fill_value=0.0,  # used when denominator is zero or null
+)
+```
+
+> When the denominator is **zero or null**, the result is replaced with `fill_value` (default `0.0`) instead of raising an error or producing `NaN`/`Inf`.
 
 ---
 

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -21,7 +21,9 @@ from .cleaning import (
     normalize_case,
     rename_columns,
     strip_whitespace,
+    safe_divide_columns,
 )
+
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame
@@ -64,6 +66,7 @@ __all__ = [
     "rename_columns",
     "cast_types",
     "clean",
+    "safe_divide_columns",
     # Conversion
     "to_pandas",
     "from_pandas",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -20,10 +20,9 @@ from .cleaning import (
     filter_rows,
     normalize_case,
     rename_columns,
-    strip_whitespace,
     safe_divide_columns,
+    strip_whitespace,
 )
-
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -308,7 +308,9 @@ def filter_rows(frame, column, op, value):
     return from_pandas(filtered) if is_arframe else filtered
 
 
-def safe_divide_columns(frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0):
+def safe_divide_columns(
+    frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0
+):
     """Divide one column by another, handling division by zero and nulls explicitly.
 
     When the denominator is zero or null, the result is replaced with
@@ -347,6 +349,14 @@ def safe_divide_columns(frame, numerator: str, denominator: str, output_column: 
         raise ValueError(f"Numerator column '{numerator}' not found in frame.")
     if denominator not in df.columns:
         raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+    if output_column in df.columns:
+        import warnings
+
+        warnings.warn(
+            f"Output column '{output_column}' already exists and will be overwritten.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     safe_denom = df[denominator].replace(0, float("nan"))
     result = df[numerator] / safe_denom
@@ -354,4 +364,3 @@ def safe_divide_columns(frame, numerator: str, denominator: str, output_column: 
     df[output_column] = result.fillna(fill_value)
 
     return from_pandas(df) if is_arframe else df
-

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -325,7 +325,9 @@ def safe_divide_columns(
     denominator : str
         Column name to use as the denominator.
     output_column : str
-        Name of the new column to store the division result.
+        Name of the new column to store the division result. Must be a
+        non-empty string. If the column already exists, it will be
+        overwritten and a ``UserWarning`` is raised.
     fill_value : float, optional
         Value to use when denominator is zero or null. Defaults to 0.0.
 
@@ -349,6 +351,8 @@ def safe_divide_columns(
         raise ValueError(f"Numerator column '{numerator}' not found in frame.")
     if denominator not in df.columns:
         raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+    if not isinstance(output_column, str) or not output_column.strip():
+        raise ValueError("output_column must be a non-empty string.")
     if output_column in df.columns:
         import warnings
 

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -306,3 +306,52 @@ def filter_rows(frame, column, op, value):
     filtered = df[getattr(df[column], ops[op])(value)]
 
     return from_pandas(filtered) if is_arframe else filtered
+
+
+def safe_divide_columns(frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0):
+    """Divide one column by another, handling division by zero and nulls explicitly.
+
+    When the denominator is zero or null, the result is replaced with
+    fill_value instead of raising an error or producing NaN/Inf.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    numerator : str
+        Column name to use as the numerator.
+    denominator : str
+        Column name to use as the denominator.
+    output_column : str
+        Name of the new column to store the division result.
+    fill_value : float, optional
+        Value to use when denominator is zero or null. Defaults to 0.0.
+
+    Returns
+    -------
+    ArFrame
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+    """
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    is_arframe = not isinstance(frame, pd.DataFrame)
+    df = to_pandas(frame) if is_arframe else frame
+
+    if numerator not in df.columns:
+        raise ValueError(f"Numerator column '{numerator}' not found in frame.")
+    if denominator not in df.columns:
+        raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+
+    safe_denom = df[denominator].replace(0, float("nan"))
+    result = df[numerator] / safe_denom
+    df = df.copy()
+    df[output_column] = result.fillna(fill_value)
+
+    return from_pandas(df) if is_arframe else df
+

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -121,3 +121,5 @@ def pipeline(
 
 
 register_step("filter_rows", cleaning.filter_rows)
+
+register_step("safe_divide_columns", cleaning.safe_divide_columns)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -148,3 +148,45 @@ class TestCleanAPI:
         # Drop nulls
         result = ar.clean(frame, strip_whitespace=False, drop_nulls=True)
         assert len(result) < len(frame)
+class TestSafeDivideColumns:
+    def test_normal_division(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n200,100\n300,150\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 2.0
+        assert df["ratio"].iloc[1] == 2.0
+        assert df["ratio"].iloc[2] == 2.0
+
+    def test_division_by_zero(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,0\n200,100\n300,0\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 0.0
+        assert df["ratio"].iloc[2] == 0.0
+
+    def test_null_inputs(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,\n200,100\n300,\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 0.0
+        assert df["ratio"].iloc[2] == 0.0
+
+    def test_missing_numerator_column(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+        with pytest.raises(ValueError, match="Numerator column"):
+            ar.safe_divide_columns(frame, numerator="nonexistent", denominator="cost", output_column="ratio")
+
+    def test_missing_denominator_column(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+        with pytest.raises(ValueError, match="Denominator column"):
+            ar.safe_divide_columns(frame, numerator="revenue", denominator="nonexistent", output_column="ratio")

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -208,3 +208,19 @@ class TestSafeDivideColumns:
                 denominator="nonexistent",
                 output_column="ratio",
             )
+
+    def test_output_column_already_exists(self, tmp_path):
+        import warnings
+
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost,ratio\n100,50,99\n200,100,99\n")
+        frame = ar.read_csv(path)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = ar.safe_divide_columns(
+                frame, numerator="revenue", denominator="cost", output_column="ratio"
+            )
+            assert len(w) == 1
+            assert "already exists" in str(w[0].message)
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 2.0

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -148,12 +148,16 @@ class TestCleanAPI:
         # Drop nulls
         result = ar.clean(frame, strip_whitespace=False, drop_nulls=True)
         assert len(result) < len(frame)
+
+
 class TestSafeDivideColumns:
     def test_normal_division(self, tmp_path):
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,50\n200,100\n300,150\n")
         frame = ar.read_csv(path)
-        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
         df = ar.to_pandas(result)
         assert df["ratio"].iloc[0] == 2.0
         assert df["ratio"].iloc[1] == 2.0
@@ -163,7 +167,9 @@ class TestSafeDivideColumns:
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,0\n200,100\n300,0\n")
         frame = ar.read_csv(path)
-        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
         df = ar.to_pandas(result)
         assert df["ratio"].iloc[0] == 0.0
         assert df["ratio"].iloc[2] == 0.0
@@ -172,7 +178,9 @@ class TestSafeDivideColumns:
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,\n200,100\n300,\n")
         frame = ar.read_csv(path)
-        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
         df = ar.to_pandas(result)
         assert df["ratio"].iloc[0] == 0.0
         assert df["ratio"].iloc[2] == 0.0
@@ -182,11 +190,21 @@ class TestSafeDivideColumns:
         path.write_text("revenue,cost\n100,50\n")
         frame = ar.read_csv(path)
         with pytest.raises(ValueError, match="Numerator column"):
-            ar.safe_divide_columns(frame, numerator="nonexistent", denominator="cost", output_column="ratio")
+            ar.safe_divide_columns(
+                frame,
+                numerator="nonexistent",
+                denominator="cost",
+                output_column="ratio",
+            )
 
     def test_missing_denominator_column(self, tmp_path):
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,50\n")
         frame = ar.read_csv(path)
         with pytest.raises(ValueError, match="Denominator column"):
-            ar.safe_divide_columns(frame, numerator="revenue", denominator="nonexistent", output_column="ratio")
+            ar.safe_divide_columns(
+                frame,
+                numerator="revenue",
+                denominator="nonexistent",
+                output_column="ratio",
+            )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -190,3 +190,32 @@ def test_filter_rows_direct_api():
     result_df = ar.to_pandas(result)
 
     assert list(result_df["age"]) == [30, 40]
+
+
+def test_safe_divide_columns_pipeline():
+    import pandas as pd
+
+    import arnio as ar
+
+    df = pd.DataFrame({"revenue": [100.0, 200.0, 0.0], "cost": [50.0, 0.0, 30.0]})
+
+    frame = ar.from_pandas(df)
+
+    result = ar.pipeline(
+        frame,
+        [
+            (
+                "safe_divide_columns",
+                {
+                    "numerator": "revenue",
+                    "denominator": "cost",
+                    "output_column": "ratio",
+                },
+            )
+        ],
+    )
+
+    result_df = ar.to_pandas(result)
+    assert result_df["ratio"].iloc[0] == 2.0
+    assert result_df["ratio"].iloc[1] == 0.0  # division by zero → fill_value
+    assert result_df["ratio"].iloc[2] == 0.0  # zero numerator


### PR DESCRIPTION
## Summary
Adds a `safe_divide_columns` cleaning step that divides one column by another while explicitly handling division by zero and null values.

## Changes
- Add `safe_divide_columns` function to `arnio/cleaning.py`
- Register step in `arnio/pipeline.py`
- Export in `arnio/__init__.py`
- Add tests for normal division, division by zero, null inputs, and missing columns

## Behavior
- When denominator is zero or null, result is replaced with `fill_value` (default: 0.0)
- Raises `ValueError` with clear message if numerator or denominator column not found

Fixes #154