### PR TITLE
feat: add drop constant columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `filter_rows` | Filter rows using comparison operators | `ar.filter_rows(frame, column="age", op=">", value=18)` |
 | `fill_nulls` | Replace nulls with a scalar | `ar.fill_nulls(frame, 0, subset=["revenue"])` |
 | `drop_duplicates` | Deduplicate rows (first/last/none) | `ar.drop_duplicates(frame, keep="first")` |
+| `drop_constant_columns` | Remove columns with only one unique value | `ar.drop_constant_columns(frame)` |
 | `strip_whitespace` | Trim leading/trailing spaces from strings | `ar.strip_whitespace(frame)` |
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -14,6 +14,7 @@ except Exception:
 from .cleaning import (
     cast_types,
     clean,
+    drop_constant_columns,
     drop_duplicates,
     drop_nulls,
     fill_nulls,
@@ -59,6 +60,7 @@ __all__ = [
     "fill_nulls",
     "filter_rows",
     "drop_duplicates",
+    "drop_constant_columns",
     "strip_whitespace",
     "normalize_case",
     "rename_columns",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -114,11 +114,16 @@ def drop_duplicates(
 
 
 def drop_constant_columns(frame: ArFrame) -> ArFrame:
-    """Remove columns with only one unique value.
+    """Remove columns with exactly one unique value.
 
     Nulls are counted as values when determining whether a column is constant.
     This means columns like ``[None, None]`` are dropped, while columns like
-    ``[1, 1, None]`` are kept.
+    ``[1, 1, None]`` are kept. Empty columns in zero-row frames are also kept,
+    since they have zero unique values rather than one.
+
+    If every column is dropped, the zero-column pandas result is converted back
+    to an ``ArFrame``. Arnio currently derives row count from stored columns, so
+    that converted frame may report zero rows.
 
     Parameters
     ----------
@@ -138,8 +143,11 @@ def drop_constant_columns(frame: ArFrame) -> ArFrame:
     from .convert import from_pandas, to_pandas
 
     df = to_pandas(frame)
+    if len(df.index) == 0:
+        return frame
+
     constant_columns = [
-        column for column in df.columns if df[column].nunique(dropna=False) <= 1
+        column for column in df.columns if df[column].nunique(dropna=False) == 1
     ]
     return from_pandas(df.drop(columns=constant_columns))
 

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -113,6 +113,37 @@ def drop_duplicates(
     return ArFrame(result)
 
 
+def drop_constant_columns(frame: ArFrame) -> ArFrame:
+    """Remove columns with only one unique value.
+
+    Nulls are counted as values when determining whether a column is constant.
+    This means columns like ``[None, None]`` are dropped, while columns like
+    ``[1, 1, None]`` are kept.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+
+    Returns
+    -------
+    ArFrame
+        New frame without constant columns.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> reduced = ar.drop_constant_columns(frame)
+    """
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame)
+    constant_columns = [
+        column for column in df.columns if df[column].nunique(dropna=False) <= 1
+    ]
+    return from_pandas(df.drop(columns=constant_columns))
+
+
 def strip_whitespace(
     frame: ArFrame,
     *,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -15,6 +15,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "drop_nulls": cleaning.drop_nulls,
     "fill_nulls": cleaning.fill_nulls,
     "drop_duplicates": cleaning.drop_duplicates,
+    "drop_constant_columns": cleaning.drop_constant_columns,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,5 +1,6 @@
 """Tests for data cleaning functions."""
 
+import pandas as pd
 import pytest
 
 import arnio as ar
@@ -67,6 +68,78 @@ class TestDropDuplicates:
         frame = ar.read_csv(csv_with_duplicates)
         result = ar.drop_duplicates(frame, subset=["name"])
         assert result.shape[0] == 3
+
+
+class TestDropConstantColumns:
+    def test_drop_constant_columns_removes_constant_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [1, 2, 3],
+                    "constant_num": [7, 7, 7],
+                    "constant_text": ["x", "x", "x"],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["value"]
+        assert list(df["value"]) == [1, 2, 3]
+
+    def test_drop_constant_columns_keeps_non_constant_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [1, 2, 1],
+                    "b": ["x", "y", "x"],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == frame.columns
+        assert result.shape == frame.shape
+
+    def test_drop_constant_columns_drops_all_null_column(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "all_null": [None, None],
+                    "value": [1, 2],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == ["value"]
+
+    def test_drop_constant_columns_keeps_value_plus_null_column(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "maybe_constant": [1, 1, None],
+                    "constant": [2, 2, 2],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["maybe_constant"]
+        assert df.shape == (3, 1)
+
+    def test_drop_constant_columns_single_row_drops_all_columns(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1], "b": ["x"], "c": [None]}))
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == []
+        assert result.shape[1] == 0
 
 
 class TestStripWhitespace:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -133,12 +133,28 @@ class TestDropConstantColumns:
         assert list(df.columns) == ["maybe_constant"]
         assert df.shape == (3, 1)
 
-    def test_drop_constant_columns_single_row_drops_all_columns(self):
+    def test_drop_constant_columns_empty_frame_keeps_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "empty_num": pd.Series(dtype="float64"),
+                    "empty_text": pd.Series(dtype="object"),
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == ["empty_num", "empty_text"]
+        assert result.shape == frame.shape
+
+    def test_drop_constant_columns_all_columns_dropped_reports_zero_rows(self):
         frame = ar.from_pandas(pd.DataFrame({"a": [1], "b": ["x"], "c": [None]}))
 
         result = ar.drop_constant_columns(frame)
 
         assert result.columns == []
+        assert result.shape[0] == 0
         assert result.shape[1] == 0
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -49,6 +49,29 @@ class TestPipeline:
         )
         assert result.shape[0] == 3
 
+    def test_pipeline_drop_constant_columns(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "constant": [1, 1, 1],
+                    "value": [1, 2, 1],
+                }
+            )
+        )
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("drop_constant_columns",),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["value"]
+        assert list(df["value"]) == [1, 2, 1]
+
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(


### PR DESCRIPTION
## Summary

Added a new `drop_constant_columns` cleaning helper that removes columns with only one unique value.

The helper:
- drops columns like `[1, 1, 1]`
- drops all-null columns like `[None, None]`
- keeps columns like `[1, 1, None]` because nulls are counted as a distinct value
- keeps non-constant columns like `[1, 2, 1]`

Also registered `drop_constant_columns` as a built-in pipeline step, exported it through the public API, added focused tests, and included a small README mention in the cleaning primitives table.

AI assistance was used to help draft and review the implementation/tests. The final changes were reviewed and tested locally before submission.

## Linked issue

Fixes #145

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [x] `make lint`
- [x] Other: `git diff --check`
- [x] Other: `pytest tests/test_cleaning.py -v`
- [x] Other: `pytest tests/test_pipeline.py -v`

Focused tests passed:
- `pytest tests/test_cleaning.py -v` — 26 passed
- `pytest tests/test_pipeline.py -v` — 16 passed

`git diff --check` passed with no output.

`make lint` passed:
- `ruff check .` — All checks passed
- `black --check .` — 23 files would be left unchanged

`make test` was not run; focused cleaning and pipeline tests were run for this scoped change.

Note: I installed CMake locally because the package build requires the compiled `_arnio_cpp` extension.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR adds a Python-backed `drop_constant_columns` cleaning primitive and registers it for pipeline usage.

No C++ files were changed.