### PR TITLE
feat: add remove_control_characters cleaning step

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -21,6 +21,7 @@ from .cleaning import (
     normalize_case,
     rename_columns,
     strip_whitespace,
+    remove_control_characters,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
@@ -59,6 +60,7 @@ __all__ = [
     "fill_nulls",
     "filter_rows",
     "drop_duplicates",
+    "remove_control_characters",
     "strip_whitespace",
     "normalize_case",
     "rename_columns",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -14,15 +14,14 @@ except Exception:
 from .cleaning import (
     cast_types,
     clean,
-    drop_constant_columns,
     drop_duplicates,
     drop_nulls,
     fill_nulls,
     filter_rows,
     normalize_case,
-    remove_control_characters,
     rename_columns,
     strip_whitespace,
+    remove_control_characters,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
@@ -62,7 +61,6 @@ __all__ = [
     "filter_rows",
     "drop_duplicates",
     "remove_control_characters",
-    "drop_constant_columns",
     "strip_whitespace",
     "normalize_case",
     "rename_columns",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -20,9 +20,9 @@ from .cleaning import (
     fill_nulls,
     filter_rows,
     normalize_case,
+    remove_control_characters,
     rename_columns,
     strip_whitespace,
-    remove_control_characters,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError

--- a/arnio/_core.py
+++ b/arnio/_core.py
@@ -17,6 +17,7 @@ try:
         normalize_case as _normalize_case,  # noqa: F401
         rename_columns as _rename_columns,  # noqa: F401
         strip_whitespace as _strip_whitespace,  # noqa: F401
+        remove_control_characters as _remove_control_characters,  # noqa: F401
     )
 except ImportError as e:
     raise ImportError(

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -6,6 +6,7 @@ Data cleaning functions.
 from __future__ import annotations
 
 from typing import Any
+from unittest import result
 
 from ._core import (
     _cast_types,
@@ -15,6 +16,7 @@ from ._core import (
     _normalize_case,
     _rename_columns,
     _strip_whitespace,
+    _remove_control_characters,
 )
 from .exceptions import TypeCastError
 from .frame import ArFrame
@@ -139,6 +141,35 @@ def strip_whitespace(
     """
     result = _strip_whitespace(frame._frame, subset=subset)
     return ArFrame(result)
+
+
+def remove_control_characters(
+    frame: ArFrame,
+    *,
+    subset: list[str] | None = None,
+) -> ArFrame:
+    """Remove control characters from string columns.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    subset : list[str], optional
+        Column names to strip whitespace from. If None, applies to all string columns.
+
+    Returns
+    -------
+    ArFrame
+        New frame with whitespace trimmed from string columns.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> clean = ar.remove_control_characters(frame, subset=["name"])
+    """
+    result = _remove_control_characters(frame._frame, subset=subset)
+    return ArFrame(result)
+        
 
 
 def normalize_case(

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -6,7 +6,6 @@ Data cleaning functions.
 from __future__ import annotations
 
 from typing import Any
-from unittest import result
 
 from ._core import (
     _cast_types,
@@ -14,9 +13,9 @@ from ._core import (
     _drop_nulls,
     _fill_nulls,
     _normalize_case,
+    _remove_control_characters,
     _rename_columns,
     _strip_whitespace,
-    _remove_control_characters,
 )
 from .exceptions import TypeCastError
 from .frame import ArFrame
@@ -208,7 +207,6 @@ def remove_control_characters(
     """
     result = _remove_control_characters(frame._frame, subset=subset)
     return ArFrame(result)
-        
 
 
 def normalize_case(

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -241,6 +241,10 @@ PYBIND11_MODULE(_arnio_cpp, m) {
     m.def("strip_whitespace", &strip_whitespace, py::arg("frame"),
           py::arg("subset") = std::nullopt);
 
+    m.def("remove_control_characters", &remove_control_characters,
+          py::arg("frame"),
+          py::arg("subset") = std::nullopt);
+
     m.def("normalize_case", &normalize_case, py::arg("frame"), py::arg("subset") = std::nullopt,
           py::arg("case_type") = "lower");
 

--- a/cpp/include/arnio/cleaning.h
+++ b/cpp/include/arnio/cleaning.h
@@ -26,6 +26,11 @@ Frame drop_duplicates(const Frame& frame,
 Frame strip_whitespace(const Frame& frame,
                        const std::optional<std::vector<std::string>>& subset = std::nullopt);
 
+// Remove control characters from string columns                       
+Frame remove_control_characters(
+    const Frame& frame,
+    const std::optional<std::vector<std::string>>& subset = std::nullopt);
+
 // Normalize case of string columns
 Frame normalize_case(const Frame& frame,
                      const std::optional<std::vector<std::string>>& subset = std::nullopt,

--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -256,6 +256,58 @@ Frame strip_whitespace(const Frame& frame, const std::optional<std::vector<std::
     return Frame(std::move(new_cols));
 }
 
+Frame remove_control_characters(
+    const Frame& frame,
+    const std::optional<std::vector<std::string>>& subset) {
+
+    auto target_indices_set = resolve_subset(frame, subset);
+    std::unordered_set<size_t> targets(
+        target_indices_set.begin(),
+        target_indices_set.end());
+
+    std::vector<Column> new_cols;
+    new_cols.reserve(frame.num_cols());
+
+    for (size_t ci = 0; ci < frame.num_cols(); ++ci) {
+        const auto& src = frame.column(ci);
+
+        if (targets.count(ci) && src.dtype() == DType::STRING) {
+
+            Column col(src.name(), src.dtype());
+
+            for (size_t r = 0; r < src.size(); ++r) {
+
+                if (src.is_null(r)) {
+                    col.push_null();
+
+                } else {
+
+                    std::string val =
+                        std::get<std::string>(src.at(r));
+
+                    std::string cleaned;
+
+                    for (char c : val) {
+                        if (!std::iscntrl(
+                                static_cast<unsigned char>(c))) {
+                            cleaned += c;
+                        }
+                    }
+
+                    col.push_back(cleaned);
+                }
+            }
+
+            new_cols.push_back(std::move(col));
+
+        } else {
+
+            new_cols.push_back(src.clone());
+        }
+    }
+
+    return Frame(std::move(new_cols));
+}
 Frame normalize_case(const Frame& frame, const std::optional<std::vector<std::string>>& subset,
                      const std::string& case_type) {
     auto target_indices_set = resolve_subset(frame, subset);

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -83,19 +83,47 @@ class TestStripWhitespace:
         df = ar.to_pandas(result)
         assert df["name"].iloc[0] == "Alice"
 
-
-class TestNormalizeCase:
-    def test_lower(self, sample_csv):
-        frame = ar.read_csv(sample_csv)
-        result = ar.normalize_case(frame, subset=["name"], case_type="lower")
+class TestRemoveControlCharacters:
+    def test_strip(self, csv_with_whitespace):
+        frame = ar.read_csv(csv_with_whitespace)
+        result = ar.strip_whitespace(frame)
         df = ar.to_pandas(result)
-        assert df["name"].iloc[0] == "alice"
+        assert df["name"].iloc[0] == "Alice"
+        assert df["city"].iloc[1] == "London"
 
-    def test_upper(self, sample_csv):
-        frame = ar.read_csv(sample_csv)
-        result = ar.normalize_case(frame, subset=["name"], case_type="upper")
+    def test_strip_subset(self, csv_with_whitespace):
+        frame = ar.read_csv(csv_with_whitespace)
+        result = ar.strip_whitespace(frame, subset=["name"])
         df = ar.to_pandas(result)
-        assert df["name"].iloc[0] == "ALICE"
+        assert df["name"].iloc[0] == "Alice"
+
+    
+class TestRemoveControlCharacters:
+
+    def test_remove_control_characters(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.remove_control_characters(
+            frame,
+            subset=["name"]
+        )
+
+        df = ar.to_pandas(result)
+
+        assert isinstance(df["name"].iloc[0], str)
+
+
+    def test_remove_control_characters_subset(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.remove_control_characters(
+            frame,
+            subset=["name"]
+        )
+
+        df = ar.to_pandas(result)
+
+        assert "name" in df.columns
 
     def test_title(self, sample_csv):
         frame = ar.read_csv(sample_csv)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -171,54 +171,51 @@ class TestStripWhitespace:
         result = ar.strip_whitespace(frame, subset=["name"])
         df = ar.to_pandas(result)
         assert df["name"].iloc[0] == "Alice"
+        # city should still have whitespace
 
-class TestRemoveControlCharacters:
-    def test_strip(self, csv_with_whitespace):
-        frame = ar.read_csv(csv_with_whitespace)
-        result = ar.strip_whitespace(frame)
+
+class TestNormalizeCase:
+
+    def test_lower(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.normalize_case(frame, subset=["name"], case_type="lower")
+
         df = ar.to_pandas(result)
-        assert df["name"].iloc[0] == "Alice"
-        assert df["city"].iloc[1] == "London"
 
-    def test_strip_subset(self, csv_with_whitespace):
-        frame = ar.read_csv(csv_with_whitespace)
-        result = ar.strip_whitespace(frame, subset=["name"])
+        assert df["name"].iloc[0] == "alice"
+
+    def test_upper(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.normalize_case(frame, subset=["name"], case_type="upper")
+
         df = ar.to_pandas(result)
+
+        assert df["name"].iloc[0] == "ALICE"
+
+    def test_title(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.normalize_case(frame, subset=["name"], case_type="title")
+
+        df = ar.to_pandas(result)
+
         assert df["name"].iloc[0] == "Alice"
 
-    
+
 class TestRemoveControlCharacters:
 
     def test_remove_control_characters(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        result = ar.remove_control_characters(
-            frame,
-            subset=["name"]
-        )
+        result = ar.remove_control_characters(frame, subset=["name"])
 
         df = ar.to_pandas(result)
 
         assert isinstance(df["name"].iloc[0], str)
-
-
-    def test_remove_control_characters_subset(self, sample_csv):
-        frame = ar.read_csv(sample_csv)
-
-        result = ar.remove_control_characters(
-            frame,
-            subset=["name"]
-        )
-
-        df = ar.to_pandas(result)
-
-        assert "name" in df.columns
-
-    def test_title(self, sample_csv):
-        frame = ar.read_csv(sample_csv)
-        result = ar.normalize_case(frame, subset=["name"], case_type="title")
-        df = ar.to_pandas(result)
-        assert df["name"].iloc[0] == "Alice"
+        assert "\n" not in df["name"].iloc[0]
+        assert "\t" not in df["name"].iloc[0]
 
 
 class TestRenameColumns:


### PR DESCRIPTION
## Summary
Added a new cleaning step `remove_control_characters` to safely remove control characters from string columns.

## Linked issue
Fixes #152

## Type of change
- [x] Feature
- [x] Tests

## Area
- [x] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps

## Testing
- [x] Other

Commands run:
```bash
pytest tests/test_cleaning.py
