### PR TITLE
feat: add trim_headers CSV option

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -60,6 +60,7 @@ def read_csv(
     usecols: list[str] | None = None,
     nrows: int | None = None,
     encoding: str = "utf-8",
+    trim_headers: bool = True,
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -77,6 +78,8 @@ def read_csv(
         Number of rows to read. If None, reads all rows.
     encoding : str, default "utf-8"
         File encoding.
+    trim_headers : bool, default True
+        Strip leading/trailing whitespace from column names.
 
     Returns
     -------
@@ -119,6 +122,7 @@ def read_csv(
     config.delimiter = delimiter
     config.has_header = has_header
     config.encoding = encoding
+    config.trim_headers = trim_headers
 
     if usecols is not None:
         config.usecols = usecols
@@ -143,6 +147,7 @@ def scan_csv(
     *,
     delimiter: str = ",",
     encoding: str = "utf-8",
+    trim_headers: bool = True,
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
 
@@ -154,6 +159,8 @@ def scan_csv(
         Field delimiter character.
     encoding : str, default "utf-8"
         File encoding. Non-UTF-8 inputs are transcoded before native scanning.
+    trim_headers : bool, default True
+        Strip leading/trailing whitespace from column names.
 
     Returns
     -------
@@ -197,6 +204,7 @@ def scan_csv(
     config = _CsvConfig()
     config.delimiter = delimiter
     config.encoding = encoding
+    config.trim_headers = trim_headers
     reader = _CsvReader(config)
     try:
         with _utf8_csv_path(path, encoding) as native_path:

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -205,7 +205,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("has_header", &CsvConfig::has_header)
         .def_readwrite("usecols", &CsvConfig::usecols)
         .def_readwrite("nrows", &CsvConfig::nrows)
-        .def_readwrite("encoding", &CsvConfig::encoding);
+        .def_readwrite("encoding", &CsvConfig::encoding)
+        .def_readwrite("trim_headers", &CsvConfig::trim_headers);
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -16,6 +16,7 @@ struct CsvConfig {
     std::optional<std::vector<std::string>> usecols = std::nullopt;
     std::optional<size_t> nrows = std::nullopt;
     std::string encoding = "utf-8";  // Currently only utf-8 supported
+    bool trim_headers = true;        // for implementing the trim_headers option
 };
 
 class CsvReader {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -202,7 +202,7 @@ Frame CsvReader::read(const std::string& path) const {
         strip_utf8_bom(line);
         header = parse_line(line);
         for (auto& h : header) {
-            trim_in_place(h);
+            if (config_.trim_headers) trim_in_place(h);
         }
         validate_header(header);
     }
@@ -290,7 +290,7 @@ std::unordered_map<std::string, std::string> CsvReader::scan_schema(const std::s
         strip_utf8_bom(line);
         header = parse_line(line);
         for (auto& h : header) {
-            trim_in_place(h);
+            if (config_.trim_headers) trim_in_place(h);
         }
         validate_header(header);
     }

--- a/cpp/tests/test_column_consistency.cpp
+++ b/cpp/tests/test_column_consistency.cpp
@@ -1,10 +1,10 @@
-#include "arnio/column.h"
-
 #include <cstdlib>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+#include "arnio/column.h"
 
 static int failures = 0;
 
@@ -20,8 +20,7 @@ int main() {
 
     // Construct an inconsistent column: dtype=INT64 but data holds strings.
     ColumnData bad_data = std::vector<std::string>{"hello"};
-    Column inconsistent("test", DType::INT64, std::move(bad_data),
-                        std::vector<bool>{false});
+    Column inconsistent("test", DType::INT64, std::move(bad_data), std::vector<bool>{false});
 
     // -- clone() ----------------------------------------------------------
     {

--- a/cpp/tests/test_column_consistency.cpp
+++ b/cpp/tests/test_column_consistency.cpp
@@ -1,10 +1,10 @@
+#include "arnio/column.h"
+
 #include <cstdlib>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include "arnio/column.h"
 
 static int failures = 0;
 
@@ -20,7 +20,8 @@ int main() {
 
     // Construct an inconsistent column: dtype=INT64 but data holds strings.
     ColumnData bad_data = std::vector<std::string>{"hello"};
-    Column inconsistent("test", DType::INT64, std::move(bad_data), std::vector<bool>{false});
+    Column inconsistent("test", DType::INT64, std::move(bad_data),
+                        std::vector<bool>{false});
 
     // -- clone() ----------------------------------------------------------
     {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -64,6 +64,31 @@ class TestReadCsv:
         frame = ar.read_csv(csv_path)
         assert frame.columns == ["name", "age"]
 
+    def test_trim_headers_true_is_default(self, tmp_path):
+        csv_path = str(tmp_path / "trim.csv")
+        with open(csv_path, "w") as f:
+            f.write(" name ,  age \nAlice,30\n")
+
+        frame = ar.read_csv(csv_path)
+        assert frame.columns == ["name", "age"]
+
+    def test_trim_headers_false_preserves_spaces(self, tmp_path):
+        csv_path = str(tmp_path / "notrim.csv")
+        with open(csv_path, "w") as f:
+            f.write(" name ,  age \nAlice,30\n")
+
+        frame = ar.read_csv(csv_path, trim_headers=False)
+        assert frame.columns == [" name ", "  age "]
+
+    def test_trim_headers_false_scan_csv(self, tmp_path):
+        csv_path = str(tmp_path / "scan_notrim.csv")
+        with open(csv_path, "w") as f:
+            f.write(" score , active \n95,true\n")
+
+        schema = ar.scan_csv(csv_path, trim_headers=False)
+        assert " score " in schema
+        assert " active " in schema
+
     def test_unsupported_extension(self, tmp_path):
         import pytest
 


### PR DESCRIPTION

### Description

This PR introduces a configurable option `trim_headers` to control whether leading/trailing whitespace is stripped from CSV column headers.

### Changes

* Added `bool trim_headers` (default: `true`) to `CsvConfig` in `csv_reader.h`
* Updated `csv_reader.cpp` to conditionally call `trim_in_place()` based on `config_.trim_headers`
* Exposed `trim_headers` in Python bindings via `bind_arnio.cpp`
* Updated `read_csv` and `scan_csv` to accept and pass the new parameter into the config
* Added test cases to verify behavior when:

  * `trim_headers = true` (default behavior)
  * `trim_headers = false` (preserves original whitespace)

### Motivation

Previously, header trimming was always applied implicitly. This change makes the behavior explicit and configurable, giving users more control over how CSV headers are handled.

### Testing

* All existing tests pass
* Added new tests covering both enabled and disabled trimming scenarios

### Notes

This maintains backward compatibility since `trim_headers` defaults to `true`.

Fixes #133 
