### PR TITLE
feat(parser): recognize standard NA sentinel values (NA, N/A, null, None, NaN, -)

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -116,9 +116,17 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
 DType CsvReader::infer_type(const std::string& value) {
     if (value.empty()) return DType::NULL_TYPE;
 
-    // Try bool
+    // Check for standard NA/null sentinel values (pandas-compatible)
     std::string lower = value;
+    trim_in_place(lower);
     std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    static const std::unordered_set<std::string> na_sentinels = {
+        "na", "n/a", "null", "none", "nan", "-",
+        "nil", "n.a.", "n.a", "#n/a", "#na",
+    };
+    if (na_sentinels.count(lower)) return DType::NULL_TYPE;
+
+    // Try bool
     if (lower == "true" || lower == "false") return DType::BOOL;
 
     // Try int64
@@ -159,6 +167,16 @@ DType CsvReader::promote_type(DType current, DType incoming) {
 
 CellValue CsvReader::parse_value(const std::string& raw, DType dtype) {
     if (raw.empty()) return std::monostate{};
+
+    // Treat NA sentinel values as null regardless of target dtype
+    std::string lowered = raw;
+    trim_in_place(lowered);
+    std::transform(lowered.begin(), lowered.end(), lowered.begin(), ::tolower);
+    static const std::unordered_set<std::string> na_sentinels = {
+        "na", "n/a", "null", "none", "nan", "-",
+        "nil", "n.a.", "n.a", "#n/a", "#na",
+    };
+    if (na_sentinels.count(lowered)) return std::monostate{};
 
     switch (dtype) {
         case DType::BOOL: {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -159,6 +159,66 @@ class TestReadCsv:
         with pytest.raises(ar.CsvReadError, match="Duplicate column name: a"):
             ar.read_csv(csv_path)
 
+    def test_na_sentinel_values(self, tmp_path):
+        """Test that standard NA sentinel values are recognized as null."""
+        csv_path = tmp_path / "na_values.csv"
+        csv_path.write_text(
+            "name,score,active\n"
+            "Alice,10,true\n"
+            "NA,NA,NA\n"
+            "N/A,N/A,N/A\n"
+            "null,null,null\n"
+            "None,None,None\n"
+            "NaN,NaN,NaN\n"
+            "-, -, -\n"
+            "Bob,20,false\n"
+        )
+
+        frame = ar.read_csv(str(csv_path))
+        df = ar.to_pandas(frame)
+
+        # Verify shape
+        assert frame.shape == (8, 3)
+
+        # Check that sentinel rows are all null
+        sentinel_rows = [1, 2, 3, 4, 5, 6]
+        for row_idx in sentinel_rows:
+            assert pd.isna(df.loc[row_idx, "name"]), f"Row {row_idx} name should be null"
+            assert pd.isna(df.loc[row_idx, "score"]), f"Row {row_idx} score should be null"
+            assert pd.isna(df.loc[row_idx, "active"]), f"Row {row_idx} active should be null"
+
+        # Check valid rows
+        assert df.loc[0, "name"] == "Alice"
+        assert df.loc[0, "score"] == 10
+        assert df.loc[0, "active"] == True
+        assert df.loc[7, "name"] == "Bob"
+        assert df.loc[7, "score"] == 20
+        assert df.loc[7, "active"] == False
+
+    def test_na_sentinels_type_inference(self, tmp_path):
+        """Test that NA sentinels don't force numeric columns to string."""
+        csv_path = tmp_path / "na_inference.csv"
+        csv_path.write_text(
+            "id,value\n"
+            "1,100.5\n"
+            "2,NA\n"
+            "3,200.0\n"
+            "4,None\n"
+        )
+
+        frame = ar.read_csv(str(csv_path))
+        dtypes = frame.dtypes
+
+        # id should be int64, value should be float64 (not string)
+        assert dtypes["id"] == "int64", f"Expected int64, got {dtypes['id']}"
+        assert dtypes["value"] == "float64", f"Expected float64, got {dtypes['value']}"
+
+        df = ar.to_pandas(frame)
+        assert pd.isna(df.loc[1, "value"])
+        assert pd.isna(df.loc[3, "value"])
+        assert df.loc[0, "value"] == 100.5
+        assert df.loc[2, "value"] == 200.0
+
 
 class TestScanCsv:
     def test_scan_schema(self, sample_csv):


### PR DESCRIPTION
## What

Adds pandas-compatible NA sentinel detection to `CsvReader::infer_type()` and `CsvReader::parse_value()`.

Currently, values like `"NA"`, `"N/A"`, `"null"`, `"None"`, `"NaN"`, and `"-"` are treated as regular strings by the CSV parser. This causes inconsistency with pandas, which recognizes a standard set of null sentinels.

## Changes

### `cpp/src/csv_reader.cpp`

**`infer_type()`:**
- Added 11 case-insensitive NA sentinels: `na`, `n/a`, `null`, `none`, `nan`, `-`, `nil`, `n.a.`, `n.a`, `#n/a`, `#na`
- Whitespace-trimmed before comparison
- Returns `NULL_TYPE` for recognized sentinels (before numeric inference)

**`parse_value()`:**
- Same sentinel detection at parse time
- Returns `std::monostate{}` for NA sentinels even when target dtype is numeric
- Prevents `std::stoll`/`std::stod` exceptions on sentinel strings

### `tests/test_csv.py`

- `test_na_sentinel_values`: validates 6 sentinel types across string, numeric, and boolean columns
- `test_na_sentinels_type_inference`: ensures numeric columns with NA values stay `float64` (not forced to `string`)

## Verification

```bash
$ pytest tests/ -v
89 passed in 0.42s
```

Closes #30