### PR TITLE
Feature/date schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,12 +335,15 @@ schema = ar.Schema({
     "id": ar.Int64(nullable=False, unique=True),
     "email": ar.Email(nullable=False),
     "revenue": ar.Float64(nullable=True, min=0),
+    "created_at": ar.Date(nullable=False),
 })
 
 result = ar.validate(frame, schema)
 if not result.passed:
     print(result.to_pandas())
 ```
+
+Date fields use the `YYYY-MM-DD` format and reject invalid calendar dates.
 
 For low-risk automatic cleanup:
 

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -36,6 +36,7 @@ from .quality import (
 from .schema import (
     URL,
     Bool,
+    Date,
     Email,
     Field,
     Float64,
@@ -91,4 +92,5 @@ __all__ = [
     "ArnioError",
     "CsvReadError",
     "TypeCastError",
+    "Date",
 ]

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -106,8 +106,8 @@ def read_csv(
     try:
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
-                raise ValueError(
-                    f"File appears to be binary: {path}. Only text-based CSV files are supported."
+                raise CsvReadError(
+                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
@@ -182,8 +182,8 @@ def scan_csv(
     try:
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
-                raise ValueError(
-                    f"File appears to be binary: {path}. Only text-based CSV files are supported."
+                raise CsvReadError(
+                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -86,7 +86,10 @@ def read_csv(
     Raises
     ------
     ValueError
-        If file format is unsupported or file appears binary.
+        If file format is unsupported.
+
+    CsvReadError
+        If CSV input contains NUL bytes and appears binary or corrupted.
 
     Examples
     --------
@@ -107,7 +110,7 @@ def read_csv(
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
                 raise CsvReadError(
-                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
+                    "CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
@@ -159,8 +162,11 @@ def scan_csv(
 
     Raises
     ------
-    ValueError
-        If file format is unsupported or file appears binary.
+        ValueError
+        If file format is unsupported.
+
+    CsvReadError
+        If CSV input contains NUL bytes and appears binary or corrupted.
 
     Examples
     --------
@@ -183,7 +189,7 @@ def scan_csv(
         with open(path, "rb") as f:
             if b"\0" in f.read(1024):
                 raise CsvReadError(
-                    f"CSV input contains NUL bytes and appears to be binary or corrupted"
+                    "CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
     except FileNotFoundError:
         pass

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -162,7 +162,7 @@ def scan_csv(
 
     Raises
     ------
-        ValueError
+    ValueError
         If file format is unsupported.
 
     CsvReadError

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -6,6 +6,7 @@ Production data contracts and validation.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
 import pandas as pd
@@ -233,6 +234,16 @@ def URL(*, nullable: bool = True, unique: bool = False) -> Field:
     return Field(dtype="string", nullable=nullable, semantic="url", unique=unique)
 
 
+def Date(*, nullable: bool = True, unique: bool = False) -> Field:
+    """Create a date schema field."""
+    return Field(
+        dtype="string",
+        nullable=nullable,
+        semantic="date",
+        unique=unique,
+    )
+
+
 def _validate_column(
     series: pd.Series,
     actual_dtype: str | None,
@@ -341,7 +352,19 @@ def _validate_column(
                 )
             )
         else:
-            invalid = non_null[~text.str.fullmatch(pattern, na=False)]
+            if field_def.semantic == "date":
+                invalid_values = []
+
+                for index, value in non_null.items():
+                    try:
+                        datetime.strptime(str(value), "%Y-%m-%d")
+                    except ValueError:
+                        invalid_values.append((index, value))
+
+                invalid = pd.Series({index: value for index, value in invalid_values})
+            else:
+                invalid = non_null[~text.str.fullmatch(pattern, na=False)]
+
             issues.extend(
                 _row_issues(
                     invalid,
@@ -407,4 +430,5 @@ _SEMANTIC_PATTERNS = {
     "email": r"[^@\s]+@[^@\s]+\.[^@\s]+",
     "url": r"https?://[^\s]+",
     "phone": r"\+?[0-9][0-9 .()\-]{6,}[0-9]",
+    "date": r"\d{4}-\d{2}-\d{2}",
 }

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -175,7 +175,7 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, encoding="latin-1")
 
         assert schema == {"name": "string"}
-        
+
     def test_scan_binary_file_rejection(self, tmp_path):
         file_path = str(tmp_path / "data.csv")
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -75,13 +75,14 @@ class TestReadCsv:
             ar.read_csv(file_path)
 
     def test_binary_file_rejection(self, tmp_path):
-        import pytest
-
         file_path = str(tmp_path / "data.csv")
         with open(file_path, "wb") as f:
             f.write(b"col1,col2\n\0binary\0,data\n")
 
-        with pytest.raises(ValueError, match="File appears to be binary"):
+        with pytest.raises(
+            ar.CsvReadError,
+            match="CSV input contains NUL bytes and appears to be binary or corrupted",
+        ):
             ar.read_csv(file_path)
 
     def test_read_with_nulls(self, csv_with_nulls):
@@ -174,3 +175,15 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, encoding="latin-1")
 
         assert schema == {"name": "string"}
+        
+    def test_scan_binary_file_rejection(self, tmp_path):
+        file_path = str(tmp_path / "data.csv")
+
+        with open(file_path, "wb") as f:
+            f.write(b"col1,col2\n\0binary\0,data\n")
+
+        with pytest.raises(
+            ar.CsvReadError,
+            match="CSV input contains NUL bytes and appears to be binary or corrupted",
+        ):
+            ar.scan_csv(file_path)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -81,3 +81,44 @@ def test_custom_pattern_validation(tmp_path):
     assert not result.passed
     assert result.issues[0].rule == "pattern"
     assert result.issues[0].row_index == 1
+
+
+def test_date_validation_accepts_valid_dates(tmp_path):
+    path = tmp_path / "dates.csv"
+    path.write_text("created_at\n2026-05-15\n2024-02-29\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"created_at": ar.Date(nullable=False)},
+    )
+
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_date_validation_rejects_invalid_dates(tmp_path):
+    path = tmp_path / "bad_dates.csv"
+    path.write_text("created_at\n2026-99-99\nhello\n15/05/2026\n2026-02-30\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"created_at": ar.Date(nullable=False)},
+    )
+
+    assert not result.passed
+    assert result.issue_count == 4
+
+    rules = {issue.rule for issue in result.issues}
+    assert "date" in rules
+
+
+def test_date_validation_handles_nullable_values(tmp_path):
+    path = tmp_path / "nullable_dates.csv"
+    path.write_text("created_at\n2026-05-15\n\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"created_at": ar.Date(nullable=True)},
+    )
+
+    assert result.passed


### PR DESCRIPTION
## Summary

Added semantic validation support for date-only fields in schema validation.

### Changes made

* Added `ar.Date()` schema field helper
* Added semantic `"date"` validation support using `datetime.strptime`
* Implemented validation for `YYYY-MM-DD` formatted dates
* Rejected invalid calendar dates such as `2026-02-30`
* Added tests for:

  * valid dates
  * invalid dates
  * invalid formats
  * nullable date values
* Updated README examples/documentation for the new Date field type

## Linked issue

Fixes #201

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Performance improvement
* [x] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [x] Schema validation
* [ ] pandas interoperability
* [x] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash
ruff check .
python -m pytest
```

Result:

* 82 tests passed successfully
* All Ruff checks passed

## Screenshots / Media

N/A

## Performance Impact

No significant performance impact expected.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

The implementation follows the existing semantic validation architecture used for Email and URL fields.
