### PR TITLE
test: preserve nullable boolean dtype round-trip

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -161,3 +161,19 @@ class TestFromPandas:
         result_df = ar.to_pandas(result)
 
         assert list(result_df.columns) == ["name", "age", "city"]
+
+    def test_nullable_boolean_roundtrip(self):
+        df = pd.DataFrame(
+            {
+                "active": pd.Series(
+                    [True, False, pd.NA],
+                    dtype="boolean",
+                )
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert str(result["active"].dtype) == "boolean"
+        assert list(result["active"]) == [True, False, pd.NA]


### PR DESCRIPTION
## Summary

Adds a regression test to verify pandas nullable boolean columns preserve:

* dtype (`boolean`)
* null semantics (`pd.NA`)
* values during round-trip conversion through Arnio

## Linked issue

Fixes #236

## Type of change

* [x] Tests

## Area

* [x] pandas interoperability

## Testing

* [x] Other:

```bash
python -m pytest tests/test_convert.py -q
python -m black --check arnio tests
```

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

