### PR TITLE
feat: add round_numeric_columns cleaning helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
-| `round_numeric_columns` | Round numeric columns to decimal places | `ar.round_numeric_columns(frame, decimals=2)` |
+| `round_numeric_columns` | Round numeric columns (non-numeric columns in subset ignored safely) | `ar.round_numeric_columns(frame, decimals=2)` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
 
 Or compose them all into a **pipeline**:

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
+| `round_numeric_columns` | Round numeric columns to decimal places | `ar.round_numeric_columns(frame, decimals=2)` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
 
 Or compose them all into a **pipeline**:

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -20,6 +20,7 @@ from .cleaning import (
     filter_rows,
     normalize_case,
     rename_columns,
+    round_numeric_columns,
     strip_whitespace,
 )
 from .convert import from_pandas, to_pandas
@@ -62,6 +63,7 @@ __all__ = [
     "strip_whitespace",
     "normalize_case",
     "rename_columns",
+    "round_numeric_columns",
     "cast_types",
     "clean",
     # Conversion

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -306,3 +306,57 @@ def filter_rows(frame, column, op, value):
     filtered = df[getattr(df[column], ops[op])(value)]
 
     return from_pandas(filtered) if is_arframe else filtered
+
+
+def round_numeric_columns(
+    frame,
+    *,
+    subset: list[str] | None = None,
+    decimals: int = 0,
+):
+    """Round numeric columns to specified decimal places.
+
+    Parameters
+    ----------
+    frame : ArFrame or pd.DataFrame
+        Input data frame.
+    subset : list[str], optional
+        Column names to round. If None, applies to all numeric columns.
+    decimals : int, default 0
+        Number of decimal places to round to.
+
+    Returns
+    -------
+    ArFrame or pd.DataFrame
+        New frame with numeric columns rounded.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> rounded = ar.round_numeric_columns(frame, decimals=2)
+    """
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    if subset is not None and not isinstance(subset, list):
+        raise TypeError("subset must be a list of column names")
+    if not isinstance(decimals, int):
+        raise TypeError("decimals must be an integer")
+
+    is_arframe = not isinstance(frame, pd.DataFrame)
+    df = to_pandas(frame) if is_arframe else frame.copy()
+
+    if subset is not None:
+        missing = [col for col in subset if col not in df.columns]
+        if missing:
+            raise KeyError(f"Columns not found in dataframe: {missing}")
+        cols_to_round = subset
+    else:
+        cols_to_round = df.select_dtypes(include=["number"]).columns
+
+    for col in cols_to_round:
+        if pd.api.types.is_numeric_dtype(df[col]):
+            df[col] = df[col].round(decimals)
+
+    return from_pandas(df) if is_arframe else df

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -316,6 +316,8 @@ def round_numeric_columns(
 ):
     """Round numeric columns to specified decimal places.
 
+    Non-numeric columns included in subset are ignored safely.
+
     Parameters
     ----------
     frame : ArFrame or pd.DataFrame
@@ -341,7 +343,7 @@ def round_numeric_columns(
 
     if subset is not None and not isinstance(subset, list):
         raise TypeError("subset must be a list of column names")
-    if not isinstance(decimals, int):
+    if isinstance(decimals, bool) or not isinstance(decimals, int):
         raise TypeError("decimals must be an integer")
 
     is_arframe = not isinstance(frame, pd.DataFrame)
@@ -350,7 +352,7 @@ def round_numeric_columns(
     if subset is not None:
         missing = [col for col in subset if col not in df.columns]
         if missing:
-            raise KeyError(f"Columns not found in dataframe: {missing}")
+            raise IndexError(f"Column not found: {missing[0]}")
         cols_to_round = subset
     else:
         cols_to_round = df.select_dtypes(include=["number"]).columns

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -19,6 +19,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
+    "round_numeric_columns": cleaning.round_numeric_columns,
 }
 
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -186,7 +186,7 @@ class TestRoundNumericColumns:
 
         df = pd.DataFrame({"a": [1.123]})
         frame = ar.from_pandas(df)
-        with pytest.raises(KeyError, match="Columns not found in dataframe"):
+        with pytest.raises(IndexError, match="Column not found"):
             ar.round_numeric_columns(frame, subset=["missing_col"])
 
     def test_with_nulls(self):
@@ -218,3 +218,26 @@ class TestRoundNumericColumns:
         frame = ar.from_pandas(df)
         with pytest.raises(TypeError, match="decimals must be an integer"):
             ar.round_numeric_columns(frame, decimals="2")
+
+    def test_decimals_rejects_bool(self):
+        import pandas as pd
+        import pytest
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="decimals must be an integer"):
+            ar.round_numeric_columns(frame, decimals=True)
+
+    def test_round_subset_with_non_numeric(self):
+        import pandas as pd
+
+        df = pd.DataFrame({
+            "name": ["john"],
+            "score": [98.765]
+        })
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, subset=["name", "score"], decimals=1)
+        result_df = ar.to_pandas(result)
+        
+        assert list(result_df["name"]) == ["john"]
+        assert list(result_df["score"]) == [98.8]

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -231,13 +231,10 @@ class TestRoundNumericColumns:
     def test_round_subset_with_non_numeric(self):
         import pandas as pd
 
-        df = pd.DataFrame({
-            "name": ["john"],
-            "score": [98.765]
-        })
+        df = pd.DataFrame({"name": ["john"], "score": [98.765]})
         frame = ar.from_pandas(df)
         result = ar.round_numeric_columns(frame, subset=["name", "score"], decimals=1)
         result_df = ar.to_pandas(result)
-        
+
         assert list(result_df["name"]) == ["john"]
         assert list(result_df["score"]) == [98.8]

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -148,3 +148,73 @@ class TestCleanAPI:
         # Drop nulls
         result = ar.clean(frame, strip_whitespace=False, drop_nulls=True)
         assert len(result) < len(frame)
+
+
+class TestRoundNumericColumns:
+    def test_round_all_numeric(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, 2.456], "b": [3.789, 4.0]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, decimals=1)
+        result_df = ar.to_pandas(result)
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["b"]) == [3.8, 4.0]
+
+    def test_round_subset(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, 2.456], "b": [3.789, 4.0]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, subset=["a"], decimals=1)
+        result_df = ar.to_pandas(result)
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["b"]) == [3.789, 4.0]
+
+    def test_round_mixed_types(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, 2.456], "c": ["str1", "str2"]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, decimals=1)
+        result_df = ar.to_pandas(result)
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["c"]) == ["str1", "str2"]
+
+    def test_missing_column(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(KeyError, match="Columns not found in dataframe"):
+            ar.round_numeric_columns(frame, subset=["missing_col"])
+
+    def test_with_nulls(self):
+        import numpy as np
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, np.nan, 2.456]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, decimals=1)
+        result_df = ar.to_pandas(result)
+        assert result_df["a"].isna().iloc[1]
+        assert result_df["a"].iloc[0] == 1.1
+        assert result_df["a"].iloc[2] == 2.5
+
+    def test_invalid_subset_type(self):
+        import pandas as pd
+        import pytest
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="subset must be a list"):
+            ar.round_numeric_columns(frame, subset="a")
+
+    def test_invalid_decimals_type(self):
+        import pandas as pd
+        import pytest
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="decimals must be an integer"):
+            ar.round_numeric_columns(frame, decimals="2")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -190,3 +190,19 @@ def test_filter_rows_direct_api():
     result_df = ar.to_pandas(result)
 
     assert list(result_df["age"]) == [30, 40]
+
+
+def test_round_numeric_columns_pipeline():
+    import pandas as pd
+
+    import arnio as ar
+
+    df = pd.DataFrame({"price": [10.555, 20.123]})
+    frame = ar.from_pandas(df)
+
+    result = ar.pipeline(
+        frame, [("round_numeric_columns", {"subset": ["price"], "decimals": 2})]
+    )
+
+    result_df = ar.to_pandas(result)
+    assert list(result_df["price"]) == [10.56, 20.12]


### PR DESCRIPTION
## Summary

Adds a new `round_numeric_columns` cleaning helper for rounding selected numeric columns with configurable precision.

This implementation:

* supports optional column subsets
* preserves null values
* safely ignores non-numeric columns
* validates unknown columns clearly
* integrates with the pipeline API
* includes direct cleaning tests and pipeline tests
* adds a README usage example

## Linked issue

Fixes #155

## Type of change

* [x] Feature
* [x] Tests
* [x] Documentation

## Area

* [x] Python API / ArFrame
* [x] Pipeline / custom steps
* [x] Docs / website

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash
pytest tests/test_cleaning.py tests/test_pipeline.py -v
```

All tests passed successfully.

## Screenshots / Media

N/A

## Performance Impact

No significant performance impact expected.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

The implementation follows the existing cleaning helper API style and registers the step through `_STEP_REGISTRY` for consistency with built-in pipeline steps.
