### PR TITLE
feat: add normalize_unicode cleaning step

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -26,6 +26,7 @@ from .cleaning import (
     safe_divide_columns,
     strip_whitespace,
     validate_columns_exist,
+    normalize_unicode,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
@@ -106,4 +107,5 @@ __all__ = [
     "ArnioError",
     "CsvReadError",
     "TypeCastError",
+    "normalize_unicode",
 ]

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -21,12 +21,12 @@ from .cleaning import (
     fill_nulls,
     filter_rows,
     normalize_case,
+    normalize_unicode,
     rename_columns,
     round_numeric_columns,
     safe_divide_columns,
     strip_whitespace,
     validate_columns_exist,
-    normalize_unicode,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -6,6 +6,7 @@ Data cleaning functions.
 from __future__ import annotations
 
 from typing import Any
+import unicodedata
 
 from ._core import (
     _cast_types,
@@ -170,6 +171,40 @@ def normalize_case(
     """
     result = _normalize_case(frame._frame, subset=subset, case_type=case_type)
     return ArFrame(result)
+
+def normalize_unicode(
+frame: ArFrame,
+*,
+subset: list[str] | None = None,
+form: str = "NFC",
+) -> ArFrame:
+    """Normalize Unicode text columns."""
+
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame).copy()
+
+    columns = (
+        subset
+        if subset is not None
+        else df.select_dtypes(include=["object", "string"]).columns
+    )
+
+    for col in columns:
+        df[col] = df[col].apply(
+            lambda x: unicodedata.normalize(form, x)
+            if isinstance(x, str)
+            else x
+        )
+
+    return from_pandas(df)
+
+
+
+
+
+
+
 
 
 def rename_columns(

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -390,6 +390,13 @@ def normalize_unicode(
 
     from .convert import from_pandas, to_pandas
 
+    if subset is not None:
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="normalize_unicode",
+        )
+
     df = to_pandas(frame).copy()
 
     columns = (

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -5,8 +5,8 @@ Data cleaning functions.
 
 from __future__ import annotations
 
-from typing import Any
 import unicodedata
+from typing import Any
 
 from ._core import (
     _cast_types,
@@ -172,11 +172,12 @@ def normalize_case(
     result = _normalize_case(frame._frame, subset=subset, case_type=case_type)
     return ArFrame(result)
 
+
 def normalize_unicode(
-frame: ArFrame,
-*,
-subset: list[str] | None = None,
-form: str = "NFC",
+    frame: ArFrame,
+    *,
+    subset: list[str] | None = None,
+    form: str = "NFC",
 ) -> ArFrame:
     """Normalize Unicode text columns."""
 
@@ -192,19 +193,10 @@ form: str = "NFC",
 
     for col in columns:
         df[col] = df[col].apply(
-            lambda x: unicodedata.normalize(form, x)
-            if isinstance(x, str)
-            else x
+            lambda x: unicodedata.normalize(form, x) if isinstance(x, str) else x
         )
 
     return from_pandas(df)
-
-
-
-
-
-
-
 
 
 def rename_columns(

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -390,6 +390,11 @@ def normalize_unicode(
 
     from .convert import from_pandas, to_pandas
 
+    valid_forms = {"NFC", "NFD", "NFKC", "NFKD"}
+
+    if form not in valid_forms:
+        raise ValueError(f"Unsupported Unicode normalization form: {form}")
+
     if subset is not None:
         validate_columns_exist(
             frame,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -17,6 +17,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "drop_duplicates": cleaning.drop_duplicates,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,
+    "normalize_unicode": cleaning.normalize_unicode,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
 }

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -346,17 +346,19 @@ class TestNormalizeCase:
 
 class TestNormalizeUnicode:
     def test_normalize_unicode(self):
-        pass
+        import pandas as pd
 
-    df = pd.DataFrame({"text": ["café"]})
+        import arnio as ar
 
-    frame = ar.from_pandas(df)
+        df = pd.DataFrame({"text": ["café"]})
 
-    result = ar.normalize_unicode(frame)
+        frame = ar.from_pandas(df)
 
-    result_df = ar.to_pandas(result)
+        result = ar.normalize_unicode(frame)
 
-    assert result_df["text"].iloc[0] == "café"
+        result_df = ar.to_pandas(result)
+
+        assert result_df["text"].iloc[0] == "café"
 
 
 class TestRenameColumns:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,5 +1,6 @@
 """Tests for data cleaning functions."""
 
+import pandas as pd
 import pytest
 
 import arnio as ar
@@ -103,13 +104,12 @@ class TestNormalizeCase:
         df = ar.to_pandas(result)
         assert df["name"].iloc[0] == "Alice"
 
+
 class TestNormalizeUnicode:
     def test_normalize_unicode(self):
-        import pandas as pd
+        pass
 
-    df = pd.DataFrame({
-        "text": ["café"]
-    })
+    df = pd.DataFrame({"text": ["café"]})
 
     frame = ar.from_pandas(df)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -350,7 +350,7 @@ class TestNormalizeUnicode:
 
         import arnio as ar
 
-        df = pd.DataFrame({"text": ["café"]})
+        df = pd.DataFrame({"text": ["cafe\u0301"]})
 
         frame = ar.from_pandas(df)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -103,6 +103,22 @@ class TestNormalizeCase:
         df = ar.to_pandas(result)
         assert df["name"].iloc[0] == "Alice"
 
+class TestNormalizeUnicode:
+    def test_normalize_unicode(self):
+        import pandas as pd
+
+    df = pd.DataFrame({
+        "text": ["café"]
+    })
+
+    frame = ar.from_pandas(df)
+
+    result = ar.normalize_unicode(frame)
+
+    result_df = ar.to_pandas(result)
+
+    assert result_df["text"].iloc[0] == "café"
+
 
 class TestRenameColumns:
     def test_rename(self, sample_csv):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -278,12 +278,31 @@ def test_filter_rows_direct_api():
     assert list(result_df["age"]) == [30, 40]
 
 
+def test_round_numeric_columns_pipeline():
+    import pandas as pd
+
+    import arnio as ar
+
+    df = pd.DataFrame({"price": [10.555, 20.123]})
+
+    frame = ar.from_pandas(df)
+
+    result = ar.pipeline(
+        frame,
+        [("round_numeric_columns", {"subset": ["price"], "decimals": 2})],
+    )
+
+    result_df = ar.to_pandas(result)
+
+    assert list(result_df["price"]) == [10.56, 20.12]
+
+
 def test_pipeline_normalize_unicode():
     import pandas as pd
 
     import arnio as ar
 
-    df = pd.DataFrame({"text": ["café"]})
+    df = pd.DataFrame({"text": ["cafe\u0301"]})
 
     frame = ar.from_pandas(df)
 
@@ -297,6 +316,55 @@ def test_pipeline_normalize_unicode():
     result_df = ar.to_pandas(result)
 
     assert result_df["text"].iloc[0] == "café"
+
+
+def test_normalize_unicode_invalid_form():
+    import pandas as pd
+    import pytest
+
+    import arnio as ar
+
+    df = pd.DataFrame({"text": ["cafe\u0301"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError):
+        ar.normalize_unicode(frame, form="INVALID")
+
+
+def test_normalize_unicode_subset():
+    import pandas as pd
+
+    import arnio as ar
+
+    df = pd.DataFrame(
+        {
+            "text": ["cafe\u0301"],
+            "other": ["test"],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.normalize_unicode(frame, subset=["text"])
+
+    result_df = ar.to_pandas(result)
+
+    assert result_df["text"].iloc[0] == "café"
+
+
+def test_normalize_unicode_unknown_subset():
+    import pandas as pd
+    import pytest
+
+    import arnio as ar
+
+    df = pd.DataFrame({"text": ["cafe\u0301"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(KeyError):
+        ar.normalize_unicode(frame, subset=["missing"])
 
 
 def test_safe_divide_columns_pipeline():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -281,6 +281,8 @@ def test_filter_rows_direct_api():
 def test_pipeline_normalize_unicode():
     import pandas as pd
 
+    import arnio as ar
+
     df = pd.DataFrame({"text": ["café"]})
 def test_round_numeric_columns_pipeline():
     import pandas as pd

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -190,3 +190,24 @@ def test_filter_rows_direct_api():
     result_df = ar.to_pandas(result)
 
     assert list(result_df["age"]) == [30, 40]
+
+
+def test_pipeline_normalize_unicode():
+    import pandas as pd
+
+    df = pd.DataFrame({
+        "text": ["café"]
+})
+
+    frame = ar.from_pandas(df)
+
+    result = ar.pipeline(
+    frame,
+    [
+        ("normalize_unicode",),
+    ],
+)
+
+    result_df = ar.to_pandas(result)
+
+    assert result_df["text"].iloc[0] == "café"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -195,18 +195,16 @@ def test_filter_rows_direct_api():
 def test_pipeline_normalize_unicode():
     import pandas as pd
 
-    df = pd.DataFrame({
-        "text": ["café"]
-})
+    df = pd.DataFrame({"text": ["café"]})
 
     frame = ar.from_pandas(df)
 
     result = ar.pipeline(
-    frame,
-    [
-        ("normalize_unicode",),
-    ],
-)
+        frame,
+        [
+            ("normalize_unicode",),
+        ],
+    )
 
     result_df = ar.to_pandas(result)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -283,21 +283,20 @@ def test_pipeline_normalize_unicode():
 
     import arnio as ar
 
-    df = pd.DataFrame({"text": ["café"]})
-def test_round_numeric_columns_pipeline():
-    import pandas as pd
+    df = pd.DataFrame({"text": ["café"]})
 
-    import arnio as ar
-
-    df = pd.DataFrame({"price": [10.555, 20.123]})
     frame = ar.from_pandas(df)
 
     result = ar.pipeline(
-        frame, [("round_numeric_columns", {"subset": ["price"], "decimals": 2})]
+        frame,
+        [
+            ("normalize_unicode",),
+        ],
     )
 
     result_df = ar.to_pandas(result)
-    assert list(result_df["price"]) == [10.56, 20.12]
+
+    assert result_df["text"].iloc[0] == "café"
 
 
 def test_safe_divide_columns_pipeline():
@@ -312,7 +311,6 @@ def test_safe_divide_columns_pipeline():
     result = ar.pipeline(
         frame,
         [
-            ("normalize_unicode",),
             (
                 "safe_divide_columns",
                 {
@@ -320,13 +318,12 @@ def test_safe_divide_columns_pipeline():
                     "denominator": "cost",
                     "output_column": "ratio",
                 },
-            )
+            ),
         ],
     )
 
     result_df = ar.to_pandas(result)
 
-    assert result_df["text"].iloc[0] == "café"
     assert result_df["ratio"].iloc[0] == 2.0
     assert result_df["ratio"].iloc[1] == 0.0  # division by zero → fill_value
     assert result_df["ratio"].iloc[2] == 0.0  # zero numerator


### PR DESCRIPTION
## Summary

Implemented a new `normalize_unicode` cleaning step for Unicode text normalization.

### Changes made

* added `normalize_unicode` in `cleaning.py`
* registered the step in `pipeline.py`
* added tests for cleaning and pipeline behavior

## Linked issue

Fixes #151

## Notes

I was unable to fully run the local test suite because the repository requires native C++ build tooling (nmake / CMake compiler setup) which is not currently configured on my system.
