### PR TITLE
feat: add drop_empty_columns cleaning step

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -135,6 +135,7 @@ __all__ = [
     "replace_values",
     "normalize_whitespace",
     "drop_duplicates",
+    "drop_empty_columns",
     "drop_constant_columns",
     "drop_empty_columns",
     "clean_column_names",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -135,7 +135,6 @@ __all__ = [
     "replace_values",
     "normalize_whitespace",
     "drop_duplicates",
-    "drop_empty_columns",
     "drop_constant_columns",
     "drop_empty_columns",
     "clean_column_names",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,3 +85,13 @@ def large_csv(tmp_path):
 def unicode_csv():
     """CSV content for Unicode file path testing."""
     return "name,value\nAlice,1\nBob,2\n"
+
+
+@pytest.fixture
+def csv_with_empty_columns(tmp_path):
+    """CSV with some columns that are completely empty."""
+    csv_content = "name,age,empty_num,empty_text\nAlice,30,,\nBob,25,,\nCharlie,35,,\n"
+    path = tmp_path / "empty_columns.csv"
+    path.write_text(csv_content)
+    return str(path)
+

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -877,7 +877,7 @@ class TestDropEmptyColumns:
         )
         assert "empty_num" not in result.columns
         assert "empty_text" not in result.columns
-    
+
     def test_drop_empty_columns_empty_frame(self):
         frame = ar.from_pandas(pd.DataFrame(columns=["a", "b", "c"]))
         result = ar.drop_empty_columns(frame)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -855,7 +855,7 @@ class TestDropEmptyColumns:
         assert "empty_text" not in result.columns
         assert "name" in result.columns
         assert "age" in result.columns
-    
+
     def test_drop_empty_columns_no_empty(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.drop_empty_columns(frame)
@@ -871,9 +871,18 @@ class TestDropEmptyColumns:
 
     def test_drop_empty_columns_pipeline(self, csv_with_empty_columns):
         frame = ar.read_csv(csv_with_empty_columns)
-        result = ar.pipeline(frame,[("drop_empty_columns",)],)
+        result = ar.pipeline(
+            frame,
+            [("drop_empty_columns",)],
+        )
         assert "empty_num" not in result.columns
         assert "empty_text" not in result.columns
+    
+    def test_drop_empty_columns_empty_frame(self):
+        frame = ar.from_pandas(pd.DataFrame(columns=["a", "b", "c"]))
+        result = ar.drop_empty_columns(frame)
+        assert result.columns == ["a", "b", "c"]
+        assert result.shape == frame.shape
 
 
 class TestDropConstantColumns:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -847,6 +847,35 @@ class TestDropColumns:
             )
 
 
+class TestDropEmptyColumns:
+    def test_drop_empty_columns_all_empty(self, csv_with_empty_columns):
+        frame = ar.read_csv(csv_with_empty_columns)
+        result = ar.drop_empty_columns(frame)
+        assert "empty_num" not in result.columns
+        assert "empty_text" not in result.columns
+        assert "name" in result.columns
+        assert "age" in result.columns
+    
+    def test_drop_empty_columns_no_empty(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = ar.drop_empty_columns(frame)
+        assert result.columns == frame.columns
+        assert result.shape == frame.shape
+
+    def test_drop_empty_columns_partially_empty(self, tmp_path):
+        path = tmp_path / "mixed.csv"
+        path.write_text("id,value,mixed\n1,10,\n2,20,data\n3,30,\n")
+        frame = ar.read_csv(path)
+        result = ar.drop_empty_columns(frame)
+        assert "mixed" in result.columns
+
+    def test_drop_empty_columns_pipeline(self, csv_with_empty_columns):
+        frame = ar.read_csv(csv_with_empty_columns)
+        result = ar.pipeline(frame,[("drop_empty_columns",)],)
+        assert "empty_num" not in result.columns
+        assert "empty_text" not in result.columns
+
+
 class TestDropConstantColumns:
     def test_drop_constant_columns_removes_constant_columns(self):
         frame = ar.from_pandas(


### PR DESCRIPTION
Implemented `drop_empty_columns` cleaning utility, registered it in the pipeline, and added tests for all-empty, partially-empty, no-empty, and pipeline usage cases.

Fixes #146
