### PR TITLE
feat: add is_empty convenience property to ArFrame

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -2,6 +2,7 @@
 arnio.frame
 ArFrame — the core data container wrapping the C++ Frame.
 """
+
 from __future__ import annotations
 
 from ._core import _Frame

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -2,7 +2,6 @@
 arnio.frame
 ArFrame — the core data container wrapping the C++ Frame.
 """
-
 from __future__ import annotations
 
 from ._core import _Frame
@@ -50,7 +49,7 @@ class ArFrame:
             Mapping of column names to their data types.
         """
         return self._frame.dtypes()
-    
+
     @property
     def is_empty(self) -> bool:
         """Check if frame has zero rows.
@@ -98,7 +97,6 @@ class ArFrame:
         ------
         TypeError
             If columns is not a valid sequence of strings.
-
         ValueError
             If the selection is empty, contains duplicates,
             or includes unknown columns.

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -50,6 +50,24 @@ class ArFrame:
             Mapping of column names to their data types.
         """
         return self._frame.dtypes()
+    
+    @property
+    def is_empty(self) -> bool:
+        """Check if frame has zero rows.
+
+        Returns
+        -------
+        bool
+            True if frame contains no rows, False otherwise.
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> if frame.is_empty:
+        ...     print("No data to process")
+        False
+        """
+        return len(self) == 0
 
     # --- Methods ---
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,0 +1,33 @@
+"""Tests for ArFrame class."""
+
+import pytest
+
+import arnio as ar
+
+
+class TestArFrame:
+    """Test ArFrame properties and methods."""
+
+    def test_is_empty_true(self, tmp_path):
+        """Test is_empty returns True for frame with zero rows."""
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("name,age\n")  # Header only, no data rows
+        
+        frame = ar.read_csv(str(csv_path))
+        assert frame.is_empty is True
+        assert len(frame) == 0
+
+    def test_is_empty_false(self, sample_csv):
+        """Test is_empty returns False for frame with rows."""
+        frame = ar.read_csv(sample_csv)
+        assert frame.is_empty is False
+        assert len(frame) > 0
+
+    def test_is_empty_single_row(self, tmp_path):
+        """Test is_empty with exactly one row."""
+        csv_path = tmp_path / "single.csv"
+        csv_path.write_text("name,age\nAlice,30\n")
+        
+        frame = ar.read_csv(str(csv_path))
+        assert frame.is_empty is False
+        assert len(frame) == 1

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -115,6 +115,7 @@ def test_preview_invalid_n_none(sample_csv):
     with pytest.raises(ValueError):
         frame.preview(n=None)
 
+
 def test_select_columns_valid():
     df = pd.DataFrame(
         {

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,7 +1,5 @@
 """Tests for ArFrame class."""
 
-import pytest
-
 import arnio as ar
 
 
@@ -31,3 +29,4 @@ class TestArFrame:
         frame = ar.read_csv(str(csv_path))
         assert frame.is_empty is False
         assert len(frame) == 1
+        

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,8 +1,100 @@
 """Tests for ArFrame class."""
 
 import pandas as pd
+import pytest
 
 import arnio as ar
+
+
+def test_select_columns_valid():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice", "Bob"],
+            "age": [25, 30],
+            "salary": [50000, 60000],
+        }
+    )
+    frame = ar.from_pandas(df)
+    selected = frame.select_columns(["name", "salary"])
+    assert selected.columns == ["name", "salary"]
+    assert selected.shape == (2, 2)
+
+
+def test_select_columns_preserves_order():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+            "salary": [50000],
+        }
+    )
+    frame = ar.from_pandas(df)
+    selected = frame.select_columns(["salary", "name"])
+    assert selected.columns == ["salary", "name"]
+
+
+def test_select_columns_unknown_column():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+        }
+    )
+    frame = ar.from_pandas(df)
+    with pytest.raises(ValueError, match="Unknown columns"):
+        frame.select_columns(["name", "salary"])
+
+
+def test_select_columns_empty():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+        }
+    )
+    frame = ar.from_pandas(df)
+    with pytest.raises(ValueError, match="cannot be empty"):
+        frame.select_columns([])
+
+
+def test_select_columns_duplicate_names():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+        }
+    )
+    frame = ar.from_pandas(df)
+    with pytest.raises(ValueError, match="Duplicate column names"):
+        frame.select_columns(["name", "name"])
+
+
+def test_select_columns_string_input():
+    df = pd.DataFrame({"name": ["Alice"]})
+    frame = ar.from_pandas(df)
+    with pytest.raises(TypeError, match="not a string"):
+        frame.select_columns("name")
+
+
+def test_select_columns_non_string_items():
+    df = pd.DataFrame({"name": ["Alice"]})
+    frame = ar.from_pandas(df)
+    with pytest.raises(TypeError, match="must be strings"):
+        frame.select_columns(["name", 123])
+
+
+def test_select_columns_invalid_container():
+    df = pd.DataFrame({"name": ["Alice"]})
+    frame = ar.from_pandas(df)
+    with pytest.raises(TypeError, match="list or tuple"):
+        frame.select_columns({"name"})
+
+
+def test_select_columns_empty_frame():
+    df = pd.DataFrame(columns=["name", "age"])
+    frame = ar.from_pandas(df)
+    selected = frame.select_columns(["name"])
+    assert selected.columns == ["name"]
+    assert selected.shape == (0, 1)
 
 
 class TestArFrame:


### PR DESCRIPTION
## Summary
Adds an `is_empty` read-only property to ArFrame that returns True when the frame has zero rows, allowing users to check emptiness without manually inspecting the shape.

## Linked issue
Fixes #215

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Local testing was not possible due to C++ extension build issues on Windows (CMAKE_CXX_COMPILER not set). However, tests are written to verify both empty and non-empty frame cases. GitHub Actions CI will handle the full test run.

- [ ] `make test`
- [ ] `make lint`
- [x] Other: Tests written in `tests/test_frame.py` (pending CI verification)

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Implementation follows the existing ArFrame property pattern (`shape`, `columns`, `dtypes`). The `is_empty` property returns `len(self) == 0`, which uses the existing `__len__` method that calls `num_rows()` on the C++ backend.