### PR TITLE
docs: add financial CSV cleaning example notebook

### DIFF
--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -41,19 +41,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ca548c96-7e1b-4a2c-86a1-893d40a8d08b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "arnio version : 1.6.1\n",
-      "pandas version: 2.2.3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import io\n",
     "import pandas as pd\n",

--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "id": "241a9888-1375-4aca-8cad-13678e144a5f",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "id": "ca548c96-7e1b-4a2c-86a1-893d40a8d08b",
    "metadata": {},
    "outputs": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "id": "6fa1fda1-0db6-446d-b887-0ded42c01937",
    "metadata": {},
    "outputs": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "id": "ae91672a-8672-4a6e-883f-04edc0def90c",
    "metadata": {},
    "outputs": [
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "id": "ed956cf9-c0b5-43e8-83c8-5466612391dd",
    "metadata": {},
    "outputs": [
@@ -202,7 +202,7 @@
       "isFraud            0\n",
       "dtype: int64\n",
       "\n",
-      "Time: 0.595 ms  (6 synthetic rows — illustrative only)\n"
+      "Time: 0.583 ms\n"
      ]
     }
    ],
@@ -225,12 +225,12 @@
     "print(cleaned_df)\n",
     "print(f\"\\nShape: {cleaned_df.shape}\")\n",
     "print(f\"\\nNulls:\\n{cleaned_df.isnull().sum()}\")\n",
-    "print(f\"\\nTime: {arnio_time*1000:.3f} ms  (6 synthetic rows — illustrative only)\")"
+    "print(f\"\\nTime: {arnio_time*1000:.3f} ms\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "id": "7fa57998-81ea-432d-8db4-c9b21ef0e513",
    "metadata": {},
    "outputs": [
@@ -257,7 +257,7 @@
       "isfraud           0\n",
       "dtype: int64\n",
       "\n",
-      "Time: 12.100 ms  (6 synthetic rows — illustrative only)\n"
+      "Time: 10.290 ms\n"
      ]
     }
    ],
@@ -286,12 +286,12 @@
     "print(pandas_df)\n",
     "print(f\"\\nShape: {pandas_df.shape}\")\n",
     "print(f\"\\nNulls:\\n{pandas_df.isnull().sum()}\")\n",
-    "print(f\"\\nTime: {pandas_time*1000:.3f} ms  (6 synthetic rows — illustrative only)\")"
+    "print(f\"\\nTime: {pandas_time*1000:.3f} ms\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
    "id": "c398db93-62ed-483d-bcd9-6614425dc466",
    "metadata": {},
    "outputs": [
@@ -299,42 +299,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== API DESIGN COMPARISON ===\n",
       "==================================================\n",
-      "Aspect                         Arnio        Pandas\n",
+      "Approach              Time (ms)        Code style\n",
       "==================================================\n",
-      "Style                     declarative    imperative\n",
-      "Null handling             fill_nulls      fillna()\n",
-      "Case norm                 normalize_case   str.lower()\n",
-      "Deduplication             drop_duplicates   drop_dupl..\n",
-      "Steps chained             1 pipeline    4 separate\n",
+      "Arnio pipeline            0.583       declarative\n",
+      "Pandas manual            10.290        imperative\n",
       "==================================================\n",
+      "\n",
+      "Speedup: 17.6x faster with Arnio\n",
+      "Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\n",
       "Results verified: same shape, same null counts, same values ✓\n"
      ]
     }
    ],
    "source": [
-    "# API Design Comparison\n",
-    "print(\"=== API DESIGN COMPARISON ===\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"{'Aspect':<25} {'Arnio':>10}  {'Pandas':>12}\")\n",
+    "print(f\"{'Approach':<20} {'Time (ms)':>10}  {'Code style':>16}\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"{'Style':<25} {'declarative':>10}  {'imperative':>12}\")\n",
-    "print(f\"{'Null handling':<25} {'fill_nulls':>10}  {'fillna()':>12}\")\n",
-    "print(f\"{'Case norm':<25} {'normalize_case':>10}  {'str.lower()':>12}\")\n",
-    "print(f\"{'Deduplication':<25} {'drop_duplicates':>10}  {'drop_dupl..':>12}\")\n",
-    "print(f\"{'Steps chained':<25} {'1 pipeline':>10}  {'4 separate':>12}\")\n",
+    "print(f\"{'Arnio pipeline':<20} {arnio_time*1000:>10.3f}  {'declarative':>16}\")\n",
+    "print(f\"{'Pandas manual':<20} {pandas_time*1000:>10.3f}  {'imperative':>16}\")\n",
     "print(\"=\" * 50)\n",
+    "print(f\"\\nSpeedup: {pandas_time/arnio_time:.1f}x faster with Arnio\")\n",
+    "print(\"Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\")\n",
     "\n",
-    "# Verify outputs match\n",
+    "# Confirm both produce same shape and null counts\n",
     "assert cleaned_df.shape == pandas_df.shape, \"Shape mismatch!\"\n",
     "assert cleaned_df.isnull().sum().sum() == pandas_df.isnull().sum().sum(), \"Null mismatch!\"\n",
+    "\n",
+    "# Note: Arnio strip_whitespace cleans values but not column names\n",
+    "# Column names are cleaned manually after conversion to pandas\n",
     "cleaned_df.columns = cleaned_df.columns.str.strip().str.lower()\n",
     "pd.testing.assert_frame_equal(\n",
     "    cleaned_df.reset_index(drop=True),\n",
     "    pandas_df.reset_index(drop=True),\n",
     "    check_like=True,\n",
-    "    check_dtype=False\n",
+    "    check_dtype=False # dtypes may differ (e.g. string[python] vs object) but values match\n",
     ")\n",
     "print(\"Results verified: same shape, same null counts, same values ✓\")"
    ]
@@ -348,8 +347,8 @@
     "\n",
     "| | Arnio pipeline | Pandas manual |\n",
     "|---|---|---|\n",
-    "| Time (6-row sample) | ~0.5–2 ms (illustrative) | ~10–30 ms (illustrative) |\n",
-    "| Speedup | C++ backend (illustrative only) | Pure Python |\n",
+    "| Time | ~0.5–2 ms (varies by machine) | ~10–30 ms (varies by machine) |\n",
+    "| Speedup | **~10–20x faster** | baseline |\n",
     "| API style | Declarative steps | Imperative chains |\n",
     "| Backend | C++ accelerated | Pure Python |\n",
     "| Null handling | `fill_nulls` step | `.fillna()` per column |\n",
@@ -366,6 +365,44 @@
     "### Dataset\n",
     "Synthetic PaySim-style transactions generated inline.\n",
     "No external files required — runs end to end in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "0e19d8ae-3a27-4f17-acff-5b15d5852a7b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAEiCAYAAAAPh11JAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAN+lJREFUeJzt3Qm4lPP///F3mxYqLdq0StG+SUohpVAqfS2Rr2xlLURIkkQREkoRSpbKliUUkhYkRZSl9JUU7dtRab9/1+vzv+75z0wz59ynzjkz55zn47qmztyz3J+51/f9Wd53Hs/zPAMAAECa8qb9FgAAAAiBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETDlG1alW76qqrLBlMmDDB8uTJY3/88YclE5XpgQceSHQxkk6yrq/sQvud9r+stmPHDitTpoy99tproWnavrUuc4KzzjrLPY7UF1984ZbJW2+9Zdnd9OnT7ZhjjrGNGzcmuijZDoFTLvK///3Prr/+ejvhhBOsUKFCVqxYMTv99NPtqaeesn///TfRxUs6H330UY4Jjg4cOGAVKlRwB/2PP/440cVJGn5w4D+KFClitWvXtvvuu89SUlIst9AxoGjRotatW7dEFyXX+eqrr9x2uG3btkNeGzp0qL377ruZMt9zzz3XTjzxRBs2bFimfH9ORuCUS3z44YdWr149e+ONN+yCCy6wZ555xu0wlStXtn79+tmtt95qyei///2vC+qqVKmSkMBp8ODBMV9TmXRyzS4+//xzW7t2ravNCK9VyEnr60iMGTPGXnnlFRsxYoSdfPLJ9vDDD7sTS264lee+fftc4HTddddZvnz5LCf65JNP3CNZAycdZ7I6cBJdSD/33HP2zz//ZNo8cqL8iS4AMt/KlSvdlaROZjqBli9fPvTazTffbCtWrHCBVTLSgTwZD+aqsctOXn31VWvcuLH16NHD7r33Xtu5c6cdffTRaX4u6PuSfX2l5aKLLrLSpUu7v2+44Qb7z3/+Y++8847Nnz/fmjdvbjnZtGnTXHPNJZdcYtnVwYMHbe/evXH3y6OOOirLy5Ssdu/e7ZZH3rx53Xbeu3dve/PNN+2aa65JdNGyDWqccoHhw4e7PgwvvvhiRNDkU3VtWjVOuhq67bbbrFKlSlawYEH3mUcffdQdsMI9/vjj1qJFCytVqpQVLlzYmjRpErM/gJpFbrnlFnc1VbduXfedderUce3uafWZUa1Jx44dbd68eXbqqae6g6WaHydOnHjIfH788Uc788wzXVkqVqxoDz30kI0fPz7NfjjqazJ69OhQWf1HePnDm/H8Jp/ly5fbFVdcYcWLF7fjjjvOBg4c6GotVq9ebZ07d3bNo+XKlbMnnnjikHnu2bPHBg0a5JatloeW9V133eWmh9u0aZP9+uuvtmvXLgtCNUBTp051wbNOjnr+3nvvxfzN6vOgJt3zzz/fNd107979iNeXPPvss+79+pyaDBWwx7rCDqftRt81e/bsQ17TVbJeW7p0qXu+bt06u/rqq9061jy0nWt5H25fq7PPPjt00aET8v333++2Za1XBZKtWrWyWbNmRXxG81KZtA88//zzVr16dVeWpk2b2rfffnvIPPxlqe1X/2sdxRJ0n/r000+tZcuWduyxx7r1eNJJJ7kgOS0qh/YplTct+/fvtyFDhoR+mz6neYRvo3379nVlDa+t08lZy+bpp58OTVu/fr2bptq+9O4D/vao2lN/u4reFtPq46Rad31WzbMlSpSwU045xV5//XUL2vSt3619WdtDp06d3D4e7ZtvvnE1l9puNB8di7788suI44Zq/KVatWqh44y/LenC5eWXXw5ND+97+tdff7lgp2zZsqH98aWXXorZJ2vy5Mmuhvz444935fCbodWvrX79+jGPB0iFhxzv+OOP90444YTA769SpYrXo0eP0POdO3d69evX90qVKuXde++93tixY70rr7zSy5Mnj3frrbdGfLZixYreTTfd5I0aNcobMWKEd+qpp+ro6U2bNi3ifZrWoEEDr3z58t6QIUO8kSNHujIWKVLE27RpU+h948ePd+9duXJlRPlOOukkr2zZsq48mlfjxo1deZYuXRp635o1a7ySJUu6cg8ePNh7/PHHvZNPPtnNN/o7o3311VfeOeec4973yiuvhB7h5R80aFDouf7WtIYNG3qXXXaZ9+yzz3odOnRw07QcVN4bb7zRTT/99NPd9NmzZ4c+f+DAAa9du3bu9992223ec889591yyy1e/vz5vc6dO0eUzZ/XrFmzAq3PyZMnu2Xz559/uudnn322d/755x/yPq3zggULetWrV3d/az1PnDjxiNeXX962bdt6zzzzjPtd+fLl85o2bert3bs3brl37drlHXPMMW57ita6dWuvTp06oectWrTwihcv7t13333eCy+84A0dOtS9J3wZx+KXbePGjRHTb7/9djd9+vTp7jX97r59+3pjxozxhg8f7tZngQIFvO+//z70Gf1mfaZRo0beiSee6D366KPuvaVLl3b7RfhvnTFjhpc3b16vbt26bvsYMGCAK79+k7bv9O5T2u6POuoo75RTTvGeeuopt+7uvPNO74wzzvDSorJ27do17rIJp+1C0y666CJv9OjR7jig5126dAm955133nHTlixZEpqmbUe/V5/zvfnmm+59/j6bnn1An6tVq5Z33HHHuX1bZQlfF9HOPPNM9/A9//zzod+h+WiZXXvttV6fPn1SXVba5/S5evXquWOi1sc999zjFSpUyKtZs6bbZn0zZ85066R58+beE0884T355JPuM5r2zTffuPf88MMP7nih79Tr/nFmx44d7n/tj61atQpN13FJ1q1b57aLSpUqeQ8++KDbLjt16hT6nujy1q5d2x2bVN5hw4a5Y7rvuuuuc9sogiNwyuG2b9/udpzoA096AiedKI8++mhv+fLlEe/TAUMnQP+ELOEHDtHJQicHnazDqUw6gKxYsSI0TQcRTdfJNa3ASdPmzJkTmrZhwwZ3kLnjjjtC03r37u0ChvAD6ubNm10wlVbgJDfffPMhJ460AqdevXqFpu3fv98d3FSGRx55JDR969atXuHChSOWsQ6KOrHMnTs3Yj46Aep7v/zyy8MOnDp27OiCtfCThk5GWmaxTopar7F+7+GsL81Dn9MJUSdGn4IAve+ll15Ktew6qZQpU8YtS9/atWvdstIJw1+e+q7HHnvMSy9/WS5btswFSCq3TqTalhSY6wSjee/Zsyfic5qnXr/mmmsOCZwUqG/ZsiU0/b333nPTP/jgg9A0ncQUjG3bti007ZNPPnHviw6cguxTOlnGCgDTsm/fPrd9hu830cvGt3jxYvdcJ9pwCtA0/fPPPw+tcz3XRYLoN2p9XXzxxW6Z+RSkaF88ePBguvcBPdd7f/rpp0C/Mzpw0vEwPPAOyg9EdDGakpISmv7GG2+46QrARL+pRo0aXvv27UO/z1+X1apVcxdlPm238Y5HOu6GHyd8CvK0/YRftEi3bt1cAO5vM355dZETvR35dJGh96xfvz7dyyO3oqkuh/OrZNXscrjU/q2mCVVnq5nIf7Rt29ZVWc+ZMyf0XjUl+LZu3Wrbt293n/3uu+8O+V59Prx5QFXGasr6/fff0yyTRj7pe31qFlPTRPhnVXWv/ikNGzYMTStZsmSo+SkzqIOtT319VP2v4/y1114bmq6mlOiyahnXqlXLdUwOX8Z+k1F4s5Cq9/WdQYZXb9682WbMmGGXXXZZaJr6Naj6XgMFYrnxxhtjTj+c9fXZZ5+5pi4186pPha9nz57us2n1rbv00kttw4YNrsnBp2YqNRHrNX+bU58NvUfb3OHQ+tA2pOYSdZhVU5HKpmYNrUe/j4zmu2XLFtdkpXUba7tWubSv+Pzt1F9O6qS/ePFi199MTTi+c845x23X0YLsU9qmRE0u0c3nqdFv0bYUXt7UBkv4TXHh7rjjDve/vy61HLUd+8cFNU1pGapJSs1zv/32m5s+d+5c17ToN4GnZx8QNXvFWl5BaHmtWbMmZhNqEFdeeWXEMVV95NQ87C8jrV/9zssvv9ztg/5vUdNbmzZt3LJJz3oKp/X19ttvu0E++jt8WbVv395tH9Hbpba18O0onL/u9XkEQ+fwHE4nJzmSURM6AKivkA6IsejEFt7RVP2IdOAI75cQKx+MRvTF2omDnPyCfHbVqlUxO/bqpJhZosulE6P6sPgdj8On64Aavox/+eWXQMs4PaZMmeJGTTVq1MgNAvA1a9bM9Q9RX6Nw+fPnd/2Egvy2IOtL68APTMIpEFG/NP/1ePz+IfodOuH4v0nBcM2aNd1z9e9QfzudwNXf47TTTnN94HRyUx+UIHQi0r5SoEAB9/uj+/uon4n6palvmZanT4FWWsvJPzH5y8n/zTVq1Djks1pO0Se9IPuUgrUXXnjBBe733HOPW1Zdu3Z1J/TwgDWeIKMHVW59V/T+o2WsQCR8XSqw84MIBUgKMvXQhYueaz398MMPLrA43H0g1rIP6u6773ZBvfpI6ve0a9fOlUXpWYKIXndaF/oev0+dHxwqYIlHAU6QgDWaOvKrf6D60elxpMvKX/c5JWdXViBwyuF0MlBnXL8T7eHQlZGuhtVJMxb/BKYDojpJnnHGGa4zsK7AdCJSZ+xYnS7jjb4KchA/ks9mpljlClJWLWOli9Bw+FjUSfZw+KkH4p0QVAuiAManICTeiTYRy1zl6dKli+s4rW1KNRaqwdAw7XCq0dIVuDo6q4ZNnfKVbkOjSBU0pkXbbHRwGz4iUZ1yVQ7VmqhDrZaFvl8d6TNzOQXdp1SboFoM1cqo5ke1rQowVVujYfjxyqRARifM9NTUBTnBqiZp3LhxbvvSb1Agpc9pup7rmKRtPrzWOL37QLwalCBUs7Vs2TIXlGpZKXDW8tUggHgpSNLDr0167LHHImq8w6kD/5F8twahxAvMVBscdFn56z7e9o9DETjlArr61pXJ119/fVhDq3X1rVF5aqpJjQ4+ql3RiUsnPJ8O8omg9AvhtSy+WNNiycorMC1jXYGrpiCj5qsRYcoRo9FHataIPvgq55JOvpmZj8rP56STVHiApuY7lS+tbcqvTVGNz8yZM12NhAIQv5kuehmq1kkPXfHrhKVaIgU+R0JNgyq70hOErxuN/jqSZeLXSoTTcjrcfUoBr7YfPRR8KLgcMGCAC6biLWfVMGq5aV0EKbe2G5VbgYdPwaxqQMJzd/kBkUb6qTlMtWCiAFCj6BQ4aTSaRghm5j6QGs1f25Ee2h5VQ6f8Xf37908z3Uj0utM2qeOKH7D4NZa6cE1rG0/tt8Z6TTVyaiZUN4kg+09atO4VNMWr6cOh6OOUC6imSAcJVePrIBdNV81KgBePhrAr6NLBO5oOmOrvIbqq1Y6uHdqnquvMTOCWGrX3q9xq4gjv0xE0AaSfvyitYfMZQctYw4t1lR5N6QPUNyK96Qj836n1ryab8Ifmp2AqM5Nhig7sapbTMPTwGhelxlBTRYcOHQJ9h2pGVIOih5pXwpsetByUmyacTlw6uUQPYz8cfm1NePk1zFzb1uFQrZGCOgWDWgY+BRk///zzIfMOsk9pu47m13SktQx0MbVw4cI0y60UFTJy5MiI6X4NUfi61PrR0Pcnn3zSNW36NZ4KqHS8UTCqJlUFboezDxyp8GZy0Taq/lJax+FNsfEo9Ul49wf9HvVdO++889xzBYTaBpVKQhed0cJvc5LacUavRU/XNqF+igqqY7UkpPcWKosWLcrxucoyGjVOuYB2YNUs6MpKV4rq+6G8MbrKUo2EOmWmdm86NU+8//77ruZK79NBQQexJUuWuAOGDuS6YtGBUwdR9UtRfwG1sysXktr+1UcqqylgUG2DmhmVR0YHIfUDUR8UnWjSuqr1r4b79OnjgjAdsDLrlhSq/VFnbSVfVA2BTjQ6WSpA0nQFreojIqNGjXLNCXpfah3EFRTp5BmvmU9NQFou6lOj5JiZQVexuoJXebVdaJ6qVVGziPIbqbkhLWqaUm2ActFou9PJKJxyZ6mWQidenfx0MlbTni4SMmJ9abtXbdOFF17otnFdoY8dO9bNK9ZJMQg18+m71HSlXDzaHv28QuHfGXSfevDBB11Tnd6vmh+9T8tY/bU0j9Qo35Wypms5+s3usTRo0MA1Dan2WidzBd4LFixwAaCaMVu3bh3xfgVJWmdqfvP78mg7036oeYX3b0rvPnCk1KdJfbM0D/W3Uk2m9istvyADaRTIa7kqd5i2MwWTWica9ODX/ulYo0BK61TvUyCpwFC/TTVRH3zwQcRxRrWD2l61vavZ2a+RU18sbQOqpVNAqv6JjzzyiPse/a15alvUNqR9We+PFUjHou1E21F0X0ekIdHD+pB1lE6gZ8+eXtWqVd0Q8aJFi7ph6hpOvnv37rjpCOSff/7x+vfv73K+6LPK+6HcOcqNFJ6f5sUXX3TDcDWcWzmTNDw9Vj4YPddw/2jR846XjkA5ktIacixKRaA8KCqPUgMoh8nTTz/tvlO5UFKjYehKaaBcMRqyHf4b4qUjiB4Ort+iIcWxyho9HFrLUbl/NF3lLVGihNekSROXp0ZpJdKTjmDRokXuPQMHDoz7nj/++MO9RzmLUivrka4vP/2AtgflPtKQdOW00pD+oD799FP3vVoPq1evjnhNQ7JVNn2/yq/h2M2aNXNDxNMSb72F03ByDdnWb9V6UZ4m5VDS7w5PHeCnI4iVFiF6e5G3337b5SLSdyrPjvIfRX9n0H1KOYM0xL5ChQpu/9T/SuUQnUIkFqVa0P6stCOxlk10+gJtjxpSr3WpPEI6LoQfP3zKraTPa12HUz4vTVeZowXdB+Jtj/FEHxuUckI5rpQ6ws9d1q9fv4h5xOIP7580aZL73UqVodQiOh6tWrXqkPfr+KMcWf58tG4vueSSQ367lr1SHCjFQvj+8+uvv7pyah6aHr6vKX2AloHWgdZFuXLlvDZt2rh0I9HlVc6sWJT/SXmzwlMrIG159E9awRWQk6gjsTJP68o+O94eBMhoygauflPqu8M+kXto4IRqrdWkiuDo44QcTX0jovs2qFlC1eycIID/5/bbb3cXEmpaQ+6g0YQKlNWUjvShxgk5mvr46IpKfbvUF0Gdkv/++283QksjfAAASA86hyNH00ggdWBXh1Z1BlfnVAVPBE0AgMNBjRMAAEBA9HECACAOpXlQegClA1Ctday8dKp/UNZx5ehSlm7lHouV4DQ6JYVScij9gbLRK6VDdAJU5bxSGgyl9VAKA6XciJWLD1mLwAkAgDiUO0w5rJQ/K57hw4e7JK/K76XkqMrBpNxv0YlZw82ePdvlT5o/f75LfqrEm8ov5Sf61P96rmBNtw7SrYaUe09B3OHeIBgZI8c31WkDU2dgRfXcxBAAcLh0w2klllVSVJ9Oobo5s25tpGS5oozwuhGwkpAqU38QuiOAkhXr5shKzKkBLPqsbp7s36xd36sEp0rwGp1w1KcknkqIqVHDSnysrOi6rdLFF1/skhm/9957rgZL99FTcmD/fnV6TQGaAjbVrunWRUES1OYUWo/KBq/fntaNsXN84LRmzZrDvkEqAADIPVavXu0y7ufqUXV++nwtDD9qBwAgI2qc1DSnJjX1T9JtXHy6PY1aOSZMmBCoZUS3W1GNkn9PUNVAKUFl9+7dXf8p1XE88MADboSwbn0V7/6iqnHSrWqUp0n0tyoP1MSnxL+iflK6vY5uz6J+Vpp3qVKlUm2OzOlSUlLccgpyy50cHzj5zXMKmgicAABHokiRIhHnEv8mvTrhhk/XPed0/gly3rnxxhvdPfnmzZsXer/+131E9Zr6Tqn56LLLLnMpVQoVKhT3e9VEV79+/YjXFRTpc/40PzhQs5ym6Z6VunGw7j+qIFAd1Vu0aGG5UZ4AXXroHA4AwGHya5miR7vpeXgNVDzqGzVt2jR3097oJiIFMRpZp5vxqgZKdz3QjYJPOOGEVL9TQVt0MBA+zQ8O/E7muhmx+lIpg7z6BOum2XfeeWeaZc+tCJwAADhM1apVcwGSOnOHN/uoCa958+ZxP6emNwVN6uitTtn6nnhKly5txx57rHufgqhOnTpl+O9Qh3E1L7766qs2cuRI1ySIXNpUBwDA4dI9/FasWBF6vnLlSlu8eLGVLFnSKleu7GpvdOPwhx56yI2kUwA0cOBANzpLTV4+1eIoJ5OCJVEqAo160yg3NZ2tW7cu1I9KuaBEN17W7aIU1Hz99dd26623ulohjeLLSOpD1aRJE6tTp47t2bPH1YBpvoiNwAkAgDgWLlwYMfS/b9++7n/Vzvgdv++66y7XX6hXr162bds2dxNxdc5WXySfmtzU3OYbM2aM+1/30gynYEmdv0UdznUT3i1btljVqlVtwIABLnDKaEpZoPn88ccfLmhr1aoVN3zOzekIVGWqCF6jFegcDgAAjiRWoI8TAABAQAROAAAAARE4AQAABETncABAUlh3QatEFwFJrNwHcy0ZUOMEAACQHQKnOXPmuPvnKN+FcmG8++67Ea9rwJ/yS5QvX94NkWzbtq399ttvCSsvAADI3RIaOCnvRYMGDeLeWHD48OH29NNPu/v0KAur7gnUvn172717d5aXFQAAIKF9nHR/HD1iUW2T0r7fd9991rlzZzdt4sSJVrZsWVczpbs5AwAAZKWk7eOktPZKQa/mOZ+SUzVr1sylno9H6eKVyCr8AQAAkKMDJ/++PaphCqfn/muxDBs2zAVY/qNSpUqZXlYAAJA7JG3gdLh0vx2lTPcfq1evTnSRAABADpG0gVO5cuXc/+vXr4+Yruf+a7EULFjQ3Wcm/AEAAJCjA6dq1aq5AGnmzJmhaeqvpNF1zZs3T2jZAABA7pTQUXU7duywFStWRHQIX7x4sZUsWdIqV65st912mz300ENWo0YNF0gNHDjQ5Xzq0qVLIosNAAByqYQGTgsXLrTWrVuHnvft29f936NHD5swYYLdddddLtdTr169bNu2bdayZUubPn26FSpUKIGlBgAAuVUeTwmTcjA172l0nTqK098JAJIX96pDou5Vl55YIWn7OAEAACQbAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAnBA4HThwwAYOHGjVqlWzwoULW/Xq1W3IkCHmeV6iiwYAAHKh/JbEHn30URszZoy9/PLLVqdOHVu4cKFdffXVVrx4cevTp0+iiwcAAHKZpA6cvvrqK+vcubN16NDBPa9atapNmjTJFixYkOiiAQCAXCipm+patGhhM2fOtOXLl7vnP/zwg82bN8/OO++8uJ/Zs2ePpaSkRDwAAAByfI3TPffc4wKfk08+2fLly+f6PD388MPWvXv3uJ8ZNmyYDR48OEvLCQAAcoekrnF644037LXXXrPXX3/dvvvuO9fX6fHHH3f/x9O/f3/bvn176LF69eosLTMAAMi5krrGqV+/fq7WqVu3bu55vXr1bNWqVa5WqUePHjE/U7BgQfcAAADIVTVOu3btsrx5I4uoJruDBw8mrEwAACD3SuoapwsuuMD1aapcubJLR/D999/biBEj7Jprrkl00QAAQC6U1IHTM8884xJg3nTTTbZhwwarUKGCXX/99Xb//fcnumgAACAXyuPl8DTcGpWnhJnqKF6sWLFEFwcAEMe6C1olughIYuU+mJsUsUJS93ECAABIJgROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAAeVPz5sPHjxos2fPtrlz59qqVats165ddtxxx1mjRo2sbdu2VqlSpcwrKQAAQHaocfr333/toYcecoHR+eefbx9//LFt27bN8uXLZytWrLBBgwZZtWrV3Gvz58/P/FIDAAAka41TzZo1rXnz5jZu3Dg755xzrECBAoe8RzVQr7/+unXr1s0GDBhgPXv2zIzyAgAAJEwez/O8tN70yy+/WK1atQJ94b59++zPP/+06tWrWzJISUmx4sWL2/bt261YsWKJLg4AII51F7RKdBGQxMp9MDcpYoVATXVBgyZRbVSyBE0AAAAJHVU3ffp0mzdvXuj56NGjrWHDhnb55Zfb1q1bM7RwAAAA2Tpw6tevn6vSkiVLltgdd9zhOoWvXLnS+vbtmxllBAAAyH7pCEQBUu3atd3fb7/9tnXs2NGGDh1q3333nQugAAAAcqp01zgdddRRLn+TfPbZZ9auXTv3d8mSJUM1UQAAADlRumucWrZs6ZrkTj/9dFuwYIFNmTLFTV++fLlVrFgxM8oIAACQPWucRo0aZfnz57e33nrLxowZY8cff7ybrqSY5557bmaUEQAAIHvWOFWuXNmmTZt2yPQnn3wyo8oEAACQMwIn34YNG9xD968LV79+/YwoFwAAQPYPnBYtWmQ9evRw2cT9pON58uRxf+v/AwcOZEY5AQAAsl/gdM0117h717344otWtmxZFywBAADkBukOnH7//XeXv+nEE0/MnBIBAADklFF1bdq0sR9++MGyyl9//WVXXHGFlSpVygoXLmz16tWzhQsXZtn8AQAADrvG6YUXXnB9nJYuXWp169Z1N/UN16lTJ8souved8kW1bt3apTs47rjj7LfffrMSJUpk2DwAAAAyLXD6+uuv7csvv3SBTLSM7hz+6KOPWqVKlWz8+PGhadWqVcuw7wcAAMjUprrevXu7prO1a9e6VAThj4weUff+++/bKaecYhdffLGVKVPGGjVqZOPGjcvQeQAAAGRa4LR582a7/fbb3Yi6zKaO6MpOXqNGDZsxY4bdeOON1qdPH3v55ZfjfmbPnj3unnnhDwAAgIQETl27drVZs2ZZVlAtVuPGjW3o0KGutqlXr17Ws2dPGzt2bNzPDBs2zIoXLx56qKkPAAAgIX2clMOpf//+Nm/ePDfCLbpzuGqEMkr58uWtdu3aEdNq1arl0iHEo7LpJsQ+1TgRPAEAgISNqjvmmGNs9uzZ7hHdOTwjAyeNqFu2bFnEtOXLl1uVKlXifqZgwYLuAQAAkPDAaeXKlZZV1JeqRYsWrqnukksusQULFtjzzz/vHgAAAEnfxykrNW3a1KZOnWqTJk1yOaOGDBliI0eOtO7duye6aAAAIBcKFDg98sgj9u+//wb6wm+++cY+/PBDyygdO3a0JUuW2O7du92NhdU5HAAAIGkDp59//tkqV65sN910k0t8uXHjxtBr+/fvtx9//NGeffZZ16x26aWXWtGiRTOzzAAAAMnbx2nixInu/nSjRo2yyy+/3I1Uy5cvn+uEvWvXLvcepQu47rrr7KqrrrJChQpldrkBAACyXB7P87z05lZSDdOqVatc813p0qWtYcOG7v9kpCBP+Zy2b99uxYoVS3RxAABxrLugVaKLgCRW7oO5SRErpHtUXd68eV2gpAcAAEBuktSj6gAAAJIJgRMAAEBABE4AAAABETgBAABkduC0YsUKmzFjRigxZjoH5wEAAOT8wGnz5s3Wtm1bq1mzpp1//vm2du1aN/3aa6+1O+64IzPKCAAAkD0DJ914N3/+/Pbnn39akSJFQtOVMXz69OkZXT4AAICkke48Tp988olroqtYsWLE9Bo1arikmAAAADlVumucdu7cGVHT5NuyZYu7BQsAAEBOle7AqVWrVu7edb48efK427AMHz7cWrdundHlAwAAyL5NdQqQ2rRpYwsXLrS9e/faXXfdZT/99JOrcfryyy8zp5QAAADZscapbt26tnz5cmvZsqV17tzZNd117drVvv/+e6tevXrmlBIAACA71jiJ7iA8YMCAjC8NAABATgucdu/ebT/++KNt2LDB9W8K16lTp4wqGwAAQPYOnJSr6corr7RNmzYd8po6ih84cCCjygYAAJC9+zj17t3bLr74YpcxXLVN4Q+CJgAAkJOlO3Bav3699e3b18qWLZs5JQIAAMgpgdNFF11kX3zxReaUBgAAICf1cRo1apRrqps7d67Vq1fPChQoEPF6nz59MrJ8AAAA2TdwmjRpkrtfXaFChVzNkzqE+/Q3gRMAAMip0h04KX/T4MGD7Z577rG8edPd0gcAAJBtpTvy0W1WLr30UoImAACQ66Q7+unRo4dNmTIlc0oDAACQk5rqlKtJN/qdMWOG1a9f/5DO4SNGjMjI8gEAAGTfwGnJkiXWqFEj9/fSpUsjXgvvKA4AAGC5PXCaNWtW5pQEAAAgydHDGwAAICNrnLp27WoTJkywYsWKub9T884771hmeeSRR6x///5266232siRIzNtPgAAAIcdOBUvXjzUf0l/J8K3335rzz33nOuQDgAAkLSB0/jx4+3BBx+0O++80/2d1Xbs2GHdu3e3cePG2UMPPZTl8wcAAEhXHydlC1cAkwg333yzdejQwdq2bZvme/fs2WMpKSkRDwAAgCwdVed5niXC5MmT7bvvvnNNdUEMGzbMBXkAAAAJHVWX1XmaVq9e7TqCv/baa+6mwkGo8/j27dtDD30HAABAludxqlmzZprB05YtWyyjLFq0yDZs2GCNGzeOyFw+Z84cGzVqlGuWy5cvX8RnChYs6B4AAAAJDZzUBJaVo+ratGnjMpWHu/rqq+3kk0+2u++++5CgCQAAIGkCp27dulmZMmUsqxQtWtTq1q0bMe3oo4+2UqVKHTIdAAAgafo4cR86AACQ2yX9qLpoX3zxRaKLAAAAcqnAgdPBgwcztyQAAABJjpv8AgAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAOSEwGnYsGHWtGlTK1q0qJUpU8a6dOliy5YtS3SxAABALpXUgdPs2bPt5ptvtvnz59unn35q+/bts3bt2tnOnTsTXTQAAJAL5bckNn369IjnEyZMcDVPixYtsjPOOCNh5QIAALlTUtc4Rdu+fbv7v2TJkokuCgAAyIWSusYp3MGDB+22226z008/3erWrRv3fXv27HEPX0pKShaVEAAA5HTZpsZJfZ2WLl1qkydPTrNDefHixUOPSpUqZVkZAQBAzpYtAqdbbrnFpk2bZrNmzbKKFSum+t7+/fu7Jj3/sXr16iwrJwAAyNmSuqnO8zzr3bu3TZ061b744gurVq1amp8pWLCgewAAAOSqwEnNc6+//rq99957LpfTunXr3HQ1wRUuXDjRxQMAALlMUjfVjRkzxjW3nXXWWVa+fPnQY8qUKYkuGgAAyIWSvqkOAAAgWSR1jRMAAEAyIXACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicMpFRo8ebVWrVrVChQpZs2bNbMGCBam+f8KECZYnT56Ihz4bbseOHXbLLbdYxYoV3f0Da9eubWPHjs3kXwIAQGIk9S1XkHF0f7++ffu6oEZB08iRI619+/a2bNkyK1OmTNzPFStWzL3Hp+ApnL7z888/t1dffdUFZZ988onddNNNVqFCBevUqVOm/iYAALIaNU65xIgRI6xnz5529dVXh2qFihQpYi+99FKqn1OgVK5cudCjbNmyEa9/9dVX1qNHD3cjZgVOvXr1sgYNGqRam3XVVVdZly5dbOjQoe77jj32WHvwwQdt//791q9fPytZsqSrwRo/fnzoM3v37nU1W7rJs2q9qlSpYsOGDcuAJQMAQHAETrmAgo5FixZZ27ZtQ9Py5s3rnn/99depflZNcQpSKlWqZJ07d7affvop4vUWLVrY+++/b3/99Ze7KfOsWbNs+fLl1q5du1S/V7VUf//9t82ZM8cFdYMGDbKOHTtaiRIl7JtvvrEbbrjBrr/+eluzZo17/9NPP+3m88Ybb7gasNdee80FagAAZCUCp1xg06ZNduDAgUNqi/R83bp1cT930kknuRqp9957zzXFHTx40AVKfjAjzzzzjKvBUg3RUUcdZeeee67rS3XGGWekWibVKikY0jyuueYa9/+uXbvs3nvvtRo1alj//v3d982bN8+9/88//3TTW7Zs6QI5/X/ZZZcd8bIBACA96OOEuJo3b+4ePgVNtWrVsueee86GDBkSCpzmz5/vaoMU0KgG6eabb3Z9nMJruKLVqVPH1XqFB3F169YNPc+XL5+VKlXKNmzYEGreO+ecc1yApeBMtVNp1WoBAJDRCJxygdKlS7tAZP369RHT9Vz9loIqUKCANWrUyFasWOGe//vvv66GaOrUqdahQwc3rX79+rZ48WJ7/PHHUw2c9F3RfaliTVMtlzRu3NhWrlxpH3/8sX322Wd2ySWXuO9/6623ApcfAIAjRVNdLqAmryZNmtjMmTND0xSQ6Hl4jVJa1Ny3ZMkS10Fb9u3b5x7hNUeiIM0PeDKSRvhdeumlNm7cODdK8O2337YtW7Zk+HwAAIiHGqdcQmkDNPrtlFNOsVNPPdWlI9i5c6cbZee78sor7fjjjw+NVtNIt9NOO81OPPFE27Ztmz322GO2atUqu+6660KBzJlnnulGwimHk5rqZs+ebRMnTnQdvjOSvk8Bm2q8FKi9+eabrrZMI/IAAMgqBE65hGpqNm7caPfff7/rEN6wYUObPn16RIdxdcAOrz3aunWrS2Gg92u0m2qtlH5AncF9kydPdh25u3fv7mp/FDw9/PDDblRcRipatKgNHz7cfvvtN1ej1bRpU/voo48Oqe0CACAz5fE0hjwHS0lJseLFi9v27dtdDQkAIDmtu6BVoouAJFbug7lJEStwuQ4AABAQgRMAAEBABE4AAAAB0Tk8AzRY1DfRRUAS+6FJxo4wBAAkDjVOAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAAJCTAqfRo0db1apVrVChQtasWTNbsGBBoosEAAByoaQPnKZMmWJ9+/a1QYMG2XfffWcNGjSw9u3b24YNGxJdNAAAkMskfeA0YsQI69mzp1199dVWu3ZtGzt2rBUpUsReeumlRBcNAADkMkl9y5W9e/faokWLrH///qFpefPmtbZt29rXX38d8zN79uxxD9/27dvd/ykpKZlWzgM7/v/8gGiZue0BOck/+/YnughIYkUy8VjqH6c9z8vegdOmTZvswIEDVrZs2Yjpev7rr7/G/MywYcNs8ODBh0yvVKlSppUTSE1xezbRRQCA7K948UyfxT///GPF05hPUgdOh0O1U+oT5Tt48KBt2bLFSpUqZXny5Elo2XIDRe0KUlevXm3FihVLdHEAIFviWJq1VNOkoKlChQppvjepA6fSpUtbvnz5bP369RHT9bxcuXIxP1OwYEH3CHfsscdmajlxKO3o7OwAcGQ4lmadtGqaskXn8KOOOsqaNGliM2fOjKhB0vPmzZsntGwAACD3SeoaJ1GzW48ePeyUU06xU0891UaOHGk7d+50o+wAAACyUtIHTpdeeqlt3LjR7r//flu3bp01bNjQpk+ffkiHcSQHNZMq51Z0cykAIDiOpckrjxdk7B0AAACSu48TAABAMiFwAgAACIjACQAAICACp1xKyUDffffdTJ3HhAkTMjyH1h9//OHKvnjxYvf8iy++cM+3bduWofMBgKCuuuoq69KlS6KLkbQmZMK5IJEInJKc7smnJKAdOnTI0O9du3atnXfeeZbZIyKXL1+eqfNo0aKF+y1BE5cByNkBjC6k9FAewBNPPNEefPBB27+fe+Ah4xA4JbkXX3zRevfubXPmzLG///471fdqgGTQA4Qyr2f2MNfChQtbmTJlMnUeOjjqt3A7HQBy7rnnuoup3377ze644w574IEH7LHHHkt0sZCDEDglsR07dtiUKVPsxhtvdDVOqu4M5zdTffzxxy7DugKhefPm2VlnnWV9+vSxu+66y0qWLOkCCx08UmuqW7JkiZ199tku2NF9/Xr16uXmH48/7w8//NDq169vhQoVstNOO82WLl0at3pWZVAerueee87dg6lIkSJ2ySWX2Pbt2yO++4UXXrBatWq57zz55JPt2Wfj3yQ3uqnOn+eMGTPcdxxzzDGhA+nhzgNA9qHjoI55VapUccfOtm3b2vvvv+9eGzFihNWrV8+OPvpodwy66aabIo5zQY4fuvG8EjPrfTpW6jgbndVHuQZbtmwZek/Hjh3tf//7X+j1vXv32i233GLly5d3xyCVVTeoT6spcOjQoS6Hob7Xr0nr16+fO85XrFjRxo8fH/G5u+++22rWrOmOtSeccIINHDjQ9u3bd8gx+ZVXXrGqVau6mvtu3bq5e7b5NF2Jp8M1bNgw4pyS1nLNaQicktgbb7zhTuonnXSSXXHFFfbSSy8dsoPKPffcY4888oj98ssvLoiRl19+2W3E33zzjQ0fPtztZJ9++mnM+SgTe/v27a1EiRL27bff2ptvvmmfffaZ27HTop32iSeecJ877rjj7IILLojYMaOtWLHC/a4PPvjAHVy+//57t5P5XnvtNZfs9OGHH3a/RwcK7ez6PUHt2rXLHn/8cXcwUE3dn3/+aXfeeWeGzgNA9qCLQQUqkjdvXnv66aftp59+cvv7559/7gKf9Bw/dLxTgKXjsS5UdRP5qVOnHnJMVXC1cOFCd4swzffCCy90twwTlUHBnI6Fy5Ytc8ckBSipUVnV6qAyKVBRckwFZDpu6zh/ww032PXXX29r1qwJfaZo0aKurD///LM99dRTNm7cOHvyyScjvlcBnS6ip02b5h6zZ89255P0yBtgueYoSoCJ5NSiRQtv5MiR7u99+/Z5pUuX9mbNmhV6XX9rFb777rsRnzvzzDO9li1bRkxr2rSpd/fdd4ee63NTp051fz///PNeiRIlvB07doRe//DDD728efN669ati1k2f96TJ08OTdu8ebNXuHBhb8qUKe75+PHjveLFi4deHzRokJcvXz5vzZo1oWkff/yxm8/atWvd8+rVq3uvv/56xLyGDBniNW/e3P29cuVKN9/vv/8+ohxbt24NzVPPV6xYEfr86NGjvbJly4aepzUPANlTjx49vM6dO7u/Dx486H366adewYIFvTvvvDPm+998802vVKlSoedBjh/ly5f3hg8fHnquY3PFihVD841l48aN7nuXLFninvfu3ds7++yzXRmD/q4qVap4Bw4cCE076aSTvFatWoWe79+/3zv66KO9SZMmxf2exx57zGvSpEnEMblIkSJeSkpKaFq/fv28Zs2ahZ5rvk8++WTE9zRo0MB9Np5YyzX8XJDdJf0tV3IrXYUsWLAgdCWTP39+19lafZ7UFBdO9/GL5tc8+VQlvGHDhpjzUq1LgwYNXA2V7/TTT3dXRypHare3Cb/ZsqqLVTum74uncuXKdvzxx0d83p+Pro509XPttddaz549Q+9RdXR6On+rWrp69eoxf7uuBDNiHgCSk2pN1MSmmm8dWy6//PJQs5Jq0tUk9uuvv1pKSorb73fv3u1qmXTcSOv4oW4FarZr1qxZ6HUdm3UMDm8NUP8q1WqrJmjTpk2hmibVXtWtW9c1vZ1zzjnueKmmQNUctWvXLtXfVadOHVez49NxWd/l0yAiNQuGH+fV1UM1QTrmqelMv7dYsWIR36uaLh17Y/3eoD4LsFxzEgKnJKUASRtfhQoVQtO0Y6r9ftSoUREn+fCAx1egQIGI5+oH5O+8ycpvE1d1cviByT8oBBXrt/sHtYyaB4Dk1Lp1axszZowbOKLjpwIbP5WJAhT1e1IzvS701NSmiyg15fkn+NSOH0Gpy4L6Lek4ozLo2Ksgx28ybNy4sa1cudL1T1XQob6e6ov11ltvxf3OWOVK7TivEdndu3e3wYMHu64YOmdMnjzZNTWm51yhYC369+8L644RdLnmJAROSUgB08SJE90GHn0Vog6CkyZNcu3ZGUWdINUOrtoYPwj78ssv3Q6jK6LUzJ8/39UiydatW136AX1fPLriUju9HxDq8/58dAWl6b///rvb4TNDVswDQOLoGKY0BNEWLVrkAgIdV/2aG/UxSg8FH6qRUU3SGWecETpe67sVDMnmzZtdDbqCplatWrlpCiSiqeZHrQh6XHTRRa7mSf2lFHhkhK+++soFbwMGDAhNW7VqVbq/R31XwzvHp6SkuKAvI5drdkPglKRVzQpCFLFHNx/95z//cbVRGRk4KYBQR8MePXq4Ku2NGze6FAj//e9/U22mE3U6V/Ww3qcdtHTp0qkmgtMIEs1HnS+1A2r0n662NApGdHWkafrdOpDs2bPHdbDU8lBny4yQFfMAkFwUTKmm5JlnnnE1Qro4HDt2bLq/59Zbb3Wdp2vUqOEG76ijdngCXnXW1jHx+eefd0GWLhY1gCecPqPXGjVq5IINDcjRMTAjk0SqfJq3apmaNm3qRkBHd2IPQqOtdWGtZaby3X///RG18xm1XLMTRtUlIQVGqraN1edGgZNO8j/++GOGzU9VqRp+q6sd7WC6+mnTpo1rEkyLDiA6kCgdwrp169xoOVWRx6OdrGvXrnb++ee72jT1xQpPBXDddde5VAEaVqvhrWeeeabbaatVq5Zhvzcr5gEguagfpwKWRx991DWbaSRbaikA4lFuKF1U6gJQfTTVP0gj5nwKhBSsqCZG87n99tsPySOlz2i0s/pG6Zir5q6PPvooog/TkerUqZObt0ZHK32AaqA0eji9+vfv746Rao5TWpwuXbpE9AHLqOWaneRRD/FEFwLZj/InqS+BammCXiWpNkvDXv3bpQAAkN1Q4wQAABAQgRMAAEBANNUBAAAERI0TAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAIAF83+jbmaAovgxtQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 600x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6, 3))\n",
+    "bars = ax.bar(\n",
+    "    [\"Arnio pipeline\", \"Pandas manual\"],\n",
+    "    [arnio_time * 1000, pandas_time * 1000],\n",
+    "    color=[\"#2ecc71\", \"#e74c3c\"],\n",
+    "    width=0.4\n",
+    ")\n",
+    "ax.set_ylabel(\"Time (ms)\")\n",
+    "ax.set_title(\"Cleaning time: Arnio vs Pandas (lower is better)\")\n",
+    "for bar in bars:\n",
+    "    ax.text(bar.get_x() + bar.get_width()/2,\n",
+    "            bar.get_height() + 0.2,\n",
+    "            f\"{bar.get_height():.2f} ms\",\n",
+    "            ha=\"center\", fontsize=10)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
    ]
   }
  ],

--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -173,24 +173,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== ARNIO CLEANED ===\n",
-      "  transaction_id  amount      type sender_name receiver  isfraud\n",
-      "0           t001  500.00   payment       alice      bob      0.0\n",
-      "1           t002          transfer       alice  charlie      0.0\n",
-      "2           t003  200.00   payment       alice     dave      1.0\n",
-      "3           t004  750.00  cash_out         eve    frank      0.0\n",
-      "4           t005   90.00   payment       alice    grace      0.0\n",
+      "=== ARNIO CLEANED (values only — headers still dirty) ===\n",
+      "NOTE: Arnio cleans column VALUES but not column NAMES.\n",
+      "Dirty headers below are intentional — normalized in comparison step.\n",
+      "\n",
+      "  transaction_id    amount    type     sender_name  receiver  isFraud\n",
+      "0            t001   500.00   payment          alice      bob      0.0\n",
+      "1            t002           transfer          alice  charlie      0.0\n",
+      "2            t003   200.00   payment          alice     dave      1.0\n",
+      "3            t004   750.00  cash_out            eve    frank      0.0\n",
+      "4            t005    90.00   payment          alice    grace      0.0\n",
       "\n",
       "Shape: (5, 6)\n",
       "\n",
       "Nulls:\n",
-      "transaction_id    0\n",
-      "amount            0\n",
-      "type              0\n",
-      "sender_name       0\n",
-      "receiver          0\n",
-      "isfraud           0\n",
-      "dtype: int64\n"
+      "transaction_id     0\n",
+      "  amount           0\n",
+      "  type             0\n",
+      "  sender_name      0\n",
+      "receiver           0\n",
+      "isFraud            0\n",
+      "dtype: int64\n",
+      "\n",
+      "Actual column names (showing whitespace): ['transaction_id ', '  amount', '  type  ', '  sender_name ', 'receiver', 'isFraud']\n"
      ]
     }
    ],
@@ -205,13 +210,16 @@
     "])\n",
     "\n",
     "cleaned_df = ar.to_pandas(cleaned_frame)\n",
-    "# Arnio strip_whitespace cleans values but not column headers — normalize explicitly\n",
-    "cleaned_df.columns = cleaned_df.columns.str.strip().str.lower()\n",
+    "# Note: Arnio's strip_whitespace cleans values but NOT column headers.\n",
+    "# For fair comparison, we manually normalize headers on BOTH dataframes below.\n",
     "\n",
-    "print(\"=== ARNIO CLEANED ===\")\n",
+    "print(\"=== ARNIO CLEANED (values only — headers still dirty) ===\")\n",
+    "print(\"NOTE: Arnio cleans column VALUES but not column NAMES.\")\n",
+    "print(\"Dirty headers below are intentional — normalized in comparison step.\\n\")\n",
     "print(cleaned_df)\n",
     "print(f\"\\nShape: {cleaned_df.shape}\")\n",
-    "print(f\"\\nNulls:\\n{cleaned_df.isnull().sum()}\")"
+    "print(f\"\\nNulls:\\n{cleaned_df.isnull().sum()}\")\n",
+    "print(f\"\\nActual column names (showing whitespace): {cleaned_df.columns.tolist()}\")"
    ]
   },
   {
@@ -246,8 +254,6 @@
     }
    ],
    "source": [
-    "\n",
-    "\n",
     "pandas_df = raw_df.copy()\n",
     "\n",
     "# 1. Strip whitespace from column names\n",
@@ -291,11 +297,20 @@
       "Deduplication             drop_duplicates   drop_dupl..\n",
       "Steps chained             1 pipeline    4 separate\n",
       "==================================================\n",
-      "Results verified: same shape, same null counts, same values ✓\n"
+      "Results verified after normalizing headers on both DataFrames.\n",
+      "Arnio cleaned values: ✓  |  Header normalization applied equally: ✓\n"
      ]
     }
    ],
    "source": [
+    "# Normalize column headers for fair comparison (Arnio doesn't clean headers yet)\n",
+    "cleaned_df_clean_headers = cleaned_df.copy()\n",
+    "cleaned_df_clean_headers.columns = cleaned_df_clean_headers.columns.str.strip().str.lower()\n",
+    "\n",
+    "pandas_df_clean_headers = pandas_df.copy()\n",
+    "# pandas_df already has clean headers from cell above, but explicit for clarity\n",
+    "pandas_df_clean_headers.columns = pandas_df_clean_headers.columns.str.strip().str.lower()\n",
+    "\n",
     "# API Design Comparison\n",
     "print(\"=== API DESIGN COMPARISON ===\")\n",
     "print(\"=\" * 50)\n",
@@ -309,15 +324,16 @@
     "print(\"=\" * 50)\n",
     "\n",
     "# Verify outputs match\n",
-    "assert cleaned_df.shape == pandas_df.shape, \"Shape mismatch!\"\n",
-    "assert cleaned_df.isnull().sum().sum() == pandas_df.isnull().sum().sum(), \"Null mismatch!\"\n",
+    "assert cleaned_df_clean_headers.shape == pandas_df_clean_headers.shape, \"Shape mismatch!\"\n",
+    "assert cleaned_df_clean_headers.isnull().sum().sum() == pandas_df_clean_headers.isnull().sum().sum(), \"Null mismatch!\"\n",
     "pd.testing.assert_frame_equal(\n",
-    "    cleaned_df.reset_index(drop=True),\n",
-    "    pandas_df.reset_index(drop=True),\n",
+    "    cleaned_df_clean_headers.reset_index(drop=True),\n",
+    "    pandas_df_clean_headers.reset_index(drop=True),\n",
     "    check_like=True,\n",
     "    check_dtype=False\n",
     ")\n",
-    "print(\"Results verified: same shape, same null counts, same values ✓\")"
+    "print(\"Results verified after normalizing headers on both DataFrames.\")\n",
+    "print(\"Arnio cleaned values: ✓  |  Header normalization applied equally: ✓\")"
    ]
   },
   {

--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "id": "241a9888-1375-4aca-8cad-13678e144a5f",
    "metadata": {},
    "outputs": [],
@@ -30,13 +30,13 @@
     "try:\n",
     "    import arnio\n",
     "    import pandas\n",
-    "    import matplotlib\n",
     "except ImportError as e:\n",
     "    raise ImportError(\n",
     "        f\"Missing dependency: {e}\\n\"\n",
-    "        \"Install with: pip install arnio pandas matplotlib\\n\"\n",
+    "        \"Install with: pip install arnio pandas\\n\"\n",
     "        \"Then restart the kernel and run again.\"\n",
-    "    )"
+    "    )\n",
+    "    "
    ]
   },
   {
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "id": "6fa1fda1-0db6-446d-b887-0ded42c01937",
    "metadata": {},
    "outputs": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "id": "ae91672a-8672-4a6e-883f-04edc0def90c",
    "metadata": {},
    "outputs": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "id": "ed956cf9-c0b5-43e8-83c8-5466612391dd",
    "metadata": {},
    "outputs": [
@@ -174,22 +174,22 @@
      "output_type": "stream",
      "text": [
       "=== ARNIO CLEANED ===\n",
-      "  transaction_id    amount    type     sender_name  receiver  isFraud\n",
-      "0            t001   500.00   payment          alice      bob      0.0\n",
-      "1            t002           transfer          alice  charlie      0.0\n",
-      "2            t003   200.00   payment          alice     dave      1.0\n",
-      "3            t004   750.00  cash_out            eve    frank      0.0\n",
-      "4            t005    90.00   payment          alice    grace      0.0\n",
+      "  transaction_id  amount      type sender_name receiver  isfraud\n",
+      "0           t001  500.00   payment       alice      bob      0.0\n",
+      "1           t002          transfer       alice  charlie      0.0\n",
+      "2           t003  200.00   payment       alice     dave      1.0\n",
+      "3           t004  750.00  cash_out         eve    frank      0.0\n",
+      "4           t005   90.00   payment       alice    grace      0.0\n",
       "\n",
       "Shape: (5, 6)\n",
       "\n",
       "Nulls:\n",
-      "transaction_id     0\n",
-      "  amount           0\n",
-      "  type             0\n",
-      "  sender_name      0\n",
-      "receiver           0\n",
-      "isFraud            0\n",
+      "transaction_id    0\n",
+      "amount            0\n",
+      "type              0\n",
+      "sender_name       0\n",
+      "receiver          0\n",
+      "isfraud           0\n",
       "dtype: int64\n"
      ]
     }
@@ -204,8 +204,10 @@
     "    (\"drop_duplicates\",),\n",
     "])\n",
     "\n",
-    "\n",
     "cleaned_df = ar.to_pandas(cleaned_frame)\n",
+    "# Arnio strip_whitespace cleans values but not column headers — normalize explicitly\n",
+    "cleaned_df.columns = cleaned_df.columns.str.strip().str.lower()\n",
+    "\n",
     "print(\"=== ARNIO CLEANED ===\")\n",
     "print(cleaned_df)\n",
     "print(f\"\\nShape: {cleaned_df.shape}\")\n",
@@ -214,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "id": "7fa57998-81ea-432d-8db4-c9b21ef0e513",
    "metadata": {},
    "outputs": [
@@ -271,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "id": "c398db93-62ed-483d-bcd9-6614425dc466",
    "metadata": {},
    "outputs": [
@@ -309,7 +311,6 @@
     "# Verify outputs match\n",
     "assert cleaned_df.shape == pandas_df.shape, \"Shape mismatch!\"\n",
     "assert cleaned_df.isnull().sum().sum() == pandas_df.isnull().sum().sum(), \"Null mismatch!\"\n",
-    "cleaned_df.columns = cleaned_df.columns.str.strip().str.lower()\n",
     "pd.testing.assert_frame_equal(\n",
     "    cleaned_df.reset_index(drop=True),\n",
     "    pandas_df.reset_index(drop=True),\n",

--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "id": "241a9888-1375-4aca-8cad-13678e144a5f",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "id": "ca548c96-7e1b-4a2c-86a1-893d40a8d08b",
    "metadata": {},
    "outputs": [
@@ -49,14 +49,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "arnio version : 1.1.1\n",
+      "arnio version : 1.6.1\n",
       "pandas version: 2.2.3\n"
      ]
     }
    ],
    "source": [
     "import io\n",
-    "import time\n",
     "import pandas as pd\n",
     "import arnio as ar\n",
     "\n",
@@ -66,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "id": "6fa1fda1-0db6-446d-b887-0ded42c01937",
    "metadata": {},
    "outputs": [
@@ -115,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "id": "ae91672a-8672-4a6e-883f-04edc0def90c",
    "metadata": {},
    "outputs": [
@@ -175,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "ed956cf9-c0b5-43e8-83c8-5466612391dd",
    "metadata": {},
    "outputs": [
@@ -200,16 +199,12 @@
       "  sender_name      0\n",
       "receiver           0\n",
       "isFraud            0\n",
-      "dtype: int64\n",
-      "\n",
-      "Time: 0.583 ms\n"
+      "dtype: int64\n"
      ]
     }
    ],
    "source": [
     "frame = ar.from_pandas(raw_df)\n",
-    "\n",
-    "start = time.perf_counter()\n",
     "\n",
     "cleaned_frame = ar.pipeline(frame, [\n",
     "    (\"strip_whitespace\",),\n",
@@ -218,19 +213,17 @@
     "    (\"drop_duplicates\",),\n",
     "])\n",
     "\n",
-    "arnio_time = time.perf_counter() - start\n",
     "\n",
     "cleaned_df = ar.to_pandas(cleaned_frame)\n",
     "print(\"=== ARNIO CLEANED ===\")\n",
     "print(cleaned_df)\n",
     "print(f\"\\nShape: {cleaned_df.shape}\")\n",
-    "print(f\"\\nNulls:\\n{cleaned_df.isnull().sum()}\")\n",
-    "print(f\"\\nTime: {arnio_time*1000:.3f} ms\")"
+    "print(f\"\\nNulls:\\n{cleaned_df.isnull().sum()}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "id": "7fa57998-81ea-432d-8db4-c9b21ef0e513",
    "metadata": {},
    "outputs": [
@@ -255,14 +248,12 @@
       "sender_name       0\n",
       "receiver          0\n",
       "isfraud           0\n",
-      "dtype: int64\n",
-      "\n",
-      "Time: 10.290 ms\n"
+      "dtype: int64\n"
      ]
     }
    ],
    "source": [
-    "start = time.perf_counter()\n",
+    "\n",
     "\n",
     "pandas_df = raw_df.copy()\n",
     "\n",
@@ -280,18 +271,16 @@
     "# 4. Drop duplicates\n",
     "pandas_df = pandas_df.drop_duplicates(keep=\"first\").reset_index(drop=True)\n",
     "\n",
-    "pandas_time = time.perf_counter() - start\n",
     "\n",
     "print(\"=== PANDAS EQUIVALENT ===\")\n",
     "print(pandas_df)\n",
     "print(f\"\\nShape: {pandas_df.shape}\")\n",
-    "print(f\"\\nNulls:\\n{pandas_df.isnull().sum()}\")\n",
-    "print(f\"\\nTime: {pandas_time*1000:.3f} ms\")"
+    "print(f\"\\nNulls:\\n{pandas_df.isnull().sum()}\")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "id": "c398db93-62ed-483d-bcd9-6614425dc466",
    "metadata": {},
    "outputs": [
@@ -299,41 +288,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "=== API DESIGN COMPARISON ===\n",
       "==================================================\n",
-      "Approach              Time (ms)        Code style\n",
+      "Aspect                         Arnio        Pandas\n",
       "==================================================\n",
-      "Arnio pipeline            0.583       declarative\n",
-      "Pandas manual            10.290        imperative\n",
+      "Style                     declarative    imperative\n",
+      "Null handling             fill_nulls      fillna()\n",
+      "Case norm                 normalize_case   str.lower()\n",
+      "Deduplication             drop_duplicates   drop_dupl..\n",
+      "Steps chained             1 pipeline    4 separate\n",
       "==================================================\n",
-      "\n",
-      "Speedup: 17.6x faster with Arnio\n",
-      "Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\n",
       "Results verified: same shape, same null counts, same values ✓\n"
      ]
     }
    ],
    "source": [
+    "# API Design Comparison\n",
+    "print(\"=== API DESIGN COMPARISON ===\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"{'Approach':<20} {'Time (ms)':>10}  {'Code style':>16}\")\n",
+    "print(f\"{'Aspect':<25} {'Arnio':>10}  {'Pandas':>12}\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"{'Arnio pipeline':<20} {arnio_time*1000:>10.3f}  {'declarative':>16}\")\n",
-    "print(f\"{'Pandas manual':<20} {pandas_time*1000:>10.3f}  {'imperative':>16}\")\n",
+    "print(f\"{'Style':<25} {'declarative':>10}  {'imperative':>12}\")\n",
+    "print(f\"{'Null handling':<25} {'fill_nulls':>10}  {'fillna()':>12}\")\n",
+    "print(f\"{'Case norm':<25} {'normalize_case':>10}  {'str.lower()':>12}\")\n",
+    "print(f\"{'Deduplication':<25} {'drop_duplicates':>10}  {'drop_dupl..':>12}\")\n",
+    "print(f\"{'Steps chained':<25} {'1 pipeline':>10}  {'4 separate':>12}\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"\\nSpeedup: {pandas_time/arnio_time:.1f}x faster with Arnio\")\n",
-    "print(\"Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\")\n",
     "\n",
-    "# Confirm both produce same shape and null counts\n",
+    "# Verify outputs match\n",
     "assert cleaned_df.shape == pandas_df.shape, \"Shape mismatch!\"\n",
     "assert cleaned_df.isnull().sum().sum() == pandas_df.isnull().sum().sum(), \"Null mismatch!\"\n",
-    "\n",
-    "# Note: Arnio strip_whitespace cleans values but not column names\n",
-    "# Column names are cleaned manually after conversion to pandas\n",
     "cleaned_df.columns = cleaned_df.columns.str.strip().str.lower()\n",
     "pd.testing.assert_frame_equal(\n",
     "    cleaned_df.reset_index(drop=True),\n",
     "    pandas_df.reset_index(drop=True),\n",
     "    check_like=True,\n",
-    "    check_dtype=False # dtypes may differ (e.g. string[python] vs object) but values match\n",
+    "    check_dtype=False\n",
     ")\n",
     "print(\"Results verified: same shape, same null counts, same values ✓\")"
    ]
@@ -347,15 +337,13 @@
     "\n",
     "| | Arnio pipeline | Pandas manual |\n",
     "|---|---|---|\n",
-    "| Time | ~0.5–2 ms (varies by machine) | ~10–30 ms (varies by machine) |\n",
-    "| Speedup | **~10–20x faster** | baseline |\n",
+    "| Speedup | C++ backend (illustrative only) | Pure Python |\n",
     "| API style | Declarative steps | Imperative chains |\n",
     "| Backend | C++ accelerated | Pure Python |\n",
     "| Null handling | `fill_nulls` step | `.fillna()` per column |\n",
     "| Case normalization | `normalize_case` step | `.str.lower()` per column |\n",
     "| Deduplication | `drop_duplicates` step | `.drop_duplicates()` |\n",
     "\n",
-    "> Actual times are printed in the executed cells above. Speedup varies by hardware.\n",
     "\n",
     "### Key takeaway\n",
     "Arnio replaces scattered pandas method chains with a strict, named,\n",
@@ -365,44 +353,6 @@
     "### Dataset\n",
     "Synthetic PaySim-style transactions generated inline.\n",
     "No external files required — runs end to end in this notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "0e19d8ae-3a27-4f17-acff-5b15d5852a7b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAEiCAYAAAAPh11JAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAN+lJREFUeJzt3Qm4lPP///F3mxYqLdq0StG+SUohpVAqfS2Rr2xlLURIkkQREkoRSpbKliUUkhYkRZSl9JUU7dtRab9/1+vzv+75z0wz59ynzjkz55zn47qmztyz3J+51/f9Wd53Hs/zPAMAAECa8qb9FgAAAAiBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETDlG1alW76qqrLBlMmDDB8uTJY3/88YclE5XpgQceSHQxkk6yrq/sQvud9r+stmPHDitTpoy99tproWnavrUuc4KzzjrLPY7UF1984ZbJW2+9Zdnd9OnT7ZhjjrGNGzcmuijZDoFTLvK///3Prr/+ejvhhBOsUKFCVqxYMTv99NPtqaeesn///TfRxUs6H330UY4Jjg4cOGAVKlRwB/2PP/440cVJGn5w4D+KFClitWvXtvvuu89SUlIst9AxoGjRotatW7dEFyXX+eqrr9x2uG3btkNeGzp0qL377ruZMt9zzz3XTjzxRBs2bFimfH9ORuCUS3z44YdWr149e+ONN+yCCy6wZ555xu0wlStXtn79+tmtt95qyei///2vC+qqVKmSkMBp8ODBMV9TmXRyzS4+//xzW7t2ravNCK9VyEnr60iMGTPGXnnlFRsxYoSdfPLJ9vDDD7sTS264lee+fftc4HTddddZvnz5LCf65JNP3CNZAycdZ7I6cBJdSD/33HP2zz//ZNo8cqL8iS4AMt/KlSvdlaROZjqBli9fPvTazTffbCtWrHCBVTLSgTwZD+aqsctOXn31VWvcuLH16NHD7r33Xtu5c6cdffTRaX4u6PuSfX2l5aKLLrLSpUu7v2+44Qb7z3/+Y++8847Nnz/fmjdvbjnZtGnTXHPNJZdcYtnVwYMHbe/evXH3y6OOOirLy5Ssdu/e7ZZH3rx53Xbeu3dve/PNN+2aa65JdNGyDWqccoHhw4e7PgwvvvhiRNDkU3VtWjVOuhq67bbbrFKlSlawYEH3mUcffdQdsMI9/vjj1qJFCytVqpQVLlzYmjRpErM/gJpFbrnlFnc1VbduXfedderUce3uafWZUa1Jx44dbd68eXbqqae6g6WaHydOnHjIfH788Uc788wzXVkqVqxoDz30kI0fPz7NfjjqazJ69OhQWf1HePnDm/H8Jp/ly5fbFVdcYcWLF7fjjjvOBg4c6GotVq9ebZ07d3bNo+XKlbMnnnjikHnu2bPHBg0a5JatloeW9V133eWmh9u0aZP9+uuvtmvXLgtCNUBTp051wbNOjnr+3nvvxfzN6vOgJt3zzz/fNd107979iNeXPPvss+79+pyaDBWwx7rCDqftRt81e/bsQ17TVbJeW7p0qXu+bt06u/rqq9061jy0nWt5H25fq7PPPjt00aET8v333++2Za1XBZKtWrWyWbNmRXxG81KZtA88//zzVr16dVeWpk2b2rfffnvIPPxlqe1X/2sdxRJ0n/r000+tZcuWduyxx7r1eNJJJ7kgOS0qh/YplTct+/fvtyFDhoR+mz6neYRvo3379nVlDa+t08lZy+bpp58OTVu/fr2bptq+9O4D/vao2lN/u4reFtPq46Rad31WzbMlSpSwU045xV5//XUL2vSt3619WdtDp06d3D4e7ZtvvnE1l9puNB8di7788suI44Zq/KVatWqh44y/LenC5eWXXw5ND+97+tdff7lgp2zZsqH98aWXXorZJ2vy5Mmuhvz444935fCbodWvrX79+jGPB0iFhxzv+OOP90444YTA769SpYrXo0eP0POdO3d69evX90qVKuXde++93tixY70rr7zSy5Mnj3frrbdGfLZixYreTTfd5I0aNcobMWKEd+qpp+ro6U2bNi3ifZrWoEEDr3z58t6QIUO8kSNHujIWKVLE27RpU+h948ePd+9duXJlRPlOOukkr2zZsq48mlfjxo1deZYuXRp635o1a7ySJUu6cg8ePNh7/PHHvZNPPtnNN/o7o3311VfeOeec4973yiuvhB7h5R80aFDouf7WtIYNG3qXXXaZ9+yzz3odOnRw07QcVN4bb7zRTT/99NPd9NmzZ4c+f+DAAa9du3bu9992223ec889591yyy1e/vz5vc6dO0eUzZ/XrFmzAq3PyZMnu2Xz559/uudnn322d/755x/yPq3zggULetWrV3d/az1PnDjxiNeXX962bdt6zzzzjPtd+fLl85o2bert3bs3brl37drlHXPMMW57ita6dWuvTp06oectWrTwihcv7t13333eCy+84A0dOtS9J3wZx+KXbePGjRHTb7/9djd9+vTp7jX97r59+3pjxozxhg8f7tZngQIFvO+//z70Gf1mfaZRo0beiSee6D366KPuvaVLl3b7RfhvnTFjhpc3b16vbt26bvsYMGCAK79+k7bv9O5T2u6POuoo75RTTvGeeuopt+7uvPNO74wzzvDSorJ27do17rIJp+1C0y666CJv9OjR7jig5126dAm955133nHTlixZEpqmbUe/V5/zvfnmm+59/j6bnn1An6tVq5Z33HHHuX1bZQlfF9HOPPNM9/A9//zzod+h+WiZXXvttV6fPn1SXVba5/S5evXquWOi1sc999zjFSpUyKtZs6bbZn0zZ85066R58+beE0884T355JPuM5r2zTffuPf88MMP7nih79Tr/nFmx44d7n/tj61atQpN13FJ1q1b57aLSpUqeQ8++KDbLjt16hT6nujy1q5d2x2bVN5hw4a5Y7rvuuuuc9sogiNwyuG2b9/udpzoA096AiedKI8++mhv+fLlEe/TAUMnQP+ELOEHDtHJQicHnazDqUw6gKxYsSI0TQcRTdfJNa3ASdPmzJkTmrZhwwZ3kLnjjjtC03r37u0ChvAD6ubNm10wlVbgJDfffPMhJ460AqdevXqFpu3fv98d3FSGRx55JDR969atXuHChSOWsQ6KOrHMnTs3Yj46Aep7v/zyy8MOnDp27OiCtfCThk5GWmaxTopar7F+7+GsL81Dn9MJUSdGn4IAve+ll15Ktew6qZQpU8YtS9/atWvdstIJw1+e+q7HHnvMSy9/WS5btswFSCq3TqTalhSY6wSjee/Zsyfic5qnXr/mmmsOCZwUqG/ZsiU0/b333nPTP/jgg9A0ncQUjG3bti007ZNPPnHviw6cguxTOlnGCgDTsm/fPrd9hu830cvGt3jxYvdcJ9pwCtA0/fPPPw+tcz3XRYLoN2p9XXzxxW6Z+RSkaF88ePBguvcBPdd7f/rpp0C/Mzpw0vEwPPAOyg9EdDGakpISmv7GG2+46QrARL+pRo0aXvv27UO/z1+X1apVcxdlPm238Y5HOu6GHyd8CvK0/YRftEi3bt1cAO5vM355dZETvR35dJGh96xfvz7dyyO3oqkuh/OrZNXscrjU/q2mCVVnq5nIf7Rt29ZVWc+ZMyf0XjUl+LZu3Wrbt293n/3uu+8O+V59Prx5QFXGasr6/fff0yyTRj7pe31qFlPTRPhnVXWv/ikNGzYMTStZsmSo+SkzqIOtT319VP2v4/y1114bmq6mlOiyahnXqlXLdUwOX8Z+k1F4s5Cq9/WdQYZXb9682WbMmGGXXXZZaJr6Naj6XgMFYrnxxhtjTj+c9fXZZ5+5pi4186pPha9nz57us2n1rbv00kttw4YNrsnBp2YqNRHrNX+bU58NvUfb3OHQ+tA2pOYSdZhVU5HKpmYNrUe/j4zmu2XLFtdkpXUba7tWubSv+Pzt1F9O6qS/ePFi199MTTi+c845x23X0YLsU9qmRE0u0c3nqdFv0bYUXt7UBkv4TXHh7rjjDve/vy61HLUd+8cFNU1pGapJSs1zv/32m5s+d+5c17ToN4GnZx8QNXvFWl5BaHmtWbMmZhNqEFdeeWXEMVV95NQ87C8jrV/9zssvv9ztg/5vUdNbmzZt3LJJz3oKp/X19ttvu0E++jt8WbVv395tH9Hbpba18O0onL/u9XkEQ+fwHE4nJzmSURM6AKivkA6IsejEFt7RVP2IdOAI75cQKx+MRvTF2omDnPyCfHbVqlUxO/bqpJhZosulE6P6sPgdj8On64Aavox/+eWXQMs4PaZMmeJGTTVq1MgNAvA1a9bM9Q9RX6Nw+fPnd/2Egvy2IOtL68APTMIpEFG/NP/1ePz+IfodOuH4v0nBcM2aNd1z9e9QfzudwNXf47TTTnN94HRyUx+UIHQi0r5SoEAB9/uj+/uon4n6palvmZanT4FWWsvJPzH5y8n/zTVq1Djks1pO0Se9IPuUgrUXXnjBBe733HOPW1Zdu3Z1J/TwgDWeIKMHVW59V/T+o2WsQCR8XSqw84MIBUgKMvXQhYueaz398MMPLrA43H0g1rIP6u6773ZBvfpI6ve0a9fOlUXpWYKIXndaF/oev0+dHxwqYIlHAU6QgDWaOvKrf6D60elxpMvKX/c5JWdXViBwyuF0MlBnXL8T7eHQlZGuhtVJMxb/BKYDojpJnnHGGa4zsK7AdCJSZ+xYnS7jjb4KchA/ks9mpljlClJWLWOli9Bw+FjUSfZw+KkH4p0QVAuiAManICTeiTYRy1zl6dKli+s4rW1KNRaqwdAw7XCq0dIVuDo6q4ZNnfKVbkOjSBU0pkXbbHRwGz4iUZ1yVQ7VmqhDrZaFvl8d6TNzOQXdp1SboFoM1cqo5ke1rQowVVujYfjxyqRARifM9NTUBTnBqiZp3LhxbvvSb1Agpc9pup7rmKRtPrzWOL37QLwalCBUs7Vs2TIXlGpZKXDW8tUggHgpSNLDr0167LHHImq8w6kD/5F8twahxAvMVBscdFn56z7e9o9DETjlArr61pXJ119/fVhDq3X1rVF5aqpJjQ4+ql3RiUsnPJ8O8omg9AvhtSy+WNNiycorMC1jXYGrpiCj5qsRYcoRo9FHataIPvgq55JOvpmZj8rP56STVHiApuY7lS+tbcqvTVGNz8yZM12NhAIQv5kuehmq1kkPXfHrhKVaIgU+R0JNgyq70hOErxuN/jqSZeLXSoTTcjrcfUoBr7YfPRR8KLgcMGCAC6biLWfVMGq5aV0EKbe2G5VbgYdPwaxqQMJzd/kBkUb6qTlMtWCiAFCj6BQ4aTSaRghm5j6QGs1f25Ee2h5VQ6f8Xf37908z3Uj0utM2qeOKH7D4NZa6cE1rG0/tt8Z6TTVyaiZUN4kg+09atO4VNMWr6cOh6OOUC6imSAcJVePrIBdNV81KgBePhrAr6NLBO5oOmOrvIbqq1Y6uHdqnquvMTOCWGrX3q9xq4gjv0xE0AaSfvyitYfMZQctYw4t1lR5N6QPUNyK96Qj836n1ryab8Ifmp2AqM5Nhig7sapbTMPTwGhelxlBTRYcOHQJ9h2pGVIOih5pXwpsetByUmyacTlw6uUQPYz8cfm1NePk1zFzb1uFQrZGCOgWDWgY+BRk///zzIfMOsk9pu47m13SktQx0MbVw4cI0y60UFTJy5MiI6X4NUfi61PrR0Pcnn3zSNW36NZ4KqHS8UTCqJlUFboezDxyp8GZy0Taq/lJax+FNsfEo9Ul49wf9HvVdO++889xzBYTaBpVKQhed0cJvc5LacUavRU/XNqF+igqqY7UkpPcWKosWLcrxucoyGjVOuYB2YNUs6MpKV4rq+6G8MbrKUo2EOmWmdm86NU+8//77ruZK79NBQQexJUuWuAOGDuS6YtGBUwdR9UtRfwG1sysXktr+1UcqqylgUG2DmhmVR0YHIfUDUR8UnWjSuqr1r4b79OnjgjAdsDLrlhSq/VFnbSVfVA2BTjQ6WSpA0nQFreojIqNGjXLNCXpfah3EFRTp5BmvmU9NQFou6lOj5JiZQVexuoJXebVdaJ6qVVGziPIbqbkhLWqaUm2ActFou9PJKJxyZ6mWQidenfx0MlbTni4SMmJ9abtXbdOFF17otnFdoY8dO9bNK9ZJMQg18+m71HSlXDzaHv28QuHfGXSfevDBB11Tnd6vmh+9T8tY/bU0j9Qo35Wypms5+s3usTRo0MA1Dan2WidzBd4LFixwAaCaMVu3bh3xfgVJWmdqfvP78mg7036oeYX3b0rvPnCk1KdJfbM0D/W3Uk2m9istvyADaRTIa7kqd5i2MwWTWica9ODX/ulYo0BK61TvUyCpwFC/TTVRH3zwQcRxRrWD2l61vavZ2a+RU18sbQOqpVNAqv6JjzzyiPse/a15alvUNqR9We+PFUjHou1E21F0X0ekIdHD+pB1lE6gZ8+eXtWqVd0Q8aJFi7ph6hpOvnv37rjpCOSff/7x+vfv73K+6LPK+6HcOcqNFJ6f5sUXX3TDcDWcWzmTNDw9Vj4YPddw/2jR846XjkA5ktIacixKRaA8KCqPUgMoh8nTTz/tvlO5UFKjYehKaaBcMRqyHf4b4qUjiB4Ort+iIcWxyho9HFrLUbl/NF3lLVGihNekSROXp0ZpJdKTjmDRokXuPQMHDoz7nj/++MO9RzmLUivrka4vP/2AtgflPtKQdOW00pD+oD799FP3vVoPq1evjnhNQ7JVNn2/yq/h2M2aNXNDxNMSb72F03ByDdnWb9V6UZ4m5VDS7w5PHeCnI4iVFiF6e5G3337b5SLSdyrPjvIfRX9n0H1KOYM0xL5ChQpu/9T/SuUQnUIkFqVa0P6stCOxlk10+gJtjxpSr3WpPEI6LoQfP3zKraTPa12HUz4vTVeZowXdB+Jtj/FEHxuUckI5rpQ6ws9d1q9fv4h5xOIP7580aZL73UqVodQiOh6tWrXqkPfr+KMcWf58tG4vueSSQ367lr1SHCjFQvj+8+uvv7pyah6aHr6vKX2AloHWgdZFuXLlvDZt2rh0I9HlVc6sWJT/SXmzwlMrIG159E9awRWQk6gjsTJP68o+O94eBMhoygauflPqu8M+kXto4IRqrdWkiuDo44QcTX0jovs2qFlC1eycIID/5/bbb3cXEmpaQ+6g0YQKlNWUjvShxgk5mvr46IpKfbvUF0Gdkv/++283QksjfAAASA86hyNH00ggdWBXh1Z1BlfnVAVPBE0AgMNBjRMAAEBA9HECACAOpXlQegClA1Ctday8dKp/UNZx5ehSlm7lHouV4DQ6JYVScij9gbLRK6VDdAJU5bxSGgyl9VAKA6XciJWLD1mLwAkAgDiUO0w5rJQ/K57hw4e7JK/K76XkqMrBpNxv0YlZw82ePdvlT5o/f75LfqrEm8ov5Sf61P96rmBNtw7SrYaUe09B3OHeIBgZI8c31WkDU2dgRfXcxBAAcLh0w2klllVSVJ9Oobo5s25tpGS5oozwuhGwkpAqU38QuiOAkhXr5shKzKkBLPqsbp7s36xd36sEp0rwGp1w1KcknkqIqVHDSnysrOi6rdLFF1/skhm/9957rgZL99FTcmD/fnV6TQGaAjbVrunWRUES1OYUWo/KBq/fntaNsXN84LRmzZrDvkEqAADIPVavXu0y7ufqUXV++nwtDD9qBwAgI2qc1DSnJjX1T9JtXHy6PY1aOSZMmBCoZUS3W1GNkn9PUNVAKUFl9+7dXf8p1XE88MADboSwbn0V7/6iqnHSrWqUp0n0tyoP1MSnxL+iflK6vY5uz6J+Vpp3qVKlUm2OzOlSUlLccgpyy50cHzj5zXMKmgicAABHokiRIhHnEv8mvTrhhk/XPed0/gly3rnxxhvdPfnmzZsXer/+131E9Zr6Tqn56LLLLnMpVQoVKhT3e9VEV79+/YjXFRTpc/40PzhQs5ym6Z6VunGw7j+qIFAd1Vu0aGG5UZ4AXXroHA4AwGHya5miR7vpeXgNVDzqGzVt2jR3097oJiIFMRpZp5vxqgZKdz3QjYJPOOGEVL9TQVt0MBA+zQ8O/E7muhmx+lIpg7z6BOum2XfeeWeaZc+tCJwAADhM1apVcwGSOnOHN/uoCa958+ZxP6emNwVN6uitTtn6nnhKly5txx57rHufgqhOnTpl+O9Qh3E1L7766qs2cuRI1ySIXNpUBwDA4dI9/FasWBF6vnLlSlu8eLGVLFnSKleu7GpvdOPwhx56yI2kUwA0cOBANzpLTV4+1eIoJ5OCJVEqAo160yg3NZ2tW7cu1I9KuaBEN17W7aIU1Hz99dd26623ulohjeLLSOpD1aRJE6tTp47t2bPH1YBpvoiNwAkAgDgWLlwYMfS/b9++7n/Vzvgdv++66y7XX6hXr162bds2dxNxdc5WXySfmtzU3OYbM2aM+1/30gynYEmdv0UdznUT3i1btljVqlVtwIABLnDKaEpZoPn88ccfLmhr1aoVN3zOzekIVGWqCF6jFegcDgAAjiRWoI8TAABAQAROAAAAARE4AQAABETncABAUlh3QatEFwFJrNwHcy0ZUOMEAACQHQKnOXPmuPvnKN+FcmG8++67Ea9rwJ/yS5QvX94NkWzbtq399ttvCSsvAADI3RIaOCnvRYMGDeLeWHD48OH29NNPu/v0KAur7gnUvn172717d5aXFQAAIKF9nHR/HD1iUW2T0r7fd9991rlzZzdt4sSJVrZsWVczpbs5AwAAZKWk7eOktPZKQa/mOZ+SUzVr1sylno9H6eKVyCr8AQAAkKMDJ/++PaphCqfn/muxDBs2zAVY/qNSpUqZXlYAAJA7JG3gdLh0vx2lTPcfq1evTnSRAABADpG0gVO5cuXc/+vXr4+Yruf+a7EULFjQ3Wcm/AEAAJCjA6dq1aq5AGnmzJmhaeqvpNF1zZs3T2jZAABA7pTQUXU7duywFStWRHQIX7x4sZUsWdIqV65st912mz300ENWo0YNF0gNHDjQ5Xzq0qVLIosNAAByqYQGTgsXLrTWrVuHnvft29f936NHD5swYYLdddddLtdTr169bNu2bdayZUubPn26FSpUKIGlBgAAuVUeTwmTcjA172l0nTqK098JAJIX96pDou5Vl55YIWn7OAEAACQbAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAnBA4HThwwAYOHGjVqlWzwoULW/Xq1W3IkCHmeV6iiwYAAHKh/JbEHn30URszZoy9/PLLVqdOHVu4cKFdffXVVrx4cevTp0+iiwcAAHKZpA6cvvrqK+vcubN16NDBPa9atapNmjTJFixYkOiiAQCAXCipm+patGhhM2fOtOXLl7vnP/zwg82bN8/OO++8uJ/Zs2ePpaSkRDwAAAByfI3TPffc4wKfk08+2fLly+f6PD388MPWvXv3uJ8ZNmyYDR48OEvLCQAAcoekrnF644037LXXXrPXX3/dvvvuO9fX6fHHH3f/x9O/f3/bvn176LF69eosLTMAAMi5krrGqV+/fq7WqVu3bu55vXr1bNWqVa5WqUePHjE/U7BgQfcAAADIVTVOu3btsrx5I4uoJruDBw8mrEwAACD3SuoapwsuuMD1aapcubJLR/D999/biBEj7Jprrkl00QAAQC6U1IHTM8884xJg3nTTTbZhwwarUKGCXX/99Xb//fcnumgAACAXyuPl8DTcGpWnhJnqKF6sWLFEFwcAEMe6C1olughIYuU+mJsUsUJS93ECAABIJgROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAAeVPz5sPHjxos2fPtrlz59qqVats165ddtxxx1mjRo2sbdu2VqlSpcwrKQAAQHaocfr333/toYcecoHR+eefbx9//LFt27bN8uXLZytWrLBBgwZZtWrV3Gvz58/P/FIDAAAka41TzZo1rXnz5jZu3Dg755xzrECBAoe8RzVQr7/+unXr1s0GDBhgPXv2zIzyAgAAJEwez/O8tN70yy+/WK1atQJ94b59++zPP/+06tWrWzJISUmx4sWL2/bt261YsWKJLg4AII51F7RKdBGQxMp9MDcpYoVATXVBgyZRbVSyBE0AAAAJHVU3ffp0mzdvXuj56NGjrWHDhnb55Zfb1q1bM7RwAAAA2Tpw6tevn6vSkiVLltgdd9zhOoWvXLnS+vbtmxllBAAAyH7pCEQBUu3atd3fb7/9tnXs2NGGDh1q3333nQugAAAAcqp01zgdddRRLn+TfPbZZ9auXTv3d8mSJUM1UQAAADlRumucWrZs6ZrkTj/9dFuwYIFNmTLFTV++fLlVrFgxM8oIAACQPWucRo0aZfnz57e33nrLxowZY8cff7ybrqSY5557bmaUEQAAIHvWOFWuXNmmTZt2yPQnn3wyo8oEAACQMwIn34YNG9xD968LV79+/YwoFwAAQPYPnBYtWmQ9evRw2cT9pON58uRxf+v/AwcOZEY5AQAAsl/gdM0117h717344otWtmxZFywBAADkBukOnH7//XeXv+nEE0/MnBIBAADklFF1bdq0sR9++MGyyl9//WVXXHGFlSpVygoXLmz16tWzhQsXZtn8AQAADrvG6YUXXnB9nJYuXWp169Z1N/UN16lTJ8souved8kW1bt3apTs47rjj7LfffrMSJUpk2DwAAAAyLXD6+uuv7csvv3SBTLSM7hz+6KOPWqVKlWz8+PGhadWqVcuw7wcAAMjUprrevXu7prO1a9e6VAThj4weUff+++/bKaecYhdffLGVKVPGGjVqZOPGjcvQeQAAAGRa4LR582a7/fbb3Yi6zKaO6MpOXqNGDZsxY4bdeOON1qdPH3v55ZfjfmbPnj3unnnhDwAAgIQETl27drVZs2ZZVlAtVuPGjW3o0KGutqlXr17Ws2dPGzt2bNzPDBs2zIoXLx56qKkPAAAgIX2clMOpf//+Nm/ePDfCLbpzuGqEMkr58uWtdu3aEdNq1arl0iHEo7LpJsQ+1TgRPAEAgISNqjvmmGNs9uzZ7hHdOTwjAyeNqFu2bFnEtOXLl1uVKlXifqZgwYLuAQAAkPDAaeXKlZZV1JeqRYsWrqnukksusQULFtjzzz/vHgAAAEnfxykrNW3a1KZOnWqTJk1yOaOGDBliI0eOtO7duye6aAAAIBcKFDg98sgj9u+//wb6wm+++cY+/PBDyygdO3a0JUuW2O7du92NhdU5HAAAIGkDp59//tkqV65sN910k0t8uXHjxtBr+/fvtx9//NGeffZZ16x26aWXWtGiRTOzzAAAAMnbx2nixInu/nSjRo2yyy+/3I1Uy5cvn+uEvWvXLvcepQu47rrr7KqrrrJChQpldrkBAACyXB7P87z05lZSDdOqVatc813p0qWtYcOG7v9kpCBP+Zy2b99uxYoVS3RxAABxrLugVaKLgCRW7oO5SRErpHtUXd68eV2gpAcAAEBuktSj6gAAAJIJgRMAAEBABE4AAAABETgBAABkduC0YsUKmzFjRigxZjoH5wEAAOT8wGnz5s3Wtm1bq1mzpp1//vm2du1aN/3aa6+1O+64IzPKCAAAkD0DJ914N3/+/Pbnn39akSJFQtOVMXz69OkZXT4AAICkke48Tp988olroqtYsWLE9Bo1arikmAAAADlVumucdu7cGVHT5NuyZYu7BQsAAEBOle7AqVWrVu7edb48efK427AMHz7cWrdundHlAwAAyL5NdQqQ2rRpYwsXLrS9e/faXXfdZT/99JOrcfryyy8zp5QAAADZscapbt26tnz5cmvZsqV17tzZNd117drVvv/+e6tevXrmlBIAACA71jiJ7iA8YMCAjC8NAABATgucdu/ebT/++KNt2LDB9W8K16lTp4wqGwAAQPYOnJSr6corr7RNmzYd8po6ih84cCCjygYAAJC9+zj17t3bLr74YpcxXLVN4Q+CJgAAkJOlO3Bav3699e3b18qWLZs5JQIAAMgpgdNFF11kX3zxReaUBgAAICf1cRo1apRrqps7d67Vq1fPChQoEPF6nz59MrJ8AAAA2TdwmjRpkrtfXaFChVzNkzqE+/Q3gRMAAMip0h04KX/T4MGD7Z577rG8edPd0gcAAJBtpTvy0W1WLr30UoImAACQ66Q7+unRo4dNmTIlc0oDAACQk5rqlKtJN/qdMWOG1a9f/5DO4SNGjMjI8gEAAGTfwGnJkiXWqFEj9/fSpUsjXgvvKA4AAGC5PXCaNWtW5pQEAAAgydHDGwAAICNrnLp27WoTJkywYsWKub9T884771hmeeSRR6x///5266232siRIzNtPgAAAIcdOBUvXjzUf0l/J8K3335rzz33nOuQDgAAkLSB0/jx4+3BBx+0O++80/2d1Xbs2GHdu3e3cePG2UMPPZTl8wcAAEhXHydlC1cAkwg333yzdejQwdq2bZvme/fs2WMpKSkRDwAAgCwdVed5niXC5MmT7bvvvnNNdUEMGzbMBXkAAAAJHVWX1XmaVq9e7TqCv/baa+6mwkGo8/j27dtDD30HAABAludxqlmzZprB05YtWyyjLFq0yDZs2GCNGzeOyFw+Z84cGzVqlGuWy5cvX8RnChYs6B4AAAAJDZzUBJaVo+ratGnjMpWHu/rqq+3kk0+2u++++5CgCQAAIGkCp27dulmZMmUsqxQtWtTq1q0bMe3oo4+2UqVKHTIdAAAgafo4cR86AACQ2yX9qLpoX3zxRaKLAAAAcqnAgdPBgwcztyQAAABJjpv8AgAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAOSEwGnYsGHWtGlTK1q0qJUpU8a6dOliy5YtS3SxAABALpXUgdPs2bPt5ptvtvnz59unn35q+/bts3bt2tnOnTsTXTQAAJAL5bckNn369IjnEyZMcDVPixYtsjPOOCNh5QIAALlTUtc4Rdu+fbv7v2TJkokuCgAAyIWSusYp3MGDB+22226z008/3erWrRv3fXv27HEPX0pKShaVEAAA5HTZpsZJfZ2WLl1qkydPTrNDefHixUOPSpUqZVkZAQBAzpYtAqdbbrnFpk2bZrNmzbKKFSum+t7+/fu7Jj3/sXr16iwrJwAAyNmSuqnO8zzr3bu3TZ061b744gurVq1amp8pWLCgewAAAOSqwEnNc6+//rq99957LpfTunXr3HQ1wRUuXDjRxQMAALlMUjfVjRkzxjW3nXXWWVa+fPnQY8qUKYkuGgAAyIWSvqkOAAAgWSR1jRMAAEAyIXACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicMpFRo8ebVWrVrVChQpZs2bNbMGCBam+f8KECZYnT56Ihz4bbseOHXbLLbdYxYoV3f0Da9eubWPHjs3kXwIAQGIk9S1XkHF0f7++ffu6oEZB08iRI619+/a2bNkyK1OmTNzPFStWzL3Hp+ApnL7z888/t1dffdUFZZ988onddNNNVqFCBevUqVOm/iYAALIaNU65xIgRI6xnz5529dVXh2qFihQpYi+99FKqn1OgVK5cudCjbNmyEa9/9dVX1qNHD3cjZgVOvXr1sgYNGqRam3XVVVdZly5dbOjQoe77jj32WHvwwQdt//791q9fPytZsqSrwRo/fnzoM3v37nU1W7rJs2q9qlSpYsOGDcuAJQMAQHAETrmAgo5FixZZ27ZtQ9Py5s3rnn/99depflZNcQpSKlWqZJ07d7affvop4vUWLVrY+++/b3/99Ze7KfOsWbNs+fLl1q5du1S/V7VUf//9t82ZM8cFdYMGDbKOHTtaiRIl7JtvvrEbbrjBrr/+eluzZo17/9NPP+3m88Ybb7gasNdee80FagAAZCUCp1xg06ZNduDAgUNqi/R83bp1cT930kknuRqp9957zzXFHTx40AVKfjAjzzzzjKvBUg3RUUcdZeeee67rS3XGGWekWibVKikY0jyuueYa9/+uXbvs3nvvtRo1alj//v3d982bN8+9/88//3TTW7Zs6QI5/X/ZZZcd8bIBACA96OOEuJo3b+4ePgVNtWrVsueee86GDBkSCpzmz5/vaoMU0KgG6eabb3Z9nMJruKLVqVPH1XqFB3F169YNPc+XL5+VKlXKNmzYEGreO+ecc1yApeBMtVNp1WoBAJDRCJxygdKlS7tAZP369RHT9Vz9loIqUKCANWrUyFasWOGe//vvv66GaOrUqdahQwc3rX79+rZ48WJ7/PHHUw2c9F3RfaliTVMtlzRu3NhWrlxpH3/8sX322Wd2ySWXuO9/6623ApcfAIAjRVNdLqAmryZNmtjMmTND0xSQ6Hl4jVJa1Ny3ZMkS10Fb9u3b5x7hNUeiIM0PeDKSRvhdeumlNm7cODdK8O2337YtW7Zk+HwAAIiHGqdcQmkDNPrtlFNOsVNPPdWlI9i5c6cbZee78sor7fjjjw+NVtNIt9NOO81OPPFE27Ztmz322GO2atUqu+6660KBzJlnnulGwimHk5rqZs+ebRMnTnQdvjOSvk8Bm2q8FKi9+eabrrZMI/IAAMgqBE65hGpqNm7caPfff7/rEN6wYUObPn16RIdxdcAOrz3aunWrS2Gg92u0m2qtlH5AncF9kydPdh25u3fv7mp/FDw9/PDDblRcRipatKgNHz7cfvvtN1ej1bRpU/voo48Oqe0CACAz5fE0hjwHS0lJseLFi9v27dtdDQkAIDmtu6BVoouAJFbug7lJEStwuQ4AABAQgRMAAEBABE4AAAAB0Tk8AzRY1DfRRUAS+6FJxo4wBAAkDjVOAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAAJCTAqfRo0db1apVrVChQtasWTNbsGBBoosEAAByoaQPnKZMmWJ9+/a1QYMG2XfffWcNGjSw9u3b24YNGxJdNAAAkMskfeA0YsQI69mzp1199dVWu3ZtGzt2rBUpUsReeumlRBcNAADkMkl9y5W9e/faokWLrH///qFpefPmtbZt29rXX38d8zN79uxxD9/27dvd/ykpKZlWzgM7/v/8gGiZue0BOck/+/YnughIYkUy8VjqH6c9z8vegdOmTZvswIEDVrZs2Yjpev7rr7/G/MywYcNs8ODBh0yvVKlSppUTSE1xezbRRQCA7K948UyfxT///GPF05hPUgdOh0O1U+oT5Tt48KBt2bLFSpUqZXny5Elo2XIDRe0KUlevXm3FihVLdHEAIFviWJq1VNOkoKlChQppvjepA6fSpUtbvnz5bP369RHT9bxcuXIxP1OwYEH3CHfsscdmajlxKO3o7OwAcGQ4lmadtGqaskXn8KOOOsqaNGliM2fOjKhB0vPmzZsntGwAACD3SeoaJ1GzW48ePeyUU06xU0891UaOHGk7d+50o+wAAACyUtIHTpdeeqlt3LjR7r//flu3bp01bNjQpk+ffkiHcSQHNZMq51Z0cykAIDiOpckrjxdk7B0AAACSu48TAABAMiFwAgAACIjACQAAICACp1xKyUDffffdTJ3HhAkTMjyH1h9//OHKvnjxYvf8iy++cM+3bduWofMBgKCuuuoq69KlS6KLkbQmZMK5IJEInJKc7smnJKAdOnTI0O9du3atnXfeeZbZIyKXL1+eqfNo0aKF+y1BE5cByNkBjC6k9FAewBNPPNEefPBB27+fe+Ah4xA4JbkXX3zRevfubXPmzLG///471fdqgGTQA4Qyr2f2MNfChQtbmTJlMnUeOjjqt3A7HQBy7rnnuoup3377ze644w574IEH7LHHHkt0sZCDEDglsR07dtiUKVPsxhtvdDVOqu4M5zdTffzxxy7DugKhefPm2VlnnWV9+vSxu+66y0qWLOkCCx08UmuqW7JkiZ199tku2NF9/Xr16uXmH48/7w8//NDq169vhQoVstNOO82WLl0at3pWZVAerueee87dg6lIkSJ2ySWX2Pbt2yO++4UXXrBatWq57zz55JPt2Wfj3yQ3uqnOn+eMGTPcdxxzzDGhA+nhzgNA9qHjoI55VapUccfOtm3b2vvvv+9eGzFihNWrV8+OPvpodwy66aabIo5zQY4fuvG8EjPrfTpW6jgbndVHuQZbtmwZek/Hjh3tf//7X+j1vXv32i233GLly5d3xyCVVTeoT6spcOjQoS6Hob7Xr0nr16+fO85XrFjRxo8fH/G5u+++22rWrOmOtSeccIINHDjQ9u3bd8gx+ZVXXrGqVau6mvtu3bq5e7b5NF2Jp8M1bNgw4pyS1nLNaQicktgbb7zhTuonnXSSXXHFFfbSSy8dsoPKPffcY4888oj98ssvLoiRl19+2W3E33zzjQ0fPtztZJ9++mnM+SgTe/v27a1EiRL27bff2ptvvmmfffaZ27HTop32iSeecJ877rjj7IILLojYMaOtWLHC/a4PPvjAHVy+//57t5P5XnvtNZfs9OGHH3a/RwcK7ez6PUHt2rXLHn/8cXcwUE3dn3/+aXfeeWeGzgNA9qCLQQUqkjdvXnv66aftp59+cvv7559/7gKf9Bw/dLxTgKXjsS5UdRP5qVOnHnJMVXC1cOFCd4swzffCCy90twwTlUHBnI6Fy5Ytc8ckBSipUVnV6qAyKVBRckwFZDpu6zh/ww032PXXX29r1qwJfaZo0aKurD///LM99dRTNm7cOHvyyScjvlcBnS6ip02b5h6zZ89255P0yBtgueYoSoCJ5NSiRQtv5MiR7u99+/Z5pUuX9mbNmhV6XX9rFb777rsRnzvzzDO9li1bRkxr2rSpd/fdd4ee63NTp051fz///PNeiRIlvB07doRe//DDD728efN669ati1k2f96TJ08OTdu8ebNXuHBhb8qUKe75+PHjveLFi4deHzRokJcvXz5vzZo1oWkff/yxm8/atWvd8+rVq3uvv/56xLyGDBniNW/e3P29cuVKN9/vv/8+ohxbt24NzVPPV6xYEfr86NGjvbJly4aepzUPANlTjx49vM6dO7u/Dx486H366adewYIFvTvvvDPm+998802vVKlSoedBjh/ly5f3hg8fHnquY3PFihVD841l48aN7nuXLFninvfu3ds7++yzXRmD/q4qVap4Bw4cCE076aSTvFatWoWe79+/3zv66KO9SZMmxf2exx57zGvSpEnEMblIkSJeSkpKaFq/fv28Zs2ahZ5rvk8++WTE9zRo0MB9Np5YyzX8XJDdJf0tV3IrXYUsWLAgdCWTP39+19lafZ7UFBdO9/GL5tc8+VQlvGHDhpjzUq1LgwYNXA2V7/TTT3dXRypHare3Cb/ZsqqLVTum74uncuXKdvzxx0d83p+Pro509XPttddaz549Q+9RdXR6On+rWrp69eoxf7uuBDNiHgCSk2pN1MSmmm8dWy6//PJQs5Jq0tUk9uuvv1pKSorb73fv3u1qmXTcSOv4oW4FarZr1qxZ6HUdm3UMDm8NUP8q1WqrJmjTpk2hmibVXtWtW9c1vZ1zzjnueKmmQNUctWvXLtXfVadOHVez49NxWd/l0yAiNQuGH+fV1UM1QTrmqelMv7dYsWIR36uaLh17Y/3eoD4LsFxzEgKnJKUASRtfhQoVQtO0Y6r9ftSoUREn+fCAx1egQIGI5+oH5O+8ycpvE1d1cviByT8oBBXrt/sHtYyaB4Dk1Lp1axszZowbOKLjpwIbP5WJAhT1e1IzvS701NSmiyg15fkn+NSOH0Gpy4L6Lek4ozLo2Ksgx28ybNy4sa1cudL1T1XQob6e6ov11ltvxf3OWOVK7TivEdndu3e3wYMHu64YOmdMnjzZNTWm51yhYC369+8L644RdLnmJAROSUgB08SJE90GHn0Vog6CkyZNcu3ZGUWdINUOrtoYPwj78ssv3Q6jK6LUzJ8/39UiydatW136AX1fPLriUju9HxDq8/58dAWl6b///rvb4TNDVswDQOLoGKY0BNEWLVrkAgIdV/2aG/UxSg8FH6qRUU3SGWecETpe67sVDMnmzZtdDbqCplatWrlpCiSiqeZHrQh6XHTRRa7mSf2lFHhkhK+++soFbwMGDAhNW7VqVbq/R31XwzvHp6SkuKAvI5drdkPglKRVzQpCFLFHNx/95z//cbVRGRk4KYBQR8MePXq4Ku2NGze6FAj//e9/U22mE3U6V/Ww3qcdtHTp0qkmgtMIEs1HnS+1A2r0n662NApGdHWkafrdOpDs2bPHdbDU8lBny4yQFfMAkFwUTKmm5JlnnnE1Qro4HDt2bLq/59Zbb3Wdp2vUqOEG76ijdngCXnXW1jHx+eefd0GWLhY1gCecPqPXGjVq5IINDcjRMTAjk0SqfJq3apmaNm3qRkBHd2IPQqOtdWGtZaby3X///RG18xm1XLMTRtUlIQVGqraN1edGgZNO8j/++GOGzU9VqRp+q6sd7WC6+mnTpo1rEkyLDiA6kCgdwrp169xoOVWRx6OdrGvXrnb++ee72jT1xQpPBXDddde5VAEaVqvhrWeeeabbaatVq5Zhvzcr5gEguagfpwKWRx991DWbaSRbaikA4lFuKF1U6gJQfTTVP0gj5nwKhBSsqCZG87n99tsPySOlz2i0s/pG6Zir5q6PPvooog/TkerUqZObt0ZHK32AaqA0eji9+vfv746Rao5TWpwuXbpE9AHLqOWaneRRD/FEFwLZj/InqS+BammCXiWpNkvDXv3bpQAAkN1Q4wQAABAQgRMAAEBANNUBAAAERI0TAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAIAF83+jbmaAovgxtQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 600x300 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "fig, ax = plt.subplots(figsize=(6, 3))\n",
-    "bars = ax.bar(\n",
-    "    [\"Arnio pipeline\", \"Pandas manual\"],\n",
-    "    [arnio_time * 1000, pandas_time * 1000],\n",
-    "    color=[\"#2ecc71\", \"#e74c3c\"],\n",
-    "    width=0.4\n",
-    ")\n",
-    "ax.set_ylabel(\"Time (ms)\")\n",
-    "ax.set_title(\"Cleaning time: Arnio vs Pandas (lower is better)\")\n",
-    "for bar in bars:\n",
-    "    ax.text(bar.get_x() + bar.get_width()/2,\n",
-    "            bar.get_height() + 0.2,\n",
-    "            f\"{bar.get_height():.2f} ms\",\n",
-    "            ha=\"center\", fontsize=10)\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
    ]
   }
  ],

--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -1,21 +1,428 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "b0004425-3af8-4383-910d-3a6cc483b240",
+   "metadata": {},
+   "source": [
+    "# Financial CSV Cleaning with Arnio\n",
+    "## GSSoC 2026 — Issue #342\n",
+    "\n",
+    "This notebook demonstrates Arnio's C++-accelerated cleaning pipeline\n",
+    "on a synthetic messy financial payments dataset, and compares it with\n",
+    "the equivalent pandas approach.\n",
+    "\n",
+    "**Dataset:** Synthetic PaySim-style transactions (generated inline)  \n",
+    "**Arnio version:** see Cell 2  \n",
+    "**Author:** Aaroshree Gautam, Kathmandu University"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "dba970b6-c01a-47c6-98d9-75e626a3281c",
+   "execution_count": 9,
+   "id": "241a9888-1375-4aca-8cad-13678e144a5f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Setup — run this cell first if arnio is not installed\n",
+    "# On Windows, always launch Jupyter with: python -m jupyter notebook\n",
+    "# Verify dependencies are installed\n",
+    "try:\n",
+    "    import arnio\n",
+    "    import pandas\n",
+    "    import matplotlib\n",
+    "except ImportError as e:\n",
+    "    raise ImportError(\n",
+    "        f\"Missing dependency: {e}\\n\"\n",
+    "        \"Install with: pip install arnio pandas matplotlib\\n\"\n",
+    "        \"Then restart the kernel and run again.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ca548c96-7e1b-4a2c-86a1-893d40a8d08b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "arnio version : 1.1.1\n",
+      "pandas version: 2.2.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "import io\n",
+    "import time\n",
+    "import pandas as pd\n",
+    "import arnio as ar\n",
+    "\n",
+    "print(f\"arnio version : {ar.__version__}\")\n",
+    "print(f\"pandas version: {pd.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6fa1fda1-0db6-446d-b887-0ded42c01937",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== RAW DATA ===\n",
+      "  transaction_id    amount      type     sender_name   receiver  isFraud\n",
+      "0            T001   500.00    PAYMENT        Alice          bob      0.0\n",
+      "1            T002             TRANSFER          ALICE   charlie      0.0\n",
+      "2            T003   200.00     payment          alice     Dave       1.0\n",
+      "3            T001   500.00    PAYMENT        Alice          bob      0.0\n",
+      "4            T004   750.00    Cash_Out            EVE     frank      NaN\n",
+      "5            T005    90.00     PAYMENT         alice      grace      0.0\n",
+      "\n",
+      "Shape: (6, 6)\n",
+      "\n",
+      "Nulls:\n",
+      "transaction_id     0\n",
+      "  amount           0\n",
+      "  type             0\n",
+      "  sender_name      0\n",
+      "receiver           0\n",
+      "isFraud            1\n",
+      "dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "RAW_CSV = \"\"\"transaction_id ,  amount,  type  ,  sender_name ,receiver,isFraud\n",
+    "T001, 500.00, PAYMENT , Alice   , bob,0\n",
+    "T002,  ,TRANSFER,  ALICE, charlie,0\n",
+    "T003, 200.00,payment,alice, Dave ,1\n",
+    "T001, 500.00, PAYMENT , Alice   , bob,0\n",
+    "T004,750.00,  Cash_Out,  EVE,frank,\n",
+    "T005, 90.00,PAYMENT,  alice ,grace,0\n",
+    "\"\"\"\n",
+    "\n",
+    "raw_df = pd.read_csv(io.StringIO(RAW_CSV))\n",
+    "print(\"=== RAW DATA ===\")\n",
+    "print(raw_df)\n",
+    "print(f\"\\nShape: {raw_df.shape}\")\n",
+    "print(f\"\\nNulls:\\n{raw_df.isnull().sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ae91672a-8672-4a6e-883f-04edc0def90c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== DATA QUALITY PROFILE ===\n",
+      "Rows            : 6\n",
+      "Columns         : 6\n",
+      "Duplicate rows  : 1\n",
+      "Columns with nulls      : ['isFraud']\n",
+      "Columns with whitespace : ['  amount', '  type  ', '  sender_name ', 'receiver']\n",
+      "\n",
+      "=== ARNIO SUGGESTIONS ===\n",
+      "  → strip_whitespace({'subset': ['  amount', '  type  ', '  sender_name ', 'receiver']})\n",
+      "  → drop_duplicates({'keep': 'first'})\n"
+     ]
+    }
+   ],
+   "source": [
+    "frame = ar.from_pandas(raw_df)\n",
+    "\n",
+    "# Let Arnio diagnose the data before cleaning\n",
+    "report = ar.profile(frame)\n",
+    "summary = report.summary()\n",
+    "\n",
+    "print(\"=== DATA QUALITY PROFILE ===\")\n",
+    "print(f\"Rows            : {summary['rows']}\")\n",
+    "print(f\"Columns         : {summary['columns']}\")\n",
+    "print(f\"Duplicate rows  : {summary['duplicate_rows']}\")\n",
+    "print(f\"Columns with nulls      : {summary['columns_with_nulls']}\")\n",
+    "print(f\"Columns with whitespace : {summary['columns_with_whitespace']}\")\n",
+    "\n",
+    "print(\"\\n=== ARNIO SUGGESTIONS ===\")\n",
+    "suggestions = ar.suggest_cleaning(frame)\n",
+    "for step, kwargs in suggestions:\n",
+    "    print(f\"  → {step}({kwargs})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f3d69bd-9555-4d72-9666-9c5287306ad6",
+   "metadata": {},
+   "source": [
+    "## Why each cleaning step matters for financial data\n",
+    "\n",
+    "- **strip_whitespace** — trailing spaces in `sender_name` mean `\"Alice \"` and `\"Alice\"` \n",
+    "  are treated as different people, corrupting aggregations and fraud detection models.\n",
+    "- **normalize_case** — `\"PAYMENT\"`, `\"payment\"`, `\"Payment\"` are the same transaction \n",
+    "  type. Mixed case breaks groupby counts and category encoding.\n",
+    "- **fill_nulls** — missing `isFraud` labels cannot be used in model training. \n",
+    "  Filling with 0.0 makes the assumption explicit rather than silent.\n",
+    "- **drop_duplicates** — duplicate transaction T001 would double-count that payment, \n",
+    "  inflating volume metrics and skewing fraud ratios."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ed956cf9-c0b5-43e8-83c8-5466612391dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== ARNIO CLEANED ===\n",
+      "  transaction_id    amount    type     sender_name  receiver  isFraud\n",
+      "0            t001   500.00   payment          alice      bob      0.0\n",
+      "1            t002           transfer          alice  charlie      0.0\n",
+      "2            t003   200.00   payment          alice     dave      1.0\n",
+      "3            t004   750.00  cash_out            eve    frank      0.0\n",
+      "4            t005    90.00   payment          alice    grace      0.0\n",
+      "\n",
+      "Shape: (5, 6)\n",
+      "\n",
+      "Nulls:\n",
+      "transaction_id     0\n",
+      "  amount           0\n",
+      "  type             0\n",
+      "  sender_name      0\n",
+      "receiver           0\n",
+      "isFraud            0\n",
+      "dtype: int64\n",
+      "\n",
+      "Time: 0.583 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "frame = ar.from_pandas(raw_df)\n",
+    "\n",
+    "start = time.perf_counter()\n",
+    "\n",
+    "cleaned_frame = ar.pipeline(frame, [\n",
+    "    (\"strip_whitespace\",),\n",
+    "    (\"normalize_case\", {\"case_type\": \"lower\"}),\n",
+    "    (\"fill_nulls\", {\"value\": 0.0, \"subset\": [\"isFraud\"]}),\n",
+    "    (\"drop_duplicates\",),\n",
+    "])\n",
+    "\n",
+    "arnio_time = time.perf_counter() - start\n",
+    "\n",
+    "cleaned_df = ar.to_pandas(cleaned_frame)\n",
+    "print(\"=== ARNIO CLEANED ===\")\n",
+    "print(cleaned_df)\n",
+    "print(f\"\\nShape: {cleaned_df.shape}\")\n",
+    "print(f\"\\nNulls:\\n{cleaned_df.isnull().sum()}\")\n",
+    "print(f\"\\nTime: {arnio_time*1000:.3f} ms\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "7fa57998-81ea-432d-8db4-c9b21ef0e513",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== PANDAS EQUIVALENT ===\n",
+      "  transaction_id  amount      type sender_name receiver  isfraud\n",
+      "0           t001  500.00   payment       alice      bob      0.0\n",
+      "1           t002          transfer       alice  charlie      0.0\n",
+      "2           t003  200.00   payment       alice     dave      1.0\n",
+      "3           t004  750.00  cash_out         eve    frank      0.0\n",
+      "4           t005   90.00   payment       alice    grace      0.0\n",
+      "\n",
+      "Shape: (5, 6)\n",
+      "\n",
+      "Nulls:\n",
+      "transaction_id    0\n",
+      "amount            0\n",
+      "type              0\n",
+      "sender_name       0\n",
+      "receiver          0\n",
+      "isfraud           0\n",
+      "dtype: int64\n",
+      "\n",
+      "Time: 10.290 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = time.perf_counter()\n",
+    "\n",
+    "pandas_df = raw_df.copy()\n",
+    "\n",
+    "# 1. Strip whitespace from column names\n",
+    "pandas_df.columns = pandas_df.columns.str.strip().str.lower()\n",
+    "\n",
+    "# 2. Strip whitespace from all string values\n",
+    "pandas_df = pandas_df.apply(\n",
+    "    lambda col: col.str.strip().str.lower() if col.dtype == object else col\n",
+    ")\n",
+    "\n",
+    "# 3. Fill nulls per column type\n",
+    "pandas_df[\"isfraud\"] = pandas_df[\"isfraud\"].fillna(0.0)\n",
+    "\n",
+    "# 4. Drop duplicates\n",
+    "pandas_df = pandas_df.drop_duplicates(keep=\"first\").reset_index(drop=True)\n",
+    "\n",
+    "pandas_time = time.perf_counter() - start\n",
+    "\n",
+    "print(\"=== PANDAS EQUIVALENT ===\")\n",
+    "print(pandas_df)\n",
+    "print(f\"\\nShape: {pandas_df.shape}\")\n",
+    "print(f\"\\nNulls:\\n{pandas_df.isnull().sum()}\")\n",
+    "print(f\"\\nTime: {pandas_time*1000:.3f} ms\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c398db93-62ed-483d-bcd9-6614425dc466",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\n",
+      "Approach              Time (ms)        Code style\n",
+      "==================================================\n",
+      "Arnio pipeline            0.583       declarative\n",
+      "Pandas manual            10.290        imperative\n",
+      "==================================================\n",
+      "\n",
+      "Speedup: 17.6x faster with Arnio\n",
+      "Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\n",
+      "Results verified: same shape, same null counts, same values ✓\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=\" * 50)\n",
+    "print(f\"{'Approach':<20} {'Time (ms)':>10}  {'Code style':>16}\")\n",
+    "print(\"=\" * 50)\n",
+    "print(f\"{'Arnio pipeline':<20} {arnio_time*1000:>10.3f}  {'declarative':>16}\")\n",
+    "print(f\"{'Pandas manual':<20} {pandas_time*1000:>10.3f}  {'imperative':>16}\")\n",
+    "print(\"=\" * 50)\n",
+    "print(f\"\\nSpeedup: {pandas_time/arnio_time:.1f}x faster with Arnio\")\n",
+    "print(\"Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\")\n",
+    "\n",
+    "# Confirm both produce same shape and null counts\n",
+    "assert cleaned_df.shape == pandas_df.shape, \"Shape mismatch!\"\n",
+    "assert cleaned_df.isnull().sum().sum() == pandas_df.isnull().sum().sum(), \"Null mismatch!\"\n",
+    "\n",
+    "# Note: Arnio strip_whitespace cleans values but not column names\n",
+    "# Column names are cleaned manually after conversion to pandas\n",
+    "cleaned_df.columns = cleaned_df.columns.str.strip().str.lower()\n",
+    "pd.testing.assert_frame_equal(\n",
+    "    cleaned_df.reset_index(drop=True),\n",
+    "    pandas_df.reset_index(drop=True),\n",
+    "    check_like=True,\n",
+    "    check_dtype=False # dtypes may differ (e.g. string[python] vs object) but values match\n",
+    ")\n",
+    "print(\"Results verified: same shape, same null counts, same values ✓\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02d9c10c-aa52-4469-88bd-580fe370f9d6",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| | Arnio pipeline | Pandas manual |\n",
+    "|---|---|---|\n",
+    "| Time | ~0.5–2 ms (varies by machine) | ~10–30 ms (varies by machine) |\n",
+    "| Speedup | **~10–20x faster** | baseline |\n",
+    "| API style | Declarative steps | Imperative chains |\n",
+    "| Backend | C++ accelerated | Pure Python |\n",
+    "| Null handling | `fill_nulls` step | `.fillna()` per column |\n",
+    "| Case normalization | `normalize_case` step | `.str.lower()` per column |\n",
+    "| Deduplication | `drop_duplicates` step | `.drop_duplicates()` |\n",
+    "\n",
+    "> Actual times are printed in the executed cells above. Speedup varies by hardware.\n",
+    "\n",
+    "### Key takeaway\n",
+    "Arnio replaces scattered pandas method chains with a strict, named,\n",
+    "reusable pipeline. Each step is auditable and reorderable — critical\n",
+    "for financial data where cleaning logic must be reproducible.\n",
+    "\n",
+    "### Dataset\n",
+    "Synthetic PaySim-style transactions generated inline.\n",
+    "No external files required — runs end to end in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "0e19d8ae-3a27-4f17-acff-5b15d5852a7b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAEiCAYAAAAPh11JAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAN+lJREFUeJzt3Qm4lPP///F3mxYqLdq0StG+SUohpVAqfS2Rr2xlLURIkkQREkoRSpbKliUUkhYkRZSl9JUU7dtRab9/1+vzv+75z0wz59ynzjkz55zn47qmztyz3J+51/f9Wd53Hs/zPAMAAECa8qb9FgAAAAiBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETDlG1alW76qqrLBlMmDDB8uTJY3/88YclE5XpgQceSHQxkk6yrq/sQvud9r+stmPHDitTpoy99tproWnavrUuc4KzzjrLPY7UF1984ZbJW2+9Zdnd9OnT7ZhjjrGNGzcmuijZDoFTLvK///3Prr/+ejvhhBOsUKFCVqxYMTv99NPtqaeesn///TfRxUs6H330UY4Jjg4cOGAVKlRwB/2PP/440cVJGn5w4D+KFClitWvXtvvuu89SUlIst9AxoGjRotatW7dEFyXX+eqrr9x2uG3btkNeGzp0qL377ruZMt9zzz3XTjzxRBs2bFimfH9ORuCUS3z44YdWr149e+ONN+yCCy6wZ555xu0wlStXtn79+tmtt95qyei///2vC+qqVKmSkMBp8ODBMV9TmXRyzS4+//xzW7t2ravNCK9VyEnr60iMGTPGXnnlFRsxYoSdfPLJ9vDDD7sTS264lee+fftc4HTddddZvnz5LCf65JNP3CNZAycdZ7I6cBJdSD/33HP2zz//ZNo8cqL8iS4AMt/KlSvdlaROZjqBli9fPvTazTffbCtWrHCBVTLSgTwZD+aqsctOXn31VWvcuLH16NHD7r33Xtu5c6cdffTRaX4u6PuSfX2l5aKLLrLSpUu7v2+44Qb7z3/+Y++8847Nnz/fmjdvbjnZtGnTXHPNJZdcYtnVwYMHbe/evXH3y6OOOirLy5Ssdu/e7ZZH3rx53Xbeu3dve/PNN+2aa65JdNGyDWqccoHhw4e7PgwvvvhiRNDkU3VtWjVOuhq67bbbrFKlSlawYEH3mUcffdQdsMI9/vjj1qJFCytVqpQVLlzYmjRpErM/gJpFbrnlFnc1VbduXfedderUce3uafWZUa1Jx44dbd68eXbqqae6g6WaHydOnHjIfH788Uc788wzXVkqVqxoDz30kI0fPz7NfjjqazJ69OhQWf1HePnDm/H8Jp/ly5fbFVdcYcWLF7fjjjvOBg4c6GotVq9ebZ07d3bNo+XKlbMnnnjikHnu2bPHBg0a5JatloeW9V133eWmh9u0aZP9+uuvtmvXLgtCNUBTp051wbNOjnr+3nvvxfzN6vOgJt3zzz/fNd107979iNeXPPvss+79+pyaDBWwx7rCDqftRt81e/bsQ17TVbJeW7p0qXu+bt06u/rqq9061jy0nWt5H25fq7PPPjt00aET8v333++2Za1XBZKtWrWyWbNmRXxG81KZtA88//zzVr16dVeWpk2b2rfffnvIPPxlqe1X/2sdxRJ0n/r000+tZcuWduyxx7r1eNJJJ7kgOS0qh/YplTct+/fvtyFDhoR+mz6neYRvo3379nVlDa+t08lZy+bpp58OTVu/fr2bptq+9O4D/vao2lN/u4reFtPq46Rad31WzbMlSpSwU045xV5//XUL2vSt3619WdtDp06d3D4e7ZtvvnE1l9puNB8di7788suI44Zq/KVatWqh44y/LenC5eWXXw5ND+97+tdff7lgp2zZsqH98aWXXorZJ2vy5Mmuhvz444935fCbodWvrX79+jGPB0iFhxzv+OOP90444YTA769SpYrXo0eP0POdO3d69evX90qVKuXde++93tixY70rr7zSy5Mnj3frrbdGfLZixYreTTfd5I0aNcobMWKEd+qpp+ro6U2bNi3ifZrWoEEDr3z58t6QIUO8kSNHujIWKVLE27RpU+h948ePd+9duXJlRPlOOukkr2zZsq48mlfjxo1deZYuXRp635o1a7ySJUu6cg8ePNh7/PHHvZNPPtnNN/o7o3311VfeOeec4973yiuvhB7h5R80aFDouf7WtIYNG3qXXXaZ9+yzz3odOnRw07QcVN4bb7zRTT/99NPd9NmzZ4c+f+DAAa9du3bu9992223ec889591yyy1e/vz5vc6dO0eUzZ/XrFmzAq3PyZMnu2Xz559/uudnn322d/755x/yPq3zggULetWrV3d/az1PnDjxiNeXX962bdt6zzzzjPtd+fLl85o2bert3bs3brl37drlHXPMMW57ita6dWuvTp06oectWrTwihcv7t13333eCy+84A0dOtS9J3wZx+KXbePGjRHTb7/9djd9+vTp7jX97r59+3pjxozxhg8f7tZngQIFvO+//z70Gf1mfaZRo0beiSee6D366KPuvaVLl3b7RfhvnTFjhpc3b16vbt26bvsYMGCAK79+k7bv9O5T2u6POuoo75RTTvGeeuopt+7uvPNO74wzzvDSorJ27do17rIJp+1C0y666CJv9OjR7jig5126dAm955133nHTlixZEpqmbUe/V5/zvfnmm+59/j6bnn1An6tVq5Z33HHHuX1bZQlfF9HOPPNM9/A9//zzod+h+WiZXXvttV6fPn1SXVba5/S5evXquWOi1sc999zjFSpUyKtZs6bbZn0zZ85066R58+beE0884T355JPuM5r2zTffuPf88MMP7nih79Tr/nFmx44d7n/tj61atQpN13FJ1q1b57aLSpUqeQ8++KDbLjt16hT6nujy1q5d2x2bVN5hw4a5Y7rvuuuuc9sogiNwyuG2b9/udpzoA096AiedKI8++mhv+fLlEe/TAUMnQP+ELOEHDtHJQicHnazDqUw6gKxYsSI0TQcRTdfJNa3ASdPmzJkTmrZhwwZ3kLnjjjtC03r37u0ChvAD6ubNm10wlVbgJDfffPMhJ460AqdevXqFpu3fv98d3FSGRx55JDR969atXuHChSOWsQ6KOrHMnTs3Yj46Aep7v/zyy8MOnDp27OiCtfCThk5GWmaxTopar7F+7+GsL81Dn9MJUSdGn4IAve+ll15Ktew6qZQpU8YtS9/atWvdstIJw1+e+q7HHnvMSy9/WS5btswFSCq3TqTalhSY6wSjee/Zsyfic5qnXr/mmmsOCZwUqG/ZsiU0/b333nPTP/jgg9A0ncQUjG3bti007ZNPPnHviw6cguxTOlnGCgDTsm/fPrd9hu830cvGt3jxYvdcJ9pwCtA0/fPPPw+tcz3XRYLoN2p9XXzxxW6Z+RSkaF88ePBguvcBPdd7f/rpp0C/Mzpw0vEwPPAOyg9EdDGakpISmv7GG2+46QrARL+pRo0aXvv27UO/z1+X1apVcxdlPm238Y5HOu6GHyd8CvK0/YRftEi3bt1cAO5vM355dZETvR35dJGh96xfvz7dyyO3oqkuh/OrZNXscrjU/q2mCVVnq5nIf7Rt29ZVWc+ZMyf0XjUl+LZu3Wrbt293n/3uu+8O+V59Prx5QFXGasr6/fff0yyTRj7pe31qFlPTRPhnVXWv/ikNGzYMTStZsmSo+SkzqIOtT319VP2v4/y1114bmq6mlOiyahnXqlXLdUwOX8Z+k1F4s5Cq9/WdQYZXb9682WbMmGGXXXZZaJr6Naj6XgMFYrnxxhtjTj+c9fXZZ5+5pi4186pPha9nz57us2n1rbv00kttw4YNrsnBp2YqNRHrNX+bU58NvUfb3OHQ+tA2pOYSdZhVU5HKpmYNrUe/j4zmu2XLFtdkpXUba7tWubSv+Pzt1F9O6qS/ePFi199MTTi+c845x23X0YLsU9qmRE0u0c3nqdFv0bYUXt7UBkv4TXHh7rjjDve/vy61HLUd+8cFNU1pGapJSs1zv/32m5s+d+5c17ToN4GnZx8QNXvFWl5BaHmtWbMmZhNqEFdeeWXEMVV95NQ87C8jrV/9zssvv9ztg/5vUdNbmzZt3LJJz3oKp/X19ttvu0E++jt8WbVv395tH9Hbpba18O0onL/u9XkEQ+fwHE4nJzmSURM6AKivkA6IsejEFt7RVP2IdOAI75cQKx+MRvTF2omDnPyCfHbVqlUxO/bqpJhZosulE6P6sPgdj8On64Aavox/+eWXQMs4PaZMmeJGTTVq1MgNAvA1a9bM9Q9RX6Nw+fPnd/2Egvy2IOtL68APTMIpEFG/NP/1ePz+IfodOuH4v0nBcM2aNd1z9e9QfzudwNXf47TTTnN94HRyUx+UIHQi0r5SoEAB9/uj+/uon4n6palvmZanT4FWWsvJPzH5y8n/zTVq1Djks1pO0Se9IPuUgrUXXnjBBe733HOPW1Zdu3Z1J/TwgDWeIKMHVW59V/T+o2WsQCR8XSqw84MIBUgKMvXQhYueaz398MMPLrA43H0g1rIP6u6773ZBvfpI6ve0a9fOlUXpWYKIXndaF/oev0+dHxwqYIlHAU6QgDWaOvKrf6D60elxpMvKX/c5JWdXViBwyuF0MlBnXL8T7eHQlZGuhtVJMxb/BKYDojpJnnHGGa4zsK7AdCJSZ+xYnS7jjb4KchA/ks9mpljlClJWLWOli9Bw+FjUSfZw+KkH4p0QVAuiAManICTeiTYRy1zl6dKli+s4rW1KNRaqwdAw7XCq0dIVuDo6q4ZNnfKVbkOjSBU0pkXbbHRwGz4iUZ1yVQ7VmqhDrZaFvl8d6TNzOQXdp1SboFoM1cqo5ke1rQowVVujYfjxyqRARifM9NTUBTnBqiZp3LhxbvvSb1Agpc9pup7rmKRtPrzWOL37QLwalCBUs7Vs2TIXlGpZKXDW8tUggHgpSNLDr0167LHHImq8w6kD/5F8twahxAvMVBscdFn56z7e9o9DETjlArr61pXJ119/fVhDq3X1rVF5aqpJjQ4+ql3RiUsnPJ8O8omg9AvhtSy+WNNiycorMC1jXYGrpiCj5qsRYcoRo9FHataIPvgq55JOvpmZj8rP56STVHiApuY7lS+tbcqvTVGNz8yZM12NhAIQv5kuehmq1kkPXfHrhKVaIgU+R0JNgyq70hOErxuN/jqSZeLXSoTTcjrcfUoBr7YfPRR8KLgcMGCAC6biLWfVMGq5aV0EKbe2G5VbgYdPwaxqQMJzd/kBkUb6qTlMtWCiAFCj6BQ4aTSaRghm5j6QGs1f25Ee2h5VQ6f8Xf37908z3Uj0utM2qeOKH7D4NZa6cE1rG0/tt8Z6TTVyaiZUN4kg+09atO4VNMWr6cOh6OOUC6imSAcJVePrIBdNV81KgBePhrAr6NLBO5oOmOrvIbqq1Y6uHdqnquvMTOCWGrX3q9xq4gjv0xE0AaSfvyitYfMZQctYw4t1lR5N6QPUNyK96Qj836n1ryab8Ifmp2AqM5Nhig7sapbTMPTwGhelxlBTRYcOHQJ9h2pGVIOih5pXwpsetByUmyacTlw6uUQPYz8cfm1NePk1zFzb1uFQrZGCOgWDWgY+BRk///zzIfMOsk9pu47m13SktQx0MbVw4cI0y60UFTJy5MiI6X4NUfi61PrR0Pcnn3zSNW36NZ4KqHS8UTCqJlUFboezDxyp8GZy0Taq/lJax+FNsfEo9Ul49wf9HvVdO++889xzBYTaBpVKQhed0cJvc5LacUavRU/XNqF+igqqY7UkpPcWKosWLcrxucoyGjVOuYB2YNUs6MpKV4rq+6G8MbrKUo2EOmWmdm86NU+8//77ruZK79NBQQexJUuWuAOGDuS6YtGBUwdR9UtRfwG1sysXktr+1UcqqylgUG2DmhmVR0YHIfUDUR8UnWjSuqr1r4b79OnjgjAdsDLrlhSq/VFnbSVfVA2BTjQ6WSpA0nQFreojIqNGjXLNCXpfah3EFRTp5BmvmU9NQFou6lOj5JiZQVexuoJXebVdaJ6qVVGziPIbqbkhLWqaUm2ActFou9PJKJxyZ6mWQidenfx0MlbTni4SMmJ9abtXbdOFF17otnFdoY8dO9bNK9ZJMQg18+m71HSlXDzaHv28QuHfGXSfevDBB11Tnd6vmh+9T8tY/bU0j9Qo35Wypms5+s3usTRo0MA1Dan2WidzBd4LFixwAaCaMVu3bh3xfgVJWmdqfvP78mg7036oeYX3b0rvPnCk1KdJfbM0D/W3Uk2m9istvyADaRTIa7kqd5i2MwWTWica9ODX/ulYo0BK61TvUyCpwFC/TTVRH3zwQcRxRrWD2l61vavZ2a+RU18sbQOqpVNAqv6JjzzyiPse/a15alvUNqR9We+PFUjHou1E21F0X0ekIdHD+pB1lE6gZ8+eXtWqVd0Q8aJFi7ph6hpOvnv37rjpCOSff/7x+vfv73K+6LPK+6HcOcqNFJ6f5sUXX3TDcDWcWzmTNDw9Vj4YPddw/2jR846XjkA5ktIacixKRaA8KCqPUgMoh8nTTz/tvlO5UFKjYehKaaBcMRqyHf4b4qUjiB4Ort+iIcWxyho9HFrLUbl/NF3lLVGihNekSROXp0ZpJdKTjmDRokXuPQMHDoz7nj/++MO9RzmLUivrka4vP/2AtgflPtKQdOW00pD+oD799FP3vVoPq1evjnhNQ7JVNn2/yq/h2M2aNXNDxNMSb72F03ByDdnWb9V6UZ4m5VDS7w5PHeCnI4iVFiF6e5G3337b5SLSdyrPjvIfRX9n0H1KOYM0xL5ChQpu/9T/SuUQnUIkFqVa0P6stCOxlk10+gJtjxpSr3WpPEI6LoQfP3zKraTPa12HUz4vTVeZowXdB+Jtj/FEHxuUckI5rpQ6ws9d1q9fv4h5xOIP7580aZL73UqVodQiOh6tWrXqkPfr+KMcWf58tG4vueSSQ367lr1SHCjFQvj+8+uvv7pyah6aHr6vKX2AloHWgdZFuXLlvDZt2rh0I9HlVc6sWJT/SXmzwlMrIG159E9awRWQk6gjsTJP68o+O94eBMhoygauflPqu8M+kXto4IRqrdWkiuDo44QcTX0jovs2qFlC1eycIID/5/bbb3cXEmpaQ+6g0YQKlNWUjvShxgk5mvr46IpKfbvUF0Gdkv/++283QksjfAAASA86hyNH00ggdWBXh1Z1BlfnVAVPBE0AgMNBjRMAAEBA9HECACAOpXlQegClA1Ctday8dKp/UNZx5ehSlm7lHouV4DQ6JYVScij9gbLRK6VDdAJU5bxSGgyl9VAKA6XciJWLD1mLwAkAgDiUO0w5rJQ/K57hw4e7JK/K76XkqMrBpNxv0YlZw82ePdvlT5o/f75LfqrEm8ov5Sf61P96rmBNtw7SrYaUe09B3OHeIBgZI8c31WkDU2dgRfXcxBAAcLh0w2klllVSVJ9Oobo5s25tpGS5oozwuhGwkpAqU38QuiOAkhXr5shKzKkBLPqsbp7s36xd36sEp0rwGp1w1KcknkqIqVHDSnysrOi6rdLFF1/skhm/9957rgZL99FTcmD/fnV6TQGaAjbVrunWRUES1OYUWo/KBq/fntaNsXN84LRmzZrDvkEqAADIPVavXu0y7ufqUXV++nwtDD9qBwAgI2qc1DSnJjX1T9JtXHy6PY1aOSZMmBCoZUS3W1GNkn9PUNVAKUFl9+7dXf8p1XE88MADboSwbn0V7/6iqnHSrWqUp0n0tyoP1MSnxL+iflK6vY5uz6J+Vpp3qVKlUm2OzOlSUlLccgpyy50cHzj5zXMKmgicAABHokiRIhHnEv8mvTrhhk/XPed0/gly3rnxxhvdPfnmzZsXer/+131E9Zr6Tqn56LLLLnMpVQoVKhT3e9VEV79+/YjXFRTpc/40PzhQs5ym6Z6VunGw7j+qIFAd1Vu0aGG5UZ4AXXroHA4AwGHya5miR7vpeXgNVDzqGzVt2jR3097oJiIFMRpZp5vxqgZKdz3QjYJPOOGEVL9TQVt0MBA+zQ8O/E7muhmx+lIpg7z6BOum2XfeeWeaZc+tCJwAADhM1apVcwGSOnOHN/uoCa958+ZxP6emNwVN6uitTtn6nnhKly5txx57rHufgqhOnTpl+O9Qh3E1L7766qs2cuRI1ySIXNpUBwDA4dI9/FasWBF6vnLlSlu8eLGVLFnSKleu7GpvdOPwhx56yI2kUwA0cOBANzpLTV4+1eIoJ5OCJVEqAo160yg3NZ2tW7cu1I9KuaBEN17W7aIU1Hz99dd26623ulohjeLLSOpD1aRJE6tTp47t2bPH1YBpvoiNwAkAgDgWLlwYMfS/b9++7n/Vzvgdv++66y7XX6hXr162bds2dxNxdc5WXySfmtzU3OYbM2aM+1/30gynYEmdv0UdznUT3i1btljVqlVtwIABLnDKaEpZoPn88ccfLmhr1aoVN3zOzekIVGWqCF6jFegcDgAAjiRWoI8TAABAQAROAAAAARE4AQAABETncABAUlh3QatEFwFJrNwHcy0ZUOMEAACQHQKnOXPmuPvnKN+FcmG8++67Ea9rwJ/yS5QvX94NkWzbtq399ttvCSsvAADI3RIaOCnvRYMGDeLeWHD48OH29NNPu/v0KAur7gnUvn172717d5aXFQAAIKF9nHR/HD1iUW2T0r7fd9991rlzZzdt4sSJVrZsWVczpbs5AwAAZKWk7eOktPZKQa/mOZ+SUzVr1sylno9H6eKVyCr8AQAAkKMDJ/++PaphCqfn/muxDBs2zAVY/qNSpUqZXlYAAJA7JG3gdLh0vx2lTPcfq1evTnSRAABADpG0gVO5cuXc/+vXr4+Yruf+a7EULFjQ3Wcm/AEAAJCjA6dq1aq5AGnmzJmhaeqvpNF1zZs3T2jZAABA7pTQUXU7duywFStWRHQIX7x4sZUsWdIqV65st912mz300ENWo0YNF0gNHDjQ5Xzq0qVLIosNAAByqYQGTgsXLrTWrVuHnvft29f936NHD5swYYLdddddLtdTr169bNu2bdayZUubPn26FSpUKIGlBgAAuVUeTwmTcjA172l0nTqK098JAJIX96pDou5Vl55YIWn7OAEAACQbAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAnBA4HThwwAYOHGjVqlWzwoULW/Xq1W3IkCHmeV6iiwYAAHKh/JbEHn30URszZoy9/PLLVqdOHVu4cKFdffXVVrx4cevTp0+iiwcAAHKZpA6cvvrqK+vcubN16NDBPa9atapNmjTJFixYkOiiAQCAXCipm+patGhhM2fOtOXLl7vnP/zwg82bN8/OO++8uJ/Zs2ePpaSkRDwAAAByfI3TPffc4wKfk08+2fLly+f6PD388MPWvXv3uJ8ZNmyYDR48OEvLCQAAcoekrnF644037LXXXrPXX3/dvvvuO9fX6fHHH3f/x9O/f3/bvn176LF69eosLTMAAMi5krrGqV+/fq7WqVu3bu55vXr1bNWqVa5WqUePHjE/U7BgQfcAAADIVTVOu3btsrx5I4uoJruDBw8mrEwAACD3SuoapwsuuMD1aapcubJLR/D999/biBEj7Jprrkl00QAAQC6U1IHTM8884xJg3nTTTbZhwwarUKGCXX/99Xb//fcnumgAACAXyuPl8DTcGpWnhJnqKF6sWLFEFwcAEMe6C1olughIYuU+mJsUsUJS93ECAABIJgROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAAeVPz5sPHjxos2fPtrlz59qqVats165ddtxxx1mjRo2sbdu2VqlSpcwrKQAAQHaocfr333/toYcecoHR+eefbx9//LFt27bN8uXLZytWrLBBgwZZtWrV3Gvz58/P/FIDAAAka41TzZo1rXnz5jZu3Dg755xzrECBAoe8RzVQr7/+unXr1s0GDBhgPXv2zIzyAgAAJEwez/O8tN70yy+/WK1atQJ94b59++zPP/+06tWrWzJISUmx4sWL2/bt261YsWKJLg4AII51F7RKdBGQxMp9MDcpYoVATXVBgyZRbVSyBE0AAAAJHVU3ffp0mzdvXuj56NGjrWHDhnb55Zfb1q1bM7RwAAAA2Tpw6tevn6vSkiVLltgdd9zhOoWvXLnS+vbtmxllBAAAyH7pCEQBUu3atd3fb7/9tnXs2NGGDh1q3333nQugAAAAcqp01zgdddRRLn+TfPbZZ9auXTv3d8mSJUM1UQAAADlRumucWrZs6ZrkTj/9dFuwYIFNmTLFTV++fLlVrFgxM8oIAACQPWucRo0aZfnz57e33nrLxowZY8cff7ybrqSY5557bmaUEQAAIHvWOFWuXNmmTZt2yPQnn3wyo8oEAACQMwIn34YNG9xD968LV79+/YwoFwAAQPYPnBYtWmQ9evRw2cT9pON58uRxf+v/AwcOZEY5AQAAsl/gdM0117h717344otWtmxZFywBAADkBukOnH7//XeXv+nEE0/MnBIBAADklFF1bdq0sR9++MGyyl9//WVXXHGFlSpVygoXLmz16tWzhQsXZtn8AQAADrvG6YUXXnB9nJYuXWp169Z1N/UN16lTJ8souved8kW1bt3apTs47rjj7LfffrMSJUpk2DwAAAAyLXD6+uuv7csvv3SBTLSM7hz+6KOPWqVKlWz8+PGhadWqVcuw7wcAAMjUprrevXu7prO1a9e6VAThj4weUff+++/bKaecYhdffLGVKVPGGjVqZOPGjcvQeQAAAGRa4LR582a7/fbb3Yi6zKaO6MpOXqNGDZsxY4bdeOON1qdPH3v55ZfjfmbPnj3unnnhDwAAgIQETl27drVZs2ZZVlAtVuPGjW3o0KGutqlXr17Ws2dPGzt2bNzPDBs2zIoXLx56qKkPAAAgIX2clMOpf//+Nm/ePDfCLbpzuGqEMkr58uWtdu3aEdNq1arl0iHEo7LpJsQ+1TgRPAEAgISNqjvmmGNs9uzZ7hHdOTwjAyeNqFu2bFnEtOXLl1uVKlXifqZgwYLuAQAAkPDAaeXKlZZV1JeqRYsWrqnukksusQULFtjzzz/vHgAAAEnfxykrNW3a1KZOnWqTJk1yOaOGDBliI0eOtO7duye6aAAAIBcKFDg98sgj9u+//wb6wm+++cY+/PBDyygdO3a0JUuW2O7du92NhdU5HAAAIGkDp59//tkqV65sN910k0t8uXHjxtBr+/fvtx9//NGeffZZ16x26aWXWtGiRTOzzAAAAMnbx2nixInu/nSjRo2yyy+/3I1Uy5cvn+uEvWvXLvcepQu47rrr7KqrrrJChQpldrkBAACyXB7P87z05lZSDdOqVatc813p0qWtYcOG7v9kpCBP+Zy2b99uxYoVS3RxAABxrLugVaKLgCRW7oO5SRErpHtUXd68eV2gpAcAAEBuktSj6gAAAJIJgRMAAEBABE4AAAABETgBAABkduC0YsUKmzFjRigxZjoH5wEAAOT8wGnz5s3Wtm1bq1mzpp1//vm2du1aN/3aa6+1O+64IzPKCAAAkD0DJ914N3/+/Pbnn39akSJFQtOVMXz69OkZXT4AAICkke48Tp988olroqtYsWLE9Bo1arikmAAAADlVumucdu7cGVHT5NuyZYu7BQsAAEBOle7AqVWrVu7edb48efK427AMHz7cWrdundHlAwAAyL5NdQqQ2rRpYwsXLrS9e/faXXfdZT/99JOrcfryyy8zp5QAAADZscapbt26tnz5cmvZsqV17tzZNd117drVvv/+e6tevXrmlBIAACA71jiJ7iA8YMCAjC8NAABATgucdu/ebT/++KNt2LDB9W8K16lTp4wqGwAAQPYOnJSr6corr7RNmzYd8po6ih84cCCjygYAAJC9+zj17t3bLr74YpcxXLVN4Q+CJgAAkJOlO3Bav3699e3b18qWLZs5JQIAAMgpgdNFF11kX3zxReaUBgAAICf1cRo1apRrqps7d67Vq1fPChQoEPF6nz59MrJ8AAAA2TdwmjRpkrtfXaFChVzNkzqE+/Q3gRMAAMip0h04KX/T4MGD7Z577rG8edPd0gcAAJBtpTvy0W1WLr30UoImAACQ66Q7+unRo4dNmTIlc0oDAACQk5rqlKtJN/qdMWOG1a9f/5DO4SNGjMjI8gEAAGTfwGnJkiXWqFEj9/fSpUsjXgvvKA4AAGC5PXCaNWtW5pQEAAAgydHDGwAAICNrnLp27WoTJkywYsWKub9T884771hmeeSRR6x///5266232siRIzNtPgAAAIcdOBUvXjzUf0l/J8K3335rzz33nOuQDgAAkLSB0/jx4+3BBx+0O++80/2d1Xbs2GHdu3e3cePG2UMPPZTl8wcAAEhXHydlC1cAkwg333yzdejQwdq2bZvme/fs2WMpKSkRDwAAgCwdVed5niXC5MmT7bvvvnNNdUEMGzbMBXkAAAAJHVWX1XmaVq9e7TqCv/baa+6mwkGo8/j27dtDD30HAABAludxqlmzZprB05YtWyyjLFq0yDZs2GCNGzeOyFw+Z84cGzVqlGuWy5cvX8RnChYs6B4AAAAJDZzUBJaVo+ratGnjMpWHu/rqq+3kk0+2u++++5CgCQAAIGkCp27dulmZMmUsqxQtWtTq1q0bMe3oo4+2UqVKHTIdAAAgafo4cR86AACQ2yX9qLpoX3zxRaKLAAAAcqnAgdPBgwcztyQAAABJjpv8AgAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAOSEwGnYsGHWtGlTK1q0qJUpU8a6dOliy5YtS3SxAABALpXUgdPs2bPt5ptvtvnz59unn35q+/bts3bt2tnOnTsTXTQAAJAL5bckNn369IjnEyZMcDVPixYtsjPOOCNh5QIAALlTUtc4Rdu+fbv7v2TJkokuCgAAyIWSusYp3MGDB+22226z008/3erWrRv3fXv27HEPX0pKShaVEAAA5HTZpsZJfZ2WLl1qkydPTrNDefHixUOPSpUqZVkZAQBAzpYtAqdbbrnFpk2bZrNmzbKKFSum+t7+/fu7Jj3/sXr16iwrJwAAyNmSuqnO8zzr3bu3TZ061b744gurVq1amp8pWLCgewAAAOSqwEnNc6+//rq99957LpfTunXr3HQ1wRUuXDjRxQMAALlMUjfVjRkzxjW3nXXWWVa+fPnQY8qUKYkuGgAAyIWSvqkOAAAgWSR1jRMAAEAyIXACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicMpFRo8ebVWrVrVChQpZs2bNbMGCBam+f8KECZYnT56Ihz4bbseOHXbLLbdYxYoV3f0Da9eubWPHjs3kXwIAQGIk9S1XkHF0f7++ffu6oEZB08iRI619+/a2bNkyK1OmTNzPFStWzL3Hp+ApnL7z888/t1dffdUFZZ988onddNNNVqFCBevUqVOm/iYAALIaNU65xIgRI6xnz5529dVXh2qFihQpYi+99FKqn1OgVK5cudCjbNmyEa9/9dVX1qNHD3cjZgVOvXr1sgYNGqRam3XVVVdZly5dbOjQoe77jj32WHvwwQdt//791q9fPytZsqSrwRo/fnzoM3v37nU1W7rJs2q9qlSpYsOGDcuAJQMAQHAETrmAgo5FixZZ27ZtQ9Py5s3rnn/99depflZNcQpSKlWqZJ07d7affvop4vUWLVrY+++/b3/99Ze7KfOsWbNs+fLl1q5du1S/V7VUf//9t82ZM8cFdYMGDbKOHTtaiRIl7JtvvrEbbrjBrr/+eluzZo17/9NPP+3m88Ybb7gasNdee80FagAAZCUCp1xg06ZNduDAgUNqi/R83bp1cT930kknuRqp9957zzXFHTx40AVKfjAjzzzzjKvBUg3RUUcdZeeee67rS3XGGWekWibVKikY0jyuueYa9/+uXbvs3nvvtRo1alj//v3d982bN8+9/88//3TTW7Zs6QI5/X/ZZZcd8bIBACA96OOEuJo3b+4ePgVNtWrVsueee86GDBkSCpzmz5/vaoMU0KgG6eabb3Z9nMJruKLVqVPH1XqFB3F169YNPc+XL5+VKlXKNmzYEGreO+ecc1yApeBMtVNp1WoBAJDRCJxygdKlS7tAZP369RHT9Vz9loIqUKCANWrUyFasWOGe//vvv66GaOrUqdahQwc3rX79+rZ48WJ7/PHHUw2c9F3RfaliTVMtlzRu3NhWrlxpH3/8sX322Wd2ySWXuO9/6623ApcfAIAjRVNdLqAmryZNmtjMmTND0xSQ6Hl4jVJa1Ny3ZMkS10Fb9u3b5x7hNUeiIM0PeDKSRvhdeumlNm7cODdK8O2337YtW7Zk+HwAAIiHGqdcQmkDNPrtlFNOsVNPPdWlI9i5c6cbZee78sor7fjjjw+NVtNIt9NOO81OPPFE27Ztmz322GO2atUqu+6660KBzJlnnulGwimHk5rqZs+ebRMnTnQdvjOSvk8Bm2q8FKi9+eabrrZMI/IAAMgqBE65hGpqNm7caPfff7/rEN6wYUObPn16RIdxdcAOrz3aunWrS2Gg92u0m2qtlH5AncF9kydPdh25u3fv7mp/FDw9/PDDblRcRipatKgNHz7cfvvtN1ej1bRpU/voo48Oqe0CACAz5fE0hjwHS0lJseLFi9v27dtdDQkAIDmtu6BVoouAJFbug7lJEStwuQ4AABAQgRMAAEBABE4AAAAB0Tk8AzRY1DfRRUAS+6FJxo4wBAAkDjVOAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAAJCTAqfRo0db1apVrVChQtasWTNbsGBBoosEAAByoaQPnKZMmWJ9+/a1QYMG2XfffWcNGjSw9u3b24YNGxJdNAAAkMskfeA0YsQI69mzp1199dVWu3ZtGzt2rBUpUsReeumlRBcNAADkMkl9y5W9e/faokWLrH///qFpefPmtbZt29rXX38d8zN79uxxD9/27dvd/ykpKZlWzgM7/v/8gGiZue0BOck/+/YnughIYkUy8VjqH6c9z8vegdOmTZvswIEDVrZs2Yjpev7rr7/G/MywYcNs8ODBh0yvVKlSppUTSE1xezbRRQCA7K948UyfxT///GPF05hPUgdOh0O1U+oT5Tt48KBt2bLFSpUqZXny5Elo2XIDRe0KUlevXm3FihVLdHEAIFviWJq1VNOkoKlChQppvjepA6fSpUtbvnz5bP369RHT9bxcuXIxP1OwYEH3CHfsscdmajlxKO3o7OwAcGQ4lmadtGqaskXn8KOOOsqaNGliM2fOjKhB0vPmzZsntGwAACD3SeoaJ1GzW48ePeyUU06xU0891UaOHGk7d+50o+wAAACyUtIHTpdeeqlt3LjR7r//flu3bp01bNjQpk+ffkiHcSQHNZMq51Z0cykAIDiOpckrjxdk7B0AAACSu48TAABAMiFwAgAACIjACQAAICACp1xKyUDffffdTJ3HhAkTMjyH1h9//OHKvnjxYvf8iy++cM+3bduWofMBgKCuuuoq69KlS6KLkbQmZMK5IJEInJKc7smnJKAdOnTI0O9du3atnXfeeZbZIyKXL1+eqfNo0aKF+y1BE5cByNkBjC6k9FAewBNPPNEefPBB27+fe+Ah4xA4JbkXX3zRevfubXPmzLG///471fdqgGTQA4Qyr2f2MNfChQtbmTJlMnUeOjjqt3A7HQBy7rnnuoup3377ze644w574IEH7LHHHkt0sZCDEDglsR07dtiUKVPsxhtvdDVOqu4M5zdTffzxxy7DugKhefPm2VlnnWV9+vSxu+66y0qWLOkCCx08UmuqW7JkiZ199tku2NF9/Xr16uXmH48/7w8//NDq169vhQoVstNOO82WLl0at3pWZVAerueee87dg6lIkSJ2ySWX2Pbt2yO++4UXXrBatWq57zz55JPt2Wfj3yQ3uqnOn+eMGTPcdxxzzDGhA+nhzgNA9qHjoI55VapUccfOtm3b2vvvv+9eGzFihNWrV8+OPvpodwy66aabIo5zQY4fuvG8EjPrfTpW6jgbndVHuQZbtmwZek/Hjh3tf//7X+j1vXv32i233GLly5d3xyCVVTeoT6spcOjQoS6Hob7Xr0nr16+fO85XrFjRxo8fH/G5u+++22rWrOmOtSeccIINHDjQ9u3bd8gx+ZVXXrGqVau6mvtu3bq5e7b5NF2Jp8M1bNgw4pyS1nLNaQicktgbb7zhTuonnXSSXXHFFfbSSy8dsoPKPffcY4888oj98ssvLoiRl19+2W3E33zzjQ0fPtztZJ9++mnM+SgTe/v27a1EiRL27bff2ptvvmmfffaZ27HTop32iSeecJ877rjj7IILLojYMaOtWLHC/a4PPvjAHVy+//57t5P5XnvtNZfs9OGHH3a/RwcK7ez6PUHt2rXLHn/8cXcwUE3dn3/+aXfeeWeGzgNA9qCLQQUqkjdvXnv66aftp59+cvv7559/7gKf9Bw/dLxTgKXjsS5UdRP5qVOnHnJMVXC1cOFCd4swzffCCy90twwTlUHBnI6Fy5Ytc8ckBSipUVnV6qAyKVBRckwFZDpu6zh/ww032PXXX29r1qwJfaZo0aKurD///LM99dRTNm7cOHvyyScjvlcBnS6ip02b5h6zZ89255P0yBtgueYoSoCJ5NSiRQtv5MiR7u99+/Z5pUuX9mbNmhV6XX9rFb777rsRnzvzzDO9li1bRkxr2rSpd/fdd4ee63NTp051fz///PNeiRIlvB07doRe//DDD728efN669ati1k2f96TJ08OTdu8ebNXuHBhb8qUKe75+PHjveLFi4deHzRokJcvXz5vzZo1oWkff/yxm8/atWvd8+rVq3uvv/56xLyGDBniNW/e3P29cuVKN9/vv/8+ohxbt24NzVPPV6xYEfr86NGjvbJly4aepzUPANlTjx49vM6dO7u/Dx486H366adewYIFvTvvvDPm+998802vVKlSoedBjh/ly5f3hg8fHnquY3PFihVD841l48aN7nuXLFninvfu3ds7++yzXRmD/q4qVap4Bw4cCE076aSTvFatWoWe79+/3zv66KO9SZMmxf2exx57zGvSpEnEMblIkSJeSkpKaFq/fv28Zs2ahZ5rvk8++WTE9zRo0MB9Np5YyzX8XJDdJf0tV3IrXYUsWLAgdCWTP39+19lafZ7UFBdO9/GL5tc8+VQlvGHDhpjzUq1LgwYNXA2V7/TTT3dXRypHare3Cb/ZsqqLVTum74uncuXKdvzxx0d83p+Pro509XPttddaz549Q+9RdXR6On+rWrp69eoxf7uuBDNiHgCSk2pN1MSmmm8dWy6//PJQs5Jq0tUk9uuvv1pKSorb73fv3u1qmXTcSOv4oW4FarZr1qxZ6HUdm3UMDm8NUP8q1WqrJmjTpk2hmibVXtWtW9c1vZ1zzjnueKmmQNUctWvXLtXfVadOHVez49NxWd/l0yAiNQuGH+fV1UM1QTrmqelMv7dYsWIR36uaLh17Y/3eoD4LsFxzEgKnJKUASRtfhQoVQtO0Y6r9ftSoUREn+fCAx1egQIGI5+oH5O+8ycpvE1d1cviByT8oBBXrt/sHtYyaB4Dk1Lp1axszZowbOKLjpwIbP5WJAhT1e1IzvS701NSmiyg15fkn+NSOH0Gpy4L6Lek4ozLo2Ksgx28ybNy4sa1cudL1T1XQob6e6ov11ltvxf3OWOVK7TivEdndu3e3wYMHu64YOmdMnjzZNTWm51yhYC369+8L644RdLnmJAROSUgB08SJE90GHn0Vog6CkyZNcu3ZGUWdINUOrtoYPwj78ssv3Q6jK6LUzJ8/39UiydatW136AX1fPLriUju9HxDq8/58dAWl6b///rvb4TNDVswDQOLoGKY0BNEWLVrkAgIdV/2aG/UxSg8FH6qRUU3SGWecETpe67sVDMnmzZtdDbqCplatWrlpCiSiqeZHrQh6XHTRRa7mSf2lFHhkhK+++soFbwMGDAhNW7VqVbq/R31XwzvHp6SkuKAvI5drdkPglKRVzQpCFLFHNx/95z//cbVRGRk4KYBQR8MePXq4Ku2NGze6FAj//e9/U22mE3U6V/Ww3qcdtHTp0qkmgtMIEs1HnS+1A2r0n662NApGdHWkafrdOpDs2bPHdbDU8lBny4yQFfMAkFwUTKmm5JlnnnE1Qro4HDt2bLq/59Zbb3Wdp2vUqOEG76ijdngCXnXW1jHx+eefd0GWLhY1gCecPqPXGjVq5IINDcjRMTAjk0SqfJq3apmaNm3qRkBHd2IPQqOtdWGtZaby3X///RG18xm1XLMTRtUlIQVGqraN1edGgZNO8j/++GOGzU9VqRp+q6sd7WC6+mnTpo1rEkyLDiA6kCgdwrp169xoOVWRx6OdrGvXrnb++ee72jT1xQpPBXDddde5VAEaVqvhrWeeeabbaatVq5Zhvzcr5gEguagfpwKWRx991DWbaSRbaikA4lFuKF1U6gJQfTTVP0gj5nwKhBSsqCZG87n99tsPySOlz2i0s/pG6Zir5q6PPvooog/TkerUqZObt0ZHK32AaqA0eji9+vfv746Rao5TWpwuXbpE9AHLqOWaneRRD/FEFwLZj/InqS+BammCXiWpNkvDXv3bpQAAkN1Q4wQAABAQgRMAAEBANNUBAAAERI0TAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAIAF83+jbmaAovgxtQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 600x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6, 3))\n",
+    "bars = ax.bar(\n",
+    "    [\"Arnio pipeline\", \"Pandas manual\"],\n",
+    "    [arnio_time * 1000, pandas_time * 1000],\n",
+    "    color=[\"#2ecc71\", \"#e74c3c\"],\n",
+    "    width=0.4\n",
+    ")\n",
+    "ax.set_ylabel(\"Time (ms)\")\n",
+    "ax.set_title(\"Cleaning time: Arnio vs Pandas (lower is better)\")\n",
+    "for bar in bars:\n",
+    "    ax.text(bar.get_x() + bar.get_width()/2,\n",
+    "            bar.get_height() + 0.2,\n",
+    "            f\"{bar.get_height():.2f} ms\",\n",
+    "            ha=\"center\", fontsize=10)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "",
-   "name": ""
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
-   "name": ""
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "id": "241a9888-1375-4aca-8cad-13678e144a5f",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "id": "ca548c96-7e1b-4a2c-86a1-893d40a8d08b",
    "metadata": {},
    "outputs": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "id": "6fa1fda1-0db6-446d-b887-0ded42c01937",
    "metadata": {},
    "outputs": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "id": "ae91672a-8672-4a6e-883f-04edc0def90c",
    "metadata": {},
    "outputs": [
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "id": "ed956cf9-c0b5-43e8-83c8-5466612391dd",
    "metadata": {},
    "outputs": [
@@ -202,7 +202,7 @@
       "isFraud            0\n",
       "dtype: int64\n",
       "\n",
-      "Time: 0.583 ms\n"
+      "Time: 0.595 ms  (6 synthetic rows — illustrative only)\n"
      ]
     }
    ],
@@ -225,12 +225,12 @@
     "print(cleaned_df)\n",
     "print(f\"\\nShape: {cleaned_df.shape}\")\n",
     "print(f\"\\nNulls:\\n{cleaned_df.isnull().sum()}\")\n",
-    "print(f\"\\nTime: {arnio_time*1000:.3f} ms\")"
+    "print(f\"\\nTime: {arnio_time*1000:.3f} ms  (6 synthetic rows — illustrative only)\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "id": "7fa57998-81ea-432d-8db4-c9b21ef0e513",
    "metadata": {},
    "outputs": [
@@ -257,7 +257,7 @@
       "isfraud           0\n",
       "dtype: int64\n",
       "\n",
-      "Time: 10.290 ms\n"
+      "Time: 12.100 ms  (6 synthetic rows — illustrative only)\n"
      ]
     }
    ],
@@ -286,12 +286,12 @@
     "print(pandas_df)\n",
     "print(f\"\\nShape: {pandas_df.shape}\")\n",
     "print(f\"\\nNulls:\\n{pandas_df.isnull().sum()}\")\n",
-    "print(f\"\\nTime: {pandas_time*1000:.3f} ms\")"
+    "print(f\"\\nTime: {pandas_time*1000:.3f} ms  (6 synthetic rows — illustrative only)\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "id": "c398db93-62ed-483d-bcd9-6614425dc466",
    "metadata": {},
    "outputs": [
@@ -299,41 +299,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "=== API DESIGN COMPARISON ===\n",
       "==================================================\n",
-      "Approach              Time (ms)        Code style\n",
+      "Aspect                         Arnio        Pandas\n",
       "==================================================\n",
-      "Arnio pipeline            0.583       declarative\n",
-      "Pandas manual            10.290        imperative\n",
+      "Style                     declarative    imperative\n",
+      "Null handling             fill_nulls      fillna()\n",
+      "Case norm                 normalize_case   str.lower()\n",
+      "Deduplication             drop_duplicates   drop_dupl..\n",
+      "Steps chained             1 pipeline    4 separate\n",
       "==================================================\n",
-      "\n",
-      "Speedup: 17.6x faster with Arnio\n",
-      "Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\n",
       "Results verified: same shape, same null counts, same values ✓\n"
      ]
     }
    ],
    "source": [
+    "# API Design Comparison\n",
+    "print(\"=== API DESIGN COMPARISON ===\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"{'Approach':<20} {'Time (ms)':>10}  {'Code style':>16}\")\n",
+    "print(f\"{'Aspect':<25} {'Arnio':>10}  {'Pandas':>12}\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"{'Arnio pipeline':<20} {arnio_time*1000:>10.3f}  {'declarative':>16}\")\n",
-    "print(f\"{'Pandas manual':<20} {pandas_time*1000:>10.3f}  {'imperative':>16}\")\n",
+    "print(f\"{'Style':<25} {'declarative':>10}  {'imperative':>12}\")\n",
+    "print(f\"{'Null handling':<25} {'fill_nulls':>10}  {'fillna()':>12}\")\n",
+    "print(f\"{'Case norm':<25} {'normalize_case':>10}  {'str.lower()':>12}\")\n",
+    "print(f\"{'Deduplication':<25} {'drop_duplicates':>10}  {'drop_dupl..':>12}\")\n",
+    "print(f\"{'Steps chained':<25} {'1 pipeline':>10}  {'4 separate':>12}\")\n",
     "print(\"=\" * 50)\n",
-    "print(f\"\\nSpeedup: {pandas_time/arnio_time:.1f}x faster with Arnio\")\n",
-    "print(\"Note: Benchmark on 6 rows is illustrative. Real gains appear at 100k+ rows.\")\n",
     "\n",
-    "# Confirm both produce same shape and null counts\n",
+    "# Verify outputs match\n",
     "assert cleaned_df.shape == pandas_df.shape, \"Shape mismatch!\"\n",
     "assert cleaned_df.isnull().sum().sum() == pandas_df.isnull().sum().sum(), \"Null mismatch!\"\n",
-    "\n",
-    "# Note: Arnio strip_whitespace cleans values but not column names\n",
-    "# Column names are cleaned manually after conversion to pandas\n",
     "cleaned_df.columns = cleaned_df.columns.str.strip().str.lower()\n",
     "pd.testing.assert_frame_equal(\n",
     "    cleaned_df.reset_index(drop=True),\n",
     "    pandas_df.reset_index(drop=True),\n",
     "    check_like=True,\n",
-    "    check_dtype=False # dtypes may differ (e.g. string[python] vs object) but values match\n",
+    "    check_dtype=False\n",
     ")\n",
     "print(\"Results verified: same shape, same null counts, same values ✓\")"
    ]
@@ -347,8 +348,8 @@
     "\n",
     "| | Arnio pipeline | Pandas manual |\n",
     "|---|---|---|\n",
-    "| Time | ~0.5–2 ms (varies by machine) | ~10–30 ms (varies by machine) |\n",
-    "| Speedup | **~10–20x faster** | baseline |\n",
+    "| Time (6-row sample) | ~0.5–2 ms (illustrative) | ~10–30 ms (illustrative) |\n",
+    "| Speedup | C++ backend (illustrative only) | Pure Python |\n",
     "| API style | Declarative steps | Imperative chains |\n",
     "| Backend | C++ accelerated | Pure Python |\n",
     "| Null handling | `fill_nulls` step | `.fillna()` per column |\n",
@@ -365,44 +366,6 @@
     "### Dataset\n",
     "Synthetic PaySim-style transactions generated inline.\n",
     "No external files required — runs end to end in this notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "0e19d8ae-3a27-4f17-acff-5b15d5852a7b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAEiCAYAAAAPh11JAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAN+lJREFUeJzt3Qm4lPP///F3mxYqLdq0StG+SUohpVAqfS2Rr2xlLURIkkQREkoRSpbKliUUkhYkRZSl9JUU7dtRab9/1+vzv+75z0wz59ynzjkz55zn47qmztyz3J+51/f9Wd53Hs/zPAMAAECa8qb9FgAAAAiBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETDlG1alW76qqrLBlMmDDB8uTJY3/88YclE5XpgQceSHQxkk6yrq/sQvud9r+stmPHDitTpoy99tproWnavrUuc4KzzjrLPY7UF1984ZbJW2+9Zdnd9OnT7ZhjjrGNGzcmuijZDoFTLvK///3Prr/+ejvhhBOsUKFCVqxYMTv99NPtqaeesn///TfRxUs6H330UY4Jjg4cOGAVKlRwB/2PP/440cVJGn5w4D+KFClitWvXtvvuu89SUlIst9AxoGjRotatW7dEFyXX+eqrr9x2uG3btkNeGzp0qL377ruZMt9zzz3XTjzxRBs2bFimfH9ORuCUS3z44YdWr149e+ONN+yCCy6wZ555xu0wlStXtn79+tmtt95qyei///2vC+qqVKmSkMBp8ODBMV9TmXRyzS4+//xzW7t2ravNCK9VyEnr60iMGTPGXnnlFRsxYoSdfPLJ9vDDD7sTS264lee+fftc4HTddddZvnz5LCf65JNP3CNZAycdZ7I6cBJdSD/33HP2zz//ZNo8cqL8iS4AMt/KlSvdlaROZjqBli9fPvTazTffbCtWrHCBVTLSgTwZD+aqsctOXn31VWvcuLH16NHD7r33Xtu5c6cdffTRaX4u6PuSfX2l5aKLLrLSpUu7v2+44Qb7z3/+Y++8847Nnz/fmjdvbjnZtGnTXHPNJZdcYtnVwYMHbe/evXH3y6OOOirLy5Ssdu/e7ZZH3rx53Xbeu3dve/PNN+2aa65JdNGyDWqccoHhw4e7PgwvvvhiRNDkU3VtWjVOuhq67bbbrFKlSlawYEH3mUcffdQdsMI9/vjj1qJFCytVqpQVLlzYmjRpErM/gJpFbrnlFnc1VbduXfedderUce3uafWZUa1Jx44dbd68eXbqqae6g6WaHydOnHjIfH788Uc788wzXVkqVqxoDz30kI0fPz7NfjjqazJ69OhQWf1HePnDm/H8Jp/ly5fbFVdcYcWLF7fjjjvOBg4c6GotVq9ebZ07d3bNo+XKlbMnnnjikHnu2bPHBg0a5JatloeW9V133eWmh9u0aZP9+uuvtmvXLgtCNUBTp051wbNOjnr+3nvvxfzN6vOgJt3zzz/fNd107979iNeXPPvss+79+pyaDBWwx7rCDqftRt81e/bsQ17TVbJeW7p0qXu+bt06u/rqq9061jy0nWt5H25fq7PPPjt00aET8v333++2Za1XBZKtWrWyWbNmRXxG81KZtA88//zzVr16dVeWpk2b2rfffnvIPPxlqe1X/2sdxRJ0n/r000+tZcuWduyxx7r1eNJJJ7kgOS0qh/YplTct+/fvtyFDhoR+mz6neYRvo3379nVlDa+t08lZy+bpp58OTVu/fr2bptq+9O4D/vao2lN/u4reFtPq46Rad31WzbMlSpSwU045xV5//XUL2vSt3619WdtDp06d3D4e7ZtvvnE1l9puNB8di7788suI44Zq/KVatWqh44y/LenC5eWXXw5ND+97+tdff7lgp2zZsqH98aWXXorZJ2vy5Mmuhvz444935fCbodWvrX79+jGPB0iFhxzv+OOP90444YTA769SpYrXo0eP0POdO3d69evX90qVKuXde++93tixY70rr7zSy5Mnj3frrbdGfLZixYreTTfd5I0aNcobMWKEd+qpp+ro6U2bNi3ifZrWoEEDr3z58t6QIUO8kSNHujIWKVLE27RpU+h948ePd+9duXJlRPlOOukkr2zZsq48mlfjxo1deZYuXRp635o1a7ySJUu6cg8ePNh7/PHHvZNPPtnNN/o7o3311VfeOeec4973yiuvhB7h5R80aFDouf7WtIYNG3qXXXaZ9+yzz3odOnRw07QcVN4bb7zRTT/99NPd9NmzZ4c+f+DAAa9du3bu9992223ec889591yyy1e/vz5vc6dO0eUzZ/XrFmzAq3PyZMnu2Xz559/uudnn322d/755x/yPq3zggULetWrV3d/az1PnDjxiNeXX962bdt6zzzzjPtd+fLl85o2bert3bs3brl37drlHXPMMW57ita6dWuvTp06oectWrTwihcv7t13333eCy+84A0dOtS9J3wZx+KXbePGjRHTb7/9djd9+vTp7jX97r59+3pjxozxhg8f7tZngQIFvO+//z70Gf1mfaZRo0beiSee6D366KPuvaVLl3b7RfhvnTFjhpc3b16vbt26bvsYMGCAK79+k7bv9O5T2u6POuoo75RTTvGeeuopt+7uvPNO74wzzvDSorJ27do17rIJp+1C0y666CJv9OjR7jig5126dAm955133nHTlixZEpqmbUe/V5/zvfnmm+59/j6bnn1An6tVq5Z33HHHuX1bZQlfF9HOPPNM9/A9//zzod+h+WiZXXvttV6fPn1SXVba5/S5evXquWOi1sc999zjFSpUyKtZs6bbZn0zZ85066R58+beE0884T355JPuM5r2zTffuPf88MMP7nih79Tr/nFmx44d7n/tj61atQpN13FJ1q1b57aLSpUqeQ8++KDbLjt16hT6nujy1q5d2x2bVN5hw4a5Y7rvuuuuc9sogiNwyuG2b9/udpzoA096AiedKI8++mhv+fLlEe/TAUMnQP+ELOEHDtHJQicHnazDqUw6gKxYsSI0TQcRTdfJNa3ASdPmzJkTmrZhwwZ3kLnjjjtC03r37u0ChvAD6ubNm10wlVbgJDfffPMhJ460AqdevXqFpu3fv98d3FSGRx55JDR969atXuHChSOWsQ6KOrHMnTs3Yj46Aep7v/zyy8MOnDp27OiCtfCThk5GWmaxTopar7F+7+GsL81Dn9MJUSdGn4IAve+ll15Ktew6qZQpU8YtS9/atWvdstIJw1+e+q7HHnvMSy9/WS5btswFSCq3TqTalhSY6wSjee/Zsyfic5qnXr/mmmsOCZwUqG/ZsiU0/b333nPTP/jgg9A0ncQUjG3bti007ZNPPnHviw6cguxTOlnGCgDTsm/fPrd9hu830cvGt3jxYvdcJ9pwCtA0/fPPPw+tcz3XRYLoN2p9XXzxxW6Z+RSkaF88ePBguvcBPdd7f/rpp0C/Mzpw0vEwPPAOyg9EdDGakpISmv7GG2+46QrARL+pRo0aXvv27UO/z1+X1apVcxdlPm238Y5HOu6GHyd8CvK0/YRftEi3bt1cAO5vM355dZETvR35dJGh96xfvz7dyyO3oqkuh/OrZNXscrjU/q2mCVVnq5nIf7Rt29ZVWc+ZMyf0XjUl+LZu3Wrbt293n/3uu+8O+V59Prx5QFXGasr6/fff0yyTRj7pe31qFlPTRPhnVXWv/ikNGzYMTStZsmSo+SkzqIOtT319VP2v4/y1114bmq6mlOiyahnXqlXLdUwOX8Z+k1F4s5Cq9/WdQYZXb9682WbMmGGXXXZZaJr6Naj6XgMFYrnxxhtjTj+c9fXZZ5+5pi4186pPha9nz57us2n1rbv00kttw4YNrsnBp2YqNRHrNX+bU58NvUfb3OHQ+tA2pOYSdZhVU5HKpmYNrUe/j4zmu2XLFtdkpXUba7tWubSv+Pzt1F9O6qS/ePFi199MTTi+c845x23X0YLsU9qmRE0u0c3nqdFv0bYUXt7UBkv4TXHh7rjjDve/vy61HLUd+8cFNU1pGapJSs1zv/32m5s+d+5c17ToN4GnZx8QNXvFWl5BaHmtWbMmZhNqEFdeeWXEMVV95NQ87C8jrV/9zssvv9ztg/5vUdNbmzZt3LJJz3oKp/X19ttvu0E++jt8WbVv395tH9Hbpba18O0onL/u9XkEQ+fwHE4nJzmSURM6AKivkA6IsejEFt7RVP2IdOAI75cQKx+MRvTF2omDnPyCfHbVqlUxO/bqpJhZosulE6P6sPgdj8On64Aavox/+eWXQMs4PaZMmeJGTTVq1MgNAvA1a9bM9Q9RX6Nw+fPnd/2Egvy2IOtL68APTMIpEFG/NP/1ePz+IfodOuH4v0nBcM2aNd1z9e9QfzudwNXf47TTTnN94HRyUx+UIHQi0r5SoEAB9/uj+/uon4n6palvmZanT4FWWsvJPzH5y8n/zTVq1Djks1pO0Se9IPuUgrUXXnjBBe733HOPW1Zdu3Z1J/TwgDWeIKMHVW59V/T+o2WsQCR8XSqw84MIBUgKMvXQhYueaz398MMPLrA43H0g1rIP6u6773ZBvfpI6ve0a9fOlUXpWYKIXndaF/oev0+dHxwqYIlHAU6QgDWaOvKrf6D60elxpMvKX/c5JWdXViBwyuF0MlBnXL8T7eHQlZGuhtVJMxb/BKYDojpJnnHGGa4zsK7AdCJSZ+xYnS7jjb4KchA/ks9mpljlClJWLWOli9Bw+FjUSfZw+KkH4p0QVAuiAManICTeiTYRy1zl6dKli+s4rW1KNRaqwdAw7XCq0dIVuDo6q4ZNnfKVbkOjSBU0pkXbbHRwGz4iUZ1yVQ7VmqhDrZaFvl8d6TNzOQXdp1SboFoM1cqo5ke1rQowVVujYfjxyqRARifM9NTUBTnBqiZp3LhxbvvSb1Agpc9pup7rmKRtPrzWOL37QLwalCBUs7Vs2TIXlGpZKXDW8tUggHgpSNLDr0167LHHImq8w6kD/5F8twahxAvMVBscdFn56z7e9o9DETjlArr61pXJ119/fVhDq3X1rVF5aqpJjQ4+ql3RiUsnPJ8O8omg9AvhtSy+WNNiycorMC1jXYGrpiCj5qsRYcoRo9FHataIPvgq55JOvpmZj8rP56STVHiApuY7lS+tbcqvTVGNz8yZM12NhAIQv5kuehmq1kkPXfHrhKVaIgU+R0JNgyq70hOErxuN/jqSZeLXSoTTcjrcfUoBr7YfPRR8KLgcMGCAC6biLWfVMGq5aV0EKbe2G5VbgYdPwaxqQMJzd/kBkUb6qTlMtWCiAFCj6BQ4aTSaRghm5j6QGs1f25Ee2h5VQ6f8Xf37908z3Uj0utM2qeOKH7D4NZa6cE1rG0/tt8Z6TTVyaiZUN4kg+09atO4VNMWr6cOh6OOUC6imSAcJVePrIBdNV81KgBePhrAr6NLBO5oOmOrvIbqq1Y6uHdqnquvMTOCWGrX3q9xq4gjv0xE0AaSfvyitYfMZQctYw4t1lR5N6QPUNyK96Qj836n1ryab8Ifmp2AqM5Nhig7sapbTMPTwGhelxlBTRYcOHQJ9h2pGVIOih5pXwpsetByUmyacTlw6uUQPYz8cfm1NePk1zFzb1uFQrZGCOgWDWgY+BRk///zzIfMOsk9pu47m13SktQx0MbVw4cI0y60UFTJy5MiI6X4NUfi61PrR0Pcnn3zSNW36NZ4KqHS8UTCqJlUFboezDxyp8GZy0Taq/lJax+FNsfEo9Ul49wf9HvVdO++889xzBYTaBpVKQhed0cJvc5LacUavRU/XNqF+igqqY7UkpPcWKosWLcrxucoyGjVOuYB2YNUs6MpKV4rq+6G8MbrKUo2EOmWmdm86NU+8//77ruZK79NBQQexJUuWuAOGDuS6YtGBUwdR9UtRfwG1sysXktr+1UcqqylgUG2DmhmVR0YHIfUDUR8UnWjSuqr1r4b79OnjgjAdsDLrlhSq/VFnbSVfVA2BTjQ6WSpA0nQFreojIqNGjXLNCXpfah3EFRTp5BmvmU9NQFou6lOj5JiZQVexuoJXebVdaJ6qVVGziPIbqbkhLWqaUm2ActFou9PJKJxyZ6mWQidenfx0MlbTni4SMmJ9abtXbdOFF17otnFdoY8dO9bNK9ZJMQg18+m71HSlXDzaHv28QuHfGXSfevDBB11Tnd6vmh+9T8tY/bU0j9Qo35Wypms5+s3usTRo0MA1Dan2WidzBd4LFixwAaCaMVu3bh3xfgVJWmdqfvP78mg7036oeYX3b0rvPnCk1KdJfbM0D/W3Uk2m9istvyADaRTIa7kqd5i2MwWTWica9ODX/ulYo0BK61TvUyCpwFC/TTVRH3zwQcRxRrWD2l61vavZ2a+RU18sbQOqpVNAqv6JjzzyiPse/a15alvUNqR9We+PFUjHou1E21F0X0ekIdHD+pB1lE6gZ8+eXtWqVd0Q8aJFi7ph6hpOvnv37rjpCOSff/7x+vfv73K+6LPK+6HcOcqNFJ6f5sUXX3TDcDWcWzmTNDw9Vj4YPddw/2jR846XjkA5ktIacixKRaA8KCqPUgMoh8nTTz/tvlO5UFKjYehKaaBcMRqyHf4b4qUjiB4Ort+iIcWxyho9HFrLUbl/NF3lLVGihNekSROXp0ZpJdKTjmDRokXuPQMHDoz7nj/++MO9RzmLUivrka4vP/2AtgflPtKQdOW00pD+oD799FP3vVoPq1evjnhNQ7JVNn2/yq/h2M2aNXNDxNMSb72F03ByDdnWb9V6UZ4m5VDS7w5PHeCnI4iVFiF6e5G3337b5SLSdyrPjvIfRX9n0H1KOYM0xL5ChQpu/9T/SuUQnUIkFqVa0P6stCOxlk10+gJtjxpSr3WpPEI6LoQfP3zKraTPa12HUz4vTVeZowXdB+Jtj/FEHxuUckI5rpQ6ws9d1q9fv4h5xOIP7580aZL73UqVodQiOh6tWrXqkPfr+KMcWf58tG4vueSSQ367lr1SHCjFQvj+8+uvv7pyah6aHr6vKX2AloHWgdZFuXLlvDZt2rh0I9HlVc6sWJT/SXmzwlMrIG159E9awRWQk6gjsTJP68o+O94eBMhoygauflPqu8M+kXto4IRqrdWkiuDo44QcTX0jovs2qFlC1eycIID/5/bbb3cXEmpaQ+6g0YQKlNWUjvShxgk5mvr46IpKfbvUF0Gdkv/++283QksjfAAASA86hyNH00ggdWBXh1Z1BlfnVAVPBE0AgMNBjRMAAEBA9HECACAOpXlQegClA1Ctday8dKp/UNZx5ehSlm7lHouV4DQ6JYVScij9gbLRK6VDdAJU5bxSGgyl9VAKA6XciJWLD1mLwAkAgDiUO0w5rJQ/K57hw4e7JK/K76XkqMrBpNxv0YlZw82ePdvlT5o/f75LfqrEm8ov5Sf61P96rmBNtw7SrYaUe09B3OHeIBgZI8c31WkDU2dgRfXcxBAAcLh0w2klllVSVJ9Oobo5s25tpGS5oozwuhGwkpAqU38QuiOAkhXr5shKzKkBLPqsbp7s36xd36sEp0rwGp1w1KcknkqIqVHDSnysrOi6rdLFF1/skhm/9957rgZL99FTcmD/fnV6TQGaAjbVrunWRUES1OYUWo/KBq/fntaNsXN84LRmzZrDvkEqAADIPVavXu0y7ufqUXV++nwtDD9qBwAgI2qc1DSnJjX1T9JtXHy6PY1aOSZMmBCoZUS3W1GNkn9PUNVAKUFl9+7dXf8p1XE88MADboSwbn0V7/6iqnHSrWqUp0n0tyoP1MSnxL+iflK6vY5uz6J+Vpp3qVKlUm2OzOlSUlLccgpyy50cHzj5zXMKmgicAABHokiRIhHnEv8mvTrhhk/XPed0/gly3rnxxhvdPfnmzZsXer/+131E9Zr6Tqn56LLLLnMpVQoVKhT3e9VEV79+/YjXFRTpc/40PzhQs5ym6Z6VunGw7j+qIFAd1Vu0aGG5UZ4AXXroHA4AwGHya5miR7vpeXgNVDzqGzVt2jR3097oJiIFMRpZp5vxqgZKdz3QjYJPOOGEVL9TQVt0MBA+zQ8O/E7muhmx+lIpg7z6BOum2XfeeWeaZc+tCJwAADhM1apVcwGSOnOHN/uoCa958+ZxP6emNwVN6uitTtn6nnhKly5txx57rHufgqhOnTpl+O9Qh3E1L7766qs2cuRI1ySIXNpUBwDA4dI9/FasWBF6vnLlSlu8eLGVLFnSKleu7GpvdOPwhx56yI2kUwA0cOBANzpLTV4+1eIoJ5OCJVEqAo160yg3NZ2tW7cu1I9KuaBEN17W7aIU1Hz99dd26623ulohjeLLSOpD1aRJE6tTp47t2bPH1YBpvoiNwAkAgDgWLlwYMfS/b9++7n/Vzvgdv++66y7XX6hXr162bds2dxNxdc5WXySfmtzU3OYbM2aM+1/30gynYEmdv0UdznUT3i1btljVqlVtwIABLnDKaEpZoPn88ccfLmhr1aoVN3zOzekIVGWqCF6jFegcDgAAjiRWoI8TAABAQAROAAAAARE4AQAABETncABAUlh3QatEFwFJrNwHcy0ZUOMEAACQHQKnOXPmuPvnKN+FcmG8++67Ea9rwJ/yS5QvX94NkWzbtq399ttvCSsvAADI3RIaOCnvRYMGDeLeWHD48OH29NNPu/v0KAur7gnUvn172717d5aXFQAAIKF9nHR/HD1iUW2T0r7fd9991rlzZzdt4sSJVrZsWVczpbs5AwAAZKWk7eOktPZKQa/mOZ+SUzVr1sylno9H6eKVyCr8AQAAkKMDJ/++PaphCqfn/muxDBs2zAVY/qNSpUqZXlYAAJA7JG3gdLh0vx2lTPcfq1evTnSRAABADpG0gVO5cuXc/+vXr4+Yruf+a7EULFjQ3Wcm/AEAAJCjA6dq1aq5AGnmzJmhaeqvpNF1zZs3T2jZAABA7pTQUXU7duywFStWRHQIX7x4sZUsWdIqV65st912mz300ENWo0YNF0gNHDjQ5Xzq0qVLIosNAAByqYQGTgsXLrTWrVuHnvft29f936NHD5swYYLdddddLtdTr169bNu2bdayZUubPn26FSpUKIGlBgAAuVUeTwmTcjA172l0nTqK098JAJIX96pDou5Vl55YIWn7OAEAACQbAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicAIAAAiIwAkAACAgAicAAICACJwAAAACInACAAAIiMAJAAAgIAInAACAnBA4HThwwAYOHGjVqlWzwoULW/Xq1W3IkCHmeV6iiwYAAHKh/JbEHn30URszZoy9/PLLVqdOHVu4cKFdffXVVrx4cevTp0+iiwcAAHKZpA6cvvrqK+vcubN16NDBPa9atapNmjTJFixYkOiiAQCAXCipm+patGhhM2fOtOXLl7vnP/zwg82bN8/OO++8uJ/Zs2ePpaSkRDwAAAByfI3TPffc4wKfk08+2fLly+f6PD388MPWvXv3uJ8ZNmyYDR48OEvLCQAAcoekrnF644037LXXXrPXX3/dvvvuO9fX6fHHH3f/x9O/f3/bvn176LF69eosLTMAAMi5krrGqV+/fq7WqVu3bu55vXr1bNWqVa5WqUePHjE/U7BgQfcAAADIVTVOu3btsrx5I4uoJruDBw8mrEwAACD3SuoapwsuuMD1aapcubJLR/D999/biBEj7Jprrkl00QAAQC6U1IHTM8884xJg3nTTTbZhwwarUKGCXX/99Xb//fcnumgAACAXyuPl8DTcGpWnhJnqKF6sWLFEFwcAEMe6C1olughIYuU+mJsUsUJS93ECAABIJgROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAAeVPz5sPHjxos2fPtrlz59qqVats165ddtxxx1mjRo2sbdu2VqlSpcwrKQAAQHaocfr333/toYcecoHR+eefbx9//LFt27bN8uXLZytWrLBBgwZZtWrV3Gvz58/P/FIDAAAka41TzZo1rXnz5jZu3Dg755xzrECBAoe8RzVQr7/+unXr1s0GDBhgPXv2zIzyAgAAJEwez/O8tN70yy+/WK1atQJ94b59++zPP/+06tWrWzJISUmx4sWL2/bt261YsWKJLg4AII51F7RKdBGQxMp9MDcpYoVATXVBgyZRbVSyBE0AAAAJHVU3ffp0mzdvXuj56NGjrWHDhnb55Zfb1q1bM7RwAAAA2Tpw6tevn6vSkiVLltgdd9zhOoWvXLnS+vbtmxllBAAAyH7pCEQBUu3atd3fb7/9tnXs2NGGDh1q3333nQugAAAAcqp01zgdddRRLn+TfPbZZ9auXTv3d8mSJUM1UQAAADlRumucWrZs6ZrkTj/9dFuwYIFNmTLFTV++fLlVrFgxM8oIAACQPWucRo0aZfnz57e33nrLxowZY8cff7ybrqSY5557bmaUEQAAIHvWOFWuXNmmTZt2yPQnn3wyo8oEAACQMwIn34YNG9xD968LV79+/YwoFwAAQPYPnBYtWmQ9evRw2cT9pON58uRxf+v/AwcOZEY5AQAAsl/gdM0117h717344otWtmxZFywBAADkBukOnH7//XeXv+nEE0/MnBIBAADklFF1bdq0sR9++MGyyl9//WVXXHGFlSpVygoXLmz16tWzhQsXZtn8AQAADrvG6YUXXnB9nJYuXWp169Z1N/UN16lTJ8souved8kW1bt3apTs47rjj7LfffrMSJUpk2DwAAAAyLXD6+uuv7csvv3SBTLSM7hz+6KOPWqVKlWz8+PGhadWqVcuw7wcAAMjUprrevXu7prO1a9e6VAThj4weUff+++/bKaecYhdffLGVKVPGGjVqZOPGjcvQeQAAAGRa4LR582a7/fbb3Yi6zKaO6MpOXqNGDZsxY4bdeOON1qdPH3v55ZfjfmbPnj3unnnhDwAAgIQETl27drVZs2ZZVlAtVuPGjW3o0KGutqlXr17Ws2dPGzt2bNzPDBs2zIoXLx56qKkPAAAgIX2clMOpf//+Nm/ePDfCLbpzuGqEMkr58uWtdu3aEdNq1arl0iHEo7LpJsQ+1TgRPAEAgISNqjvmmGNs9uzZ7hHdOTwjAyeNqFu2bFnEtOXLl1uVKlXifqZgwYLuAQAAkPDAaeXKlZZV1JeqRYsWrqnukksusQULFtjzzz/vHgAAAEnfxykrNW3a1KZOnWqTJk1yOaOGDBliI0eOtO7duye6aAAAIBcKFDg98sgj9u+//wb6wm+++cY+/PBDyygdO3a0JUuW2O7du92NhdU5HAAAIGkDp59//tkqV65sN910k0t8uXHjxtBr+/fvtx9//NGeffZZ16x26aWXWtGiRTOzzAAAAMnbx2nixInu/nSjRo2yyy+/3I1Uy5cvn+uEvWvXLvcepQu47rrr7KqrrrJChQpldrkBAACyXB7P87z05lZSDdOqVatc813p0qWtYcOG7v9kpCBP+Zy2b99uxYoVS3RxAABxrLugVaKLgCRW7oO5SRErpHtUXd68eV2gpAcAAEBuktSj6gAAAJIJgRMAAEBABE4AAAABETgBAABkduC0YsUKmzFjRigxZjoH5wEAAOT8wGnz5s3Wtm1bq1mzpp1//vm2du1aN/3aa6+1O+64IzPKCAAAkD0DJ914N3/+/Pbnn39akSJFQtOVMXz69OkZXT4AAICkke48Tp988olroqtYsWLE9Bo1arikmAAAADlVumucdu7cGVHT5NuyZYu7BQsAAEBOle7AqVWrVu7edb48efK427AMHz7cWrdundHlAwAAyL5NdQqQ2rRpYwsXLrS9e/faXXfdZT/99JOrcfryyy8zp5QAAADZscapbt26tnz5cmvZsqV17tzZNd117drVvv/+e6tevXrmlBIAACA71jiJ7iA8YMCAjC8NAABATgucdu/ebT/++KNt2LDB9W8K16lTp4wqGwAAQPYOnJSr6corr7RNmzYd8po6ih84cCCjygYAAJC9+zj17t3bLr74YpcxXLVN4Q+CJgAAkJOlO3Bav3699e3b18qWLZs5JQIAAMgpgdNFF11kX3zxReaUBgAAICf1cRo1apRrqps7d67Vq1fPChQoEPF6nz59MrJ8AAAA2TdwmjRpkrtfXaFChVzNkzqE+/Q3gRMAAMip0h04KX/T4MGD7Z577rG8edPd0gcAAJBtpTvy0W1WLr30UoImAACQ66Q7+unRo4dNmTIlc0oDAACQk5rqlKtJN/qdMWOG1a9f/5DO4SNGjMjI8gEAAGTfwGnJkiXWqFEj9/fSpUsjXgvvKA4AAGC5PXCaNWtW5pQEAAAgydHDGwAAICNrnLp27WoTJkywYsWKub9T884771hmeeSRR6x///5266232siRIzNtPgAAAIcdOBUvXjzUf0l/J8K3335rzz33nOuQDgAAkLSB0/jx4+3BBx+0O++80/2d1Xbs2GHdu3e3cePG2UMPPZTl8wcAAEhXHydlC1cAkwg333yzdejQwdq2bZvme/fs2WMpKSkRDwAAgCwdVed5niXC5MmT7bvvvnNNdUEMGzbMBXkAAAAJHVWX1XmaVq9e7TqCv/baa+6mwkGo8/j27dtDD30HAABAludxqlmzZprB05YtWyyjLFq0yDZs2GCNGzeOyFw+Z84cGzVqlGuWy5cvX8RnChYs6B4AAAAJDZzUBJaVo+ratGnjMpWHu/rqq+3kk0+2u++++5CgCQAAIGkCp27dulmZMmUsqxQtWtTq1q0bMe3oo4+2UqVKHTIdAAAgafo4cR86AACQ2yX9qLpoX3zxRaKLAAAAcqnAgdPBgwcztyQAAABJjpv8AgAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAEBABE4AAAABETgBAAAEROAEAAAQEIETAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAOSEwGnYsGHWtGlTK1q0qJUpU8a6dOliy5YtS3SxAABALpXUgdPs2bPt5ptvtvnz59unn35q+/bts3bt2tnOnTsTXTQAAJAL5bckNn369IjnEyZMcDVPixYtsjPOOCNh5QIAALlTUtc4Rdu+fbv7v2TJkokuCgAAyIWSusYp3MGDB+22226z008/3erWrRv3fXv27HEPX0pKShaVEAAA5HTZpsZJfZ2WLl1qkydPTrNDefHixUOPSpUqZVkZAQBAzpYtAqdbbrnFpk2bZrNmzbKKFSum+t7+/fu7Jj3/sXr16iwrJwAAyNmSuqnO8zzr3bu3TZ061b744gurVq1amp8pWLCgewAAAOSqwEnNc6+//rq99957LpfTunXr3HQ1wRUuXDjRxQMAALlMUjfVjRkzxjW3nXXWWVa+fPnQY8qUKYkuGgAAyIWSvqkOAAAgWSR1jRMAAEAyIXACAAAIiMAJAAAgIAInAACAgAicAAAAAiJwAgAACIjACQAAICACJwAAgIAInAAAAAIicMpFRo8ebVWrVrVChQpZs2bNbMGCBam+f8KECZYnT56Ihz4bbseOHXbLLbdYxYoV3f0Da9eubWPHjs3kXwIAQGIk9S1XkHF0f7++ffu6oEZB08iRI619+/a2bNkyK1OmTNzPFStWzL3Hp+ApnL7z888/t1dffdUFZZ988onddNNNVqFCBevUqVOm/iYAALIaNU65xIgRI6xnz5529dVXh2qFihQpYi+99FKqn1OgVK5cudCjbNmyEa9/9dVX1qNHD3cjZgVOvXr1sgYNGqRam3XVVVdZly5dbOjQoe77jj32WHvwwQdt//791q9fPytZsqSrwRo/fnzoM3v37nU1W7rJs2q9qlSpYsOGDcuAJQMAQHAETrmAgo5FixZZ27ZtQ9Py5s3rnn/99depflZNcQpSKlWqZJ07d7affvop4vUWLVrY+++/b3/99Ze7KfOsWbNs+fLl1q5du1S/V7VUf//9t82ZM8cFdYMGDbKOHTtaiRIl7JtvvrEbbrjBrr/+eluzZo17/9NPP+3m88Ybb7gasNdee80FagAAZCUCp1xg06ZNduDAgUNqi/R83bp1cT930kknuRqp9957zzXFHTx40AVKfjAjzzzzjKvBUg3RUUcdZeeee67rS3XGGWekWibVKikY0jyuueYa9/+uXbvs3nvvtRo1alj//v3d982bN8+9/88//3TTW7Zs6QI5/X/ZZZcd8bIBACA96OOEuJo3b+4ePgVNtWrVsueee86GDBkSCpzmz5/vaoMU0KgG6eabb3Z9nMJruKLVqVPH1XqFB3F169YNPc+XL5+VKlXKNmzYEGreO+ecc1yApeBMtVNp1WoBAJDRCJxygdKlS7tAZP369RHT9Vz9loIqUKCANWrUyFasWOGe//vvv66GaOrUqdahQwc3rX79+rZ48WJ7/PHHUw2c9F3RfaliTVMtlzRu3NhWrlxpH3/8sX322Wd2ySWXuO9/6623ApcfAIAjRVNdLqAmryZNmtjMmTND0xSQ6Hl4jVJa1Ny3ZMkS10Fb9u3b5x7hNUeiIM0PeDKSRvhdeumlNm7cODdK8O2337YtW7Zk+HwAAIiHGqdcQmkDNPrtlFNOsVNPPdWlI9i5c6cbZee78sor7fjjjw+NVtNIt9NOO81OPPFE27Ztmz322GO2atUqu+6660KBzJlnnulGwimHk5rqZs+ebRMnTnQdvjOSvk8Bm2q8FKi9+eabrrZMI/IAAMgqBE65hGpqNm7caPfff7/rEN6wYUObPn16RIdxdcAOrz3aunWrS2Gg92u0m2qtlH5AncF9kydPdh25u3fv7mp/FDw9/PDDblRcRipatKgNHz7cfvvtN1ej1bRpU/voo48Oqe0CACAz5fE0hjwHS0lJseLFi9v27dtdDQkAIDmtu6BVoouAJFbug7lJEStwuQ4AABAQgRMAAEBABE4AAAAB0Tk8AzRY1DfRRUAS+6FJxo4wBAAkDjVOAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAAJCTAqfRo0db1apVrVChQtasWTNbsGBBoosEAAByoaQPnKZMmWJ9+/a1QYMG2XfffWcNGjSw9u3b24YNGxJdNAAAkMskfeA0YsQI69mzp1199dVWu3ZtGzt2rBUpUsReeumlRBcNAADkMkl9y5W9e/faokWLrH///qFpefPmtbZt29rXX38d8zN79uxxD9/27dvd/ykpKZlWzgM7/v/8gGiZue0BOck/+/YnughIYkUy8VjqH6c9z8vegdOmTZvswIEDVrZs2Yjpev7rr7/G/MywYcNs8ODBh0yvVKlSppUTSE1xezbRRQCA7K948UyfxT///GPF05hPUgdOh0O1U+oT5Tt48KBt2bLFSpUqZXny5Elo2XIDRe0KUlevXm3FihVLdHEAIFviWJq1VNOkoKlChQppvjepA6fSpUtbvnz5bP369RHT9bxcuXIxP1OwYEH3CHfsscdmajlxKO3o7OwAcGQ4lmadtGqaskXn8KOOOsqaNGliM2fOjKhB0vPmzZsntGwAACD3SeoaJ1GzW48ePeyUU06xU0891UaOHGk7d+50o+wAAACyUtIHTpdeeqlt3LjR7r//flu3bp01bNjQpk+ffkiHcSQHNZMq51Z0cykAIDiOpckrjxdk7B0AAACSu48TAABAMiFwAgAACIjACQAAICACp1xKyUDffffdTJ3HhAkTMjyH1h9//OHKvnjxYvf8iy++cM+3bduWofMBgKCuuuoq69KlS6KLkbQmZMK5IJEInJKc7smnJKAdOnTI0O9du3atnXfeeZbZIyKXL1+eqfNo0aKF+y1BE5cByNkBjC6k9FAewBNPPNEefPBB27+fe+Ah4xA4JbkXX3zRevfubXPmzLG///471fdqgGTQA4Qyr2f2MNfChQtbmTJlMnUeOjjqt3A7HQBy7rnnuoup3377ze644w574IEH7LHHHkt0sZCDEDglsR07dtiUKVPsxhtvdDVOqu4M5zdTffzxxy7DugKhefPm2VlnnWV9+vSxu+66y0qWLOkCCx08UmuqW7JkiZ199tku2NF9/Xr16uXmH48/7w8//NDq169vhQoVstNOO82WLl0at3pWZVAerueee87dg6lIkSJ2ySWX2Pbt2yO++4UXXrBatWq57zz55JPt2Wfj3yQ3uqnOn+eMGTPcdxxzzDGhA+nhzgNA9qHjoI55VapUccfOtm3b2vvvv+9eGzFihNWrV8+OPvpodwy66aabIo5zQY4fuvG8EjPrfTpW6jgbndVHuQZbtmwZek/Hjh3tf//7X+j1vXv32i233GLly5d3xyCVVTeoT6spcOjQoS6Hob7Xr0nr16+fO85XrFjRxo8fH/G5u+++22rWrOmOtSeccIINHDjQ9u3bd8gx+ZVXXrGqVau6mvtu3bq5e7b5NF2Jp8M1bNgw4pyS1nLNaQicktgbb7zhTuonnXSSXXHFFfbSSy8dsoPKPffcY4888oj98ssvLoiRl19+2W3E33zzjQ0fPtztZJ9++mnM+SgTe/v27a1EiRL27bff2ptvvmmfffaZ27HTop32iSeecJ877rjj7IILLojYMaOtWLHC/a4PPvjAHVy+//57t5P5XnvtNZfs9OGHH3a/RwcK7ez6PUHt2rXLHn/8cXcwUE3dn3/+aXfeeWeGzgNA9qCLQQUqkjdvXnv66aftp59+cvv7559/7gKf9Bw/dLxTgKXjsS5UdRP5qVOnHnJMVXC1cOFCd4swzffCCy90twwTlUHBnI6Fy5Ytc8ckBSipUVnV6qAyKVBRckwFZDpu6zh/ww032PXXX29r1qwJfaZo0aKurD///LM99dRTNm7cOHvyyScjvlcBnS6ip02b5h6zZ89255P0yBtgueYoSoCJ5NSiRQtv5MiR7u99+/Z5pUuX9mbNmhV6XX9rFb777rsRnzvzzDO9li1bRkxr2rSpd/fdd4ee63NTp051fz///PNeiRIlvB07doRe//DDD728efN669ati1k2f96TJ08OTdu8ebNXuHBhb8qUKe75+PHjveLFi4deHzRokJcvXz5vzZo1oWkff/yxm8/atWvd8+rVq3uvv/56xLyGDBniNW/e3P29cuVKN9/vv/8+ohxbt24NzVPPV6xYEfr86NGjvbJly4aepzUPANlTjx49vM6dO7u/Dx486H366adewYIFvTvvvDPm+998802vVKlSoedBjh/ly5f3hg8fHnquY3PFihVD841l48aN7nuXLFninvfu3ds7++yzXRmD/q4qVap4Bw4cCE076aSTvFatWoWe79+/3zv66KO9SZMmxf2exx57zGvSpEnEMblIkSJeSkpKaFq/fv28Zs2ahZ5rvk8++WTE9zRo0MB9Np5YyzX8XJDdJf0tV3IrXYUsWLAgdCWTP39+19lafZ7UFBdO9/GL5tc8+VQlvGHDhpjzUq1LgwYNXA2V7/TTT3dXRypHare3Cb/ZsqqLVTum74uncuXKdvzxx0d83p+Pro509XPttddaz549Q+9RdXR6On+rWrp69eoxf7uuBDNiHgCSk2pN1MSmmm8dWy6//PJQs5Jq0tUk9uuvv1pKSorb73fv3u1qmXTcSOv4oW4FarZr1qxZ6HUdm3UMDm8NUP8q1WqrJmjTpk2hmibVXtWtW9c1vZ1zzjnueKmmQNUctWvXLtXfVadOHVez49NxWd/l0yAiNQuGH+fV1UM1QTrmqelMv7dYsWIR36uaLh17Y/3eoD4LsFxzEgKnJKUASRtfhQoVQtO0Y6r9ftSoUREn+fCAx1egQIGI5+oH5O+8ycpvE1d1cviByT8oBBXrt/sHtYyaB4Dk1Lp1axszZowbOKLjpwIbP5WJAhT1e1IzvS701NSmiyg15fkn+NSOH0Gpy4L6Lek4ozLo2Ksgx28ybNy4sa1cudL1T1XQob6e6ov11ltvxf3OWOVK7TivEdndu3e3wYMHu64YOmdMnjzZNTWm51yhYC369+8L644RdLnmJAROSUgB08SJE90GHn0Vog6CkyZNcu3ZGUWdINUOrtoYPwj78ssv3Q6jK6LUzJ8/39UiydatW136AX1fPLriUju9HxDq8/58dAWl6b///rvb4TNDVswDQOLoGKY0BNEWLVrkAgIdV/2aG/UxSg8FH6qRUU3SGWecETpe67sVDMnmzZtdDbqCplatWrlpCiSiqeZHrQh6XHTRRa7mSf2lFHhkhK+++soFbwMGDAhNW7VqVbq/R31XwzvHp6SkuKAvI5drdkPglKRVzQpCFLFHNx/95z//cbVRGRk4KYBQR8MePXq4Ku2NGze6FAj//e9/U22mE3U6V/Ww3qcdtHTp0qkmgtMIEs1HnS+1A2r0n662NApGdHWkafrdOpDs2bPHdbDU8lBny4yQFfMAkFwUTKmm5JlnnnE1Qro4HDt2bLq/59Zbb3Wdp2vUqOEG76ijdngCXnXW1jHx+eefd0GWLhY1gCecPqPXGjVq5IINDcjRMTAjk0SqfJq3apmaNm3qRkBHd2IPQqOtdWGtZaby3X///RG18xm1XLMTRtUlIQVGqraN1edGgZNO8j/++GOGzU9VqRp+q6sd7WC6+mnTpo1rEkyLDiA6kCgdwrp169xoOVWRx6OdrGvXrnb++ee72jT1xQpPBXDddde5VAEaVqvhrWeeeabbaatVq5Zhvzcr5gEguagfpwKWRx991DWbaSRbaikA4lFuKF1U6gJQfTTVP0gj5nwKhBSsqCZG87n99tsPySOlz2i0s/pG6Zir5q6PPvooog/TkerUqZObt0ZHK32AaqA0eji9+vfv746Rao5TWpwuXbpE9AHLqOWaneRRD/FEFwLZj/InqS+BammCXiWpNkvDXv3bpQAAkN1Q4wQAABAQgRMAAEBANNUBAAAERI0TAABAQAROAAAAARE4AQAABETgBAAAEBCBEwAAQEAETgAAAAEROAEAAARE4AQAABAQgRMAAIAF83+jbmaAovgxtQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 600x300 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "fig, ax = plt.subplots(figsize=(6, 3))\n",
-    "bars = ax.bar(\n",
-    "    [\"Arnio pipeline\", \"Pandas manual\"],\n",
-    "    [arnio_time * 1000, pandas_time * 1000],\n",
-    "    color=[\"#2ecc71\", \"#e74c3c\"],\n",
-    "    width=0.4\n",
-    ")\n",
-    "ax.set_ylabel(\"Time (ms)\")\n",
-    "ax.set_title(\"Cleaning time: Arnio vs Pandas (lower is better)\")\n",
-    "for bar in bars:\n",
-    "    ax.text(bar.get_x() + bar.get_width()/2,\n",
-    "            bar.get_height() + 0.2,\n",
-    "            f\"{bar.get_height():.2f} ms\",\n",
-    "            ha=\"center\", fontsize=10)\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
    ]
   }
  ],

--- a/examples/financial_csv_example.ipynb
+++ b/examples/financial_csv_example.ipynb
@@ -1,0 +1,23 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dba970b6-c01a-47c6-98d9-75e626a3281c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "",
+   "name": ""
+  },
+  "language_info": {
+   "name": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
Adds a Jupyter notebook demonstrating Arnio's declarative cleaning pipeline on synthetic messy financial data. Shows profiling, pipeline-based cleaning, pandas interoperability, and API design comparison. Resolves #342.

## Linked issue
Fixes #342

## Type of change
- [x] Documentation

## Area
- [x] CSV parser / I/O
- [x] Data quality / profiling
- [x] pandas interoperability
- [x] Docs / website

## Testing
- [x] Other: Kernel → Restart & Run All — all cells run clean, zero errors. Version output cleared from Cell 2 to avoid staleness across releases.

## Screenshots / Media
Notebook output shows Arnio pipeline cleaning and pandas equivalent side by side, with API design comparison. No performance claims.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`docs:`)