### PR TITLE
feat: add keep_rows_with_nulls pipeline step

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | Primitive | What it does | Example |
 |:---|:---|:---|
 | `drop_nulls` | Remove rows with null/empty values | `ar.drop_nulls(frame, subset=["age"])` |
+| `keep_rows_with_nulls` | Keep only rows that contain at least one null | `ar.keep_rows_with_nulls(frame, subset=["age"])` |
 | `validate_columns_exist` | Fail early when required columns are missing | `ar.validate_columns_exist(frame, ["age"])` |
 | `filter_rows` | Filter rows using comparison operators | `ar.filter_rows(frame, column="age", op=">", value=18)` |
 | `fill_nulls` | Replace nulls with a scalar | `ar.fill_nulls(frame, 0, subset=["revenue"])` |
@@ -437,6 +438,27 @@ Works with:
 - floats
 - strings
 - booleans
+
+### 🔎 Isolate rows with null values
+
+Use `keep_rows_with_nulls` to audit incomplete data — keep only rows that have at least one null.
+
+```python
+frame = ar.read_csv("data.csv")
+
+# Keep all rows that have at least one null anywhere
+nulls = ar.keep_rows_with_nulls(frame)
+
+# Keep rows where specifically 'age' or 'score' is null
+nulls = ar.keep_rows_with_nulls(frame, subset=["age", "score"])
+
+# Works inside a pipeline too
+result = ar.pipeline(frame, [
+    ("keep_rows_with_nulls", {"subset": ["age"]}),
+])
+```
+
+Useful for data auditing — inspect what's missing before deciding how to fill or drop.
 
 <br>
 ### 🔢 Safe column division

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -20,6 +20,7 @@ from .cleaning import (
     drop_nulls,
     fill_nulls,
     filter_rows,
+    keep_rows_with_nulls,
     normalize_case,
     rename_columns,
     round_numeric_columns,
@@ -62,6 +63,7 @@ __all__ = [
     "scan_csv",
     # Cleaning
     "drop_nulls",
+    "keep_rows_with_nulls",
     "fill_nulls",
     "validate_columns_exist",
     "filter_rows",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -138,6 +138,8 @@ def keep_rows_with_nulls(
 
     Raises
     ------
+    TypeError
+        If subset is passed as a string instead of a list.
     ValueError
         If any column in subset does not exist in the frame.
 
@@ -147,6 +149,13 @@ def keep_rows_with_nulls(
     >>> nulls = ar.keep_rows_with_nulls(frame)
     >>> nulls_age = ar.keep_rows_with_nulls(frame, subset=["age"])
     """
+
+    if isinstance(subset, str):
+        raise TypeError(
+            f"keep_rows_with_nulls: 'subset' must be a list of column names, "
+            f"not a string. Did you mean subset=['{subset}']?"
+        )
+
     import pandas as pd
 
     from .convert import from_pandas, to_pandas

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -116,6 +116,60 @@ def drop_nulls(
     return ArFrame(result)
 
 
+def keep_rows_with_nulls(
+    frame: ArFrame,
+    *,
+    subset: list[str] | None = None,
+) -> ArFrame:
+    """Keep only rows that contain at least one null/empty value.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    subset : list[str], optional
+        Column names to check for nulls. If None, checks all columns.
+        A row is kept if ANY column in the subset contains a null.
+
+    Returns
+    -------
+    ArFrame
+        New frame containing only rows with at least one null value.
+
+    Raises
+    ------
+    ValueError
+        If any column in subset does not exist in the frame.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> nulls = ar.keep_rows_with_nulls(frame)
+    >>> nulls_age = ar.keep_rows_with_nulls(frame, subset=["age"])
+    """
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    is_arframe = not isinstance(frame, pd.DataFrame)
+    df = to_pandas(frame) if is_arframe else frame
+
+    cols = subset if subset is not None else df.columns.tolist()
+
+    # validate that all subset columns actually exist
+    unknown = [c for c in cols if c not in df.columns]
+    if unknown:
+        raise ValueError(
+            f"keep_rows_with_nulls: unknown column(s) in subset: {unknown}. "
+            f"Available columns: {df.columns.tolist()}"
+        )
+
+    mask = df[cols].isnull().any(axis=1)
+    result = df[mask].reset_index(drop=True)
+
+    return from_pandas(result) if is_arframe else result
+
+
 def fill_nulls(
     frame: ArFrame,
     value: Any,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -127,4 +127,3 @@ def pipeline(
 
 register_step("filter_rows", cleaning.filter_rows)
 register_step("safe_divide_columns", cleaning.safe_divide_columns)
-

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -13,6 +13,7 @@ from .frame import ArFrame
 # Map step names to cleaning functions
 _STEP_REGISTRY: dict[str, Callable] = {
     "drop_nulls": cleaning.drop_nulls,
+    "keep_rows_with_nulls": cleaning.keep_rows_with_nulls,
     "fill_nulls": cleaning.fill_nulls,
     "validate_columns_exist": cleaning.validate_columns_exist,
     "drop_duplicates": cleaning.drop_duplicates,
@@ -125,5 +126,5 @@ def pipeline(
 
 
 register_step("filter_rows", cleaning.filter_rows)
-
 register_step("safe_divide_columns", cleaning.safe_divide_columns)
+

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -21,6 +21,69 @@ class TestDropNulls:
         assert result.shape[0] == 3
 
 
+class TestKeepRowsWithNulls:
+    def test_keeps_only_null_rows(self, csv_with_nulls):
+        # full frame has 4 rows, 2 have nulls (row1: null name+score, row2: null age)
+        frame = ar.read_csv(csv_with_nulls)
+        result = ar.keep_rows_with_nulls(frame)
+        assert result.shape[0] == 2
+
+    def test_no_nulls_returns_empty(self, sample_csv):
+        # sample_csv has no nulls — result should be empty
+        frame = ar.read_csv(sample_csv)
+        result = ar.keep_rows_with_nulls(frame)
+        assert result.shape[0] == 0
+
+    def test_all_nulls_returns_all_rows(self, tmp_path):
+        # every row has a null — all rows should be kept
+        path = tmp_path / "all_nulls.csv"
+        path.write_text("name,age\nAlice,\n,25\nCharlie,\n")
+        frame = ar.read_csv(path)
+        result = ar.keep_rows_with_nulls(frame)
+        assert result.shape[0] == frame.shape[0]
+
+    def test_subset_targets_specific_column(self, csv_with_nulls):
+        # only checking 'age' column — only Charlie has null age
+        frame = ar.read_csv(csv_with_nulls)
+        result = ar.keep_rows_with_nulls(frame, subset=["age"])
+        assert result.shape[0] == 1
+
+    def test_subset_unknown_column_raises(self, csv_with_nulls):
+        # passing a column that doesn't exist should raise ValueError
+        frame = ar.read_csv(csv_with_nulls)
+        with pytest.raises(ValueError, match="unknown column"):
+            ar.keep_rows_with_nulls(frame, subset=["nonexistent"])
+
+    def test_index_is_reset(self, csv_with_nulls):
+        # returned frame should have clean 0-based index
+        frame = ar.read_csv(csv_with_nulls)
+        result = ar.keep_rows_with_nulls(frame)
+        df = ar.to_pandas(result)
+        assert list(df.index) == list(range(len(df)))
+
+    def test_pipeline_usage(self, csv_with_nulls):
+        # function should work correctly when called via pipeline
+        frame = ar.read_csv(csv_with_nulls)
+        result = ar.pipeline(
+            frame,
+            [
+                ("keep_rows_with_nulls",),
+            ],
+        )
+        assert result.shape[0] == 2
+
+    def test_pipeline_subset(self, csv_with_nulls):
+        # pipeline with subset parameter
+        frame = ar.read_csv(csv_with_nulls)
+        result = ar.pipeline(
+            frame,
+            [
+                ("keep_rows_with_nulls", {"subset": ["age"]}),
+            ],
+        )
+        assert result.shape[0] == 1
+
+
 class TestFillNulls:
     def test_fill_with_string(self, csv_with_nulls):
         frame = ar.read_csv(csv_with_nulls)


### PR DESCRIPTION
## Summary
Add `keep_rows_with_nulls` as a new Python pipeline step. It keeps only rows 
that contain at least one null value, with an optional `subset` parameter to 
target specific columns. Unknown subset columns raise a clear `ValueError`.

## Linked issue
Fixes #148

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` — all tests pass including 8 new tests for `keep_rows_with_nulls`
- [ ] `make lint`
- [x] Other: pre-commit run --all-files — passed on changed files

## Screenshots / Media
N/A

## Performance Impact
N/A — pure Python step, no C++ changes.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Step follows the same pure-Python pattern as `filter_rows`. Registered in 
`pipeline.py` and exported from `__init__.py`.