### PR TITLE
feat(parser): recognize pandas-compatible NA sentinel values as null

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -60,6 +60,7 @@ def read_csv(
     usecols: list[str] | None = None,
     nrows: int | None = None,
     encoding: str = "utf-8",
+    null_values: set[str] | None = None,
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -77,6 +78,11 @@ def read_csv(
         Number of rows to read. If None, reads all rows.
     encoding : str, default "utf-8"
         File encoding.
+    null_values : set[str], optional
+        Set of strings to treat as null/missing values.
+        Defaults to pandas-compatible set:
+        {"NA", "N/A", "null", "None", "NaN", "nan", "#N/A", "-"}.
+        Pass an empty set to disable null sentinel recognition.
 
     Returns
     -------
@@ -120,6 +126,9 @@ def read_csv(
     config.has_header = has_header
     config.encoding = encoding
 
+    if null_values is not None:
+        config.null_values = null_values
+
     if usecols is not None:
         config.usecols = usecols
     if nrows is not None:
@@ -143,6 +152,7 @@ def scan_csv(
     *,
     delimiter: str = ",",
     encoding: str = "utf-8",
+    null_values: set[str] | None = None,
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
 
@@ -154,6 +164,10 @@ def scan_csv(
         Field delimiter character.
     encoding : str, default "utf-8"
         File encoding. Non-UTF-8 inputs are transcoded before native scanning.
+    null_values : set[str], optional
+        Set of strings to treat as null/missing values.
+        Defaults to pandas-compatible set:
+        {"NA", "N/A", "null", "None", "NaN", "nan", "#N/A", "-"}.
 
     Returns
     -------
@@ -197,6 +211,10 @@ def scan_csv(
     config = _CsvConfig()
     config.delimiter = delimiter
     config.encoding = encoding
+
+    if null_values is not None:
+        config.null_values = null_values
+
     reader = _CsvReader(config)
     try:
         with _utf8_csv_path(path, encoding) as native_path:

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -205,7 +205,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("has_header", &CsvConfig::has_header)
         .def_readwrite("usecols", &CsvConfig::usecols)
         .def_readwrite("nrows", &CsvConfig::nrows)
-        .def_readwrite("encoding", &CsvConfig::encoding);
+        .def_readwrite("encoding", &CsvConfig::encoding)
+        .def_readwrite("null_values", &CsvConfig::null_values);
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -16,6 +16,9 @@ struct CsvConfig {
     std::optional<std::vector<std::string>> usecols = std::nullopt;
     std::optional<size_t> nrows = std::nullopt;
     std::string encoding = "utf-8";  // Currently only utf-8 supported
+    std::unordered_set<std::string> null_values = {
+        "NA", "N/A", "null", "None", "NaN", "nan", "#N/A", "-"
+    };
 };
 
 class CsvReader {
@@ -35,7 +38,7 @@ class CsvReader {
     std::vector<std::string> parse_line(const std::string& line) const;
 
     // Infer DType from a string value
-    static DType infer_type(const std::string& value);
+    DType infer_type(const std::string& value) const;
 
     // Promote dtype when merging inferences
     static DType promote_type(DType current, DType incoming);

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -113,8 +113,11 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
     return fields;
 }
 
-DType CsvReader::infer_type(const std::string& value) {
+DType CsvReader::infer_type(const std::string& value) const {
     if (value.empty()) return DType::NULL_TYPE;
+
+    // Check configurable null sentinel values (pandas-compatible defaults)
+    if (config_.null_values.count(value)) return DType::NULL_TYPE;
 
     // Try bool
     std::string lower = value;
@@ -158,7 +161,7 @@ DType CsvReader::promote_type(DType current, DType incoming) {
 }
 
 CellValue CsvReader::parse_value(const std::string& raw, DType dtype) {
-    if (raw.empty()) return std::monostate{};
+    if (raw.empty() || config_.null_values.count(raw)) return std::monostate{};
 
     switch (dtype) {
         case DType::BOOL: {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -160,6 +160,70 @@ class TestReadCsv:
             ar.read_csv(csv_path)
 
 
+    def test_na_sentinel_recognition(self, tmp_path):
+        """Values like NA, N/A, null, None, NaN should be treated as null."""
+        csv_content = (
+            "name,score,grade\n"
+            "Alice,95,A\n"
+            "Bob,NA,B\n"
+            "Charlie,N/A,C\n"
+            "Diana,null,D\n"
+            "Eve,None,A\n"
+            "Frank,NaN,B\n"
+            "Grace,,C\n"
+        )
+        csv_path = tmp_path / "na_sentinels.csv"
+        csv_path.write_text(csv_content)
+
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+
+        # Alice should have score 95.0
+        assert df.loc[0, "score"] == 95.0
+        # NA sentinels should all be null
+        for row_idx in [1, 2, 3, 4, 5, 6]:
+            assert pd.isna(df.loc[row_idx, "score"]), \
+                f"Row {row_idx}: expected null for '{csv_content.split(chr(10))[row_idx+1].split(',')[1]}'"
+
+        # Grade should still be string (not affected)
+        assert df.loc[0, "grade"] == "A"
+        assert df.loc[1, "grade"] == "B"
+
+    def test_null_values_param(self, tmp_path):
+        """Custom null_values parameter should override defaults."""
+        csv_content = "name,status\nAlice,OK\nBob,UNKNOWN\nCharlie,OK\n"
+        csv_path = tmp_path / "custom_nulls.csv"
+        csv_path.write_text(csv_content)
+
+        # With custom null_values, "UNKNOWN" should be null
+        frame = ar.read_csv(csv_path, null_values={"UNKNOWN"})
+        df = ar.to_pandas(frame)
+        assert pd.isna(df.loc[1, "status"])
+        assert df.loc[0, "status"] == "OK"
+
+    def test_disable_null_sentinels(self, tmp_path):
+        """Empty set should disable null sentinel recognition."""
+        csv_content = "name,value\nAlice,NA\nBob,N/A\n"
+        csv_path = tmp_path / "disable_nulls.csv"
+        csv_path.write_text(csv_content)
+
+        # With empty null_values, "NA" and "N/A" should be strings
+        frame = ar.read_csv(csv_path, null_values=set())
+        df = ar.to_pandas(frame)
+        assert df.loc[0, "value"] == "NA"
+        assert df.loc[1, "value"] == "N/A"
+
+    def test_scan_schema_with_na(self, tmp_path):
+        """scan_csv should also recognize NA sentinels."""
+        csv_content = "name,score\nAlice,95\nBob,NA\nCharlie,100\n"
+        csv_path = tmp_path / "scan_na.csv"
+        csv_path.write_text(csv_content)
+
+        schema = ar.scan_csv(csv_path)
+        # "NA" is treated as null, so remaining values (95, 100) → int64
+        assert schema["score"] == "int64"
+
+
 class TestScanCsv:
     def test_scan_schema(self, sample_csv):
         schema = ar.scan_csv(sample_csv)


### PR DESCRIPTION
## Summary

Adds configurable NA sentinel value recognition to the CSV parser, defaulting to pandas-compatible null sentinels.

Currently, `CsvReader::infer_type()` treats values like `"NA"`, `"N/A"`, `"null"`, `"None"`, `"NaN"` as regular strings. This causes type inference to incorrectly default to STRING for columns containing these values, inconsistent with pandas behavior.

## Changes

### C++ Core
- **`csv_reader.h`**: Added `null_values` field to `CsvConfig` struct with pandas-compatible defaults: `{"NA", "N/A", "null", "None", "NaN", "nan", "#N/A", "-"}`
- **`csv_reader.cpp`**: 
  - `infer_type()`: Check against `config_.null_values` before type inference (made non-static)
  - `parse_value()`: Also treat NA sentinels as null during value parsing

### Python Bindings
- **`bind_arnio.cpp`**: Exposed `null_values` as a read-write property on `CsvConfig`

### Python API
- **`io.py`**: Added `null_values: set[str] | None = None` parameter to both `read_csv()` and `scan_csv()`

### Tests
- `test_na_sentinel_recognition`: Verifies NA, N/A, null, None, NaN, "" all become null
- `test_null_values_param`: Custom null_values set (e.g., `{"UNKNOWN"}`)
- `test_disable_null_sentinels`: Empty set disables all sentinel recognition  
- `test_scan_schema_with_na`: scan_csv properly infers numeric type when NA values present

## Behavior

```python
# Before: "NA" treated as string → entire column becomes STRING
# After:  "NA" treated as null → column correctly inferred as INT64

frame = ar.read_csv("data.csv")  # score column: [95, NA, N/A, 100] → int64
```

Closes #30