### PR TITLE
feat: implement compare_schema helper for ArFrame #228

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor_task.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_task.yml
@@ -1,0 +1,51 @@
+name: Refactor task
+description: Propose a code refactor to improve maintainability, performance, or clarity.
+title: "Refactor: "
+labels: ["type: refactor", "status: needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Refactoring helps keep Arnio's codebase healthy. Please describe the area you want to improve.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Current situation
+      description: What is the current state of the code that needs refactoring?
+      placeholder: "The logic in src/cleaning.cpp for strip_whitespace is repeated..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: How do you propose to refactor the code?
+      placeholder: "Extract the common logic into a separate utility function..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefit
+    attributes:
+      label: Expected benefit
+      description: Why is this refactor important? (e.g., performance, readability, reduced duplication)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: risk
+    attributes:
+      label: Risk assessment
+      options:
+        - label: This change is backwards-compatible.
+          required: true
+        - label: This change does not alter the public API.
+          required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other information or related issues.

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -1,0 +1,211 @@
+# Issue Triage Guide
+
+This document explains how Arnio maintainers triage incoming issues. It defines each label category, provides real-world examples, and outlines the standard triage workflow. Contributors are also welcome to read this to understand how their issues get categorized.
+
+---
+
+## Why Triage?
+
+Every issue that lands in our backlog gets categorized along key dimensions:
+
+1. **Priority** — how urgent it is
+2. **Difficulty** — how much expertise it needs
+3. **Size** — how much effort it'll take
+4. **Status** — where it sits in the workflow
+5. **Type** — what kind of change it is
+6. **Area** — which part of the codebase it touches
+
+This makes the backlog navigable: a beginner GSSoC contributor can filter for `difficulty: beginner` + `size: s` + `status: ready` and instantly find an entry point. Maintainers can spot `priority: critical` + `status: blocked` issues that need unblocking.
+
+---
+
+## Label Categories
+
+### Priority
+
+How urgent is this issue?
+
+| Label | Meaning | Example |
+|:---|:---|:---|
+| `priority: critical` | Production-breaking bug, security issue, or release blocker. Drop everything. | A regression that crashes `read_csv()` on valid input |
+| `priority: high` | Important and time-sensitive. Should be picked up this week. | A documented public API returns wrong results for common case |
+| `priority: medium` | Solid improvement, not urgent. Pick up this milestone. | Add new pipeline step or improve an existing one |
+| `priority: low` | Nice-to-have. May sit in backlog for a while. | Tweak terminology in an internal log message |
+
+---
+
+### Difficulty
+
+How much expertise does this need?
+
+| Label | Meaning | Who should pick it up |
+|:---|:---|:---|
+| `difficulty: beginner` | Self-contained, well-scoped, no prior repo context required. Touching one or two files. | First-time contributors, students new to open source |
+| `difficulty: intermediate` | Requires reading existing code, following established patterns, writing tests. | Contributors comfortable with Python and the codebase |
+| `difficulty: advanced` | Architecture-level work, C++ optimization, performance-critical paths. | Contributors with C++ experience or deep familiarity |
+
+---
+
+### Size
+
+How much effort will this take?
+
+| Label | Estimate | Typical scope |
+|:---|:---|:---|
+| `size: xs` | < 30 minutes | Single docstring, tiny fix, comment update |
+| `size: s` | < 2 hours | Single function, doc fix, small test addition |
+| `size: m` | Half a day | New pipeline step + tests, small refactor |
+| `size: l` | 1–2 days | New module, multi-file feature, schema validation |
+
+---
+
+### Type
+
+What kind of change is this?
+
+| Label | Use for |
+|:---|:---|
+| `type: bug` | Fixing incorrect behavior |
+| `type: feature` | Adding new capability |
+| `type: docs` | Documentation only |
+| `type: tests` | Test suite improvements |
+| `type: refactor` | Code restructuring with no behavior change |
+| `type: performance` | Speed or memory improvements |
+| `type: security` | Security fix or hardening |
+| `type: ci` | GitHub Actions, build pipeline, release tooling |
+| `type: discussion` | Needs community input before implementation |
+
+---
+
+### Area
+
+Which part of the codebase does this touch?
+
+| Label | Covers |
+|:---|:---|
+| `area: csv-parser` | CSV reading, RFC 4180 compliance, BOM handling |
+| `area: cpp-core` | C++ runtime — types, columns, frames, cleaning engine |
+| `area: python-api` | Python API in `arnio/` — IO, pipeline, conversion |
+| `area: pipeline` | Step registry, pipeline executor, custom steps |
+| `area: cleaning` | Cleaning primitives — drop_nulls, fill_nulls, dedup, etc. |
+| `area: pandas-interop` | pandas bridge, zero-copy conversion, buffer protocol |
+| `area: quality` | Data quality engine, profiling, validation, suggestions |
+| `area: schema` | Schema definition, type casting, validation |
+| `area: docs` | README, architecture docs, guides, examples |
+| `area: website` | arnio.vercel.app, landing page, tutorials |
+| `area: ci-packaging` | GitHub Actions, PyPI wheels, releases |
+| `area: benchmarks` | Performance testing, reproduction scripts |
+| `area: examples` | Usage examples, notebooks, tutorials |
+| `area: developer-experience` | Error messages, CLI tooling, dev setup |
+| `area: release` | Version bumping, changelogs, deployment |
+
+---
+
+### Workflow Status
+
+Where is the issue in the lifecycle?
+
+| Label | Meaning |
+|:---|:---|
+| `status: needs triage` | New issue, not yet categorized or scoped |
+| `status: ready` | Triaged, scoped, ready for a contributor to pick up |
+| `status: claimed` | Assigned and being actively worked on |
+| `status: blocked` | Cannot proceed — waiting on a decision, dependency, or upstream change |
+| `status: needs maintainer` | Requires maintainer decision or code review |
+
+---
+
+### GSSoC Labels
+
+For [GSSoC 2026](https://gssoc.girlscript.tech/) participants:
+
+| Label | Meaning |
+|:---|:---|
+| `gssoc` | Issue is eligible for GSSoC contribution credit |
+| `gssoc: good first issue` | Strongly recommended starting point for new GSSoC contributors |
+| `gssoc: level 1` | Beginner-tier scoring |
+| `gssoc: level 2` | Intermediate-tier scoring |
+| `gssoc: level 3` | Advanced-tier scoring |
+
+See [GSSOC_GUIDE.md](../GSSOC_GUIDE.md) for full scoring details.
+
+---
+
+## Triage Workflow
+
+When a new issue arrives, work through these steps in order:
+
+### 1. Read and reproduce
+
+- For bugs: try to reproduce locally. If the report lacks information, apply `status: needs triage` and ask for: OS, Python version, arnio version, minimal reproduction.
+- For feature requests: confirm the proposed behavior fits the project scope. If unclear, apply `status: needs triage` and start a discussion.
+
+### 2. Categorize
+
+Apply labels from each required category:
+
+- ✅ `priority: *` (required)
+- ✅ `difficulty: *` (required)
+- ✅ `size: *` (required)
+- ✅ `status: *` (required — start with `status: needs triage`)
+- ✅ `type: *` (required)
+- ✅ `area: *` (one or more, required)
+- 🟡 `gssoc: *` (only if appropriate for GSSoC contributors)
+
+### 3. Scope the issue
+
+A well-triaged issue includes:
+
+- **Context** — why this matters
+- **Suggested files** — pointers to where the work lives
+- **Scope** — what's in and out of scope
+- **Acceptance criteria** — checkboxes the contributor can tick off
+
+If any of these are missing, keep the issue at `status: needs triage`.
+
+### 4. Set status and assign
+
+- Move to `status: ready` once the issue is fully scoped and ready for pickup
+- Move to `status: claimed` when a contributor is assigned
+- Move to `status: blocked` if external dependencies appear during work
+- Use `status: needs maintainer` if you need another maintainer's input
+
+---
+
+## Worked Example
+
+**Incoming issue title:** "drop_duplicates is slow on large datasets"
+
+**Triage decision:**
+
+| Label | Value | Reasoning |
+|:---|:---|:---|
+| Priority | `priority: high` | Performance is a roadmap focus for v1.2 |
+| Difficulty | `difficulty: advanced` | Requires C++ work in the cleaning engine |
+| Size | `size: l` | Hash-based comparison replacement is multi-file |
+| Status | `status: ready` | Reproducible, well-scoped, fix path is clear |
+| Type | `type: performance` | Performance improvement |
+| Area | `area: cpp-core` | Lives in `cpp/src/cleaning.cpp` |
+| GSSoC | `gssoc: level 3` | Advanced-tier scoring if a GSSoC contributor picks it up |
+
+---
+
+## Quick Reference for Maintainers
+
+When in doubt, default to:
+
+- **Priority** → `priority: medium`
+- **Difficulty** → match the actual code complexity, not the issue description length
+- **Size** → estimate as a maintainer would do it, not as a beginner would
+- **Status** → start at `status: needs triage` if anything is unclear; promote to `status: ready` once scoped
+- **Type** → `type: discussion` if direction is unclear
+
+For consistency, every issue should reach `status: ready` before being advertised as a good first issue or GSSoC pickup.
+
+---
+
+## Questions?
+
+- Open a [Discussion](https://github.com/im-anishraj/arnio/discussions) for triage process questions
+- Tag `@im-anishraj` on the issue for category disputes
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor-side workflow

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,12 @@
 - [ ] `make lint`
 - [ ] Other:
 
+## Screenshots / Media
+<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->
+
+## Performance Impact
+<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->
+
 ## Contributor checklist
 - [ ] I read the contributing guide.
 - [ ] I kept the PR focused on one issue or one logical change.

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -6,7 +6,12 @@ on:
       tag_name:
         required: true
         type: string
-  workflow_dispatch:  # allows manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Git tag or ref to build and publish"
+        required: false
+        type: string
 
 jobs:
   build_sdist:
@@ -41,6 +46,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.22
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_TEST_COMMAND: >-
+            python -c "import pathlib, sys, pytest; sys.path.insert(0, str(pathlib.Path(r'{project}'))); raise SystemExit(pytest.main([str(pathlib.Path(r'{project}') / 'tests'), '-v', '--tb=short', '-x']))"
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -49,6 +49,14 @@ jobs:
           CIBW_TEST_COMMAND: >-
             python -c "import pathlib, sys, pytest; sys.path.append(str(pathlib.Path(r'{project}'))); raise SystemExit(pytest.main([str(pathlib.Path(r'{project}') / 'tests'), '-v', '--tb=short', '-x']))"
 
+      - name: Set up Python for wheel smoke test
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Smoke test wheel install
+        run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse
+
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: >-
-            python -c "import pathlib, sys, pytest; sys.path.insert(0, str(pathlib.Path(r'{project}'))); raise SystemExit(pytest.main([str(pathlib.Path(r'{project}') / 'tests'), '-v', '--tb=short', '-x']))"
+            python -c "import pathlib, sys, pytest; sys.path.append(str(pathlib.Path(r'{project}'))); raise SystemExit(pytest.main([str(pathlib.Path(r'{project}') / 'tests'), '-v', '--tb=short', '-x']))"
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,114 @@
+name: Release Dry-Run Checklist
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # ── 1. Validate version in pyproject.toml ─────────────────────────────────
+  validate-version:
+    name: "✅ Validate pyproject.toml version"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract and validate version
+        id: get-version
+        run: |
+          python - <<'EOF'
+          import tomllib, re, sys
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+          version = data["project"]["version"]
+          if not re.match(r"^\d+\.\d+\.\d+", version):
+              print(f"❌ Invalid version format: {version}", file=sys.stderr)
+              sys.exit(1)
+          print(f"✅ Version looks valid: {version}")
+          EOF
+          VERSION=$(python -c "import tomllib; f=open('pyproject.toml','rb'); d=tomllib.load(f); print(d['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  # ── 2. Build sdist ─────────────────────────────────────────────────────────
+  build_sdist:
+    name: "📦 Build source distribution"
+    runs-on: ubuntu-latest
+    needs: validate-version
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: Twine check sdist
+        run: |
+          pip install twine
+          twine check dist/*.tar.gz && echo "✅ Twine check passed" || { echo "❌ Twine check failed"; exit 1; }
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          retention-days: 3
+
+  # ── 3. Build platform wheels + smoke test (mirrors build_wheels.yml) ───────
+  build_wheels:
+    name: "🔨 Build & smoke test wheels (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    needs: validate-version
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels via cibuildwheel
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_TEST_COMMAND: >-
+            python -c "import pathlib, sys, pytest; sys.path.append(str(pathlib.Path(r'{project}'))); raise SystemExit(pytest.main([str(pathlib.Path(r'{project}') / 'tests'), '-v', '--tb=short', '-x']))"
+
+      - name: Set up Python for smoke test
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Smoke test wheel install
+        run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+          retention-days: 3
+
+  # ── 4. Summary report ─────────────────────────────────────────────────────
+  summary:
+    name: "📋 Dry-Run Summary"
+    runs-on: ubuntu-latest
+    needs: [validate-version, build_sdist, build_wheels]
+    if: always()
+    steps:
+      - name: Write step summary
+        run: |
+          echo "## 🚀 Release Dry-Run Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Version validation     | ${{ needs.validate-version.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| sdist build + twine    | ${{ needs.build_sdist.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Wheels + smoke (Linux) | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Wheels + smoke (macOS) | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Wheels + smoke (Win)   | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package version:** ${{ needs.validate-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ needs.validate-version.result }}" == "success" && \
+                "${{ needs.build_sdist.result }}" == "success" && \
+                "${{ needs.build_wheels.result }}" == "success" ]]; then
+            echo "### ✅ All checks passed — safe to publish to PyPI." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ❌ One or more checks failed — do NOT publish yet." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,12 +4,19 @@ Arnio is designed to provide high-performance, memory-efficient data ingestion a
 
 This document outlines the core architecture and the boundary between Python and C++.
 
+---
+
 ## 1. The Core Philosophy
 
 Data preprocessing often involves operations that are inherently slow in Python (e.g., string manipulation, repeated passes over data). Arnio solves this by:
+
 1. **Loading data directly into C++ memory structures.**
-2. **Performing all cleaning operations natively in C++ without Python GIL contention.**
-3. **Translating the final, pristine dataset to a pandas DataFrame via a zero-copy (or near zero-copy) boundary.**
+
+2. **Prioritizing native C++ execution for core cleaning operations to avoid Python GIL contention, while seamlessly supporting Python-backed and custom steps.**
+
+3. **Translating the final dataset to a `pandas.DataFrame` via a boundary that aims to minimize unnecessary copies.**
+
+---
 
 ## 2. Python ↔ C++ Boundary
 
@@ -32,92 +39,142 @@ graph TD
     E -->|to_pandas| A
 ```
 
+---
+
 ## 3. Data Model
 
 Arnio's data model is columnar, strongly resembling Apache Arrow or modern Pandas internals.
 
-### `Column`
-A `Column` represents a single 1D array of homogeneous data.
-- **Variant Storage**: Data is stored using `std::variant` over strongly-typed `std::vector`s (e.g., `std::vector<int64_t>`, `std::vector<std::string>`).
-- **Null Handling**: Nulls are tracked via a separate boolean mask (`std::vector<bool>`), allowing the underlying data vectors to remain dense and cache-friendly.
+### Column
 
-### `Frame`
-A `Frame` is an ordered collection of `Column` objects, representing a 2D dataset.
-- The `Frame` maintains an index mapping column names to their respective `Column` objects for `O(1)` access.
+A Column represents a single 1D array of homogeneous data.
+
+- **Variant Storage:** Data is stored using `std::variant` over strongly-typed `std::vector`s (e.g., `std::vector<int64_t>`, `std::vector<std::string>`).
+
+- **Null Handling:** Nulls are tracked via a separate boolean mask (`std::vector<bool>`), allowing the underlying data vectors to remain dense and cache-friendly.
+
+### Frame
+
+A Frame is an ordered collection of Column objects, representing a 2D dataset.
+
+The Frame maintains an index mapping column names to their respective Column objects for O(1) access.
+
+---
 
 ## 4. Pandas Dtype Compatibility
 
-Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model. Some advanced pandas dtypes are currently handled through conversion or have limited support depending on the workflow.
-
-This section describes the current implementation status for each dtype category.
+Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model.
 
 ### Fully Supported
 
-The following dtypes are natively supported and map efficiently to strongly typed C++ vectors:
-
 - `int64`
+
 - `float64`
+
 - `bool`
+
 - `string`
 
-These allow efficient parsing, cleaning operations, and zero-copy or near zero-copy conversion back to pandas where possible.
+These allow efficient parsing and cleaning operations within the C++ core.
 
-### Limited Support
-
-The following dtypes are not natively supported but may work through conversion or partial compatibility layers depending on the workflow:
+### Limited/Unsupported Support
 
 - `category`
-- mixed `object` columns
-- nullable pandas dtypes such as `Int64` and `boolean`
 
-Categorical columns may be converted to string/object representations during processing. Mixed object columns can reduce type inference reliability. Nullable pandas dtypes are partially supported through pandas extension dtypes and existing null-mask handling.
+- Mixed `object` columns
 
-### Unsupported
+- Nullable pandas dtypes (e.g., `Int64`)
 
-The following dtypes are currently unsupported in the native runtime:
+These may require conversion.
 
-- `datetime64[ns]`
-- `timedelta64[ns]`
+`datetime64[ns]` and `timedelta64[ns]` are currently unsupported in the native runtime.
 
-These require additional parsing and inference support in the C++ runtime and are not yet available.
+---
 
-### User-facing Behavior
+## 5. Pipeline Execution & Dispatch Flow
 
-When unsupported or partially supported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
+The `pipeline()` function orchestrates data flow by prioritizing C++ efficiency while allowing Python extensibility.
 
-For best performance and compatibility, users are encouraged to prefer strongly typed columns such as `int64`, `float64`, `bool`, and `string`.
+Arnio supports a mix of C++-backed steps, Python-backed built-ins, and custom pipeline steps.
 
-## 5. Pipeline Execution
+When a step is invoked, the system follows a priority-based dispatch model:
 
-The `pipeline()` function in Python accepts a list of declarative steps.
+### Built-in Step Path
 
-1. **Step Registry**: Arnio maintains a registry mapping string names (e.g., `"strip_whitespace"`) to function pointers.
-2. **C++ Execution**: For natively supported operations, the Python wrapper calls the C++ function directly, passing the `Frame` pointer. The operation modifies the data or returns a new `Frame` entirely within C++.
-3. **Python Fallback**: If a step is registered via pure Python (`ar.register_step()`), the `Frame` is temporarily converted to a pandas DataFrame, the Python function executes, and the result is converted back. *(Note: This incurs a conversion penalty and is intended for prototyping or operations not yet supported in C++).*
+The system first queries `_STEP_REGISTRY`.
+
+This built-in registry routes operations to highly optimized C++-backed steps (executing directly within the `Frame` / C++ core), while also housing Python-backed built-ins.
+
+### Custom Pipeline Steps
+
+If the name is absent from the built-in registries, it searches `_PYTHON_STEP_REGISTRY` for custom, user-defined Python fallbacks.
+
+### The Conversion Penalty
+
+Because Python-based steps expect a `pandas.DataFrame`, the system performs a roundtrip:
+
+```text
+Frame → to_pandas() → from_pandas() → Frame
+```
+
+### Performance Note
+
+This roundtrip involves memory re-allocation.
+
+- `to_pandas()` creates a DataFrame representation.
+
+- `from_pandas()` re-infers types to re-populate the internal data structures.
+
+Core cleaning primitives should ideally be implemented as C++ built-ins to bypass this overhead.
+
+---
 
 ## 6. Converting to Pandas
 
-The `to_pandas()` function is the most critical boundary. It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory directly to pandas, avoiding expensive element-by-element copies where possible (zero-copy for numerics and booleans). String columns currently require instantiation of Python `str` objects.
+The `to_pandas()` function is a critical boundary.
 
+It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory to pandas, aiming to avoid element-by-element copies for numerics and booleans where supported.
 
-## 6. Data Quality and Schema Validation
+String columns currently require instantiation of Python `str` objects.
+
+---
+
+## 7. Data Quality and Schema Validation
 
 Arnio is split into two layers:
 
-- The **C++ layer** handles parsing CSVs, storing data in memory, and cleaning operations such as `drop_nulls()` and `strip_whitespace()`. These execute through pybind11 directly in C++.
-- The **Python/pandas layer** handles data quality: profiling, validation, and schema checks.
+- The C++ layer handles parsing CSVs, storing data in memory, and cleaning operations such as `drop_nulls()` and `strip_whitespace()`. These execute through pybind11 directly in C++.
+
+- The Python/pandas layer handles data quality: profiling, validation, and schema checks.
 
 Each function in the quality layer behaves as follows:
-- `profile()` and `validate()` convert an `ArFrame` to pandas for analysis/validation.
-- `suggest_cleaning()` can inspect an existing `DataQualityReport` directly, or call `profile()` when given an `ArFrame`.
-- `auto_clean()` calls `profile()` first, then applies selected cleaning helpers/pipeline steps to the original frame flow.
 
-### What each function does
+### `profile()`
 
-1. `profile()`: converts `ArFrame` to a pandas DataFrame internally, then computes per-column statistics including null counts, duplicate rows, data types, and unique value ratios. Returns a `DataQualityReport`.
-2. `suggest_cleaning()`: accepts an `ArFrame` or an existing `DataQualityReport`. If given an `ArFrame`, it calls `profile()` first. Returns a list of cleaning steps that can be passed to `pipeline()`.
-3. `auto_clean()`: accepts an `ArFrame`, calls `profile()` internally, then applies suggested cleaning steps directly to the original `ArFrame`. Returns a cleaned `ArFrame`.
-4. `validate()`: converts `ArFrame` to a pandas DataFrame internally, then evaluates each column against rules defined in a `Schema` including nullability, dtype, range, pattern, and semantic constraints. Returns a `ValidationResult`.
+- Converts an `ArFrame` to a pandas DataFrame internally.
+- Computes per-column statistics including null counts, duplicate rows, data types, and unique value ratios.
+- Returns a `DataQualityReport`.
+
+### `suggest_cleaning()`
+
+- Accepts an `ArFrame` or an existing `DataQualityReport`.
+- If given an `ArFrame`, it calls `profile()` first.
+- Returns a list of cleaning steps that can be passed to `pipeline()`.
+
+### `auto_clean()`
+
+- Accepts an `ArFrame`.
+- Calls `profile()` internally.
+- Applies suggested cleaning steps directly to the original `ArFrame`.
+- Returns a cleaned `ArFrame`.
+
+### `validate()`
+
+- Converts `ArFrame` to a pandas DataFrame internally.
+- Evaluates each column against rules defined in a `Schema` including nullability, dtype, range, pattern, and semantic constraints.
+- Returns a `ValidationResult`.
+
+### Flow Diagram
 
 ```mermaid
 graph TD
@@ -131,3 +188,43 @@ graph TD
     C --> G[cleaned ArFrame]
     H --> I[ValidationResult]
 ```
+
+---
+
+## 8. Cleaning Module Architecture
+
+The cleaning module is designed around immutable semantics to ensure data integrity across pipeline steps.
+
+To ensure consistency, the C++ core utilizes internal helper functions:
+
+- `resolve_subset`: Translates user-provided column names into integer indices.
+
+- `select_rows`: A utility that takes a list of row indices and constructs a new `Frame`.
+
+- `row_key`: Generates a deterministic string serialization key for a row to facilitate duplicate detection.
+
+### Copy-Always Semantics
+
+Arnio follows an immutable design pattern.
+
+Most cleaning operations do not modify the existing `Frame` in-place; instead, they produce a new `std::vector<Column>` and return a brand-new `Frame` instance, often utilizing `std::move` to transfer ownership efficiently.
+
+---
+
+## 9. Error Handling & Translation
+
+Arnio uses a unified exception hierarchy to bridge the C++/Python boundary.
+
+### Base Exception
+
+- `ArnioError`: The base exception class.
+
+### Specialized Exceptions
+
+- `CsvReadError`
+
+- `UnknownStepError`
+
+- `TypeCastError`
+
+When supported by the specific implementation, exceptions raised within the core are translated into standard Python exceptions to maintain interpreter stability.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,49 @@ A `Column` represents a single 1D array of homogeneous data.
 A `Frame` is an ordered collection of `Column` objects, representing a 2D dataset.
 - The `Frame` maintains an index mapping column names to their respective `Column` objects for `O(1)` access.
 
-## 4. Pipeline Execution
+## 4. Pandas Dtype Compatibility
+
+Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model. Some advanced pandas dtypes are currently handled through conversion or have limited support depending on the workflow.
+
+This section describes the current implementation status for each dtype category.
+
+### Fully Supported
+
+The following dtypes are natively supported and map efficiently to strongly typed C++ vectors:
+
+- `int64`
+- `float64`
+- `bool`
+- `string`
+
+These allow efficient parsing, cleaning operations, and zero-copy or near zero-copy conversion back to pandas where possible.
+
+### Limited Support
+
+The following dtypes are not natively supported but may work through conversion or partial compatibility layers depending on the workflow:
+
+- `category`
+- mixed `object` columns
+- nullable pandas dtypes such as `Int64` and `boolean`
+
+Categorical columns may be converted to string/object representations during processing. Mixed object columns can reduce type inference reliability. Nullable pandas dtypes are partially supported through pandas extension dtypes and existing null-mask handling.
+
+### Unsupported
+
+The following dtypes are currently unsupported in the native runtime:
+
+- `datetime64[ns]`
+- `timedelta64[ns]`
+
+These require additional parsing and inference support in the C++ runtime and are not yet available.
+
+### User-facing Behavior
+
+When unsupported or partially supported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
+
+For best performance and compatibility, users are encouraged to prefer strongly typed columns such as `int64`, `float64`, `bool`, and `string`.
+
+## 5. Pipeline Execution
 
 The `pipeline()` function in Python accepts a list of declarative steps. 
 
@@ -53,6 +95,6 @@ The `pipeline()` function in Python accepts a list of declarative steps.
 2. **C++ Execution**: For natively supported operations, the Python wrapper calls the C++ function directly, passing the `Frame` pointer. The operation modifies the data or returns a new `Frame` entirely within C++.
 3. **Python Fallback**: If a step is registered via pure Python (`ar.register_step()`), the `Frame` is temporarily converted to a pandas DataFrame, the Python function executes, and the result is converted back. *(Note: This incurs a conversion penalty and is intended for prototyping or operations not yet supported in C++).*
 
-## 5. Converting to Pandas
+## 6. Converting to Pandas
 
 The `to_pandas()` function is the most critical boundary. It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory directly to pandas, avoiding expensive element-by-element copies where possible (zero-copy for numerics and booleans). String columns currently require instantiation of Python `str` objects.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Data preprocessing often involves operations that are inherently slow in Python 
 
 ## 2. Python ↔ C++ Boundary
 
-The boundary is managed using [`pybind11`](https://github.com/pybind/pybind11). 
+The boundary is managed using [`pybind11`](https://github.com/pybind/pybind11).
 
 The C++ core is compiled into a Python extension module (`_arnio_cpp`). The Python API (in `arnio/`) serves as a lightweight, type-hinted wrapper around this compiled extension.
 
@@ -21,13 +21,13 @@ The C++ core is compiled into a Python extension module (`_arnio_cpp`). The Pyth
 graph TD
     A[Python User Code] --> B[Arnio Python API]
     B -->|pybind11| C[C++ Core _arnio_cpp]
-    
+
     subgraph C++ Runtime
         C --> D[CsvReader]
         C --> E[Frame / Column]
         C --> F[Cleaning Primitives]
     end
-    
+
     F -->|Return| E
     E -->|to_pandas| A
 ```
@@ -89,7 +89,7 @@ For best performance and compatibility, users are encouraged to prefer strongly 
 
 ## 5. Pipeline Execution
 
-The `pipeline()` function in Python accepts a list of declarative steps. 
+The `pipeline()` function in Python accepts a list of declarative steps.
 
 1. **Step Registry**: Arnio maintains a registry mapping string names (e.g., `"strip_whitespace"`) to function pointers.
 2. **C++ Execution**: For natively supported operations, the Python wrapper calls the C++ function directly, passing the `Frame` pointer. The operation modifies the data or returns a new `Frame` entirely within C++.
@@ -98,3 +98,36 @@ The `pipeline()` function in Python accepts a list of declarative steps.
 ## 6. Converting to Pandas
 
 The `to_pandas()` function is the most critical boundary. It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory directly to pandas, avoiding expensive element-by-element copies where possible (zero-copy for numerics and booleans). String columns currently require instantiation of Python `str` objects.
+
+
+## 6. Data Quality and Schema Validation
+
+Arnio is split into two layers:
+
+- The **C++ layer** handles parsing CSVs, storing data in memory, and cleaning operations such as `drop_nulls()` and `strip_whitespace()`. These execute through pybind11 directly in C++.
+- The **Python/pandas layer** handles data quality: profiling, validation, and schema checks.
+
+Each function in the quality layer behaves as follows:
+- `profile()` and `validate()` convert an `ArFrame` to pandas for analysis/validation.
+- `suggest_cleaning()` can inspect an existing `DataQualityReport` directly, or call `profile()` when given an `ArFrame`.
+- `auto_clean()` calls `profile()` first, then applies selected cleaning helpers/pipeline steps to the original frame flow.
+
+### What each function does
+
+1. `profile()`: converts `ArFrame` to a pandas DataFrame internally, then computes per-column statistics including null counts, duplicate rows, data types, and unique value ratios. Returns a `DataQualityReport`.
+2. `suggest_cleaning()`: accepts an `ArFrame` or an existing `DataQualityReport`. If given an `ArFrame`, it calls `profile()` first. Returns a list of cleaning steps that can be passed to `pipeline()`.
+3. `auto_clean()`: accepts an `ArFrame`, calls `profile()` internally, then applies suggested cleaning steps directly to the original `ArFrame`. Returns a cleaned `ArFrame`.
+4. `validate()`: converts `ArFrame` to a pandas DataFrame internally, then evaluates each column against rules defined in a `Schema` including nullability, dtype, range, pattern, and semantic constraints. Returns a `ValidationResult`.
+
+```mermaid
+graph TD
+    A[ArFrame] -->|or| D[suggest_cleaning]
+    A --> B[profile]
+    A --> C[auto_clean]
+    A --> H[validate]
+    B --> E[DataQualityReport]
+    E -->|or| D
+    D --> F[step list]
+    C --> G[cleaned ArFrame]
+    H --> I[ValidationResult]
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.1](https://github.com/im-anishraj/arnio/compare/v1.5.0...v1.5.1) (2026-05-16)
+
+
+### Bug Fixes
+
+* normalize title case across punctuation boundaries ([4a9b947](https://github.com/im-anishraj/arnio/commit/4a9b947f4045edf61839e70247fcce5b54fe5b1d))
+
 ## [1.5.0](https://github.com/im-anishraj/arnio/compare/v1.4.0...v1.5.0) (2026-05-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [1.2.0](https://github.com/im-anishraj/arnio/compare/v1.1.1...v1.2.0) (2026-05-15)
+
+
+### Features
+
+* add ArFrame preview method ([814102e](https://github.com/im-anishraj/arnio/commit/814102e35b153cf75b3a759a5e33867edfe03321))
+* add ArFrame select_columns helper ([fff406d](https://github.com/im-anishraj/arnio/commit/fff406d9a10943cb6f2bd76d32240933da90ed51))
+* add clip_numeric cleaning helper ([4022449](https://github.com/im-anishraj/arnio/commit/4022449c7bbe5e31c94e756ff29a36b4c274a232))
+* add drop constant columns ([#357](https://github.com/im-anishraj/arnio/issues/357)) ([3e13d3d](https://github.com/im-anishraj/arnio/commit/3e13d3d576add9fd8113cdf185ca08e61e75c4ee))
+* add filter_rows pipeline step ([#288](https://github.com/im-anishraj/arnio/issues/288)) ([a3b7386](https://github.com/im-anishraj/arnio/commit/a3b7386e75bc45c9a7fde403ea373334ef528f75))
+* add refactor task issue template ([#334](https://github.com/im-anishraj/arnio/issues/334)) ([6690947](https://github.com/im-anishraj/arnio/commit/6690947bcada6dc825853036a11ad2310acdd4e4))
+* add round_numeric_columns cleaning helper ([61cd110](https://github.com/im-anishraj/arnio/commit/61cd1105e60c6daa38d34ef602f3f9fac28de7ea))
+* add safe_divide_columns cleaning step ([80e4a65](https://github.com/im-anishraj/arnio/commit/80e4a654d81a1bd95e96b1f5ec83f5f82deff590))
+* add trim_headers CSV option ([022460e](https://github.com/im-anishraj/arnio/commit/022460e1fa7e9510960a789aa38f835731dec700))
+* add ValidationResult.to_markdown ([168e525](https://github.com/im-anishraj/arnio/commit/168e525409ce3a8d60f972dadacfaab01c4cafa8))
+* enhance pull request template with media and performance sections ([#336](https://github.com/im-anishraj/arnio/issues/336)) ([99b588b](https://github.com/im-anishraj/arnio/commit/99b588b62910a68b83abdb39455c0d59de6bba56))
+
+
+### Bug Fixes
+
+* improve nested object error messages in from_pandas ([ca90974](https://github.com/im-anishraj/arnio/commit/ca90974cdef4b25824525aa2d4482968054adba2))
+
+
+### Documentation
+
+* add beginner-friendly auto_clean tutorial with profiling and cleaning workflow  ([#326](https://github.com/im-anishraj/arnio/issues/326)) ([b604a0d](https://github.com/im-anishraj/arnio/commit/b604a0d067f6603cf6bb5037b5b33b6ff0c19248))
+* add contributor glossary ([#308](https://github.com/im-anishraj/arnio/issues/308)) ([da52804](https://github.com/im-anishraj/arnio/commit/da5280486603e2d630adf33ec8d7162acb9ba0ba))
+* add data quality report examples [#279](https://github.com/im-anishraj/arnio/issues/279) ([#295](https://github.com/im-anishraj/arnio/issues/295)) ([ca42e87](https://github.com/im-anishraj/arnio/commit/ca42e87cf2c596b78286ab3fe4ce8a9c305a6f2a))
+* add Discord community links ([#305](https://github.com/im-anishraj/arnio/issues/305)) ([64cb4a1](https://github.com/im-anishraj/arnio/commit/64cb4a1d871ac7ec8471e28c5386eb8ebfb20ef4))
+* add gssoc faq ([#309](https://github.com/im-anishraj/arnio/issues/309)) ([dc32e56](https://github.com/im-anishraj/arnio/commit/dc32e563ba5ff8e2ed2680dec9451d27c65a14e5))
+* add issue triage guide for maintainers ([#300](https://github.com/im-anishraj/arnio/issues/300)) ([2d6dd6f](https://github.com/im-anishraj/arnio/commit/2d6dd6f9c566479757c2146f02e186c1d7d57c2e))
+* add release process guide ([#304](https://github.com/im-anishraj/arnio/issues/304)) ([f5e1325](https://github.com/im-anishraj/arnio/commit/f5e13252889865e24cd464379c9fa3974d2fff03))
+* align pandas dtype support documentation with implementation ([#327](https://github.com/im-anishraj/arnio/issues/327)) ([badd815](https://github.com/im-anishraj/arnio/commit/badd8150a3859ffb1598bdf21f71a8cd2c4c6b0b))
+* fix non-sequential roadmap versions ([#107](https://github.com/im-anishraj/arnio/issues/107)) ([db3b8e4](https://github.com/im-anishraj/arnio/commit/db3b8e47fc721ad899df0b6239bc706824d168a5))
+* remove large Discord badge from README ([#307](https://github.com/im-anishraj/arnio/issues/307)) ([1f0ff3a](https://github.com/im-anishraj/arnio/commit/1f0ff3ab15d111344cc9c6281226ef6361f919f9))
+
 ## [1.1.1](https://github.com/im-anishraj/arnio/compare/v1.1.0...v1.1.1) (2026-05-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.5.0](https://github.com/im-anishraj/arnio/compare/v1.4.0...v1.5.0) (2026-05-16)
+
+
+### Features
+
+* add is_empty convenience property to ArFrame ([37df94d](https://github.com/im-anishraj/arnio/commit/37df94d0e4f782fc4510ea8ad179960f51c0fc7d))
+* add validation summary counts ([#444](https://github.com/im-anishraj/arnio/issues/444)) ([6575491](https://github.com/im-anishraj/arnio/commit/657549174aaca524ce77f169a7e7b3a7b230cba0))
+
+
+### Bug Fixes
+
+* allow encoded csv nul handling ([5796a35](https://github.com/im-anishraj/arnio/commit/5796a35a32aff5a5d889a72deee255232c527929)), closes [#422](https://github.com/im-anishraj/arnio/issues/422)
+
 ## [1.4.0](https://github.com/im-anishraj/arnio/compare/v1.3.1...v1.4.0) (2026-05-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.3.0](https://github.com/im-anishraj/arnio/compare/v1.2.0...v1.3.0) (2026-05-15)
+
+
+### Features
+
+* add column existence validation helper ([517d1e0](https://github.com/im-anishraj/arnio/commit/517d1e07d3b19252027ecdfac23d17b19e0aa793))
+* add pandas integration direction ([#399](https://github.com/im-anishraj/arnio/issues/399)) ([22f9b58](https://github.com/im-anishraj/arnio/commit/22f9b58458383549d97d81ff7828b7a047063525))
+* **convert:** preserve DataFrame attrs roundtrip ([4018f27](https://github.com/im-anishraj/arnio/commit/4018f27f76dbb021591b4aa6844e2c130887dceb))
+
+
+### Bug Fixes
+
+* preserve Int64 dtype for all-null nullable integer columns in from_pandas roundtrip ([#394](https://github.com/im-anishraj/arnio/issues/394)) ([ef726ed](https://github.com/im-anishraj/arnio/commit/ef726ed0e1af588c7c0f74a04e02ccfd6a1d688f))
+
+
+### Documentation
+
+* add quality and schema architecture flow ([d22fa56](https://github.com/im-anishraj/arnio/commit/d22fa56c393c2005c9a351f30ca6132c4ae3c863))
+
 ## [1.2.0](https://github.com/im-anishraj/arnio/compare/v1.1.1...v1.2.0) (2026-05-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.1](https://github.com/im-anishraj/arnio/compare/v1.3.0...v1.3.1) (2026-05-16)
+
+
+### Bug Fixes
+
+* handle empty CSV files with a dedicated error path ([b359173](https://github.com/im-anishraj/arnio/commit/b359173f15b5cf6b4cb68b9f04b418d5380c0c44))
+
 ## [1.3.0](https://github.com/im-anishraj/arnio/compare/v1.2.0...v1.3.0) (2026-05-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.0](https://github.com/im-anishraj/arnio/compare/v1.3.1...v1.4.0) (2026-05-16)
+
+
+### Features
+
+* add bounded profiling sample_size validation ([1e31269](https://github.com/im-anishraj/arnio/commit/1e3126986bdc21e128fc734a71a77aa7f242441a))
+
 ## [1.3.1](https://github.com/im-anishraj/arnio/compare/v1.3.0...v1.3.1) (2026-05-16)
 
 

--- a/COLAB_SMOKE_TEST.md
+++ b/COLAB_SMOKE_TEST.md
@@ -1,0 +1,56 @@
+# Google Colab install smoke test
+
+This is a lightweight, copy-pasteable smoke test to verify that `pip install arnio` works in a fresh Google Colab runtime.
+
+## 1) Install
+
+Run this in a new Colab notebook cell:
+
+```python
+!pip install arnio
+```
+
+## 2) Verify import
+
+```python
+import arnio as ar
+
+print("arnio version:", ar.__version__)
+print("arnio imported successfully")
+```
+
+## 3) Create a tiny CSV
+
+This creates a small file directly in Colab (no uploads needed):
+
+```python
+from pathlib import Path
+
+csv_text = """name,revenue,city
+ Ishan ,10,London
+ Pranay, ,Paris
+ Ishan ,10,London
+"""
+
+Path("sample.csv").write_text(csv_text, encoding="utf-8")
+print("wrote sample.csv")
+```
+
+## 4) Minimal validation
+
+```python
+import arnio as ar
+
+print("scan_csv:", ar.scan_csv("sample.csv"))
+
+frame = ar.read_csv("sample.csv")
+df = ar.to_pandas(frame)
+
+print("shape:", df.shape)
+df
+```
+
+## Troubleshooting
+
+- If you get unexpected import errors after re-running cells, use **Runtime → Restart runtime**, then re-run the notebook top to bottom.
+- If `pip install arnio` fails, copy the full error output into a GitHub issue and include your Colab runtime type (Python version) and the exact install commands you ran.

--- a/PROJECT_DIRECTION.md
+++ b/PROJECT_DIRECTION.md
@@ -1,0 +1,64 @@
+# Arnio Project Direction
+
+Arnio is a fast data-preparation layer for the Python data ecosystem.
+
+The project is not trying to replace pandas, NumPy, scikit-learn, DuckDB, or
+Arrow. Arnio should make those tools easier to use by handling the messy,
+repetitive, and risky preparation work before data reaches analysis, modeling,
+or storage workflows.
+
+## Core Identity
+
+Arnio focuses on:
+
+- fast CSV ingestion and schema scanning
+- predictable cleaning pipelines
+- data quality profiling
+- schema validation and data contracts
+- safe pandas interoperability
+- integrations that fit existing data workflows
+
+The existing C++ runtime, `ArFrame`, cleaning primitives, and schema layer
+remain the foundation. Integrations are the next layer built on top of that
+foundation.
+
+## Product Positioning
+
+Use this framing when writing docs, issues, release notes, or examples:
+
+> Arnio prepares messy data for the Python data stack.
+
+Good examples:
+
+- Clean with Arnio, analyze with pandas.
+- Validate with Arnio, train with scikit-learn.
+- Profile with Arnio, query with DuckDB.
+- Prepare with Arnio, exchange with Arrow.
+
+Avoid framing Arnio as a pandas replacement. Arnio should be useful to people
+who already love pandas and simply want fewer fragile preprocessing chains.
+
+## Contributor Guidance
+
+Existing issues around parsing, cleaning, schema validation, profiling,
+performance, and packaging are still important. They directly improve the
+foundation that integrations rely on.
+
+New integration work should be:
+
+- small and focused
+- compatible with existing public APIs
+- tested against real user workflows
+- documented with short examples
+- careful about optional dependencies
+
+Prefer additive APIs over breaking changes.
+
+## Near-Term Integration Roadmap
+
+1. Pandas accessor: `df.arnio.clean()`, `df.arnio.profile()`,
+   `df.arnio.validate()`.
+2. scikit-learn transformer for preprocessing pipelines.
+3. Arrow bridge for DuckDB, Polars, and PyArrow workflows.
+4. NumPy preparation helpers for numeric/modeling workflows.
+5. Interoperability examples that show Arnio working with popular libraries.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ clean = ar.pipeline(frame, [
 # Out comes a standard pandas DataFrame — use it like you always have
 df = ar.to_pandas(clean)
 ```
+### Select specific columns
+
+Use `select_columns()` to create a new `ArFrame` with only the required columns before converting to pandas.
+
+```python
+selected = frame.select_columns(["name", "revenue"])
+
+print(selected.columns)
+# ['name', 'revenue']
+```
+
 
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
+| `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 
 Or compose them all into a **pipeline**:
 
@@ -352,6 +353,21 @@ Works with:
 - booleans
 
 <br>
+### 🔢 Safe column division
+
+Divide one column by another while handling division by zero and null denominators explicitly:
+
+```python
+result = ar.safe_divide_columns(
+    frame,
+    numerator="revenue",
+    denominator="cost",
+    output_column="ratio",
+    fill_value=0.0,  # used when denominator is zero or null
+)
+```
+
+> When the denominator is **zero or null**, the result is replaced with `fill_value` (default `0.0`) instead of raising an error or producing `NaN`/`Inf`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,62 @@ clean, report = ar.auto_clean(frame, mode="strict", return_report=True)
 This is the layer pandas does not try to own: profiling, data contracts, row-level validation issues, and safe cleaning suggestions for messy incoming datasets.
 
 <br>
+
+### Beginner-friendly auto-clean tutorial
+
+Use this workflow when you receive a small messy dataset and want to inspect what Arnio will change before applying it.
+
+```python
+import arnio as ar
+import pandas as pd
+
+raw = pd.DataFrame(
+    {
+        "order_id": [1001, 1002, 1002, 1003, 1004],
+        "customer": [" Ishan ", " Prasoon ", " Prasoon ", " Pranay ", " Dhruv "],
+        "city": [" Paris ", "London", "London", " New York ", " Tokyo "],
+    }
+)
+
+frame = ar.from_pandas(raw)
+
+report = ar.profile(frame)
+summary = report.summary()
+print(summary)
+
+suggestions = ar.suggest_cleaning(frame)
+print(suggestions)
+# [('strip_whitespace', {'subset': ['customer', 'city']}), ('drop_duplicates', {'keep': 'first'})]
+
+safe = ar.auto_clean(frame)
+strict = ar.auto_clean(frame, mode="strict")
+```
+
+Messy input:
+
+| order_id | customer | city |
+|:--|:--|:--|
+| 1001 | ` Ishan ` | ` Paris ` |
+| 1002 | ` Prasoon ` | `London` |
+| 1002 | ` Prasoon ` | `London` |
+| 1003 | ` Pranay ` | ` New York ` |
+| 1004 | ` Dhruv ` | ` Tokyo ` |
+
+Expected cleaned output with `mode="strict"`:
+
+| order_id | customer | city |
+|:--|:--|:--|
+| 1001 | Ishan | Paris |
+| 1002 | Prasoon | London |
+| 1003 | Pranay | New York |
+| 1004 | Dhruv | Tokyo |
+
+`mode="safe"` only trims whitespace. Use `mode="strict"` when you also want deterministic built-in cleanup such as exact duplicate removal.
+
+See [examples/auto_clean_tutorial.py](examples/auto_clean_tutorial.py) for a runnable version of this walkthrough.
+
+<br>
+
 ## Data Quality Reports
 
 Arnio provides detailed profiling for datasets via `ar.profile()`. To generate the report shown in these examples, the following code was used:
@@ -611,7 +667,7 @@ arnio/
 │   └── exceptions.py        # ArnioError, UnknownStepError, CsvReadError, TypeCastError
 ├── tests/                   # pytest suite — CSV, cleaning, pipeline, conversions
 ├── benchmarks/              # Reproducible arnio vs pandas benchmark
-├── examples/                # basic_usage.py, custom_step.py
+├── examples/                # basic_usage.py, auto_clean_tutorial.py, custom_step.py
 └── website/                 # Project website — arnio.vercel.app
 ```
 

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Arnio is not a pandas wrapper. It's a separate runtime with its own data model.
 
 ## 🏎️ Benchmarks
 
-> **Reference environment**: Ubuntu, Python 3.12, 1M rows × 12 columns, synthetic messy CSV.<br>
-> **Reproduce**: `make benchmark` — generates the deterministic dataset and runs both engines.
+> **Reference environment**: Ubuntu, Python 3.12, synthetic messy CSV inputs.<br>
+> **Reproduce**: `make benchmark` — generates deterministic tall and wide datasets and runs both engines.
 
 To reproduce the published numbers from a fresh checkout:
 
@@ -238,16 +238,24 @@ python benchmarks/generate_data.py
 python benchmarks/benchmark_vs_pandas.py
 ```
 
-`benchmarks/generate_data.py` uses NumPy's `default_rng(42)`, so every run creates the same `benchmarks/benchmark_1m.csv` input. The benchmark then executes three pandas runs and three arnio runs, printing average wall-clock time from `time.perf_counter()` and peak Python allocation from `tracemalloc`. For cleaner comparisons, close other memory-heavy processes and run the script from the repository root after installing the same Python, pandas, NumPy, compiler, and arnio commit you want to compare.
+`benchmarks/generate_data.py` uses deterministic NumPy seeds, so every run creates the same `benchmarks/benchmark_1m.csv` tall input and `benchmarks/benchmark_wide.csv` wide input. The benchmark then executes three pandas runs and three arnio runs for each case, printing average wall-clock time from `time.perf_counter()` and peak Python allocation from `tracemalloc`. For cleaner comparisons, close other memory-heavy processes and run the script from the repository root after installing the same Python, pandas, NumPy, compiler, and arnio commit you want to compare.
 
 Expected output format:
 
 ```text
-                     pandas         arnio
+Tall CSV (1,000,000 rows x 12 columns)
+Metric                     pandas        arnio
 ────────────────────────────────────────────
 Exec Time (avg)       4.73s         5.75s
 Peak RAM               211MB         212MB
-API Clarity         Imperative    Declarative
+Speed: 0.8x | RAM: -1% reduction
+
+Wide CSV (5,000 rows x 256 columns)
+Metric                     pandas        arnio
+────────────────────────────────────────────
+Exec Time (avg)       ...s          ...s
+Peak RAM              ...MB         ...MB
+Speed: ...x | RAM: ...% reduction
 ```
 
 Small differences are expected across CPUs, operating systems, compilers, Python builds, and pandas/NumPy versions. If you share benchmark results in an issue or PR, include your OS, Python version, CPU model, pandas/NumPy versions, arnio commit, and the full command output so maintainers can compare like for like.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
+| `round_numeric_columns` | Round numeric columns (non-numeric columns in subset ignored safely) | `ar.round_numeric_columns(frame, decimals=2)` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
 | `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `filter_rows` | Filter rows using comparison operators | `ar.filter_rows(frame, column="age", op=">", value=18)` |
 | `fill_nulls` | Replace nulls with a scalar | `ar.fill_nulls(frame, 0, subset=["revenue"])` |
 | `drop_duplicates` | Deduplicate rows (first/last/none) | `ar.drop_duplicates(frame, keep="first")` |
+| `drop_constant_columns` | Remove columns with only one unique value | `ar.drop_constant_columns(frame)` |
 | `strip_whitespace` | Trim leading/trailing spaces from strings | `ar.strip_whitespace(frame)` |
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `fill_nulls` | Replace nulls with a scalar | `ar.fill_nulls(frame, 0, subset=["revenue"])` |
 | `drop_duplicates` | Deduplicate rows (first/last/none) | `ar.drop_duplicates(frame, keep="first")` |
 | `drop_constant_columns` | Remove columns with only one unique value | `ar.drop_constant_columns(frame)` |
+| `clip_numeric` | Clip numeric values to lower and/or upper bounds | `ar.clip_numeric(frame, lower=0, upper=100)` |
 | `strip_whitespace` | Trim leading/trailing spaces from strings | `ar.strip_whitespace(frame)` |
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 <br><br>
 
-### Your CSV hits C++ before Python even wakes up.
+### Fast data preparation for the Python data stack.
 
 <br>
 
-**Arnio** is a compiled C++ data cleaning engine that slots in _before_ pandas.<br>
-It parses, infers types, strips whitespace, deduplicates, and normalizes —<br>
-all natively, in columnar memory — then hands you a pristine `DataFrame`.<br>
-No `.apply()`. No lambda chains. No spaghetti.
+**Arnio** is a compiled C++ data preparation engine for messy CSV and pandas workflows.<br>
+It parses, infers types, strips whitespace, deduplicates, validates, and profiles data —<br>
+then hands clean results back to the tools you already use.<br>
+Use Arnio _before_ and _alongside_ pandas, NumPy, scikit-learn, DuckDB, and Arrow.
 
 <br>
 
@@ -37,7 +37,7 @@ pip install arnio
 
 <br>
 
-<a href="#-quickstart">Quickstart</a>&ensp;·&ensp;<a href="#-why-arnio-exists">Why Arnio</a>&ensp;·&ensp;<a href="#%EF%B8%8F-architecture">Architecture</a>&ensp;·&ensp;<a href="#-benchmarks">Benchmarks</a>&ensp;·&ensp;<a href="#-community">Community</a>&ensp;·&ensp;<a href="#-contribute">Contribute</a>
+<a href="#-quickstart">Quickstart</a>&ensp;·&ensp;<a href="#-integrations">Integrations</a>&ensp;·&ensp;<a href="#-why-arnio-exists">Why Arnio</a>&ensp;·&ensp;<a href="#%EF%B8%8F-architecture">Architecture</a>&ensp;·&ensp;<a href="#-benchmarks">Benchmarks</a>&ensp;·&ensp;<a href="#-community">Community</a>&ensp;·&ensp;<a href="#-contribute">Contribute</a>
 
 </div>
 
@@ -69,6 +69,25 @@ clean = ar.pipeline(frame, [
 # Out comes a standard pandas DataFrame — use it like you always have
 df = ar.to_pandas(clean)
 ```
+
+Already have a pandas `DataFrame`? Use Arnio in-place in your existing pandas
+workflow:
+
+```python
+import pandas as pd
+import arnio as ar
+
+df = pd.read_csv("messy_sales_data.csv")
+
+clean_df = df.arnio.clean([
+    ("strip_whitespace",),
+    ("normalize_case", {"case_type": "lower"}),
+    ("drop_duplicates",),
+])
+
+report = clean_df.arnio.profile()
+```
+
 ### Select specific columns
 
 Use `select_columns()` to create a new `ArFrame` with only the required columns before converting to pandas.
@@ -144,6 +163,43 @@ Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Pyth
 
 <br>
 
+## 🔗 Integrations
+
+Arnio is designed to make the rest of the Python data stack more productive,
+not to replace it.
+
+| Workflow | How Arnio helps |
+|:---|:---|
+| **pandas** | Clean, validate, and profile messy `DataFrame`s through `df.arnio`. |
+| **NumPy** | Prepare typed numeric data before array/modeling workflows. |
+| **scikit-learn** | Use Arnio cleaning as a preprocessing layer before model training. |
+| **DuckDB / Arrow** | Validate and prepare data before analytics and columnar exchange. |
+| **notebooks** | Inspect quality issues and cleaning suggestions before analysis. |
+
+### Pandas accessor
+
+```python
+df = pd.read_csv("raw_customers.csv")
+
+clean_df = df.arnio.clean(drop_duplicates=True)
+quality = clean_df.arnio.profile()
+validation = clean_df.arnio.validate({
+    "email": ar.Email(nullable=False),
+    "age": ar.Int64(nullable=True, min=0),
+})
+```
+
+This keeps pandas as the analysis tool while Arnio handles the preparation,
+quality, and validation layer.
+
+> Product direction: **[PROJECT_DIRECTION.md](PROJECT_DIRECTION.md)**
+
+<br>
+
+---
+
+<br>
+
 ## 🔍 Why Arnio exists
 
 Every data project starts the same way:
@@ -159,7 +215,7 @@ df = df.drop_duplicates()                  # Another pass
 
 Six lines. Four full-data passes. All in interpreted Python. This is fine for a Jupyter demo — but it doesn't scale, it doesn't compose, and it definitely doesn't belong in production.
 
-**Arnio intercepts this entire pattern.** It moves the heavy lifting to C++, replaces imperative chains with a declarative pipeline, and gives you a clean `DataFrame` in one shot.
+**Arnio intercepts this entire pattern.** It moves the preparation layer into a predictable pipeline, accelerates supported operations in C++, and gives you clean data for pandas, NumPy, scikit-learn, DuckDB, or notebooks.
 
 <table>
 <tr>

--- a/README.md
+++ b/README.md
@@ -601,7 +601,8 @@ data = {
     "score": [85.5, 90.0, None, 88.2]
 }
 df = ar.from_pandas(pd.DataFrame(data))
-report = ar.profile(df)
+# Bounded profiling for large datasets (controls how many sample values are kept)
+report = ar.profile(df, sample_size=5)
 ```
 
 ### 1. Terminal Representation (Simplified Example)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Use Arnio _before_ and _alongside_ pandas, NumPy, scikit-learn, DuckDB, and Arro
 pip install arnio
 ```
 
+Colab install smoke test: **[COLAB_SMOKE_TEST.md](COLAB_SMOKE_TEST.md)**
+
 <br>
 
 <a href="#-quickstart">Quickstart</a>&ensp;·&ensp;<a href="#-integrations">Integrations</a>&ensp;·&ensp;<a href="#-why-arnio-exists">Why Arnio</a>&ensp;·&ensp;<a href="#%EF%B8%8F-architecture">Architecture</a>&ensp;·&ensp;<a href="#-benchmarks">Benchmarks</a>&ensp;·&ensp;<a href="#-community">Community</a>&ensp;·&ensp;<a href="#-contribute">Contribute</a>

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | Primitive | What it does | Example |
 |:---|:---|:---|
 | `drop_nulls` | Remove rows with null/empty values | `ar.drop_nulls(frame, subset=["age"])` |
+| `validate_columns_exist` | Fail early when required columns are missing | `ar.validate_columns_exist(frame, ["age"])` |
 | `filter_rows` | Filter rows using comparison operators | `ar.filter_rows(frame, column="age", op=">", value=18)` |
 | `fill_nulls` | Replace nulls with a scalar | `ar.fill_nulls(frame, 0, subset=["revenue"])` |
 | `drop_duplicates` | Deduplicate rows (first/last/none) | `ar.drop_duplicates(frame, keep="first")` |
@@ -344,6 +345,7 @@ Or compose them all into a **pipeline**:
 
 ```python
 clean = ar.pipeline(frame, [
+    ("validate_columns_exist", {"columns": ["name", "city", "revenue"]}),
     ("strip_whitespace",),
     ("normalize_case", {"case_type": "lower"}),
     ("fill_nulls", {"value": "unknown", "subset": ["city"]}),

--- a/README.md
+++ b/README.md
@@ -515,11 +515,16 @@ schema = ar.Schema({
 
 result = ar.validate(frame, schema)
 if not result.passed:
+    summary = result.summary()
+    print(summary["issues_by_rule"])
+    print(summary["issues_by_column"])
+    print(summary["issues_by_column_and_rule"])
     print(result.to_pandas())
     print(result.to_markdown(max_issues=10))
 ```
 
 `ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
+Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
 
 For low-risk automatic cleanup:
 

--- a/README.md
+++ b/README.md
@@ -455,7 +455,10 @@ schema = ar.Schema({
 result = ar.validate(frame, schema)
 if not result.passed:
     print(result.to_pandas())
+    print(result.to_markdown(max_issues=10))
 ```
+
+`ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
 
 For low-risk automatic cleanup:
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ Useful for exploring datasets before committing memory.
 </details>
 
 <details>
+<summary><b>👀 Preview rows without pandas conversion or full-column Python list materialization</b></summary>
+<br>
+
+`preview()` reads only the first `n` rows directly from the C++ frame — no pandas conversion triggered.
+
+```python
+frame = ar.read_csv("huge_file.csv")
+
+print(frame.preview())      # first 5 rows (default)
+print(frame.preview(n=10))  # first 10 rows
+```
+
+Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
+</details>
+
+<details>
 <summary><b>🧩 Add custom steps without touching C++</b></summary>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,37 @@ Works with:
 
 <br>
 
+## 📊 Pandas Dtype Support Matrix
+
+This table helps users understand which pandas dtypes and workflows are fully supported, partially supported, unsupported, or planned.
+
+If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
+
+| Pandas Dtype | Support Status | Notes |
+|---|---|---|
+| `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
+| `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
+| `bool` | ✅ Supported | Native supported boolean type |
+| `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
+| `datetime64[ns]` | ❌ Unsupported | No native datetime parsing or conversion support yet |
+| `category` | ⚠️ Limited | Converted to string/object during processing |
+| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may coerce to string and reduce type inference reliability |
+| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited | Supported through pandas extension dtypes with null-mask handling |
+| `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
+
+### Notes
+
+- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
+- String columns require Python string object creation during `to_pandas()` conversion.
+- Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
+- Unsupported dtypes should raise clear user-facing errors instead of silent failures.
+
+<br>
+
+---
+
+<br>
+
 ## 🧠 Data quality engine
 
 Arnio now includes built-in dataset understanding before you analyze in pandas.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,7 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 
 - Make CSV parsing and cleaning behavior predictable across platforms.
 - Expand the data quality and schema validation layer.
+- Make Arnio useful inside existing pandas and Python data-stack workflows.
 - Improve contributor onboarding for GSSoC 2026.
 - Increase unit, integration, packaging, and benchmark coverage.
 - Keep PyPI releases reliable and easy to verify.
@@ -15,6 +16,7 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 - Harden CSV edge cases: row width validation, comments, encodings, malformed quotes, delimiter detection, and better diagnostics.
 - Make `ArFrame` easier to inspect and test with row previews, column access, equality, and copy behavior.
 - Expand pipeline ergonomics with validation, registry introspection, and safer custom step execution.
+- Add focused interoperability features, starting with the pandas `df.arnio` accessor.
 - Add more schema validators for real-world data contracts.
 - Build reproducible performance baselines and regression checks.
 
@@ -23,6 +25,7 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 - Chunked and streaming processing for datasets that do not fit comfortably in memory.
 - Native writers for CSV and other common export formats.
 - Better pandas interoperability for datetime, categorical, nullable, and timedelta types.
+- Add scikit-learn, Arrow, DuckDB, and NumPy integration paths where they make existing workflows easier.
 - More automatic data quality suggestions with confidence levels and explainable actions.
 - Documentation site with API reference, tutorials, recipes, and contribution tracks.
 
@@ -36,4 +39,6 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 
 ## Product Direction
 
-Arnio should become the fast, explicit preparation layer before pandas: inspect messy data, clean it predictably, validate it against contracts, and hand a trustworthy DataFrame to the rest of the Python ecosystem.
+Arnio should become the fast, explicit preparation layer for the Python data ecosystem: inspect messy data, clean it predictably, validate it against contracts, and hand trustworthy results to pandas, NumPy, scikit-learn, DuckDB, Arrow, and notebooks.
+
+For the full positioning, see [PROJECT_DIRECTION.md](PROJECT_DIRECTION.md).

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -14,6 +14,7 @@ except Exception:
 from .cleaning import (
     cast_types,
     clean,
+    clip_numeric,
     drop_constant_columns,
     drop_duplicates,
     drop_nulls,
@@ -61,6 +62,7 @@ __all__ = [
     "filter_rows",
     "drop_duplicates",
     "drop_constant_columns",
+    "clip_numeric",
     "strip_whitespace",
     "normalize_case",
     "rename_columns",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -30,6 +30,7 @@ from .cleaning import (
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame
+from .integrations import ArnioPandasAccessor
 from .io import read_csv, scan_csv
 from .pipeline import pipeline, register_step
 from .quality import (
@@ -77,6 +78,8 @@ __all__ = [
     # Conversion
     "to_pandas",
     "from_pandas",
+    # Integrations
+    "ArnioPandasAccessor",
     # Pipeline
     "pipeline",
     "register_step",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -14,6 +14,7 @@ except Exception:
 from .cleaning import (
     cast_types,
     clean,
+    drop_constant_columns,
     drop_duplicates,
     drop_nulls,
     fill_nulls,
@@ -59,6 +60,7 @@ __all__ = [
     "fill_nulls",
     "filter_rows",
     "drop_duplicates",
+    "drop_constant_columns",
     "strip_whitespace",
     "normalize_case",
     "rename_columns",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -22,6 +22,7 @@ from .cleaning import (
     filter_rows,
     normalize_case,
     rename_columns,
+    safe_divide_columns,
     strip_whitespace,
 )
 from .convert import from_pandas, to_pandas
@@ -68,6 +69,7 @@ __all__ = [
     "rename_columns",
     "cast_types",
     "clean",
+    "safe_divide_columns",
     # Conversion
     "to_pandas",
     "from_pandas",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -25,6 +25,7 @@ from .cleaning import (
     round_numeric_columns,
     safe_divide_columns,
     strip_whitespace,
+    validate_columns_exist,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
@@ -61,6 +62,7 @@ __all__ = [
     # Cleaning
     "drop_nulls",
     "fill_nulls",
+    "validate_columns_exist",
     "filter_rows",
     "drop_duplicates",
     "drop_constant_columns",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -22,6 +22,7 @@ from .cleaning import (
     filter_rows,
     normalize_case,
     rename_columns,
+    round_numeric_columns,
     safe_divide_columns,
     strip_whitespace,
 )
@@ -67,6 +68,7 @@ __all__ = [
     "strip_whitespace",
     "normalize_case",
     "rename_columns",
+    "round_numeric_columns",
     "cast_types",
     "clean",
     "safe_divide_columns",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -5,6 +5,7 @@ Data cleaning functions.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from ._core import (
@@ -18,6 +19,66 @@ from ._core import (
 )
 from .exceptions import TypeCastError
 from .frame import ArFrame
+
+
+def validate_columns_exist(
+    frame: ArFrame,
+    columns: Sequence[str],
+    *,
+    operation: str | None = None,
+) -> ArFrame:
+    """Validate that all requested columns exist in a frame.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    columns : sequence of str
+        Column names that must exist.
+    operation : str, optional
+        Operation name to include in the error message.
+
+    Returns
+    -------
+    ArFrame
+        The original frame, unchanged. This makes the helper pipeline-friendly.
+
+    Raises
+    ------
+    TypeError
+        If columns is a string/bytes value or contains non-string items.
+    KeyError
+        If any requested column is missing.
+    """
+    requested_columns = _validate_column_sequence(columns, argument_name="columns")
+    missing = [column for column in requested_columns if column not in frame.columns]
+    if missing:
+        available = ", ".join(frame.columns) or "<none>"
+        context = f" for {operation}" if operation else ""
+        raise KeyError(
+            f"Missing columns{context}: {missing}. Available columns: {available}"
+        )
+    return frame
+
+
+def _validate_column_sequence(
+    columns: Sequence[str],
+    *,
+    argument_name: str,
+) -> list[str]:
+    if isinstance(columns, (str, bytes)):
+        raise TypeError(
+            f"{argument_name} must be a sequence of column names, not a string"
+        )
+    if not isinstance(columns, Sequence):
+        raise TypeError(f"{argument_name} must be a sequence of column names")
+
+    normalized = list(columns)
+    invalid_columns = [column for column in normalized if not isinstance(column, str)]
+    if invalid_columns:
+        raise TypeError(f"{argument_name} must contain only string column names")
+
+    return normalized
 
 
 def drop_nulls(
@@ -45,6 +106,12 @@ def drop_nulls(
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.drop_nulls(frame, subset=["age", "name"])
     """
+    if subset is not None:
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="drop_nulls",
+        )
     result = _drop_nulls(frame._frame, subset=subset)
     return ArFrame(result)
 
@@ -76,6 +143,12 @@ def fill_nulls(
     >>> frame = ar.read_csv("data.csv")
     >>> filled = ar.fill_nulls(frame, 0, subset=["age"])
     """
+    if subset is not None:
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="fill_nulls",
+        )
     result = _fill_nulls(frame._frame, value, subset=subset)
     return ArFrame(result)
 
@@ -108,6 +181,12 @@ def drop_duplicates(
     >>> frame = ar.read_csv("data.csv")
     >>> unique = ar.drop_duplicates(frame, subset=["name"], keep="first")
     """
+    if subset is not None:
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="drop_duplicates",
+        )
     keep_arg = "none" if keep is False else keep
     result = _drop_duplicates(frame._frame, subset=subset, keep=keep_arg)
     return ArFrame(result)
@@ -253,6 +332,12 @@ def strip_whitespace(
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.strip_whitespace(frame, subset=["name"])
     """
+    if subset is not None:
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="strip_whitespace",
+        )
     result = _strip_whitespace(frame._frame, subset=subset)
     return ArFrame(result)
 
@@ -284,6 +369,12 @@ def normalize_case(
     >>> frame = ar.read_csv("data.csv")
     >>> lower = ar.normalize_case(frame, case_type="lower")
     """
+    if subset is not None:
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="normalize_case",
+        )
     result = _normalize_case(frame._frame, subset=subset, case_type=case_type)
     return ArFrame(result)
 
@@ -311,6 +402,11 @@ def rename_columns(
     >>> frame = ar.read_csv("data.csv")
     >>> renamed = ar.rename_columns(frame, {"old_name": "new_name"})
     """
+    validate_columns_exist(
+        frame,
+        _validate_column_sequence(list(mapping), argument_name="mapping keys"),
+        operation="rename_columns",
+    )
     result = _rename_columns(frame._frame, mapping)
     return ArFrame(result)
 
@@ -338,6 +434,11 @@ def cast_types(
     >>> frame = ar.read_csv("data.csv")
     >>> casted = ar.cast_types(frame, {"age": "int64", "score": "float64"})
     """
+    validate_columns_exist(
+        frame,
+        _validate_column_sequence(list(mapping), argument_name="mapping keys"),
+        operation="cast_types",
+    )
     try:
         result = _cast_types(frame._frame, mapping)
     except ValueError as e:

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -422,3 +422,65 @@ def filter_rows(frame, column, op, value):
     filtered = df[getattr(df[column], ops[op])(value)]
 
     return from_pandas(filtered) if is_arframe else filtered
+
+
+def safe_divide_columns(
+    frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0
+):
+    """Divide one column by another, handling division by zero and nulls explicitly.
+
+    When the denominator is zero or null, the result is replaced with
+    fill_value instead of raising an error or producing NaN/Inf.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    numerator : str
+        Column name to use as the numerator.
+    denominator : str
+        Column name to use as the denominator.
+    output_column : str
+        Name of the new column to store the division result. Must be a
+        non-empty string. If the column already exists, it will be
+        overwritten and a ``UserWarning`` is raised.
+    fill_value : float, optional
+        Value to use when denominator is zero or null. Defaults to 0.0.
+
+    Returns
+    -------
+    ArFrame
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+    """
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    is_arframe = not isinstance(frame, pd.DataFrame)
+    df = to_pandas(frame) if is_arframe else frame
+
+    if numerator not in df.columns:
+        raise ValueError(f"Numerator column '{numerator}' not found in frame.")
+    if denominator not in df.columns:
+        raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+    if not isinstance(output_column, str) or not output_column.strip():
+        raise ValueError("output_column must be a non-empty string.")
+    if output_column in df.columns:
+        import warnings
+
+        warnings.warn(
+            f"Output column '{output_column}' already exists and will be overwritten.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    safe_denom = df[denominator].replace(0, float("nan"))
+    result = df[numerator] / safe_denom
+    df = df.copy()
+    df[output_column] = result.fillna(fill_value)
+
+    return from_pandas(df) if is_arframe else df

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -152,6 +152,83 @@ def drop_constant_columns(frame: ArFrame) -> ArFrame:
     return from_pandas(df.drop(columns=constant_columns))
 
 
+def clip_numeric(
+    frame: ArFrame,
+    *,
+    lower: int | float | None = None,
+    upper: int | float | None = None,
+    subset: list[str] | None = None,
+) -> ArFrame:
+    """Clip numeric columns to lower and/or upper bounds.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    lower : int or float, optional
+        Lower bound. Values below this are raised to the bound.
+    upper : int or float, optional
+        Upper bound. Values above this are lowered to the bound.
+    subset : list[str], optional
+        Numeric columns to clip. If None, applies to all numeric columns except bools.
+
+    Returns
+    -------
+    ArFrame
+        New frame with clipped numeric values.
+
+    Raises
+    ------
+    ValueError
+        If no bounds are provided, bounds are inverted, subset contains unknown
+        columns, or subset contains non-numeric columns.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> clipped = ar.clip_numeric(frame, lower=0, upper=100)
+    """
+    from pandas.api.types import is_bool_dtype, is_numeric_dtype
+
+    from .convert import from_pandas, to_pandas
+
+    if lower is None and upper is None:
+        raise ValueError("At least one of 'lower' or 'upper' must be provided")
+    if lower is not None and upper is not None and lower > upper:
+        raise ValueError("lower cannot be greater than upper")
+
+    df = to_pandas(frame)
+
+    def _is_supported_numeric(column_name: str) -> bool:
+        series = df[column_name]
+        return is_numeric_dtype(series) and not is_bool_dtype(series)
+
+    if subset is None:
+        target_columns = [
+            column for column in df.columns if _is_supported_numeric(column)
+        ]
+    else:
+        unknown_columns = [column for column in subset if column not in df.columns]
+        if unknown_columns:
+            raise ValueError(f"Unknown columns in subset: {unknown_columns}")
+
+        non_numeric_columns = [
+            column for column in subset if not _is_supported_numeric(column)
+        ]
+        if non_numeric_columns:
+            raise ValueError(
+                "clip_numeric only supports numeric columns: " f"{non_numeric_columns}"
+            )
+        target_columns = subset
+
+    if not target_columns:
+        return frame
+
+    clipped = df.copy()
+    clipped[target_columns] = clipped[target_columns].clip(lower=lower, upper=upper)
+    return from_pandas(clipped)
+
+
 def strip_whitespace(
     frame: ArFrame,
     *,

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -113,6 +113,45 @@ def drop_duplicates(
     return ArFrame(result)
 
 
+def drop_constant_columns(frame: ArFrame) -> ArFrame:
+    """Remove columns with exactly one unique value.
+
+    Nulls are counted as values when determining whether a column is constant.
+    This means columns like ``[None, None]`` are dropped, while columns like
+    ``[1, 1, None]`` are kept. Empty columns in zero-row frames are also kept,
+    since they have zero unique values rather than one.
+
+    If every column is dropped, the zero-column pandas result is converted back
+    to an ``ArFrame``. Arnio currently derives row count from stored columns, so
+    that converted frame may report zero rows.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+
+    Returns
+    -------
+    ArFrame
+        New frame without constant columns.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> reduced = ar.drop_constant_columns(frame)
+    """
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame)
+    if len(df.index) == 0:
+        return frame
+
+    constant_columns = [
+        column for column in df.columns if df[column].nunique(dropna=False) == 1
+    ]
+    return from_pandas(df.drop(columns=constant_columns))
+
+
 def strip_whitespace(
     frame: ArFrame,
     *,

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -424,6 +424,62 @@ def filter_rows(frame, column, op, value):
     return from_pandas(filtered) if is_arframe else filtered
 
 
+def round_numeric_columns(
+    frame,
+    *,
+    subset: list[str] | None = None,
+    decimals: int = 0,
+):
+    """Round numeric columns to specified decimal places.
+
+    Non-numeric columns included in subset are ignored safely.
+
+    Parameters
+    ----------
+    frame : ArFrame or pd.DataFrame
+        Input data frame.
+    subset : list[str], optional
+        Column names to round. If None, applies to all numeric columns.
+    decimals : int, default 0
+        Number of decimal places to round to.
+
+    Returns
+    -------
+    ArFrame or pd.DataFrame
+        New frame with numeric columns rounded.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> rounded = ar.round_numeric_columns(frame, decimals=2)
+    """
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    if subset is not None and not isinstance(subset, list):
+        raise TypeError("subset must be a list of column names")
+    if isinstance(decimals, bool) or not isinstance(decimals, int):
+        raise TypeError("decimals must be an integer")
+
+    is_arframe = not isinstance(frame, pd.DataFrame)
+    df = to_pandas(frame) if is_arframe else frame.copy()
+
+    if subset is not None:
+        missing = [col for col in subset if col not in df.columns]
+        if missing:
+            raise IndexError(f"Column not found: {missing[0]}")
+        cols_to_round = subset
+    else:
+        cols_to_round = df.select_dtypes(include=["number"]).columns
+
+    for col in cols_to_round:
+        if pd.api.types.is_numeric_dtype(df[col]):
+            df[col] = df[col].round(decimals)
+
+    return from_pandas(df) if is_arframe else df
+
+
 def safe_divide_columns(
     frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0
 ):

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -43,8 +43,9 @@ def _series_to_python_values(series: pd.Series, col_name: object) -> list[object
     for raw in series.tolist():
         if _is_nested(raw):
             raise TypeError(
-                f"Unsupported nested/complex type in column '{col_name}': "
-                f"{type(raw).__name__}"
+                f"Column '{col_name}' contains unsupported nested value "
+                f"of type '{type(raw).__name__}' at value {raw!r}. "
+                "Convert nested objects to strings or flatten them first."
             )
 
         value = _normalize_scalar(raw)

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -124,6 +124,12 @@ def to_pandas(frame: ArFrame) -> pd.DataFrame:
     return result
 
 
+def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
+    if dtype == pd.Int64Dtype():
+        return _DType.INT64
+    return None
+
+
 def from_pandas(df: pd.DataFrame) -> ArFrame:
     """Convert pandas.DataFrame to ArFrame.
 
@@ -149,10 +155,18 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
     >>> frame = ar.from_pandas(df)
     """
     columns = {}
+    dtype_hints = {}
+
     for col_name in df.columns:
         series = df[col_name]
-        columns[str(col_name)] = _series_to_python_values(series, col_name)
+        name = str(col_name)
 
-    cpp_frame = _Frame.from_dict(columns)
+        columns[name] = _series_to_python_values(series, col_name)
 
+        dtype_hint = _pandas_dtype_to_arnio(series.dtype)
+        if dtype_hint is not None:
+            dtype_hints[name] = dtype_hint
+
+    cpp_frame = _Frame.from_dict(columns, dtype_hints)
     return ArFrame(cpp_frame, attrs=copy.deepcopy(df.attrs))
+

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -5,6 +5,8 @@ Pandas conversion functions.
 
 from __future__ import annotations
 
+import copy
+
 import numpy as np
 import pandas as pd
 
@@ -77,6 +79,8 @@ def to_pandas(frame: ArFrame) -> pd.DataFrame:
     -------
     pd.DataFrame
         Equivalent pandas DataFrame with proper dtypes and null handling.
+        If the ArFrame was created via ``from_pandas()``, any ``attrs``
+        metadata from the original DataFrame is restored on the result.
 
     Examples
     --------
@@ -114,7 +118,10 @@ def to_pandas(frame: ArFrame) -> pd.DataFrame:
             series[mask] = pd.NA
             data[name] = series
 
-    return pd.DataFrame(data)
+    result = pd.DataFrame(data)
+    if frame._attrs:
+        result.attrs = copy.deepcopy(frame._attrs)
+    return result
 
 
 def from_pandas(df: pd.DataFrame) -> ArFrame:
@@ -147,4 +154,5 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
         columns[str(col_name)] = _series_to_python_values(series, col_name)
 
     cpp_frame = _Frame.from_dict(columns)
-    return ArFrame(cpp_frame)
+
+    return ArFrame(cpp_frame, attrs=copy.deepcopy(df.attrs))

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -149,7 +149,6 @@ class ArFrame:
         lines.append(f"DTypes:  {self.dtypes}")
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
-    
 
     def compare_schema(self, other: "ArFrame", strict: bool = False) -> bool:
         """Compare the schema (columns and data types) with another ArFrame.
@@ -179,8 +178,6 @@ class ArFrame:
 
         # 4. Non-Strict Mode (Step B): Map columns to verify their values share identical data types
         return all(self.dtypes[col] == other.dtypes[col] for col in self.columns)
-    
-    
 
     def preview(self, n: int = 5) -> str:
         """Return a lightweight string preview of the first ``n`` rows.

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -4,6 +4,7 @@ ArFrame — the core data container wrapping the C++ Frame.
 """
 
 from __future__ import annotations
+from email.policy import strict
 
 from ._core import _Frame
 
@@ -81,3 +82,14 @@ class ArFrame:
         lines.append(f"DTypes:  {self.dtypes}")
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
+def compare_schema(self, other: "ArFrame", strict: bool = False) -> bool:
+#Compare column names and types b/w frame
+    if not isinstance(other, ArFrame):
+        return False
+
+    if strict:
+            # Order must match exactly
+         return list(self.columns) == list(other.columns) and self.dtypes == other.dtypes
+        
+        # Order doesn't matter
+    return set(self.columns) == set(other.columns) and self.dtypes == other.dtypes

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -150,7 +150,7 @@ class ArFrame:
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
 
-    def compare_schema(self, other: "ArFrame", strict: bool = False) -> bool:
+    def compare_schema(self, other: ArFrame, strict: bool = False) -> bool:
         """Compare the schema (columns and data types) with another ArFrame.
         Parameters
         ----------

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -83,6 +83,7 @@ class ArFrame:
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
     
+
     def compare_schema(self, other: "ArFrame", strict: bool = False) -> bool:
         """Compare the schema (columns and data types) with another ArFrame.
         Parameters

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -5,7 +5,6 @@ ArFrame — the core data container wrapping the C++ Frame.
 
 from __future__ import annotations
 
-
 from ._core import _Frame
 
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -82,6 +82,7 @@ class ArFrame:
         lines.append(f"DTypes:  {self.dtypes}")
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
+    
     def compare_schema(self, other: "ArFrame", strict: bool = False) -> bool:
         """Compare the schema (columns and data types) with another ArFrame.
         Parameters
@@ -110,4 +111,5 @@ class ArFrame:
 
         # 4. Non-Strict Mode (Step B): Map columns to verify their values share identical data types
         return all(self.dtypes[col] == other.dtypes[col] for col in self.columns)
+    
     

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -4,7 +4,7 @@ ArFrame — the core data container wrapping the C++ Frame.
 """
 
 from __future__ import annotations
-from email.policy import strict
+
 
 from ._core import _Frame
 
@@ -82,14 +82,32 @@ class ArFrame:
         lines.append(f"DTypes:  {self.dtypes}")
         lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
-def compare_schema(self, other: "ArFrame", strict: bool = False) -> bool:
-#Compare column names and types b/w frame
-    if not isinstance(other, ArFrame):
-        return False
+    def compare_schema(self, other: "ArFrame", strict: bool = False) -> bool:
+        """Compare the schema (columns and data types) with another ArFrame.
+        Parameters
+        ----------
+        other : ArFrame
+            The other frame to compare against.
+        strict : bool, default False
+            If True, enforces identical column sequence/order.
+            If False, verifies column existence regardless of sequence.
 
-    if strict:
-            # Order must match exactly
-         return list(self.columns) == list(other.columns) and self.dtypes == other.dtypes
-        
-        # Order doesn't matter
-    return set(self.columns) == set(other.columns) and self.dtypes == other.dtypes
+        Returns
+        bool
+            True if schemas match, False otherwise.
+        """
+        # 1. Invalid Input Check: Safely handle non-ArFrame inputs
+        if not isinstance(other, ArFrame):
+            raise TypeError("The 'other' object must be an instance of ArFrame.")
+
+        # 2. Strict Mode: Exact matching of both column order and dtypes
+        if strict:
+            return (self.columns == other.columns) and (self.dtypes == other.dtypes)
+
+        # 3. Non-Strict Mode (Step A): Check if the column sets match completely
+        if set(self.columns) != set(other.columns):
+            return False
+
+        # 4. Non-Strict Mode (Step B): Map columns to verify their values share identical data types
+        return all(self.dtypes[col] == other.dtypes[col] for col in self.columns)
+    

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -53,6 +53,24 @@ class ArFrame:
         """
         return self._frame.dtypes()
 
+    @property
+    def is_empty(self) -> bool:
+        """Check if frame has zero rows.
+
+        Returns
+        -------
+        bool
+            True if frame contains no rows, False otherwise.
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> if frame.is_empty:
+        ...     print("No data to process")
+        False
+        """
+        return len(self) == 0
+
     # --- Methods ---
 
     def memory_usage(self) -> int:
@@ -82,7 +100,6 @@ class ArFrame:
         ------
         TypeError
             If columns is not a valid sequence of strings.
-
         ValueError
             If the selection is empty, contains duplicates,
             or includes unknown columns.

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -12,10 +12,11 @@ from ._core import _Frame
 class ArFrame:
     """Lightweight columnar data container backed by C++."""
 
-    __slots__ = ("_frame",)
+    __slots__ = ("_frame", "_attrs")
 
-    def __init__(self, cpp_frame: _Frame) -> None:
+    def __init__(self, cpp_frame: _Frame, attrs: dict | None = None) -> None:
         self._frame = cpp_frame
+        self._attrs: dict = attrs if attrs is not None else {}
 
     # --- Properties ---
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -64,6 +64,55 @@ class ArFrame:
         """
         return self._frame.memory_usage()
 
+    def select_columns(self, columns: list[str]) -> ArFrame:
+        """Return a new ArFrame with only the selected columns.
+
+        Parameters
+        ----------
+        columns : list[str]
+            List of column names to select.
+
+        Returns
+        -------
+        ArFrame
+            New ArFrame containing only the selected columns.
+
+        Raises
+        ------
+        TypeError
+            If columns is not a valid sequence of strings.
+
+        ValueError
+            If the selection is empty, contains duplicates,
+            or includes unknown columns.
+        """
+        if isinstance(columns, str):
+            raise TypeError("columns must be a sequence of column names, not a string.")
+
+        if not isinstance(columns, (list, tuple)):
+            raise TypeError("columns must be a list or tuple of column names.")
+
+        if not columns:
+            raise ValueError("Column selection cannot be empty.")
+
+        if any(not isinstance(col, str) for col in columns):
+            raise TypeError("All column names must be strings.")
+
+        if len(columns) != len(set(columns)):
+            raise ValueError("Duplicate column names are not allowed.")
+
+        missing = [col for col in columns if col not in self.columns]
+
+        if missing:
+            raise ValueError(f"Unknown columns: {missing}")
+
+        from .convert import from_pandas, to_pandas
+
+        df = to_pandas(self)
+        selected_df = df[columns]
+
+        return from_pandas(selected_df)
+
     # --- Dunder methods ---
 
     def __len__(self) -> int:

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -163,3 +163,71 @@ class ArFrame:
         return all(self.dtypes[col] == other.dtypes[col] for col in self.columns)
     
     
+
+    def preview(self, n: int = 5) -> str:
+        """Return a lightweight string preview of the first ``n`` rows.
+
+        Reads only the first ``n`` rows directly from the C++ frame without
+        triggering a full pandas conversion, making it safe to call on very
+        large frames from the CLI or a notebook.
+
+        Parameters
+        ----------
+        n : int, optional
+            Number of rows to preview. Must be a positive integer.
+            Defaults to 5.
+
+        Returns
+        -------
+        str
+            A formatted string table showing the first ``n`` rows.
+
+        Raises
+        ------
+        ValueError
+            If ``n`` is not a positive integer.
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> print(frame.preview())       # first 5 rows
+        >>> print(frame.preview(n=10))   # first 10 rows
+        """
+        if isinstance(n, bool) or not isinstance(n, int) or n < 1:
+            raise ValueError(f"`n` must be a positive integer, got {n!r}")
+
+        num_rows, num_cols = self.shape
+
+        if num_rows == 0:
+            return "ArFrame preview: (empty frame)"
+
+        actual_n = min(n, num_rows)
+
+        # Pull only the first `actual_n` values per column — no full conversion
+        col_names = self.columns
+        col_data = [
+            [self._frame.column_by_index(i).at(r) for r in range(actual_n)]
+            for i in range(num_cols)
+        ]
+
+        # Calculate column widths for alignment
+        col_widths = [
+            max(
+                len(col_names[i]),
+                max((len(str(col_data[i][r])) for r in range(actual_n)), default=0),
+            )
+            for i in range(num_cols)
+        ]
+
+        # Build header and separator
+        header = "  ".join(col_names[i].ljust(col_widths[i]) for i in range(num_cols))
+        separator = "  ".join("-" * col_widths[i] for i in range(num_cols))
+
+        # Build rows
+        rows = [
+            "  ".join(str(col_data[i][r]).ljust(col_widths[i]) for i in range(num_cols))
+            for r in range(actual_n)
+        ]
+
+        label = f"ArFrame preview (showing {actual_n} of {num_rows} rows):"
+        return "\n".join([label, header, separator] + rows)

--- a/arnio/integrations/__init__.py
+++ b/arnio/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Integration helpers for the Python data ecosystem."""
+
+from .pandas import ArnioPandasAccessor
+
+__all__ = ["ArnioPandasAccessor"]

--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -1,0 +1,88 @@
+"""Pandas DataFrame accessor for Arnio workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import pandas as pd
+
+from arnio.convert import from_pandas, to_pandas
+from arnio.frame import ArFrame
+from arnio.pipeline import pipeline as run_pipeline
+from arnio.quality import DataQualityReport, auto_clean, profile, suggest_cleaning
+from arnio.schema import Schema, ValidationResult, validate
+
+
+@pd.api.extensions.register_dataframe_accessor("arnio")
+class ArnioPandasAccessor:
+    """Run Arnio preparation helpers from an existing pandas DataFrame."""
+
+    def __init__(self, pandas_obj: pd.DataFrame) -> None:
+        self._df = pandas_obj
+
+    def to_arframe(self) -> ArFrame:
+        """Convert the DataFrame into an Arnio frame."""
+        return from_pandas(self._df)
+
+    def pipeline(self, steps: Sequence[Any]) -> pd.DataFrame:
+        """Run an Arnio pipeline and return a pandas DataFrame."""
+        frame = self.to_arframe()
+        return to_pandas(run_pipeline(frame, steps))
+
+    def clean(
+        self,
+        steps: Sequence[Any] | None = None,
+        *,
+        strip_whitespace: bool = True,
+        drop_nulls: bool = False,
+        drop_duplicates: bool = False,
+    ) -> pd.DataFrame:
+        """Clean a DataFrame with Arnio and return pandas output.
+
+        When ``steps`` is provided, it is passed directly to ``ar.pipeline``.
+        Otherwise this uses Arnio's convenience ``clean`` behavior.
+        """
+        if steps is not None:
+            return self.pipeline(steps)
+
+        from arnio.cleaning import clean
+
+        frame = clean(
+            self.to_arframe(),
+            strip_whitespace=strip_whitespace,
+            drop_nulls=drop_nulls,
+            drop_duplicates=drop_duplicates,
+        )
+        return to_pandas(frame)
+
+    def profile(self, *, sample_size: int = 5) -> DataQualityReport:
+        """Profile DataFrame quality with Arnio."""
+        return profile(self.to_arframe(), sample_size=sample_size)
+
+    def suggest_cleaning(self) -> list[tuple[str, dict[str, Any]]]:
+        """Return Arnio pipeline-compatible cleaning suggestions."""
+        return suggest_cleaning(self.to_arframe())
+
+    def auto_clean(
+        self,
+        *,
+        mode: str = "safe",
+        return_report: bool = False,
+    ) -> pd.DataFrame | tuple[pd.DataFrame, DataQualityReport]:
+        """Run Arnio's automatic cleaning and return pandas output."""
+        result = auto_clean(
+            self.to_arframe(),
+            mode=mode,
+            return_report=return_report,
+        )
+
+        if return_report:
+            frame, report = result
+            return to_pandas(frame), report
+
+        return to_pandas(result)
+
+    def validate(self, schema: Schema | dict[str, Any]) -> ValidationResult:
+        """Validate the DataFrame against an Arnio schema."""
+        return validate(self.to_arframe(), schema)

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -118,6 +118,12 @@ def read_csv(
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
 
+    try:
+        if os.path.getsize(path) == 0:
+            raise CsvReadError(f"CSV file is empty: {path!r}")
+    except FileNotFoundError:
+        pass  # Let C++ backend handle or raise standard error
+
     config = _CsvConfig()
     config.delimiter = delimiter
     config.has_header = has_header
@@ -198,6 +204,12 @@ def scan_csv(
                 raise CsvReadError(
                     "CSV input contains NUL bytes and appears to be binary or corrupted"
                 )
+    except FileNotFoundError:
+        pass  # Let C++ backend handle or raise standard error
+    try:
+        if os.path.getsize(path) == 0:
+            raise CsvReadError(f"CSV file is empty: {path!r}")
+
     except FileNotFoundError:
         pass
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -15,6 +15,11 @@ from .exceptions import CsvReadError
 from .frame import ArFrame
 
 
+def _is_utf8_encoding(encoding: str) -> bool:
+    """Return whether the encoding should be treated as raw UTF-8 input."""
+    return encoding.lower().replace("_", "-") in {"utf-8", "utf8"}
+
+
 @contextmanager
 def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
     """Return a UTF-8 file path for the C++ reader.
@@ -23,7 +28,7 @@ def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
     transcode through a temporary UTF-8 file so the public encoding parameter is
     honored without leaking platform-specific decoding behavior through pybind.
     """
-    if encoding.lower().replace("_", "-") in {"utf-8", "utf8"}:
+    if _is_utf8_encoding(encoding):
         yield path
         return
 
@@ -109,14 +114,15 @@ def read_csv(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
 
-    try:
-        with open(path, "rb") as f:
-            if b"\0" in f.read(1024):
-                raise CsvReadError(
-                    "CSV input contains NUL bytes and appears to be binary or corrupted"
-                )
-    except FileNotFoundError:
-        pass  # Let C++ backend handle or raise standard error
+    if _is_utf8_encoding(encoding):
+        try:
+            with open(path, "rb") as f:
+                if b"\0" in f.read(1024):
+                    raise CsvReadError(
+                        "CSV input contains NUL bytes and appears to be binary or corrupted"
+                    )
+        except FileNotFoundError:
+            pass  # Let C++ backend handle or raise standard error
 
     try:
         if os.path.getsize(path) == 0:
@@ -198,14 +204,15 @@ def scan_csv(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
 
-    try:
-        with open(path, "rb") as f:
-            if b"\0" in f.read(1024):
-                raise CsvReadError(
-                    "CSV input contains NUL bytes and appears to be binary or corrupted"
-                )
-    except FileNotFoundError:
-        pass  # Let C++ backend handle or raise standard error
+    if _is_utf8_encoding(encoding):
+        try:
+            with open(path, "rb") as f:
+                if b"\0" in f.read(1024):
+                    raise CsvReadError(
+                        "CSV input contains NUL bytes and appears to be binary or corrupted"
+                    )
+        except FileNotFoundError:
+            pass  # Let C++ backend handle or raise standard error
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -60,6 +60,7 @@ def read_csv(
     usecols: list[str] | None = None,
     nrows: int | None = None,
     encoding: str = "utf-8",
+    trim_headers: bool = True,
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -77,6 +78,8 @@ def read_csv(
         Number of rows to read. If None, reads all rows.
     encoding : str, default "utf-8"
         File encoding.
+    trim_headers : bool, default True
+        Strip leading/trailing whitespace from column names.
 
     Returns
     -------
@@ -119,6 +122,7 @@ def read_csv(
     config.delimiter = delimiter
     config.has_header = has_header
     config.encoding = encoding
+    config.trim_headers = trim_headers
 
     if usecols is not None:
         config.usecols = usecols
@@ -143,6 +147,7 @@ def scan_csv(
     *,
     delimiter: str = ",",
     encoding: str = "utf-8",
+    trim_headers: bool = True,
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
 
@@ -154,6 +159,8 @@ def scan_csv(
         Field delimiter character.
     encoding : str, default "utf-8"
         File encoding. Non-UTF-8 inputs are transcoded before native scanning.
+    trim_headers : bool, default True
+        Strip leading/trailing whitespace from column names.
 
     Returns
     -------
@@ -197,6 +204,7 @@ def scan_csv(
     config = _CsvConfig()
     config.delimiter = delimiter
     config.encoding = encoding
+    config.trim_headers = trim_headers
     reader = _CsvReader(config)
     try:
         with _utf8_csv_path(path, encoding) as native_path:

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -123,3 +123,5 @@ def pipeline(
 
 
 register_step("filter_rows", cleaning.filter_rows)
+
+register_step("safe_divide_columns", cleaning.safe_divide_columns)

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -14,6 +14,7 @@ from .frame import ArFrame
 _STEP_REGISTRY: dict[str, Callable] = {
     "drop_nulls": cleaning.drop_nulls,
     "fill_nulls": cleaning.fill_nulls,
+    "validate_columns_exist": cleaning.validate_columns_exist,
     "drop_duplicates": cleaning.drop_duplicates,
     "drop_constant_columns": cleaning.drop_constant_columns,
     "clip_numeric": cleaning.clip_numeric,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -16,6 +16,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "fill_nulls": cleaning.fill_nulls,
     "drop_duplicates": cleaning.drop_duplicates,
     "drop_constant_columns": cleaning.drop_constant_columns,
+    "clip_numeric": cleaning.clip_numeric,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -21,6 +21,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
+    "round_numeric_columns": cleaning.round_numeric_columns,
 }
 
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -15,6 +15,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "drop_nulls": cleaning.drop_nulls,
     "fill_nulls": cleaning.fill_nulls,
     "drop_duplicates": cleaning.drop_duplicates,
+    "drop_constant_columns": cleaning.drop_constant_columns,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -149,9 +149,14 @@ def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
     Examples
     --------
     >>> frame = ar.read_csv("raw.csv")
-    >>> report = ar.profile(frame)
+    >>> report = ar.profile(frame, sample_size=3)
     >>> report.summary()
     """
+    if not isinstance(sample_size, int) or isinstance(sample_size, bool):
+        raise TypeError("sample_size must be an integer")
+    if sample_size < 0:
+        raise ValueError("sample_size must be non-negative")
+
     df = to_pandas(frame)
     row_count, column_count = frame.shape
     duplicate_rows = int(df.duplicated().sum()) if row_count else 0

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -88,19 +88,27 @@ class ValidationResult:
         }
 
     def summary(self) -> dict[str, Any]:
-        """Return a compact validation summary."""
+        """Return a compact validation summary.
+
+        Severity counts are not included because ``ValidationIssue`` does not
+        currently carry severity information.
+        """
         by_rule: dict[str, int] = {}
         by_column: dict[str, int] = {}
+        by_column_and_rule: dict[str, dict[str, int]] = {}
         for issue in self.issues:
             by_rule[issue.rule] = by_rule.get(issue.rule, 0) + 1
             if issue.column is not None:
                 by_column[issue.column] = by_column.get(issue.column, 0) + 1
+                column_rules = by_column_and_rule.setdefault(issue.column, {})
+                column_rules[issue.rule] = column_rules.get(issue.rule, 0) + 1
         return {
             "passed": self.passed,
             "issue_count": self.issue_count,
             "bad_row_count": len(self.bad_rows),
             "issues_by_rule": by_rule,
             "issues_by_column": by_column,
+            "issues_by_column_and_rule": by_column_and_rule,
         }
 
     def to_pandas(self) -> pd.DataFrame:

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -107,6 +107,65 @@ class ValidationResult:
         """Return issues as a pandas DataFrame."""
         return pd.DataFrame([issue.to_dict() for issue in self.issues])
 
+    def to_markdown(self, *, max_issues: int | None = None) -> str:
+        """Return a GitHub-friendly Markdown validation report.
+
+        Parameters
+        ----------
+        max_issues : int, optional
+            Maximum number of issues to include in the table. When omitted, all
+            issues are shown.
+        """
+        if max_issues is not None and (
+            not isinstance(max_issues, int) or isinstance(max_issues, bool)
+        ):
+            raise TypeError("max_issues must be an integer or None")
+        if max_issues is not None and max_issues < 0:
+            raise ValueError("max_issues must be non-negative")
+
+        status = "passed" if self.passed else "failed"
+        lines = [
+            "## Validation Report",
+            "",
+            f"- Status: **{status}**",
+            f"- Rows checked: {self.row_count}",
+            f"- Issues found: {self.issue_count}",
+            f"- Bad rows: {len(self.bad_rows)}",
+        ]
+
+        if self.passed:
+            return "\n".join(lines)
+
+        visible_issues = self.issues if max_issues is None else self.issues[:max_issues]
+        if not visible_issues:
+            lines.extend(["", "_Issue table omitted by `max_issues=0`._"])
+            return "\n".join(lines)
+
+        lines.extend(
+            [
+                "",
+                "| Column | Rule | Row | Value | Message |",
+                "| --- | --- | ---: | --- | --- |",
+            ]
+        )
+        for issue in visible_issues:
+            lines.append(
+                "| "
+                f"{_markdown_cell(issue.column)} | "
+                f"{_markdown_cell(issue.rule)} | "
+                f"{_markdown_cell(issue.row_index)} | "
+                f"{_markdown_cell(_clean_scalar(issue.value))} | "
+                f"{_markdown_cell(issue.message)} |"
+            )
+
+        hidden_count = self.issue_count - len(visible_issues)
+        if hidden_count > 0:
+            lines.extend(
+                ["", f"_Showing {len(visible_issues)} of {self.issue_count} issues._"]
+            )
+
+        return "\n".join(lines)
+
 
 def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationResult:
     """Validate an ArFrame against a schema.
@@ -401,6 +460,13 @@ def _clean_scalar(value: Any) -> Any:
     if hasattr(value, "item"):
         return value.item()
     return value
+
+
+def _markdown_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).replace("\n", "<br>").replace("|", "\\|")
+    return text
 
 
 _SEMANTIC_PATTERNS = {

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -5,16 +5,40 @@ Run: python benchmarks/benchmark_vs_pandas.py
 
 import time
 import tracemalloc
+from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
 
 import arnio as ar
 
 CSV_FILE = "benchmarks/benchmark_1m.csv"
+WIDE_CSV_FILE = "benchmarks/benchmark_wide.csv"
 RUNS = 3
 
 
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    path: str
+
+
+BENCHMARKS = (
+    BenchmarkCase("Tall CSV (1,000,000 rows x 12 columns)", CSV_FILE),
+    BenchmarkCase("Wide CSV (5,000 rows x 256 columns)", WIDE_CSV_FILE),
+)
+
+
+def ensure_dataset_exists(path):
+    if not Path(path).exists():
+        raise FileNotFoundError(
+            f"Missing benchmark dataset: {path}. "
+            "Run `python benchmarks/generate_data.py` first."
+        )
+
+
 def benchmark_pandas(path):
+    ensure_dataset_exists(path)
     tracemalloc.start()
     t0 = time.perf_counter()
 
@@ -22,9 +46,8 @@ def benchmark_pandas(path):
     df.columns = df.columns.str.strip()
     df = df.dropna()
     df = df.drop_duplicates()
-    for col in ["name", "city", "active", "category", "region"]:
-        if col in df.columns:
-            df[col] = df[col].astype(str).str.strip().str.lower()
+    for col in df.select_dtypes(include=["object", "string"]).columns:
+        df[col] = df[col].astype(str).str.strip().str.lower()
 
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
@@ -33,6 +56,7 @@ def benchmark_pandas(path):
 
 
 def benchmark_arnio(path):
+    ensure_dataset_exists(path)
     tracemalloc.start()
     t0 = time.perf_counter()
 
@@ -54,7 +78,12 @@ def benchmark_arnio(path):
     return elapsed, peak / 1024 / 1024
 
 
-if __name__ == "__main__":
+def avg(values):
+    return sum(values) / len(values)
+
+
+def run_case(case):
+    print(case.name)
     print(f"{'Metric':<20} {'pandas':>12} {'arnio':>12}")
     print("-" * 46)
 
@@ -62,18 +91,21 @@ if __name__ == "__main__":
     pd_rams, ar_rams = [], []
 
     for i in range(RUNS):
-        pt, pr = benchmark_pandas(CSV_FILE)
-        at, ar_r = benchmark_arnio(CSV_FILE)
+        pt, pr = benchmark_pandas(case.path)
+        at, ar_r = benchmark_arnio(case.path)
         pd_times.append(pt)
         ar_times.append(at)
         pd_rams.append(pr)
         ar_rams.append(ar_r)
-
-    def avg(x):
-        return sum(x) / len(x)
 
     print(f"{'Exec Time (avg)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s")
     print(f"{'Peak RAM':<20} {avg(pd_rams):>10.0f}MB {avg(ar_rams):>10.0f}MB")
     print(
         f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams)/avg(pd_rams))*100:.0f}% reduction"
     )
+    print()
+
+
+if __name__ == "__main__":
+    for benchmark_case in BENCHMARKS:
+        run_case(benchmark_case)

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -1,10 +1,13 @@
-"""Generate synthetic benchmark CSV — run this before benchmarking."""
+"""Generate deterministic benchmark CSV files before benchmarking."""
 
 import numpy as np
 import pandas as pd
 
+DEFAULT_TALL_PATH = "benchmarks/benchmark_1m.csv"
+DEFAULT_WIDE_PATH = "benchmarks/benchmark_wide.csv"
 
-def generate(rows=1_000_000, path="benchmarks/benchmark_1m.csv"):
+
+def generate(rows=1_000_000, path=DEFAULT_TALL_PATH):
     rng = np.random.default_rng(42)
     df = pd.DataFrame(
         {
@@ -32,5 +35,43 @@ def generate(rows=1_000_000, path="benchmarks/benchmark_1m.csv"):
     print(f"Generated {rows:,} row CSV -> {path}")
 
 
+def generate_wide(rows=5_000, columns=256, path=DEFAULT_WIDE_PATH):
+    if rows < 1:
+        raise ValueError("wide benchmark requires at least 1 row")
+    if columns < 4:
+        raise ValueError("wide benchmark requires at least 4 columns")
+
+    rng = np.random.default_rng(252)
+    data = {"row_id": np.arange(rows)}
+
+    for index in range(columns - 1):
+        column_id = f"{index:03d}"
+        kind = index % 4
+
+        if kind == 0:
+            data[f"metric_{column_id}"] = rng.normal(1_000, 250, rows).round(4)
+        elif kind == 1:
+            values = rng.choice(
+                ["  alpha", "BETA  ", " gamma", "DELTA ", None],
+                rows,
+            )
+            values[0] = "  alpha"
+            data[f"label_{column_id}"] = values
+        elif kind == 2:
+            values = rng.choice(
+                ["true", "false", "TRUE", "FALSE", None],
+                rows,
+            )
+            values[0] = "true"
+            data[f"flag_{column_id}"] = values
+        else:
+            data[f"amount_{column_id}"] = rng.uniform(0, 10_000, rows).round(2)
+
+    df = pd.DataFrame(data)
+    df.to_csv(path, index=False, lineterminator="\n")
+    print(f"Generated {rows:,} row x {columns:,} column CSV -> {path}")
+
+
 if __name__ == "__main__":
     generate()
+    generate_wide()

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -154,49 +154,62 @@ PYBIND11_MODULE(_arnio_cpp, m) {
             py::return_value_policy::reference_internal)
         .def("add_column", &Frame::add_column)
         .def("clone", &Frame::clone)
-        .def_static("from_dict", [](py::dict cols_dict) {
-            Frame frame;
-            for (auto item : cols_dict) {
-                std::string name = py::cast<std::string>(item.first);
-                py::list values = py::cast<py::list>(item.second);
+        .def_static("from_dict",
+                    [](py::dict cols_dict, py::dict dtype_hints) {
+                        Frame frame;
 
-                DType dtype = DType::STRING;
-                for (auto val : values) {
-                    if (val.is_none()) continue;
-                    if (py::isinstance<py::bool_>(val)) {
-                        dtype = DType::BOOL;
-                        break;
-                    }
-                    if (py::isinstance<py::int_>(val)) {
-                        dtype = DType::INT64;
-                        break;
-                    }
-                    if (py::isinstance<py::float_>(val)) {
-                        dtype = DType::FLOAT64;
-                        break;
-                    }
-                    break;
-                }
+                        for (auto item : cols_dict) {
+                            std::string name = py::cast<std::string>(item.first);
+                            py::list values = py::cast<py::list>(item.second);
 
-                Column col(name, dtype);
-                for (auto val : values) {
-                    if (val.is_none()) {
-                        col.push_null();
-                        continue;
-                    }
-                    if (dtype == DType::BOOL)
-                        col.push_back(val.cast<bool>());
-                    else if (dtype == DType::INT64)
-                        col.push_back(val.cast<int64_t>());
-                    else if (dtype == DType::FLOAT64)
-                        col.push_back(val.cast<double>());
-                    else
-                        col.push_back(py::str(val).cast<std::string>());
-                }
-                frame.add_column(col);
-            }
-            return frame;
-        });
+                            DType dtype = DType::STRING;
+                            py::str py_name(name);
+
+                            if (dtype_hints.contains(py_name)) {
+                                dtype = dtype_hints[py_name].cast<DType>();
+                            } else {
+                                for (auto val : values) {
+                                    if (val.is_none()) continue;
+                                    if (py::isinstance<py::bool_>(val)) {
+                                        dtype = DType::BOOL;
+                                        break;
+                                    }
+                                    if (py::isinstance<py::int_>(val)) {
+                                        dtype = DType::INT64;
+                                        break;
+                                    }
+                                    if (py::isinstance<py::float_>(val)) {
+                                        dtype = DType::FLOAT64;
+                                        break;
+                                    }
+                                    break;
+                                }
+                            }
+
+                            Column col(name, dtype);
+                            for (auto val : values) {
+                                if (val.is_none()) {
+                                    col.push_null();
+                                    continue;
+                                }
+
+                                if (dtype == DType::BOOL)
+                                    col.push_back(val.cast<bool>());
+                                else if (dtype == DType::INT64)
+                                    col.push_back(val.cast<int64_t>());
+                                else if (dtype == DType::FLOAT64)
+                                    col.push_back(val.cast<double>());
+                                else
+                                    col.push_back(py::str(val).cast<std::string>());
+                            }
+
+                            frame.add_column(col);
+                        }
+
+                        return frame;
+                    },
+                    py::arg("cols_dict"),
+                    py::arg("dtype_hints") = py::dict());
 
     // --- CsvReader ---
     py::class_<CsvConfig>(m, "CsvConfig")

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -205,7 +205,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("has_header", &CsvConfig::has_header)
         .def_readwrite("usecols", &CsvConfig::usecols)
         .def_readwrite("nrows", &CsvConfig::nrows)
-        .def_readwrite("encoding", &CsvConfig::encoding);
+        .def_readwrite("encoding", &CsvConfig::encoding)
+        .def_readwrite("trim_headers", &CsvConfig::trim_headers);
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -16,6 +16,7 @@ struct CsvConfig {
     std::optional<std::vector<std::string>> usecols = std::nullopt;
     std::optional<size_t> nrows = std::nullopt;
     std::string encoding = "utf-8";  // Currently only utf-8 supported
+    bool trim_headers = true;        // for implementing the trim_headers option
 };
 
 class CsvReader {

--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -278,8 +278,12 @@ Frame normalize_case(const Frame& frame, const std::optional<std::vector<std::st
         transform_fn = [](const std::string& s) {
             std::string result = s;
             bool next_upper = true;
+            auto is_word_boundary = [](char c) -> bool {
+                return std::isspace(static_cast<unsigned char>(c)) ||
+                       c == '-' || c == '_' || c == '.' || c == '/';
+            };
             for (auto& c : result) {
-                if (std::isspace(static_cast<unsigned char>(c))) {
+                if (is_word_boundary(c)) {
                     next_upper = true;
                 } else if (next_upper) {
                     c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -202,7 +202,7 @@ Frame CsvReader::read(const std::string& path) const {
         strip_utf8_bom(line);
         header = parse_line(line);
         for (auto& h : header) {
-            trim_in_place(h);
+            if (config_.trim_headers) trim_in_place(h);
         }
         validate_header(header);
     }
@@ -290,7 +290,7 @@ std::unordered_map<std::string, std::string> CsvReader::scan_schema(const std::s
         strip_utf8_bom(line);
         header = parse_line(line);
         for (auto& h : header) {
-            trim_in_place(h);
+            if (config_.trim_headers) trim_in_place(h);
         }
         validate_header(header);
     }

--- a/examples/auto_clean_tutorial.py
+++ b/examples/auto_clean_tutorial.py
@@ -1,0 +1,48 @@
+"""
+Beginner-friendly data quality walkthrough for Arnio.
+
+This example shows a small messy input, the profiling signals Arnio reports,
+the suggested cleaning steps, and the difference between safe and strict
+auto-cleaning.
+"""
+
+import pandas as pd
+
+import arnio as ar
+
+
+def main():
+    raw = pd.DataFrame(
+        {
+            "order_id": [1001, 1002, 1002, 1003, 1004],
+            "customer": [" Ishan ", " Prasoon ", " Prasoon ", " Pranay ", " Dhruv "],
+            "city": [" Paris ", "London", "London", " New York ", " Tokyo "],
+        }
+    )
+
+    frame = ar.from_pandas(raw)
+
+    print("--- Messy Input ---")
+    print(raw)
+
+    report = ar.profile(frame)
+    summary = report.summary()
+    suggestions = ar.suggest_cleaning(frame)
+
+    print("\n--- Profiling Summary ---")
+    print(summary)
+
+    print("\n--- Suggested Cleaning Steps ---")
+    print(suggestions)
+
+    safe = ar.auto_clean(frame)
+    print("\n--- auto_clean(mode='safe') ---")
+    print(ar.to_pandas(safe))
+
+    strict = ar.auto_clean(frame, mode="strict")
+    print("\n--- auto_clean(mode='strict') ---")
+    print(ar.to_pandas(strict))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "arnio"
 version = "1.2.0"
-description = "C++ accelerated CSV preprocessing and data cleaning for pandas"
+description = "C++ accelerated data preparation for pandas and the Python data stack"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9"
 authors = [
     { name = "Anish Raj", email = "anishrajyadav97@gmail.com" }
 ]
-keywords = ["pandas", "csv", "data-cleaning", "preprocessing", "c++", "performance"]
+keywords = ["pandas", "csv", "data-cleaning", "preprocessing", "data-quality", "schema-validation", "c++", "performance"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "arnio"
-version = "1.3.1"
+version = "1.4.0"
 description = "C++ accelerated data preparation for pandas and the Python data stack"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "arnio"
-version = "1.5.0"
+version = "1.5.1"
 description = "C++ accelerated data preparation for pandas and the Python data stack"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "arnio"
-version = "1.1.1"
+version = "1.2.0"
 description = "C++ accelerated CSV preprocessing and data cleaning for pandas"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "arnio"
-version = "1.4.0"
+version = "1.5.0"
 description = "C++ accelerated data preparation for pandas and the Python data stack"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "arnio"
-version = "1.3.0"
+version = "1.3.1"
 description = "C++ accelerated data preparation for pandas and the Python data stack"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "arnio"
-version = "1.2.0"
+version = "1.3.0"
 description = "C++ accelerated data preparation for pandas and the Python data stack"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/smoke_wheel_install.py
+++ b/tests/smoke_wheel_install.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+def run(cmd: list[str], *, cwd: Path | None = None) -> None:
+    print("+", " ".join(cmd), flush=True)
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def venv_python(env_dir: Path) -> Path:
+    if os.name == "nt":
+        return env_dir / "Scripts" / "python.exe"
+    return env_dir / "bin" / "python"
+
+
+def installed_wheel_from_report(report_path: Path) -> str | None:
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+
+    for item in data.get("install", []):
+        metadata = item.get("metadata", {})
+        name = str(metadata.get("name", "")).lower()
+
+        if name != "arnio":
+            continue
+
+        url = item.get("download_info", {}).get("url")
+        if not url:
+            return None
+
+        parsed = urlparse(url)
+        if parsed.scheme == "file":
+            return Path(unquote(parsed.path)).name
+
+        return url
+
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Smoke test that a built arnio wheel installs and imports."
+    )
+    parser.add_argument(
+        "--wheelhouse",
+        default="wheelhouse",
+        help="Directory containing built .whl files.",
+    )
+    args = parser.parse_args()
+
+    wheelhouse = Path(args.wheelhouse).resolve()
+    wheels = sorted(wheelhouse.glob("*.whl"))
+
+    if not wheels:
+        raise SystemExit(f"No wheels found in {wheelhouse}")
+
+    print(f"Wheelhouse: {wheelhouse}")
+    print("Available wheels:")
+    for wheel in wheels:
+        print(f"  - {wheel.name}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        env_dir = tmp_dir / "smoke-venv"
+        report_path = tmp_dir / "pip-install-report.json"
+
+        venv.EnvBuilder(with_pip=True).create(env_dir)
+        python = venv_python(env_dir)
+
+        run([str(python), "-m", "pip", "install", "--upgrade", "pip"])
+        run([str(python), "-m", "pip", "install", "pandas>=1.5", "numpy>=1.23"])
+
+        run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--no-index",
+                "--find-links",
+                str(wheelhouse),
+                "--report",
+                str(report_path),
+                "arnio",
+            ]
+        )
+
+        selected_wheel = installed_wheel_from_report(report_path)
+
+        if selected_wheel is None:
+            raise SystemExit(
+                "Could not determine which arnio wheel was installed from pip report."
+            )
+
+        print(f"Selected wheel installed from wheelhouse: {selected_wheel}")
+
+        import_check = (
+            "import arnio as ar; "
+            "print('arnio import ok:', ar.__version__); "
+            "assert hasattr(ar, 'read_csv'); "
+            "assert hasattr(ar, 'pipeline'); "
+            "assert hasattr(ar, 'to_pandas')"
+        )
+
+        run([str(python), "-c", import_check], cwd=tmp_dir)
+
+    print("Wheel install smoke test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,72 @@
+"""Tests for benchmark dataset helpers."""
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+from benchmarks import benchmark_vs_pandas
+from benchmarks.generate_data import generate, generate_wide
+
+
+def test_generate_tall_benchmark_csv_shape(tmp_path):
+    csv_path = tmp_path / "benchmark_tall.csv"
+
+    generate(rows=5, path=csv_path)
+
+    df = pd.read_csv(csv_path)
+    assert df.shape == (5, 12)
+    assert list(df.columns) == [
+        "id",
+        "name",
+        "revenue",
+        "age",
+        "city",
+        "score",
+        "active",
+        "category",
+        "visits",
+        "amount",
+        "region",
+        "code",
+    ]
+
+
+def test_generate_wide_benchmark_csv_round_trips_through_arnio(tmp_path):
+    csv_path = tmp_path / "benchmark_wide.csv"
+
+    generate_wide(rows=4, columns=9, path=csv_path)
+
+    pandas_df = pd.read_csv(csv_path)
+    frame = ar.read_csv(csv_path)
+    arnio_df = ar.to_pandas(frame)
+
+    assert pandas_df.shape == (4, 9)
+    assert frame.shape == (4, 9)
+    assert arnio_df.shape == (4, 9)
+    assert arnio_df.columns.tolist() == pandas_df.columns.tolist()
+    assert ar.scan_csv(csv_path).keys() == set(pandas_df.columns)
+
+
+def test_generate_wide_rejects_too_few_columns(tmp_path):
+    csv_path = tmp_path / "too_narrow.csv"
+
+    with pytest.raises(ValueError, match="at least 4 columns"):
+        generate_wide(rows=4, columns=3, path=csv_path)
+
+
+def test_run_case_benchmarks_the_selected_case_path(monkeypatch):
+    seen_paths = []
+
+    def fake_benchmark(path):
+        seen_paths.append(path)
+        return 1.0, 1.0
+
+    monkeypatch.setattr(benchmark_vs_pandas, "RUNS", 2)
+    monkeypatch.setattr(benchmark_vs_pandas, "benchmark_pandas", fake_benchmark)
+    monkeypatch.setattr(benchmark_vs_pandas, "benchmark_arnio", fake_benchmark)
+
+    benchmark_vs_pandas.run_case(
+        benchmark_vs_pandas.BenchmarkCase("Wide fixture", "wide.csv")
+    )
+
+    assert seen_paths == ["wide.csv", "wide.csv", "wide.csv", "wide.csv"]

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -336,3 +336,79 @@ class TestCleanAPI:
         # Drop nulls
         result = ar.clean(frame, strip_whitespace=False, drop_nulls=True)
         assert len(result) < len(frame)
+
+
+class TestSafeDivideColumns:
+    def test_normal_division(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n200,100\n300,150\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 2.0
+        assert df["ratio"].iloc[1] == 2.0
+        assert df["ratio"].iloc[2] == 2.0
+
+    def test_division_by_zero(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,0\n200,100\n300,0\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 0.0
+        assert df["ratio"].iloc[2] == 0.0
+
+    def test_null_inputs(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,\n200,100\n300,\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 0.0
+        assert df["ratio"].iloc[2] == 0.0
+
+    def test_missing_numerator_column(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+        with pytest.raises(ValueError, match="Numerator column"):
+            ar.safe_divide_columns(
+                frame,
+                numerator="nonexistent",
+                denominator="cost",
+                output_column="ratio",
+            )
+
+    def test_missing_denominator_column(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+        with pytest.raises(ValueError, match="Denominator column"):
+            ar.safe_divide_columns(
+                frame,
+                numerator="revenue",
+                denominator="nonexistent",
+                output_column="ratio",
+            )
+
+    def test_output_column_already_exists(self, tmp_path):
+        import warnings
+
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost,ratio\n100,50,99\n200,100,99\n")
+        frame = ar.read_csv(path)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = ar.safe_divide_columns(
+                frame, numerator="revenue", denominator="cost", output_column="ratio"
+            )
+            assert len(w) == 1
+            assert "already exists" in str(w[0].message)
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 2.0

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -338,6 +338,96 @@ class TestCleanAPI:
         assert len(result) < len(frame)
 
 
+class TestRoundNumericColumns:
+    def test_round_all_numeric(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, 2.456], "b": [3.789, 4.0]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, decimals=1)
+        result_df = ar.to_pandas(result)
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["b"]) == [3.8, 4.0]
+
+    def test_round_subset(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, 2.456], "b": [3.789, 4.0]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, subset=["a"], decimals=1)
+        result_df = ar.to_pandas(result)
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["b"]) == [3.789, 4.0]
+
+    def test_round_mixed_types(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, 2.456], "c": ["str1", "str2"]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, decimals=1)
+        result_df = ar.to_pandas(result)
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["c"]) == ["str1", "str2"]
+
+    def test_missing_column(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(IndexError, match="Column not found"):
+            ar.round_numeric_columns(frame, subset=["missing_col"])
+
+    def test_with_nulls(self):
+        import numpy as np
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, np.nan, 2.456]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, decimals=1)
+        result_df = ar.to_pandas(result)
+        assert result_df["a"].isna().iloc[1]
+        assert result_df["a"].iloc[0] == 1.1
+        assert result_df["a"].iloc[2] == 2.5
+
+    def test_invalid_subset_type(self):
+        import pandas as pd
+        import pytest
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="subset must be a list"):
+            ar.round_numeric_columns(frame, subset="a")
+
+    def test_invalid_decimals_type(self):
+        import pandas as pd
+        import pytest
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="decimals must be an integer"):
+            ar.round_numeric_columns(frame, decimals="2")
+
+    def test_decimals_rejects_bool(self):
+        import pandas as pd
+        import pytest
+
+        df = pd.DataFrame({"a": [1.123]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="decimals must be an integer"):
+            ar.round_numeric_columns(frame, decimals=True)
+
+    def test_round_subset_with_non_numeric(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"name": ["john"], "score": [98.765]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(frame, subset=["name", "score"], decimals=1)
+        result_df = ar.to_pandas(result)
+
+        assert list(result_df["name"]) == ["john"]
+        assert list(result_df["score"]) == [98.8]
+
+
 class TestSafeDivideColumns:
     def test_normal_division(self, tmp_path):
         path = tmp_path / "data.csv"

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -343,6 +343,44 @@ class TestNormalizeCase:
         df = ar.to_pandas(result)
         assert df["name"].iloc[0] == "Alice"
 
+    def test_title_hyphen(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame({"name": ["hello-world", "jean-luc picard"]})
+        )
+        result = ar.normalize_case(frame, subset=["name"], case_type="title")
+        df = ar.to_pandas(result)
+        assert df["name"].iloc[0] == "Hello-World"
+        assert df["name"].iloc[1] == "Jean-Luc Picard"
+
+    def test_title_underscore(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"name": ["hello_world", "foo_bar_baz"]}))
+        result = ar.normalize_case(frame, subset=["name"], case_type="title")
+        df = ar.to_pandas(result)
+        assert df["name"].iloc[0] == "Hello_World"
+        assert df["name"].iloc[1] == "Foo_Bar_Baz"
+
+    def test_title_period(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"name": ["dr.strange", "mr.smith"]}))
+        result = ar.normalize_case(frame, subset=["name"], case_type="title")
+        df = ar.to_pandas(result)
+        assert df["name"].iloc[0] == "Dr.Strange"
+        assert df["name"].iloc[1] == "Mr.Smith"
+
+    def test_title_slash(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"name": ["hello/world", "foo/bar"]}))
+        result = ar.normalize_case(frame, subset=["name"], case_type="title")
+        df = ar.to_pandas(result)
+        assert df["name"].iloc[0] == "Hello/World"
+        assert df["name"].iloc[1] == "Foo/Bar"
+
 
 class TestRenameColumns:
     def test_rename(self, sample_csv):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -158,6 +158,105 @@ class TestDropConstantColumns:
         assert result.shape[1] == 0
 
 
+class TestClipNumeric:
+    def test_clip_numeric_lower_only(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [-5, 0, 10]}))
+
+        result = ar.clip_numeric(frame, lower=1)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [1, 1, 10]
+
+    def test_clip_numeric_upper_only(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [-5, 0, 10]}))
+
+        result = ar.clip_numeric(frame, upper=3)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [-5, 0, 3]
+
+    def test_clip_numeric_both_bounds(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [-5, 2, 10]}))
+
+        result = ar.clip_numeric(frame, lower=0, upper=5)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [0, 2, 5]
+
+    def test_clip_numeric_all_numeric_subset_skips_non_numeric_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [-5, 5, 20],
+                    "label": ["low", "ok", "high"],
+                }
+            )
+        )
+
+        result = ar.clip_numeric(frame, lower=0, upper=10)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [0, 5, 10]
+        assert list(df["label"]) == ["low", "ok", "high"]
+
+    def test_clip_numeric_subset_only_requested_numeric_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [-5, 0, 10],
+                    "b": [-10, 5, 20],
+                    "label": ["x", "y", "z"],
+                }
+            )
+        )
+
+        result = ar.clip_numeric(frame, lower=0, upper=8, subset=["b"])
+        df = ar.to_pandas(result)
+
+        assert list(df["a"]) == [-5, 0, 10]
+        assert list(df["b"]) == [0, 5, 8]
+        assert list(df["label"]) == ["x", "y", "z"]
+
+    def test_clip_numeric_keeps_missing_values(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [None, -5.0, 10.0]}))
+
+        result = ar.clip_numeric(frame, lower=0, upper=5)
+        df = ar.to_pandas(result)
+
+        assert pd.isna(df["value"].iloc[0])
+        assert list(df["value"].iloc[1:]) == [0.0, 5.0]
+
+    def test_clip_numeric_unknown_subset_column_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(ValueError, match="Unknown columns in subset"):
+            ar.clip_numeric(frame, lower=0, subset=["missing"])
+
+    def test_clip_numeric_non_numeric_subset_column_raises(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"value": [1, 2, 3], "label": ["x", "y", "z"]})
+        )
+
+        with pytest.raises(
+            ValueError, match="clip_numeric only supports numeric columns"
+        ):
+            ar.clip_numeric(frame, lower=0, subset=["label"])
+
+    def test_clip_numeric_no_bounds_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(
+            ValueError, match="At least one of 'lower' or 'upper' must be provided"
+        ):
+            ar.clip_numeric(frame)
+
+    def test_clip_numeric_inverted_bounds_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(ValueError, match="lower cannot be greater than upper"):
+            ar.clip_numeric(frame, lower=5, upper=1)
+
+
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):
         frame = ar.read_csv(csv_with_whitespace)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,5 +1,6 @@
 """Tests for data cleaning functions."""
 
+import pandas as pd
 import pytest
 
 import arnio as ar
@@ -67,6 +68,94 @@ class TestDropDuplicates:
         frame = ar.read_csv(csv_with_duplicates)
         result = ar.drop_duplicates(frame, subset=["name"])
         assert result.shape[0] == 3
+
+
+class TestDropConstantColumns:
+    def test_drop_constant_columns_removes_constant_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [1, 2, 3],
+                    "constant_num": [7, 7, 7],
+                    "constant_text": ["x", "x", "x"],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["value"]
+        assert list(df["value"]) == [1, 2, 3]
+
+    def test_drop_constant_columns_keeps_non_constant_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [1, 2, 1],
+                    "b": ["x", "y", "x"],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == frame.columns
+        assert result.shape == frame.shape
+
+    def test_drop_constant_columns_drops_all_null_column(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "all_null": [None, None],
+                    "value": [1, 2],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == ["value"]
+
+    def test_drop_constant_columns_keeps_value_plus_null_column(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "maybe_constant": [1, 1, None],
+                    "constant": [2, 2, 2],
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["maybe_constant"]
+        assert df.shape == (3, 1)
+
+    def test_drop_constant_columns_empty_frame_keeps_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "empty_num": pd.Series(dtype="float64"),
+                    "empty_text": pd.Series(dtype="object"),
+                }
+            )
+        )
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == ["empty_num", "empty_text"]
+        assert result.shape == frame.shape
+
+    def test_drop_constant_columns_all_columns_dropped_reports_zero_rows(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1], "b": ["x"], "c": [None]}))
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result.columns == []
+        assert result.shape[0] == 0
+        assert result.shape[1] == 0
 
 
 class TestStripWhitespace:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -41,6 +41,58 @@ class TestFillNulls:
             ar.fill_nulls(frame, "bad", subset=["x"])
 
 
+class TestValidateColumnsExist:
+    def test_returns_original_frame_when_columns_exist(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.validate_columns_exist(frame, ["name", "age"])
+
+        assert result is frame
+
+    def test_allows_empty_column_list(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.validate_columns_exist(frame, [])
+
+        assert result is frame
+
+    def test_raises_clear_error_for_missing_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for test_op"):
+            ar.validate_columns_exist(frame, ["missing"], operation="test_op")
+
+    def test_rejects_string_columns_argument(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="not a string"):
+            ar.validate_columns_exist(frame, "name")
+
+    def test_rejects_non_string_column_items(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="only string column names"):
+            ar.validate_columns_exist(frame, ["name", 1])
+
+    def test_drop_nulls_rejects_string_subset(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="subset must be a sequence"):
+            ar.drop_nulls(frame, subset="name")
+
+    def test_drop_nulls_rejects_missing_subset_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for drop_nulls"):
+            ar.drop_nulls(frame, subset=["missing"])
+
+    def test_rename_rejects_missing_mapping_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for rename_columns"):
+            ar.rename_columns(frame, {"missing": "new_name"})
+
+
 class TestDropDuplicates:
     def test_drop_dupes_first(self, csv_with_duplicates):
         frame = ar.read_csv(csv_with_duplicates)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -161,3 +161,19 @@ class TestFromPandas:
         result_df = ar.to_pandas(result)
 
         assert list(result_df.columns) == ["name", "age", "city"]
+
+    def test_nullable_boolean_roundtrip(self):
+        df = pd.DataFrame(
+            {
+                "active": pd.Series(
+                    [True, False, pd.NA],
+                    dtype="boolean",
+                )
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert str(result["active"].dtype) == "boolean"
+        assert list(result["active"]) == [True, False, pd.NA]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -73,18 +73,14 @@ class TestFromPandas:
         assert "z" in frame.columns
 
     def test_nullable_int64_roundtrip_mixed_values(self):
-        df = pd.DataFrame(
-            {"id": pd.Series([1, pd.NA, 3], dtype=pd.Int64Dtype())}
-        )
+        df = pd.DataFrame({"id": pd.Series([1, pd.NA, 3], dtype=pd.Int64Dtype())})
 
         result = ar.to_pandas(ar.from_pandas(df))
 
         pd.testing.assert_series_equal(result["id"], df["id"])
 
     def test_nullable_int64_roundtrip_all_nulls(self):
-        df = pd.DataFrame(
-            {"id": pd.Series([pd.NA, pd.NA], dtype=pd.Int64Dtype())}
-        )
+        df = pd.DataFrame({"id": pd.Series([pd.NA, pd.NA], dtype=pd.Int64Dtype())})
 
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
@@ -94,9 +90,7 @@ class TestFromPandas:
         assert result["id"].isna().tolist() == [True, True]
 
     def test_nullable_int64_roundtrip_without_nulls(self):
-        df = pd.DataFrame(
-            {"id": pd.Series([1, 2, 3], dtype=pd.Int64Dtype())}
-        )
+        df = pd.DataFrame({"id": pd.Series([1, 2, 3], dtype=pd.Int64Dtype())})
 
         result = ar.to_pandas(ar.from_pandas(df))
 
@@ -222,6 +216,21 @@ class TestFromPandas:
         assert str(result["active"].dtype) == "boolean"
         assert list(result["active"]) == [True, False, pd.NA]
 
+    def test_bool_null_mask_roundtrip(self):
+        df = pd.DataFrame(
+            {
+                "flag": pd.Series(
+                    [True, False, pd.NA],
+                    dtype="boolean",
+                )
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert list(result["flag"]) == [True, False, pd.NA]
+
 
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):
@@ -274,4 +283,3 @@ class TestAttrsPreservation:
         result = ar.to_pandas(frame)
         # stored copy must be unaffected
         assert result.attrs["meta"]["tags"] == ["a", "b"]
-

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -72,6 +72,36 @@ class TestFromPandas:
         assert "y" in frame.columns
         assert "z" in frame.columns
 
+    def test_nullable_int64_roundtrip_mixed_values(self):
+        df = pd.DataFrame(
+            {"id": pd.Series([1, pd.NA, 3], dtype=pd.Int64Dtype())}
+        )
+
+        result = ar.to_pandas(ar.from_pandas(df))
+
+        pd.testing.assert_series_equal(result["id"], df["id"])
+
+    def test_nullable_int64_roundtrip_all_nulls(self):
+        df = pd.DataFrame(
+            {"id": pd.Series([pd.NA, pd.NA], dtype=pd.Int64Dtype())}
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert frame.dtypes["id"] == "int64"
+        assert str(result["id"].dtype) == "Int64"
+        assert result["id"].isna().tolist() == [True, True]
+
+    def test_nullable_int64_roundtrip_without_nulls(self):
+        df = pd.DataFrame(
+            {"id": pd.Series([1, 2, 3], dtype=pd.Int64Dtype())}
+        )
+
+        result = ar.to_pandas(ar.from_pandas(df))
+
+        pd.testing.assert_series_equal(result["id"], df["id"])
+
     def test_roundtrip_values(self):
         df = pd.DataFrame(
             {
@@ -244,3 +274,4 @@ class TestAttrsPreservation:
         result = ar.to_pandas(frame)
         # stored copy must be unaffected
         assert result.attrs["meta"]["tags"] == ["a", "b"]
+

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -191,3 +191,56 @@ class TestFromPandas:
 
         assert str(result["active"].dtype) == "boolean"
         assert list(result["active"]) == [True, False, pd.NA]
+
+
+class TestAttrsPreservation:
+    def test_attrs_roundtrip(self):
+        """attrs set on input DataFrame survive from_pandas -> to_pandas."""
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        df.attrs = {"source": "test_db", "version": 2}
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert result.attrs == {"source": "test_db", "version": 2}
+
+    def test_empty_attrs_roundtrip(self):
+        """Empty attrs stay empty — no pollution."""
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        df.attrs = {}
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert result.attrs == {}
+
+    def test_attrs_not_shared(self):
+        """Mutating result.attrs must not affect the ArFrame's stored attrs."""
+        df = pd.DataFrame({"x": [1, 2]})
+        df.attrs = {"key": "original"}
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        result.attrs["key"] = "mutated"
+        # original frame attrs must be untouched
+        assert frame._attrs["key"] == "original"
+
+    def test_attrs_through_pipeline(self):
+        """attrs survive a direct round-trip — pipeline frames are out of scope."""
+        df = pd.DataFrame({"name": [" Alice ", " Bob "]})
+        df.attrs = {"owner": "data_team"}
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert result.attrs.get("owner") == "data_team"
+
+    def test_read_csv_has_no_attrs(self, sample_csv):
+        """ArFrames from read_csv start with empty attrs — no junk metadata."""
+        frame = ar.read_csv(sample_csv)
+        result = ar.to_pandas(frame)
+        assert result.attrs == {}
+
+    def test_nested_mutable_attrs_are_deep_copied(self):
+        """Nested mutable values in attrs are deep-copied, not shared."""
+        df = pd.DataFrame({"x": [1, 2]})
+        df.attrs = {"meta": {"version": 1, "tags": ["a", "b"]}}
+        frame = ar.from_pandas(df)
+        # mutate the original nested object
+        df.attrs["meta"]["tags"].append("c")
+        result = ar.to_pandas(frame)
+        # stored copy must be unaffected
+        assert result.attrs["meta"]["tags"] == ["a", "b"]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,7 @@
 """Tests for pandas conversion."""
 
 import pandas as pd
+import pytest
 
 import arnio as ar
 
@@ -84,14 +85,17 @@ class TestFromPandas:
         assert list(df2["score"]) == [95.5, 87.0]
 
     def test_from_pandas_nested_data(self):
-        import pytest
 
         df_list = pd.DataFrame({"a": [[1, 2], [3, 4]]})
-        with pytest.raises(TypeError, match="Unsupported nested/complex type"):
+        with pytest.raises(
+            TypeError, match="Column 'a' contains unsupported nested value"
+        ):
             ar.from_pandas(df_list)
 
         df_dict = pd.DataFrame({"a": [{"x": 1}, {"y": 2}]})
-        with pytest.raises(TypeError, match="Unsupported nested/complex type"):
+        with pytest.raises(
+            TypeError, match="Column 'a' contains unsupported nested value"
+        ):
             ar.from_pandas(df_dict)
 
     def test_from_pandas_mixed_object_column(self):
@@ -100,6 +104,16 @@ class TestFromPandas:
         df2 = ar.to_pandas(frame)
 
         assert list(df2["a"]) == ["1", "x", "3"]
+
+    def test_from_pandas_mixed_object_column_with_nested_value(self):
+
+        df = pd.DataFrame({"mixed": [1, "hello", {"a": 1}]}, dtype=object)
+
+        with pytest.raises(
+            TypeError,
+            match="Column 'mixed' contains unsupported nested value",
+        ):
+            ar.from_pandas(df)
 
     def test_from_pandas_unsupported_scalar_object_column(self):
         timestamp = pd.Timestamp("2026-05-14 12:30:00")

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -108,3 +108,56 @@ class TestFromPandas:
         assert frame._frame.column_by_name("created_at").to_python_list() == [
             str(timestamp)
         ]
+
+    def test_from_pandas_preserves_column_order(self):
+        df = pd.DataFrame(
+            {
+                "name": ["Alice"],
+                "age": [20],
+                "city": ["Delhi"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert list(result.columns) == ["name", "age", "city"]
+
+    def test_cleaning_preserves_column_order(self):
+        df = pd.DataFrame(
+            {
+                "name": [" Alice "],
+                "age": [20],
+                "city": ["Delhi"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+
+        result = ar.strip_whitespace(frame)
+        result_df = ar.to_pandas(result)
+
+        assert list(result_df.columns) == ["name", "age", "city"]
+
+    def test_pipeline_preserves_column_order(self):
+        df = pd.DataFrame(
+            {
+                "name": [" Alice "],
+                "age": [20],
+                "city": ["Delhi"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("strip_whitespace",),
+                ("normalize_case", {"case_type": "lower"}),
+            ],
+        )
+
+        result_df = ar.to_pandas(result)
+
+        assert list(result_df.columns) == ["name", "age", "city"]

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -159,6 +159,18 @@ class TestReadCsv:
 
         assert df["name"].iloc[0] == "André"
 
+    def test_utf16_encoding_with_nul_bytes_reads_successfully(self, tmp_path):
+        csv_path = tmp_path / "utf16.csv"
+        csv_path.write_text("name,age\nAlice,30\n", encoding="utf-16")
+
+        frame = ar.read_csv(csv_path, encoding="utf-16")
+        df = ar.to_pandas(frame)
+
+        assert frame.columns == ["name", "age"]
+        assert frame.shape == (1, 2)
+        assert df["name"].iloc[0] == "Alice"
+        assert df["age"].iloc[0] == 30
+
     def test_quoted_newline_record(self, tmp_path):
         csv_path = tmp_path / "quoted_newline.csv"
         csv_path.write_text('id,text\n1,"hello\nworld"\n2,ok\n')
@@ -210,6 +222,14 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, encoding="latin-1")
 
         assert schema == {"name": "string"}
+
+    def test_scan_utf16_encoding_with_nul_bytes_reads_successfully(self, tmp_path):
+        csv_path = tmp_path / "utf16.csv"
+        csv_path.write_text("name,age\nAlice,30\n", encoding="utf-16")
+
+        schema = ar.scan_csv(csv_path, encoding="utf-16")
+
+        assert schema == {"name": "string", "age": "int64"}
 
     def test_scan_binary_file_rejection(self, tmp_path):
         file_path = str(tmp_path / "data.csv")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -184,6 +184,16 @@ class TestReadCsv:
         with pytest.raises(ar.CsvReadError, match="Duplicate column name: a"):
             ar.read_csv(csv_path)
 
+    def test_empty_file_raises(self, tmp_path):
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("")
+        with pytest.raises(ar.CsvReadError, match="CSV file is empty"):
+            ar.read_csv(str(csv_path))
+
+    def test_missing_file_passthrough(self, tmp_path):
+        with pytest.raises(ar.CsvReadError):
+            ar.read_csv(str(tmp_path / "nonexistent.csv"))
+
 
 class TestScanCsv:
     def test_scan_schema(self, sample_csv):
@@ -212,3 +222,13 @@ class TestScanCsv:
             match="CSV input contains NUL bytes and appears to be binary or corrupted",
         ):
             ar.scan_csv(file_path)
+
+    def test_scan_empty_file_raises(self, tmp_path):
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("")
+        with pytest.raises(ar.CsvReadError, match="CSV file is empty"):
+            ar.scan_csv(str(csv_path))
+
+    def test_scan_missing_file_passthrough(self, tmp_path):
+        with pytest.raises(ar.CsvReadError):
+            ar.scan_csv(str(tmp_path / "nonexistent.csv"))

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -64,6 +64,31 @@ class TestReadCsv:
         frame = ar.read_csv(csv_path)
         assert frame.columns == ["name", "age"]
 
+    def test_trim_headers_true_is_default(self, tmp_path):
+        csv_path = str(tmp_path / "trim.csv")
+        with open(csv_path, "w") as f:
+            f.write(" name ,  age \nAlice,30\n")
+
+        frame = ar.read_csv(csv_path)
+        assert frame.columns == ["name", "age"]
+
+    def test_trim_headers_false_preserves_spaces(self, tmp_path):
+        csv_path = str(tmp_path / "notrim.csv")
+        with open(csv_path, "w") as f:
+            f.write(" name ,  age \nAlice,30\n")
+
+        frame = ar.read_csv(csv_path, trim_headers=False)
+        assert frame.columns == [" name ", "  age "]
+
+    def test_trim_headers_false_scan_csv(self, tmp_path):
+        csv_path = str(tmp_path / "scan_notrim.csv")
+        with open(csv_path, "w") as f:
+            f.write(" score , active \n95,true\n")
+
+        schema = ar.scan_csv(csv_path, trim_headers=False)
+        assert " score " in schema
+        assert " active " in schema
+
     def test_unsupported_extension(self, tmp_path):
         import pytest
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,0 +1,116 @@
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+def test_select_columns_valid():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice", "Bob"],
+            "age": [25, 30],
+            "salary": [50000, 60000],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    selected = frame.select_columns(["name", "salary"])
+
+    assert selected.columns == ["name", "salary"]
+    assert selected.shape == (2, 2)
+
+
+def test_select_columns_preserves_order():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+            "salary": [50000],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    selected = frame.select_columns(["salary", "name"])
+
+    assert selected.columns == ["salary", "name"]
+
+
+def test_select_columns_unknown_column():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="Unknown columns"):
+        frame.select_columns(["name", "salary"])
+
+
+def test_select_columns_empty():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        frame.select_columns([])
+
+
+def test_select_columns_duplicate_names():
+    df = pd.DataFrame(
+        {
+            "name": ["Alice"],
+            "age": [25],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="Duplicate column names"):
+        frame.select_columns(["name", "name"])
+
+
+def test_select_columns_string_input():
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="not a string"):
+        frame.select_columns("name")
+
+
+def test_select_columns_non_string_items():
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="must be strings"):
+        frame.select_columns(["name", 123])
+
+
+def test_select_columns_invalid_container():
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="list or tuple"):
+        frame.select_columns({"name"})
+
+
+def test_select_columns_empty_frame():
+    df = pd.DataFrame(columns=["name", "age"])
+
+    frame = ar.from_pandas(df)
+
+    selected = frame.select_columns(["name"])
+
+    assert selected.columns == ["name"]
+    assert selected.shape == (0, 1)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -115,6 +115,7 @@ def test_preview_invalid_n_none(sample_csv):
     with pytest.raises(ValueError):
         frame.preview(n=None)
 
+
 def test_select_columns_valid():
     df = pd.DataFrame(
         {
@@ -123,11 +124,8 @@ def test_select_columns_valid():
             "salary": [50000, 60000],
         }
     )
-
     frame = ar.from_pandas(df)
-
     selected = frame.select_columns(["name", "salary"])
-
     assert selected.columns == ["name", "salary"]
     assert selected.shape == (2, 2)
 
@@ -140,11 +138,8 @@ def test_select_columns_preserves_order():
             "salary": [50000],
         }
     )
-
     frame = ar.from_pandas(df)
-
     selected = frame.select_columns(["salary", "name"])
-
     assert selected.columns == ["salary", "name"]
 
 
@@ -155,9 +150,7 @@ def test_select_columns_unknown_column():
             "age": [25],
         }
     )
-
     frame = ar.from_pandas(df)
-
     with pytest.raises(ValueError, match="Unknown columns"):
         frame.select_columns(["name", "salary"])
 
@@ -168,9 +161,7 @@ def test_select_columns_empty():
             "name": ["Alice"],
         }
     )
-
     frame = ar.from_pandas(df)
-
     with pytest.raises(ValueError, match="cannot be empty"):
         frame.select_columns([])
 
@@ -182,46 +173,63 @@ def test_select_columns_duplicate_names():
             "age": [25],
         }
     )
-
     frame = ar.from_pandas(df)
-
     with pytest.raises(ValueError, match="Duplicate column names"):
         frame.select_columns(["name", "name"])
 
 
 def test_select_columns_string_input():
     df = pd.DataFrame({"name": ["Alice"]})
-
     frame = ar.from_pandas(df)
-
     with pytest.raises(TypeError, match="not a string"):
         frame.select_columns("name")
 
 
 def test_select_columns_non_string_items():
     df = pd.DataFrame({"name": ["Alice"]})
-
     frame = ar.from_pandas(df)
-
     with pytest.raises(TypeError, match="must be strings"):
         frame.select_columns(["name", 123])
 
 
 def test_select_columns_invalid_container():
     df = pd.DataFrame({"name": ["Alice"]})
-
     frame = ar.from_pandas(df)
-
     with pytest.raises(TypeError, match="list or tuple"):
         frame.select_columns({"name"})
 
 
 def test_select_columns_empty_frame():
     df = pd.DataFrame(columns=["name", "age"])
-
     frame = ar.from_pandas(df)
-
     selected = frame.select_columns(["name"])
-
     assert selected.columns == ["name"]
     assert selected.shape == (0, 1)
+
+
+class TestArFrame:
+    """Test ArFrame properties and methods."""
+
+    def test_is_empty_true(self, tmp_path):
+        """Test is_empty returns True for frame with zero rows."""
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("name,age\n")  # Header only, no data rows
+
+        frame = ar.read_csv(str(csv_path))
+        assert frame.is_empty is True
+        assert len(frame) == 0
+
+    def test_is_empty_false(self, sample_csv):
+        """Test is_empty returns False for frame with rows."""
+        frame = ar.read_csv(sample_csv)
+        assert frame.is_empty is False
+        assert len(frame) > 0
+
+    def test_is_empty_single_row(self, tmp_path):
+        """Test is_empty with exactly one row."""
+        csv_path = tmp_path / "single.csv"
+        csv_path.write_text("name,age\nAlice,30\n")
+
+        frame = ar.read_csv(str(csv_path))
+        assert frame.is_empty is False
+        assert len(frame) == 1

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,8 +1,119 @@
+"""
+Tests for ArFrame.preview()
+"""
+
 import pandas as pd
 import pytest
 
 import arnio as ar
 
+# ── Normal behaviour ──────────────────────────────────────────────────────────
+
+
+def test_preview_returns_string(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    assert isinstance(result, str)
+
+
+def test_preview_contains_word_preview(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    assert "preview" in result.lower()
+
+
+def test_preview_contains_column_names(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    for col in frame.columns:
+        assert col in result  # "name", "age", "email", "active" all appear
+
+
+def test_preview_default_shows_three_rows(sample_csv):
+    # sample_csv only has 3 rows, so default n=5 clamps to 3
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview()
+    assert "showing 3 of 3" in result
+
+
+def test_preview_custom_n(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=2)
+    assert "showing 2 of 3" in result
+
+
+def test_preview_n_equals_one(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=1)
+    assert "showing 1 of 3" in result
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+
+def test_preview_n_exceeds_row_count(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=9999)
+    assert "showing 3 of 3" in result  # clamps, doesn't crash
+
+
+def test_preview_n_equals_exact_row_count(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    result = frame.preview(n=3)
+    assert "showing 3 of 3" in result
+
+
+def test_preview_with_nulls(csv_with_nulls):
+    # Should not crash on missing values
+    frame = ar.read_csv(csv_with_nulls)
+    result = frame.preview()
+    assert isinstance(result, str)
+
+
+def test_preview_large_csv(large_csv):
+    # 1000 rows — default should only show 5
+    frame = ar.read_csv(large_csv)
+    result = frame.preview()
+    assert "showing 5 of 1000" in result
+
+
+# ── Invalid inputs ────────────────────────────────────────────────────────────
+
+
+def test_preview_invalid_n_zero(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=0)
+
+
+def test_preview_invalid_n_negative(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=-1)
+
+
+def test_preview_invalid_n_string(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n="five")
+
+
+def test_preview_invalid_n_float(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=2.5)
+
+
+def test_preview_invalid_n_bool(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=True)  # bool is subclass of int — must still be rejected
+
+
+def test_preview_invalid_n_none(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(ValueError):
+        frame.preview(n=None)
 
 def test_select_columns_valid():
     df = pd.DataFrame(

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -1,0 +1,70 @@
+"""Tests for the pandas DataFrame accessor."""
+
+import pandas as pd
+
+import arnio as ar
+
+
+def test_pandas_accessor_converts_to_arframe():
+    df = pd.DataFrame({"name": ["Alice"], "age": [30]})
+
+    frame = df.arnio.to_arframe()
+
+    assert isinstance(frame, ar.ArFrame)
+    assert frame.shape == (1, 2)
+    assert frame.columns == ["name", "age"]
+
+
+def test_pandas_accessor_runs_explicit_pipeline_without_mutating_source():
+    df = pd.DataFrame({"name": [" Alice ", " Bob "], "age": [30, 40]})
+
+    result = df.arnio.clean(
+        [
+            ("strip_whitespace", {"subset": ["name"]}),
+            ("normalize_case", {"subset": ["name"], "case_type": "lower"}),
+        ]
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["alice", "bob"]
+    assert list(df["name"]) == [" Alice ", " Bob "]
+
+
+def test_pandas_accessor_runs_convenience_clean():
+    df = pd.DataFrame({"name": [" Alice ", " Alice "], "score": [10, 10]})
+
+    result = df.arnio.clean(drop_duplicates=True)
+
+    assert list(result["name"]) == ["Alice"]
+    assert list(result["score"]) == [10]
+
+
+def test_pandas_accessor_profiles_dataframe_quality():
+    df = pd.DataFrame({"name": [" Alice ", "Bob"], "score": [1.5, None]})
+
+    report = df.arnio.profile()
+
+    assert isinstance(report, ar.DataQualityReport)
+    assert report.row_count == 2
+    assert report.columns["name"].whitespace_count == 1
+    assert report.columns["score"].null_count == 1
+
+
+def test_pandas_accessor_auto_clean_returns_dataframe_and_report():
+    df = pd.DataFrame({"name": [" Alice ", "Bob"]})
+
+    result, report = df.arnio.auto_clean(return_report=True)
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["Alice", "Bob"]
+    assert isinstance(report, ar.DataQualityReport)
+
+
+def test_pandas_accessor_validates_dataframe():
+    df = pd.DataFrame({"email": ["alice@example.com", "bad"]})
+
+    result = df.arnio.validate({"email": ar.Email(nullable=False)})
+
+    assert isinstance(result, ar.ValidationResult)
+    assert not result.passed
+    assert result.issues[0].rule == "email"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -72,6 +72,29 @@ class TestPipeline:
         assert list(df.columns) == ["value"]
         assert list(df["value"]) == [1, 2, 1]
 
+    def test_pipeline_clip_numeric(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [-5, 2, 10],
+                    "label": ["a", "b", "c"],
+                }
+            )
+        )
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("clip_numeric", {"lower": 0, "upper": 5}),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [0, 2, 5]
+        assert list(df["label"]) == ["a", "b", "c"]
+
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -121,6 +121,46 @@ class TestPipeline:
         assert result.dtypes["years"] == "float64"
         assert "age" not in result.columns
 
+    def test_pipeline_validate_columns_exist(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = ar.pipeline(
+            frame,
+            [
+                ("validate_columns_exist", {"columns": ["name", "age"]}),
+                ("strip_whitespace", {"subset": ["name"]}),
+            ],
+        )
+
+        assert result.shape == frame.shape
+
+    def test_pipeline_validate_columns_exist_allows_empty_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = ar.pipeline(frame, [("validate_columns_exist", {"columns": []})])
+
+        assert result is frame
+
+    def test_pipeline_validate_columns_exist_rejects_missing_columns(self, sample_csv):
+        import pytest
+
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns"):
+            ar.pipeline(
+                frame,
+                [("validate_columns_exist", {"columns": ["missing"]})],
+            )
+
+    def test_pipeline_subset_step_rejects_missing_columns(self, sample_csv):
+        import pytest
+
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Missing columns for strip_whitespace"):
+            ar.pipeline(
+                frame,
+                [("strip_whitespace", {"subset": ["missing"]})],
+            )
+
     def test_empty_pipeline(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -238,6 +238,22 @@ def test_filter_rows_direct_api():
     assert list(result_df["age"]) == [30, 40]
 
 
+def test_round_numeric_columns_pipeline():
+    import pandas as pd
+
+    import arnio as ar
+
+    df = pd.DataFrame({"price": [10.555, 20.123]})
+    frame = ar.from_pandas(df)
+
+    result = ar.pipeline(
+        frame, [("round_numeric_columns", {"subset": ["price"], "decimals": 2})]
+    )
+
+    result_df = ar.to_pandas(result)
+    assert list(result_df["price"]) == [10.56, 20.12]
+
+
 def test_safe_divide_columns_pipeline():
     import pandas as pd
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -236,3 +236,32 @@ def test_filter_rows_direct_api():
     result_df = ar.to_pandas(result)
 
     assert list(result_df["age"]) == [30, 40]
+
+
+def test_safe_divide_columns_pipeline():
+    import pandas as pd
+
+    import arnio as ar
+
+    df = pd.DataFrame({"revenue": [100.0, 200.0, 0.0], "cost": [50.0, 0.0, 30.0]})
+
+    frame = ar.from_pandas(df)
+
+    result = ar.pipeline(
+        frame,
+        [
+            (
+                "safe_divide_columns",
+                {
+                    "numerator": "revenue",
+                    "denominator": "cost",
+                    "output_column": "ratio",
+                },
+            )
+        ],
+    )
+
+    result_df = ar.to_pandas(result)
+    assert result_df["ratio"].iloc[0] == 2.0
+    assert result_df["ratio"].iloc[1] == 0.0  # division by zero → fill_value
+    assert result_df["ratio"].iloc[2] == 0.0  # zero numerator

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -49,6 +49,29 @@ class TestPipeline:
         )
         assert result.shape[0] == 3
 
+    def test_pipeline_drop_constant_columns(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "constant": [1, 1, 1],
+                    "value": [1, 2, 1],
+                }
+            )
+        )
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("drop_constant_columns",),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["value"]
+        assert list(df["value"]) == [1, 2, 1]
+
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -75,3 +75,46 @@ def test_auto_clean_rejects_unknown_mode(sample_csv):
         assert False, "Expected ValueError"
     except ValueError as exc:
         assert "mode must be" in str(exc)
+
+
+def test_profile_sample_size(tmp_path):
+    path = tmp_path / "sample.csv"
+    path.write_text("id\n1\n2\n3\n4\n5\n6\n7\n")
+    frame = ar.read_csv(path)
+
+    report_default = ar.profile(frame)
+    assert len(report_default.columns["id"].sample_values) == 5
+
+    report_custom = ar.profile(frame, sample_size=3)
+    assert len(report_custom.columns["id"].sample_values) == 3
+
+    report_zero = ar.profile(frame, sample_size=0)
+    assert len(report_zero.columns["id"].sample_values) == 0
+
+
+def test_profile_sample_size_small_dataset_and_nulls(tmp_path):
+    path = tmp_path / "sample.csv"
+    path.write_text("id\n1\n\n3\n")
+    frame = ar.read_csv(path)
+
+    report = ar.profile(frame, sample_size=5)
+    assert len(report.columns["id"].sample_values) == 2
+    assert report.columns["id"].sample_values == [1.0, 3.0]
+
+
+def test_profile_sample_size_validation(tmp_path):
+    path = tmp_path / "sample.csv"
+    path.write_text("id\n1\n")
+    frame = ar.read_csv(path)
+
+    try:
+        ar.profile(frame, sample_size=-1)
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "sample_size must be non-negative" in str(exc)
+
+    try:
+        ar.profile(frame, sample_size="5")
+        assert False, "Expected TypeError"
+    except TypeError as exc:
+        assert "sample_size must be an integer" in str(exc)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -131,3 +131,5 @@ def test_compare_schema_method(sample_csv, tmp_path):
     # Requirement E: Invalid object class input safe rejection handling
     with pytest.raises(TypeError):
         df_base.compare_schema(["not", "an", "ArFrame", "object"])
+
+        

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,6 @@
 """Tests for schema validation."""
 
+import pytest
 import arnio as ar
 
 
@@ -81,13 +82,13 @@ def test_custom_pattern_validation(tmp_path):
     assert not result.passed
     assert result.issues[0].rule == "pattern"
     assert result.issues[0].row_index == 1
-    def test_compare_schema_method(sample_csv, tmp_path):
+
+def test_compare_schema_method(sample_csv, tmp_path):
     # 1. Base Frame and Matching Frame Setup
     df_base = ar.read_csv(sample_csv)
     df_match = ar.read_csv(sample_csv)
 
     # 2. Setup Shuffled/Swapped Order Frame
-    # (Same columns as sample_csv, but positions are swapped)
     shuffled_path = tmp_path / "shuffled.csv"
     shuffled_path.write_text(
         "age,name,email,active\n"
@@ -96,7 +97,6 @@ def test_custom_pattern_validation(tmp_path):
     df_shuffled = ar.read_csv(shuffled_path)
 
     # 3. Setup Wrong Data Type Frame
-    # (Here, 'age' is a decimal/float instead of an integer)
     wrong_dtype_path = tmp_path / "wrong_dtype.csv"
     wrong_dtype_path.write_text(
         "name,age,email,active\n"
@@ -105,7 +105,6 @@ def test_custom_pattern_validation(tmp_path):
     df_wrong_dtype = ar.read_csv(wrong_dtype_path)
 
     # 4. Setup Wrong Column Names Frame
-    # (Replaced 'active' with an unexpected column name 'status')
     wrong_cols_path = tmp_path / "wrong_cols.csv"
     wrong_cols_path.write_text(
         "name,age,email,status\n"
@@ -113,9 +112,8 @@ def test_custom_pattern_validation(tmp_path):
     )
     df_wrong_cols = ar.read_csv(wrong_cols_path)
 
-    # --- ASSERTIONS (Verifying all review requirements) ---
-
-    # Requirement A: Same schema test (Strict vs Non-Strict should both be True)
+    # --- ASSERTIONS ---
+    # Requirement A: Same schema test
     assert df_base.compare_schema(df_match, strict=True) is True
     assert df_base.compare_schema(df_match, strict=False) is True
 
@@ -130,6 +128,5 @@ def test_custom_pattern_validation(tmp_path):
     assert df_base.compare_schema(df_wrong_cols, strict=False) is False
 
     # Requirement E: Invalid object class input safe rejection handling
-    import pytest
     with pytest.raises(TypeError):
         df_base.compare_schema(["not", "an", "ArFrame", "object"])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -83,6 +83,7 @@ def test_custom_pattern_validation(tmp_path):
     assert result.issues[0].rule == "pattern"
     assert result.issues[0].row_index == 1
 
+
 def test_compare_schema_method(sample_csv, tmp_path):
     # 1. Base Frame and Matching Frame Setup
     df_base = ar.read_csv(sample_csv)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 """Tests for schema validation."""
 
 import pytest
+
 import arnio as ar
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -81,3 +81,55 @@ def test_custom_pattern_validation(tmp_path):
     assert not result.passed
     assert result.issues[0].rule == "pattern"
     assert result.issues[0].row_index == 1
+    def test_compare_schema_method(sample_csv, tmp_path):
+    # 1. Base Frame and Matching Frame Setup
+    df_base = ar.read_csv(sample_csv)
+    df_match = ar.read_csv(sample_csv)
+
+    # 2. Setup Shuffled/Swapped Order Frame
+    # (Same columns as sample_csv, but positions are swapped)
+    shuffled_path = tmp_path / "shuffled.csv"
+    shuffled_path.write_text(
+        "age,name,email,active\n"
+        "30,Alice,alice@test.com,True\n"
+    )
+    df_shuffled = ar.read_csv(shuffled_path)
+
+    # 3. Setup Wrong Data Type Frame
+    # (Here, 'age' is a decimal/float instead of an integer)
+    wrong_dtype_path = tmp_path / "wrong_dtype.csv"
+    wrong_dtype_path.write_text(
+        "name,age,email,active\n"
+        "Alice,30.5,alice@test.com,True\n"
+    )
+    df_wrong_dtype = ar.read_csv(wrong_dtype_path)
+
+    # 4. Setup Wrong Column Names Frame
+    # (Replaced 'active' with an unexpected column name 'status')
+    wrong_cols_path = tmp_path / "wrong_cols.csv"
+    wrong_cols_path.write_text(
+        "name,age,email,status\n"
+        "Alice,30,alice@test.com,active\n"
+    )
+    df_wrong_cols = ar.read_csv(wrong_cols_path)
+
+    # --- ASSERTIONS (Verifying all review requirements) ---
+
+    # Requirement A: Same schema test (Strict vs Non-Strict should both be True)
+    assert df_base.compare_schema(df_match, strict=True) is True
+    assert df_base.compare_schema(df_match, strict=False) is True
+
+    # Requirement B: Strict vs Non-Strict order behavior tracking
+    assert df_base.compare_schema(df_shuffled, strict=True) is False
+    assert df_base.compare_schema(df_shuffled, strict=False) is True
+
+    # Requirement C: Data type mismatch validation
+    assert df_base.compare_schema(df_wrong_dtype, strict=False) is False
+
+    # Requirement D: Column naming structural mismatch validation
+    assert df_base.compare_schema(df_wrong_cols, strict=False) is False
+
+    # Requirement E: Invalid object class input safe rejection handling
+    import pytest
+    with pytest.raises(TypeError):
+        df_base.compare_schema(["not", "an", "ArFrame", "object"])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -72,6 +72,91 @@ def test_validation_result_to_pandas(sample_csv):
     assert list(df["row_index"]) == [0, 1]
 
 
+def test_validation_result_to_markdown_for_success(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64()})
+
+    markdown = result.to_markdown()
+
+    assert "## Validation Report" in markdown
+    assert "- Status: **passed**" in markdown
+    assert "- Issues found: 0" in markdown
+    assert "| Column | Rule | Row | Value | Message |" not in markdown
+
+
+def test_validation_result_to_markdown_includes_issue_table(sample_csv):
+    result = ar.validate(
+        ar.read_csv(sample_csv),
+        {"age": ar.Int64(min=31), "missing": ar.String()},
+    )
+
+    markdown = result.to_markdown()
+
+    assert "- Status: **failed**" in markdown
+    assert "- Issues found: 3" in markdown
+    assert "| Column | Rule | Row | Value | Message |" in markdown
+    assert "| age | min | 0 |" in markdown
+    assert (
+        "| missing | required_column |  |  | Missing required column: missing |"
+        in markdown
+    )
+
+
+def test_validation_result_to_markdown_limits_visible_issues(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64(min=31)})
+
+    markdown = result.to_markdown(max_issues=1)
+
+    assert "| age | min | 0 |" in markdown
+    assert "| age | min | 1 |" not in markdown
+    assert "_Showing 1 of 2 issues._" in markdown
+
+
+def test_validation_result_to_markdown_escapes_table_cells():
+    result = ar.ValidationResult(
+        row_count=1,
+        issue_count=1,
+        issues=[
+            ar.ValidationIssue(
+                column="notes|raw",
+                rule="pattern",
+                row_index=0,
+                value="left|right\nnext",
+                message="Expected one|two\nlines",
+            )
+        ],
+        bad_rows=[0],
+    )
+
+    markdown = result.to_markdown()
+
+    assert "notes\\|raw" in markdown
+    assert "left\\|right<br>next" in markdown
+    assert "Expected one\\|two<br>lines" in markdown
+
+
+def test_validation_result_to_markdown_rejects_negative_max_issues(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64(min=31)})
+
+    try:
+        result.to_markdown(max_issues=-1)
+    except ValueError as exc:
+        assert "max_issues" in str(exc)
+    else:
+        raise AssertionError("Expected max_issues validation to raise")
+
+
+def test_validation_result_to_markdown_rejects_non_integer_max_issues(sample_csv):
+    result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64(min=31)})
+
+    for invalid in ("1", 1.5, True):
+        try:
+            result.to_markdown(max_issues=invalid)  # type: ignore[arg-type]
+        except TypeError as exc:
+            assert "max_issues must be an integer or None" in str(exc)
+        else:
+            raise AssertionError(f"Expected max_issues={invalid!r} to raise")
+
+
 def test_custom_pattern_validation(tmp_path):
     path = tmp_path / "codes.csv"
     path.write_text("code\nAA-123\nbad\n")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -257,13 +257,13 @@ def test_validation_result_to_markdown_rejects_non_integer_max_issues(sample_csv
             assert "max_issues must be an integer or None" in str(exc)
         else:
             raise AssertionError(f"Expected max_issues={invalid!r} to raise")
-        
-        
+
+
 def test_custom_pattern_validation(tmp_path):
     path = tmp_path / "codes.csv"
     path.write_text("code\nAA-123\nbad\n")
     result = ar.validate(
-        ar.read_csv(path), {"code": ar.String(regex=r"^[A-Z]{2}-\d{3}$")}
+        ar.read_csv(path), {"code": ar.String(pattern=r"^[A-Z]{2}-\d{3}$")}
     )
 
     assert not result.passed
@@ -278,25 +278,20 @@ def test_compare_schema_method(sample_csv, tmp_path):
 
     # 2. Setup Shuffled/Swapped Order Frame
     shuffled_path = tmp_path / "shuffled.csv"
-    shuffled_path.write_text(
-        "age,name,email,active\n"
-        "30,Alice,alice@test.com,True\n"
-    )
+    shuffled_path.write_text("age,name,email,active\n" "30,Alice,alice@test.com,True\n")
     df_shuffled = ar.read_csv(shuffled_path)
 
     # 3. Setup Wrong Data Type Frame
     wrong_dtype_path = tmp_path / "wrong_dtype.csv"
     wrong_dtype_path.write_text(
-        "name,age,email,active\n"
-        "Alice,30.5,alice@test.com,True\n"
+        "name,age,email,active\n" "Alice,30.5,alice@test.com,True\n"
     )
     df_wrong_dtype = ar.read_csv(wrong_dtype_path)
 
     # 4. Setup Wrong Column Names Frame
     wrong_cols_path = tmp_path / "wrong_cols.csv"
     wrong_cols_path.write_text(
-        "name,age,email,status\n"
-        "Alice,30,alice@test.com,active\n"
+        "name,age,email,status\n" "Alice,30,alice@test.com,active\n"
     )
     df_wrong_cols = ar.read_csv(wrong_cols_path)
 
@@ -319,8 +314,6 @@ def test_compare_schema_method(sample_csv, tmp_path):
     with pytest.raises(TypeError):
         df_base.compare_schema(["not", "an", "ArFrame", "object"])
 
-        
-    
 
 def test_string_min_length_boundary(tmp_path):
     path = tmp_path / "names.csv"
@@ -381,10 +374,7 @@ def test_compare_schema_order_difference(sample_csv, tmp_path):
     df_base = ar.read_csv(sample_csv)
 
     shuffled_path = tmp_path / "shuffled.csv"
-    shuffled_path.write_text(
-        "age,name,email,active\n"
-        "30,Alice,alice@test.com,True\n"
-    )
+    shuffled_path.write_text("age,name,email,active\n" "30,Alice,alice@test.com,True\n")
     df_shuffled = ar.read_csv(shuffled_path)
 
     assert df_base.compare_schema(df_shuffled, strict=True) is False
@@ -397,8 +387,7 @@ def test_compare_schema_dtype_mismatch(sample_csv, tmp_path):
 
     wrong_dtype_path = tmp_path / "wrong_dtype.csv"
     wrong_dtype_path.write_text(
-        "name,age,email,active\n"
-        "Alice,30.5,alice@test.com,True\n"
+        "name,age,email,active\n" "Alice,30.5,alice@test.com,True\n"
     )
     df_wrong_dtype = ar.read_csv(wrong_dtype_path)
 
@@ -411,8 +400,7 @@ def test_compare_schema_column_mismatch(sample_csv, tmp_path):
 
     wrong_cols_path = tmp_path / "wrong_cols.csv"
     wrong_cols_path.write_text(
-        "name,age,email,status\n"
-        "Alice,30,alice@test.com,active\n"
+        "name,age,email,status\n" "Alice,30,alice@test.com,active\n"
     )
     df_wrong_cols = ar.read_csv(wrong_cols_path)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -72,6 +72,108 @@ def test_validation_result_to_pandas(sample_csv):
     assert list(df["row_index"]) == [0, 1]
 
 
+def test_validation_result_summary_counts_repeated_issues_in_one_column():
+    result = ar.ValidationResult(
+        row_count=3,
+        issue_count=3,
+        issues=[
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=0
+            ),
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=1
+            ),
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=2
+            ),
+        ],
+        bad_rows=[0, 1, 2],
+    )
+
+    summary = result.summary()
+
+    assert summary["issues_by_rule"] == {"min": 3}
+    assert summary["issues_by_column"] == {"age": 3}
+    assert summary["issues_by_column_and_rule"] == {"age": {"min": 3}}
+
+
+def test_validation_result_summary_counts_issues_across_multiple_columns():
+    result = ar.ValidationResult(
+        row_count=3,
+        issue_count=4,
+        issues=[
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=0
+            ),
+            ar.ValidationIssue(
+                column="status", rule="allowed", message="bad status", row_index=1
+            ),
+            ar.ValidationIssue(
+                column="email", rule="email", message="bad email", row_index=1
+            ),
+            ar.ValidationIssue(
+                column=None, rule="required_column", message="missing column"
+            ),
+        ],
+        bad_rows=[0, 1],
+    )
+
+    summary = result.summary()
+
+    assert summary["issues_by_rule"] == {
+        "min": 1,
+        "allowed": 1,
+        "email": 1,
+        "required_column": 1,
+    }
+    assert summary["issues_by_column"] == {"age": 1, "status": 1, "email": 1}
+    assert summary["issues_by_column_and_rule"] == {
+        "age": {"min": 1},
+        "status": {"allowed": 1},
+        "email": {"email": 1},
+    }
+
+
+def test_validation_result_summary_counts_grouped_rules_under_one_column():
+    result = ar.ValidationResult(
+        row_count=2,
+        issue_count=3,
+        issues=[
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=0
+            ),
+            ar.ValidationIssue(
+                column="age", rule="max", message="too large", row_index=1
+            ),
+            ar.ValidationIssue(
+                column="age", rule="numeric", message="not numeric", row_index=1
+            ),
+        ],
+        bad_rows=[0, 1],
+    )
+
+    summary = result.summary()
+
+    assert summary["issues_by_rule"] == {"min": 1, "max": 1, "numeric": 1}
+    assert summary["issues_by_column"] == {"age": 3}
+    assert summary["issues_by_column_and_rule"] == {
+        "age": {"min": 1, "max": 1, "numeric": 1}
+    }
+
+
+def test_validation_result_summary_counts_no_issue_result():
+    result = ar.ValidationResult(row_count=3, issue_count=0, issues=[], bad_rows=[])
+
+    summary = result.summary()
+
+    assert summary["passed"] is True
+    assert summary["issue_count"] == 0
+    assert summary["bad_row_count"] == 0
+    assert summary["issues_by_rule"] == {}
+    assert summary["issues_by_column"] == {}
+    assert summary["issues_by_column_and_rule"] == {}
+
+
 def test_validation_result_to_markdown_for_success(sample_csv):
     result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64()})
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -257,13 +257,13 @@ def test_validation_result_to_markdown_rejects_non_integer_max_issues(sample_csv
             assert "max_issues must be an integer or None" in str(exc)
         else:
             raise AssertionError(f"Expected max_issues={invalid!r} to raise")
-
-
+        
+        
 def test_custom_pattern_validation(tmp_path):
     path = tmp_path / "codes.csv"
     path.write_text("code\nAA-123\nbad\n")
     result = ar.validate(
-        ar.read_csv(path), {"code": ar.String(pattern=r"[A-Z]{2}-\d{3}")}
+        ar.read_csv(path), {"code": ar.String(regex=r"^[A-Z]{2}-\d{3}$")}
     )
 
     assert not result.passed
@@ -320,3 +320,108 @@ def test_compare_schema_method(sample_csv, tmp_path):
         df_base.compare_schema(["not", "an", "ArFrame", "object"])
 
         
+    
+
+def test_string_min_length_boundary(tmp_path):
+    path = tmp_path / "names.csv"
+    path.write_text("name\nab\nabc\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"name": ar.String(min_length=3)},
+    )
+
+    assert not result.passed
+    assert result.issue_count == 1
+    assert result.issues[0].rule == "min_length"
+    assert result.issues[0].row_index == 0
+
+
+def test_string_max_length_boundary(tmp_path):
+    path = tmp_path / "names.csv"
+    path.write_text("name\nabcde\nabcdef\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"name": ar.String(max_length=5)},
+    )
+
+    assert not result.passed
+    assert result.issue_count == 1
+    assert result.issues[0].rule == "max_length"
+    assert result.issues[0].row_index == 1
+
+
+def test_null_values_skip_length_validation(tmp_path):
+    path = tmp_path / "names.csv"
+    path.write_text("name\n\nabcd\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"name": ar.String(min_length=5)},
+    )
+
+    assert not result.passed
+    assert result.issue_count == 1
+    assert result.issues[0].rule == "min_length"
+    assert result.issues[0].row_index == 0
+
+
+def test_compare_schema_matching(sample_csv):
+    """Test that identical schemas match under both strict and non-strict modes."""
+    df_base = ar.read_csv(sample_csv)
+    df_match = ar.read_csv(sample_csv)
+
+    assert df_base.compare_schema(df_match, strict=True) is True
+    assert df_base.compare_schema(df_match, strict=False) is True
+
+
+def test_compare_schema_order_difference(sample_csv, tmp_path):
+    """Test that column order differences fail strict mode but pass non-strict mode."""
+    df_base = ar.read_csv(sample_csv)
+
+    shuffled_path = tmp_path / "shuffled.csv"
+    shuffled_path.write_text(
+        "age,name,email,active\n"
+        "30,Alice,alice@test.com,True\n"
+    )
+    df_shuffled = ar.read_csv(shuffled_path)
+
+    assert df_base.compare_schema(df_shuffled, strict=True) is False
+    assert df_base.compare_schema(df_shuffled, strict=False) is True
+
+
+def test_compare_schema_dtype_mismatch(sample_csv, tmp_path):
+    """Test that schema matching fails when column data types mismatch."""
+    df_base = ar.read_csv(sample_csv)
+
+    wrong_dtype_path = tmp_path / "wrong_dtype.csv"
+    wrong_dtype_path.write_text(
+        "name,age,email,active\n"
+        "Alice,30.5,alice@test.com,True\n"
+    )
+    df_wrong_dtype = ar.read_csv(wrong_dtype_path)
+
+    assert df_base.compare_schema(df_wrong_dtype, strict=False) is False
+
+
+def test_compare_schema_column_mismatch(sample_csv, tmp_path):
+    """Test that schema matching fails when column names do not match."""
+    df_base = ar.read_csv(sample_csv)
+
+    wrong_cols_path = tmp_path / "wrong_cols.csv"
+    wrong_cols_path.write_text(
+        "name,age,email,status\n"
+        "Alice,30,alice@test.com,active\n"
+    )
+    df_wrong_cols = ar.read_csv(wrong_cols_path)
+
+    assert df_base.compare_schema(df_wrong_cols, strict=False) is False
+
+
+def test_compare_schema_invalid_input(sample_csv):
+    """Test that passing a non-ArFrame object correctly raises a TypeError."""
+    df_base = ar.read_csv(sample_csv)
+
+    with pytest.raises(TypeError):
+        df_base.compare_schema(["not", "an", "ArFrame", "object"])

--- a/tests/test_zero_copy.py
+++ b/tests/test_zero_copy.py
@@ -1,0 +1,252 @@
+"""
+Regression tests for zero-copy lifetime safety.
+
+Verifies that NumPy arrays and pandas Series derived from ArFrame columns
+remain valid and correct after the source ArFrame (or its C++ backing) is
+deleted and garbage collected.
+
+Issue: #242
+"""
+
+import gc
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_frame_int():
+    return ar.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}))
+
+
+def make_frame_float():
+    return ar.from_pandas(pd.DataFrame({"x": [1.1, 2.2, 3.3]}))
+
+
+def make_frame_bool():
+    return ar.from_pandas(
+        pd.DataFrame({"flag": pd.Series([True, False, True], dtype="boolean")})
+    )
+
+
+def make_frame_with_nulls():
+    return ar.from_pandas(
+        pd.DataFrame(
+            {
+                "score": pd.array([10, None, 30], dtype=pd.Int64Dtype()),
+                "ratio": [1.0, float("nan"), 3.0],
+                "active": pd.array([True, None, False], dtype=pd.BooleanDtype()),
+            }
+        )
+    )
+
+
+def make_frame_single_row():
+    return ar.from_pandas(pd.DataFrame({"v": [42]}))
+
+
+def make_frame_empty():
+    return ar.from_pandas(pd.DataFrame({"v": pd.Series([], dtype="int64")}))
+
+
+# ---------------------------------------------------------------------------
+# INT64 lifetime tests
+# ---------------------------------------------------------------------------
+
+
+class TestIntLifetime:
+    def test_int_values_survive_frame_deletion(self):
+        """INT64 column values remain correct after ArFrame is GC'd."""
+        frame = make_frame_int()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert list(df["a"]) == [1, 2, 3]
+        assert list(df["b"]) == [10, 20, 30]
+
+    def test_int_values_survive_multiple_gc_cycles(self):
+        """Values stay correct across repeated GC passes."""
+        frame = make_frame_int()
+        df = ar.to_pandas(frame)
+        del frame
+        for _ in range(5):
+            gc.collect()
+        assert list(df["a"]) == [1, 2, 3]
+
+    def test_int_mutation_does_not_corrupt_second_conversion(self):
+        """Mutating one derived DataFrame must not affect a second conversion."""
+        frame = make_frame_int()
+        df1 = ar.to_pandas(frame)
+        df2 = ar.to_pandas(frame)
+        # mutate df1 in place
+        df1["a"].iloc[0] = 999
+        # df2 must be unaffected
+        assert df2["a"].iloc[0] == 1
+
+    def test_int_dtype_preserved_after_gc(self):
+        """Nullable Int64 dtype survives GC of source frame."""
+        frame = make_frame_int()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert str(df["a"].dtype) == "Int64"
+
+
+# ---------------------------------------------------------------------------
+# FLOAT64 lifetime tests
+# ---------------------------------------------------------------------------
+
+
+class TestFloatLifetime:
+    def test_float_values_survive_frame_deletion(self):
+        """FLOAT64 column values remain correct after ArFrame is GC'd."""
+        frame = make_frame_float()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert pytest.approx(list(df["x"])) == [1.1, 2.2, 3.3]
+
+    def test_float_copy_is_independent(self):
+        """to_pandas makes a .copy() of float arrays — mutations are isolated."""
+        frame = make_frame_float()
+        df1 = ar.to_pandas(frame)
+        df2 = ar.to_pandas(frame)
+        df1["x"].iloc[0] = -999.0
+        assert pytest.approx(df2["x"].iloc[0]) == 1.1
+
+    def test_float_values_survive_multiple_gc_cycles(self):
+        frame = make_frame_float()
+        df = ar.to_pandas(frame)
+        del frame
+        for _ in range(5):
+            gc.collect()
+        assert pytest.approx(list(df["x"])) == [1.1, 2.2, 3.3]
+
+
+# ---------------------------------------------------------------------------
+# BOOL lifetime tests
+# ---------------------------------------------------------------------------
+
+
+class TestBoolLifetime:
+    def test_bool_values_survive_frame_deletion(self):
+        """BOOL column values remain correct after ArFrame is GC'd."""
+        frame = make_frame_bool()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert list(df["flag"]) == [True, False, True]
+
+    def test_bool_dtype_preserved_after_gc(self):
+        """Nullable boolean dtype survives GC of source frame."""
+        frame = make_frame_bool()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert str(df["flag"].dtype) == "boolean"
+
+    def test_bool_values_survive_multiple_gc_cycles(self):
+        frame = make_frame_bool()
+        df = ar.to_pandas(frame)
+        del frame
+        for _ in range(5):
+            gc.collect()
+        assert list(df["flag"]) == [True, False, True]
+
+
+# ---------------------------------------------------------------------------
+# Null mask lifetime tests
+# ---------------------------------------------------------------------------
+
+
+class TestNullMaskLifetime:
+    def test_null_mask_int_survives_gc(self):
+        """Null positions in INT64 columns survive GC of source frame."""
+        frame = make_frame_with_nulls()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert pd.isna(df["score"].iloc[1])
+        assert df["score"].iloc[0] == 10
+        assert df["score"].iloc[2] == 30
+
+    def test_null_mask_float_survives_gc(self):
+        """NaN positions in FLOAT64 columns survive GC of source frame."""
+        frame = make_frame_with_nulls()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert np.isnan(df["ratio"].iloc[1])
+        assert pytest.approx(df["ratio"].iloc[0]) == 1.0
+
+    def test_null_mask_bool_survives_gc(self):
+        """Null positions in BOOL columns survive GC of source frame."""
+        frame = make_frame_with_nulls()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert pd.isna(df["active"].iloc[1])
+        assert df["active"].iloc[0] == True  # noqa: E712
+        assert df["active"].iloc[2] == False  # noqa: E712
+
+    def test_all_null_column_survives_gc(self):
+        """A fully-null column produces all-NA after GC."""
+        df_in = pd.DataFrame(
+            {"empty_col": pd.array([None, None, None], dtype=pd.Int64Dtype())}
+        )
+        frame = ar.from_pandas(df_in)
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert df["empty_col"].isna().all()
+
+
+# ---------------------------------------------------------------------------
+# Edge case lifetime tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCaseLifetime:
+    def test_single_row_int_survives_gc(self):
+        """Single-row INT64 frame survives GC."""
+        frame = make_frame_single_row()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert df["v"].iloc[0] == 42
+
+    def test_empty_frame_survives_gc(self):
+        """Empty frame (0 rows) converts without error and survives GC."""
+        frame = make_frame_empty()
+        df = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert len(df) == 0
+        assert "v" in df.columns
+
+    def test_multiple_independent_conversions_stay_isolated(self):
+        """Three independent to_pandas() calls produce isolated DataFrames."""
+        frame = make_frame_int()
+        dfs = [ar.to_pandas(frame) for _ in range(3)]
+        del frame
+        gc.collect()
+        # mutate first, rest untouched
+        dfs[0]["a"].iloc[0] = 999
+        assert dfs[1]["a"].iloc[0] == 1
+        assert dfs[2]["a"].iloc[0] == 1
+
+    def test_roundtrip_after_gc(self):
+        """from_pandas → to_pandas → del → gc → values correct."""
+        original = pd.DataFrame({"p": [7, 8, 9], "q": [0.1, 0.2, 0.3]})
+        frame = ar.from_pandas(original)
+        result = ar.to_pandas(frame)
+        del frame
+        gc.collect()
+        assert list(result["p"]) == [7, 8, 9]
+        assert pytest.approx(list(result["q"])) == [0.1, 0.2, 0.3]


### PR DESCRIPTION
Greetings @im-anishraj ! I've implemented the compare_schema method in ArFrame as per the previous plan.
Before performing operations with the data, we can check the consistency b/w diff frames

Brief Description:
1. Added a compare_schema helper that checks both column names and dtypes.
2. Strict Mode (strict=True): Performs an ordered comparison (using list) to ensure the column sequence is identical.
3. Flexible Mode (strict=False): Uses set logic to verify that all required columns exist, regardless of their index order.
Also includes a type check to ensure the other object is an instance of ArFrame

Summary: It supports both strict (ordered) and non-strict (unordered) column name or dtype validation

Fixes #228

## Checkboxes: (tick)
 Feature
 Python API / ArFrame
 Schema validation
 I read the contributing guide.
 I kept the PR focused on one issue.
 My PR title uses Conventional Commits

## Testing
[python -m pip install .]
Verified the fix by running 'pip install .' in the local environment (Python 3.14). 
Build and installation were successful (arnio-1.1.01) without C++ compilation errors. (refer screenshot below)

## Screenshots:
<img width="1911" height="1013" alt="image" src="https://github.com/user-attachments/assets/7dd3e950-52b7-406f-9a5b-c08889a31dc5" />


