### PR TITLE
tests: add wheel install smoke test

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -42,6 +42,14 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
 
+      - name: Set up Python for wheel smoke test
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Smoke test wheel install
+        run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse
+
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/tests/smoke_wheel_install.py
+++ b/tests/smoke_wheel_install.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from pathlib import Path
+
+
+def run(cmd: list[str], *, cwd: Path | None = None) -> None:
+    print("+", " ".join(cmd), flush=True)
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def venv_python(env_dir: Path) -> Path:
+    if os.name == "nt":
+        return env_dir / "Scripts" / "python.exe"
+    return env_dir / "bin" / "python"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Smoke test that a built arnio wheel installs and imports."
+    )
+    parser.add_argument(
+        "--wheelhouse",
+        default="wheelhouse",
+        help="Directory containing built .whl files.",
+    )
+    args = parser.parse_args()
+
+    wheelhouse = Path(args.wheelhouse).resolve()
+    wheels = sorted(wheelhouse.glob("*.whl"))
+
+    if not wheels:
+        raise SystemExit(f"No wheels found in {wheelhouse}")
+
+    print("Found wheels:")
+    for wheel in wheels:
+        print(f"  - {wheel.name}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        env_dir = tmp_dir / "smoke-venv"
+
+        venv.EnvBuilder(with_pip=True).create(env_dir)
+        python = venv_python(env_dir)
+
+        run([str(python), "-m", "pip", "install", "--upgrade", "pip"])
+        run([str(python), "-m", "pip", "install", "pandas>=1.5", "numpy>=1.23"])
+
+        # Force installation from the built local wheel, not from source checkout.
+        run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--no-index",
+                "--find-links",
+                str(wheelhouse),
+                "arnio",
+            ]
+        )
+
+        import_check = (
+            "import arnio as ar; "
+            "print('arnio import ok:', ar.__version__); "
+            "assert hasattr(ar, 'read_csv'); "
+            "assert hasattr(ar, 'pipeline'); "
+            "assert hasattr(ar, 'to_pandas')"
+        )
+
+        # Run outside the repo so Python cannot accidentally import local source files.
+        run([str(python), "-c", import_check], cwd=tmp_dir)
+
+    print("Wheel install smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/smoke_wheel_install.py
+++ b/tests/smoke_wheel_install.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
 import tempfile
 import venv
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 
 def run(cmd: list[str], *, cwd: Path | None = None) -> None:
@@ -18,6 +20,29 @@ def venv_python(env_dir: Path) -> Path:
     if os.name == "nt":
         return env_dir / "Scripts" / "python.exe"
     return env_dir / "bin" / "python"
+
+
+def installed_wheel_from_report(report_path: Path) -> str | None:
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+
+    for item in data.get("install", []):
+        metadata = item.get("metadata", {})
+        name = str(metadata.get("name", "")).lower()
+
+        if name != "arnio":
+            continue
+
+        url = item.get("download_info", {}).get("url")
+        if not url:
+            return None
+
+        parsed = urlparse(url)
+        if parsed.scheme == "file":
+            return Path(unquote(parsed.path)).name
+
+        return url
+
+    return None
 
 
 def main() -> int:
@@ -37,13 +62,15 @@ def main() -> int:
     if not wheels:
         raise SystemExit(f"No wheels found in {wheelhouse}")
 
-    print("Found wheels:")
+    print(f"Wheelhouse: {wheelhouse}")
+    print("Available wheels:")
     for wheel in wheels:
         print(f"  - {wheel.name}")
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_dir = Path(tmp)
         env_dir = tmp_dir / "smoke-venv"
+        report_path = tmp_dir / "pip-install-report.json"
 
         venv.EnvBuilder(with_pip=True).create(env_dir)
         python = venv_python(env_dir)
@@ -51,7 +78,6 @@ def main() -> int:
         run([str(python), "-m", "pip", "install", "--upgrade", "pip"])
         run([str(python), "-m", "pip", "install", "pandas>=1.5", "numpy>=1.23"])
 
-        # Force installation from the built local wheel, not from source checkout.
         run(
             [
                 str(python),
@@ -61,9 +87,20 @@ def main() -> int:
                 "--no-index",
                 "--find-links",
                 str(wheelhouse),
+                "--report",
+                str(report_path),
                 "arnio",
             ]
         )
+
+        selected_wheel = installed_wheel_from_report(report_path)
+
+        if selected_wheel is None:
+            raise SystemExit(
+                "Could not determine which arnio wheel was installed from pip report."
+            )
+
+        print(f"Selected wheel installed from wheelhouse: {selected_wheel}")
 
         import_check = (
             "import arnio as ar; "
@@ -73,7 +110,6 @@ def main() -> int:
             "assert hasattr(ar, 'to_pandas')"
         )
 
-        # Run outside the repo so Python cannot accidentally import local source files.
         run([str(python), "-c", import_check], cwd=tmp_dir)
 
     print("Wheel install smoke test passed.")


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->
Adds a wheel install smoke test for release builds. Built wheels should be verified by installing and importing them before they are trusted for release. This helps catch packaging issues that may not appear during normal editable-install testing.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
Fixes #262

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [x] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other:

```bash
python -m pip install -e ".[dev]"
python -m pytest
python -m build --wheel
python tests/smoke_wheel_install.py --wheelhouse dist
```

Result: wheel build and smoke install flow completed successfully locally.