### PR TITLE
chore: add wide CSV benchmark coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Arnio is not a pandas wrapper. It's a separate runtime with its own data model.
 
 ## 🏎️ Benchmarks
 
-> **Reference environment**: Ubuntu, Python 3.12, 1M rows × 12 columns, synthetic messy CSV.<br>
-> **Reproduce**: `make benchmark` — generates the deterministic dataset and runs both engines.
+> **Reference environment**: Ubuntu, Python 3.12, synthetic messy CSV inputs.<br>
+> **Reproduce**: `make benchmark` — generates deterministic tall and wide datasets and runs both engines.
 
 To reproduce the published numbers from a fresh checkout:
 
@@ -238,16 +238,24 @@ python benchmarks/generate_data.py
 python benchmarks/benchmark_vs_pandas.py
 ```
 
-`benchmarks/generate_data.py` uses NumPy's `default_rng(42)`, so every run creates the same `benchmarks/benchmark_1m.csv` input. The benchmark then executes three pandas runs and three arnio runs, printing average wall-clock time from `time.perf_counter()` and peak Python allocation from `tracemalloc`. For cleaner comparisons, close other memory-heavy processes and run the script from the repository root after installing the same Python, pandas, NumPy, compiler, and arnio commit you want to compare.
+`benchmarks/generate_data.py` uses deterministic NumPy seeds, so every run creates the same `benchmarks/benchmark_1m.csv` tall input and `benchmarks/benchmark_wide.csv` wide input. The benchmark then executes three pandas runs and three arnio runs for each case, printing average wall-clock time from `time.perf_counter()` and peak Python allocation from `tracemalloc`. For cleaner comparisons, close other memory-heavy processes and run the script from the repository root after installing the same Python, pandas, NumPy, compiler, and arnio commit you want to compare.
 
 Expected output format:
 
 ```text
-                     pandas         arnio
+Tall CSV (1,000,000 rows x 12 columns)
+Metric                     pandas        arnio
 ────────────────────────────────────────────
 Exec Time (avg)       4.73s         5.75s
 Peak RAM               211MB         212MB
-API Clarity         Imperative    Declarative
+Speed: 0.8x | RAM: -1% reduction
+
+Wide CSV (5,000 rows x 256 columns)
+Metric                     pandas        arnio
+────────────────────────────────────────────
+Exec Time (avg)       ...s          ...s
+Peak RAM              ...MB         ...MB
+Speed: ...x | RAM: ...% reduction
 ```
 
 Small differences are expected across CPUs, operating systems, compilers, Python builds, and pandas/NumPy versions. If you share benchmark results in an issue or PR, include your OS, Python version, CPU model, pandas/NumPy versions, arnio commit, and the full command output so maintainers can compare like for like.

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -5,16 +5,40 @@ Run: python benchmarks/benchmark_vs_pandas.py
 
 import time
 import tracemalloc
+from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
 
 import arnio as ar
 
 CSV_FILE = "benchmarks/benchmark_1m.csv"
+WIDE_CSV_FILE = "benchmarks/benchmark_wide.csv"
 RUNS = 3
 
 
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    path: str
+
+
+BENCHMARKS = (
+    BenchmarkCase("Tall CSV (1,000,000 rows x 12 columns)", CSV_FILE),
+    BenchmarkCase("Wide CSV (5,000 rows x 256 columns)", WIDE_CSV_FILE),
+)
+
+
+def ensure_dataset_exists(path):
+    if not Path(path).exists():
+        raise FileNotFoundError(
+            f"Missing benchmark dataset: {path}. "
+            "Run `python benchmarks/generate_data.py` first."
+        )
+
+
 def benchmark_pandas(path):
+    ensure_dataset_exists(path)
     tracemalloc.start()
     t0 = time.perf_counter()
 
@@ -22,9 +46,8 @@ def benchmark_pandas(path):
     df.columns = df.columns.str.strip()
     df = df.dropna()
     df = df.drop_duplicates()
-    for col in ["name", "city", "active", "category", "region"]:
-        if col in df.columns:
-            df[col] = df[col].astype(str).str.strip().str.lower()
+    for col in df.select_dtypes(include=["object", "string"]).columns:
+        df[col] = df[col].astype(str).str.strip().str.lower()
 
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
@@ -33,6 +56,7 @@ def benchmark_pandas(path):
 
 
 def benchmark_arnio(path):
+    ensure_dataset_exists(path)
     tracemalloc.start()
     t0 = time.perf_counter()
 
@@ -54,7 +78,12 @@ def benchmark_arnio(path):
     return elapsed, peak / 1024 / 1024
 
 
-if __name__ == "__main__":
+def avg(values):
+    return sum(values) / len(values)
+
+
+def run_case(case):
+    print(case.name)
     print(f"{'Metric':<20} {'pandas':>12} {'arnio':>12}")
     print("-" * 46)
 
@@ -69,11 +98,14 @@ if __name__ == "__main__":
         pd_rams.append(pr)
         ar_rams.append(ar_r)
 
-    def avg(x):
-        return sum(x) / len(x)
-
     print(f"{'Exec Time (avg)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s")
     print(f"{'Peak RAM':<20} {avg(pd_rams):>10.0f}MB {avg(ar_rams):>10.0f}MB")
     print(
         f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams)/avg(pd_rams))*100:.0f}% reduction"
     )
+    print()
+
+
+if __name__ == "__main__":
+    for benchmark_case in BENCHMARKS:
+        run_case(benchmark_case)

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -91,8 +91,8 @@ def run_case(case):
     pd_rams, ar_rams = [], []
 
     for i in range(RUNS):
-        pt, pr = benchmark_pandas(CSV_FILE)
-        at, ar_r = benchmark_arnio(CSV_FILE)
+        pt, pr = benchmark_pandas(case.path)
+        at, ar_r = benchmark_arnio(case.path)
         pd_times.append(pt)
         ar_times.append(at)
         pd_rams.append(pr)

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -1,10 +1,13 @@
-"""Generate synthetic benchmark CSV — run this before benchmarking."""
+"""Generate deterministic benchmark CSV files before benchmarking."""
 
 import numpy as np
 import pandas as pd
 
+DEFAULT_TALL_PATH = "benchmarks/benchmark_1m.csv"
+DEFAULT_WIDE_PATH = "benchmarks/benchmark_wide.csv"
 
-def generate(rows=1_000_000, path="benchmarks/benchmark_1m.csv"):
+
+def generate(rows=1_000_000, path=DEFAULT_TALL_PATH):
     rng = np.random.default_rng(42)
     df = pd.DataFrame(
         {
@@ -32,5 +35,43 @@ def generate(rows=1_000_000, path="benchmarks/benchmark_1m.csv"):
     print(f"Generated {rows:,} row CSV -> {path}")
 
 
+def generate_wide(rows=5_000, columns=256, path=DEFAULT_WIDE_PATH):
+    if rows < 1:
+        raise ValueError("wide benchmark requires at least 1 row")
+    if columns < 4:
+        raise ValueError("wide benchmark requires at least 4 columns")
+
+    rng = np.random.default_rng(252)
+    data = {"row_id": np.arange(rows)}
+
+    for index in range(columns - 1):
+        column_id = f"{index:03d}"
+        kind = index % 4
+
+        if kind == 0:
+            data[f"metric_{column_id}"] = rng.normal(1_000, 250, rows).round(4)
+        elif kind == 1:
+            values = rng.choice(
+                ["  alpha", "BETA  ", " gamma", "DELTA ", None],
+                rows,
+            )
+            values[0] = "  alpha"
+            data[f"label_{column_id}"] = values
+        elif kind == 2:
+            values = rng.choice(
+                ["true", "false", "TRUE", "FALSE", None],
+                rows,
+            )
+            values[0] = "true"
+            data[f"flag_{column_id}"] = values
+        else:
+            data[f"amount_{column_id}"] = rng.uniform(0, 10_000, rows).round(2)
+
+    df = pd.DataFrame(data)
+    df.to_csv(path, index=False, lineterminator="\n")
+    print(f"Generated {rows:,} row x {columns:,} column CSV -> {path}")
+
+
 if __name__ == "__main__":
     generate()
+    generate_wide()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,53 @@
+"""Tests for benchmark dataset helpers."""
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+from benchmarks.generate_data import generate, generate_wide
+
+
+def test_generate_tall_benchmark_csv_shape(tmp_path):
+    csv_path = tmp_path / "benchmark_tall.csv"
+
+    generate(rows=5, path=csv_path)
+
+    df = pd.read_csv(csv_path)
+    assert df.shape == (5, 12)
+    assert list(df.columns) == [
+        "id",
+        "name",
+        "revenue",
+        "age",
+        "city",
+        "score",
+        "active",
+        "category",
+        "visits",
+        "amount",
+        "region",
+        "code",
+    ]
+
+
+def test_generate_wide_benchmark_csv_round_trips_through_arnio(tmp_path):
+    csv_path = tmp_path / "benchmark_wide.csv"
+
+    generate_wide(rows=4, columns=9, path=csv_path)
+
+    pandas_df = pd.read_csv(csv_path)
+    frame = ar.read_csv(csv_path)
+    arnio_df = ar.to_pandas(frame)
+
+    assert pandas_df.shape == (4, 9)
+    assert frame.shape == (4, 9)
+    assert arnio_df.shape == (4, 9)
+    assert arnio_df.columns.tolist() == pandas_df.columns.tolist()
+    assert ar.scan_csv(csv_path).keys() == set(pandas_df.columns)
+
+
+def test_generate_wide_rejects_too_few_columns(tmp_path):
+    csv_path = tmp_path / "too_narrow.csv"
+
+    with pytest.raises(ValueError, match="at least 4 columns"):
+        generate_wide(rows=4, columns=3, path=csv_path)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import arnio as ar
+from benchmarks import benchmark_vs_pandas
 from benchmarks.generate_data import generate, generate_wide
 
 
@@ -51,3 +52,21 @@ def test_generate_wide_rejects_too_few_columns(tmp_path):
 
     with pytest.raises(ValueError, match="at least 4 columns"):
         generate_wide(rows=4, columns=3, path=csv_path)
+
+
+def test_run_case_benchmarks_the_selected_case_path(monkeypatch):
+    seen_paths = []
+
+    def fake_benchmark(path):
+        seen_paths.append(path)
+        return 1.0, 1.0
+
+    monkeypatch.setattr(benchmark_vs_pandas, "RUNS", 2)
+    monkeypatch.setattr(benchmark_vs_pandas, "benchmark_pandas", fake_benchmark)
+    monkeypatch.setattr(benchmark_vs_pandas, "benchmark_arnio", fake_benchmark)
+
+    benchmark_vs_pandas.run_case(
+        benchmark_vs_pandas.BenchmarkCase("Wide fixture", "wide.csv")
+    )
+
+    assert seen_paths == ["wide.csv", "wide.csv", "wide.csv", "wide.csv"]


### PR DESCRIPTION
## Summary
Adds a deterministic wide CSV benchmark scenario alongside the existing tall CSV benchmark. The benchmark runner now reports tall and wide CSV cases separately, and the README explains the expanded benchmark workflow.

## Linked issue
Fixes #252

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [x] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `python -m black --check benchmarks\generate_data.py benchmarks\benchmark_vs_pandas.py tests\test_benchmarks.py`
  - `ruff check benchmarks\generate_data.py benchmarks\benchmark_vs_pandas.py tests\test_benchmarks.py`
  - `python -m py_compile benchmarks\generate_data.py benchmarks\benchmark_vs_pandas.py tests\test_benchmarks.py`
  - Tiny generator smoke test passed for tall and wide CSV outputs.

Note: Full pytest was blocked locally because the arnio C++ extension could not be built in this Windows shell. `pip install -e ".[dev]"` failed during CMake configuration because `nmake` / a C++ compiler was unavailable.

## Screenshots / Media
N/A

## Performance Impact
This adds benchmark coverage for wide CSV files but does not change runtime parser or cleaning behavior. The benchmark suite now includes a deterministic `5,000 rows x 256 columns` wide CSV case to exercise header parsing, column storage, and pandas conversion.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The wide dataset uses a modest row count so `make benchmark` gains wide CSV coverage without making the benchmark suite too heavy.
