### PR TITLE
feat: add select_columns helper to ArFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ clean = ar.pipeline(frame, [
 # Out comes a standard pandas DataFrame — use it like you always have
 df = ar.to_pandas(clean)
 ```
+### Select specific columns
+
+Use `select_columns()` to create a new `ArFrame` with only the required columns before converting to pandas.
+
+```python
+selected = frame.select_columns(["name", "revenue"])
+
+print(selected.columns)
+# ['name', 'revenue']
+```
+
 
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -62,8 +62,8 @@ class ArFrame:
             Memory usage in bytes.
         """
         return self._frame.memory_usage()
-    
-    def select_columns(self, columns: list[str]) -> "ArFrame":
+
+    def select_columns(self, columns: list[str]) -> ArFrame:
         """Return a new ArFrame with only the selected columns.
 
         Parameters
@@ -78,12 +78,24 @@ class ArFrame:
 
         Raises
         ------
+        TypeError
+            If columns is not a valid sequence of strings.
+
         ValueError
             If the selection is empty, contains duplicates,
             or includes unknown columns.
         """
+        if isinstance(columns, str):
+            raise TypeError("columns must be a sequence of column names, not a string.")
+
+        if not isinstance(columns, list | tuple):
+            raise TypeError("columns must be a list or tuple of column names.")
+
         if not columns:
             raise ValueError("Column selection cannot be empty.")
+
+        if any(not isinstance(col, str) for col in columns):
+            raise TypeError("All column names must be strings.")
 
         if len(columns) != len(set(columns)):
             raise ValueError("Duplicate column names are not allowed.")

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -88,7 +88,7 @@ class ArFrame:
         if isinstance(columns, str):
             raise TypeError("columns must be a sequence of column names, not a string.")
 
-        if not isinstance(columns, list | tuple):
+        if not isinstance(columns, (list, tuple)):
             raise TypeError("columns must be a list or tuple of column names.")
 
         if not columns:

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -62,6 +62,43 @@ class ArFrame:
             Memory usage in bytes.
         """
         return self._frame.memory_usage()
+    
+    def select_columns(self, columns: list[str]) -> "ArFrame":
+        """Return a new ArFrame with only the selected columns.
+
+        Parameters
+        ----------
+        columns : list[str]
+            List of column names to select.
+
+        Returns
+        -------
+        ArFrame
+            New ArFrame containing only the selected columns.
+
+        Raises
+        ------
+        ValueError
+            If the selection is empty, contains duplicates,
+            or includes unknown columns.
+        """
+        if not columns:
+            raise ValueError("Column selection cannot be empty.")
+
+        if len(columns) != len(set(columns)):
+            raise ValueError("Duplicate column names are not allowed.")
+
+        missing = [col for col in columns if col not in self.columns]
+
+        if missing:
+            raise ValueError(f"Unknown columns: {missing}")
+
+        from .convert import from_pandas, to_pandas
+
+        df = to_pandas(self)
+        selected_df = df[columns]
+
+        return from_pandas(selected_df)
 
     # --- Dunder methods ---
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,0 +1,78 @@
+import pytest
+import pandas as pd
+
+import arnio as ar
+
+
+def test_select_columns_valid():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice", "Bob"],
+            "age": [25, 30],
+            "salary": [50000, 60000],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    selected = frame.select_columns(["name", "salary"])
+
+    assert selected.columns == ["name", "salary"]
+    assert selected.shape == (2, 2)
+
+
+def test_select_columns_preserves_order():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+            "salary": [50000],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    selected = frame.select_columns(["salary", "name"])
+
+    assert selected.columns == ["salary", "name"]
+
+
+def test_select_columns_unknown_column():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="Unknown columns"):
+        frame.select_columns(["name", "salary"])
+
+
+def test_select_columns_empty():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        frame.select_columns([])
+
+
+def test_select_columns_duplicate_names():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="Duplicate column names"):
+        frame.select_columns(["name", "name"])

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,5 +1,5 @@
-import pytest
 import pandas as pd
+import pytest
 
 import arnio as ar
 
@@ -76,3 +76,41 @@ def test_select_columns_duplicate_names():
 
     with pytest.raises(ValueError, match="Duplicate column names"):
         frame.select_columns(["name", "name"])
+
+
+def test_select_columns_string_input():
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="not a string"):
+        frame.select_columns("name")
+
+
+def test_select_columns_non_string_items():
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="must be strings"):
+        frame.select_columns(["name", 123])
+
+
+def test_select_columns_invalid_container():
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="list or tuple"):
+        frame.select_columns({"name"})
+
+
+def test_select_columns_empty_frame():
+    df = pd.DataFrame(columns=["name", "age"])
+
+    frame = ar.from_pandas(df)
+
+    selected = frame.select_columns(["name"])
+
+    assert selected.columns == ["name"]
+    assert selected.shape == (0, 1)


### PR DESCRIPTION
## Summary

Implemented a lightweight "select_columns()" helper for "ArFrame" that allows users to select a subset of columns before converting to pandas.

The implementation:

* preserves the requested column order
* raises clear errors for unknown columns
* defines behavior for empty selections and duplicate column names
* keeps the implementation minimal and aligned with the existing API design

Additionally:

* added focused tests for normal and invalid cases
* added a minimal README usage example for the new helper

## Linked issue

Fixes #218

## Type of change

* [x] Feature
* [x] Documentation
* [x] Tests

## Area

* [x] Python API / ArFrame
* [x] pandas interoperability
* [x] Docs / website

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

Commands run locally:

```bash id="jlwm55"
python -m pytest
```

Result:

* Existing tests passed successfully
* Added tests for:

  * valid column selection
  * requested column order preservation
  * unknown column handling
  * empty selections
  * duplicate requested column names

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Implemented the helper using the existing pandas conversion pipeline to keep the change lightweight and avoid unnecessary backend/C++ modifications.
