### PR TITLE
Improve nested type error messages in from_pandas

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -47,7 +47,6 @@ def _series_to_python_values(series: pd.Series, col_name: object) -> list[object
                 f"of type '{type(raw).__name__}' at value {raw!r}. "
                 "Convert nested objects to strings or flatten them first."
             )
-        
 
         value = _normalize_scalar(raw)
         values.append(value)

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -43,9 +43,11 @@ def _series_to_python_values(series: pd.Series, col_name: object) -> list[object
     for raw in series.tolist():
         if _is_nested(raw):
             raise TypeError(
-                f"Unsupported nested/complex type in column '{col_name}': "
-                f"{type(raw).__name__}"
+                f"Column '{col_name}' contains unsupported nested value "
+                f"of type '{type(raw).__name__}' at value {raw!r}. "
+                "Convert nested objects to strings or flatten them first."
             )
+        
 
         value = _normalize_scalar(raw)
         values.append(value)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,7 @@
 """Tests for pandas conversion."""
 
 import pandas as pd
+import pytest
 
 import arnio as ar
 
@@ -84,14 +85,17 @@ class TestFromPandas:
         assert list(df2["score"]) == [95.5, 87.0]
 
     def test_from_pandas_nested_data(self):
-        import pytest
 
         df_list = pd.DataFrame({"a": [[1, 2], [3, 4]]})
-        with pytest.raises(TypeError, match="Column 'a' contains unsupported nested value"):
+        with pytest.raises(
+            TypeError, match="Column 'a' contains unsupported nested value"
+        ):
             ar.from_pandas(df_list)
 
         df_dict = pd.DataFrame({"a": [{"x": 1}, {"y": 2}]})
-        with pytest.raises(TypeError, match="Column 'a' contains unsupported nested value"):
+        with pytest.raises(
+            TypeError, match="Column 'a' contains unsupported nested value"
+        ):
             ar.from_pandas(df_dict)
 
     def test_from_pandas_mixed_object_column(self):
@@ -100,6 +104,16 @@ class TestFromPandas:
         df2 = ar.to_pandas(frame)
 
         assert list(df2["a"]) == ["1", "x", "3"]
+
+    def test_from_pandas_mixed_object_column_with_nested_value(self):
+
+        df = pd.DataFrame({"mixed": [1, "hello", {"a": 1}]}, dtype=object)
+
+        with pytest.raises(
+            TypeError,
+            match="Column 'mixed' contains unsupported nested value",
+        ):
+            ar.from_pandas(df)
 
     def test_from_pandas_unsupported_scalar_object_column(self):
         timestamp = pd.Timestamp("2026-05-14 12:30:00")

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -87,11 +87,11 @@ class TestFromPandas:
         import pytest
 
         df_list = pd.DataFrame({"a": [[1, 2], [3, 4]]})
-        with pytest.raises(TypeError, match="Unsupported nested/complex type"):
+        with pytest.raises(TypeError, match="Column 'a' contains unsupported nested value"):
             ar.from_pandas(df_list)
 
         df_dict = pd.DataFrame({"a": [{"x": 1}, {"y": 2}]})
-        with pytest.raises(TypeError, match="Unsupported nested/complex type"):
+        with pytest.raises(TypeError, match="Column 'a' contains unsupported nested value"):
             ar.from_pandas(df_dict)
 
     def test_from_pandas_mixed_object_column(self):


### PR DESCRIPTION
## Summary

Improved developer-facing error messages for unsupported nested object values during 'from_pandas()' conversion.

## Changes Made

* Added clearer error context including:

  * column name
  * unsupported nested type
  * offending value
  * suggested resolution guidance
* Updated tests to validate the improved error message behavior.
* Verified all existing tests pass successfully.

## Example

Previous error:
'Unsupported nested/complex type'

New error:
'Column 'mixed' contains unsupported nested value of type 'dict' at value {'a': 1}. Convert nested objects to strings or flatten them first.'

Fixes #239
