### PR TITLE
feat: add trim_column_names to strip whitespace from column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `round_numeric_columns` | Round numeric columns (non-numeric columns in subset ignored safely) | `ar.round_numeric_columns(frame, decimals=2)` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
 | `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
+| `trim_column_names` | Strip leading/trailing whitespace from column names | `ar.trim_column_names(frame)` |
 
 Or compose them all into a **pipeline**:
 

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -25,6 +25,7 @@ from .cleaning import (
     round_numeric_columns,
     safe_divide_columns,
     strip_whitespace,
+    trim_column_names,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
@@ -72,6 +73,7 @@ __all__ = [
     "cast_types",
     "clean",
     "safe_divide_columns",
+    "trim_column_names",
     # Conversion
     "to_pandas",
     "from_pandas",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -315,6 +315,43 @@ def rename_columns(
     return ArFrame(result)
 
 
+# changes done to trim white spaces.
+def trim_column_names(frame: ArFrame) -> ArFrame:
+    """Strip leading and trailing whitespace from column names.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+
+    Returns
+    -------
+    ArFrame
+        New frame with trimmed column names.
+
+    Raises
+    ------
+    ValueError
+        If trimming would create duplicate column names.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")  # columns: [" name ", " age "]
+    >>> clean = ar.trim_column_names(frame)  # columns: ["name", "age"]
+    """
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame)
+    trimmed = [col.strip() for col in df.columns]
+
+    if len(trimmed) != len(set(trimmed)):
+        raise ValueError(f"Trimming column names would create duplicates: {trimmed}")
+
+    df = df.copy()
+    df.columns = trimmed
+    return from_pandas(df)
+
+
 def cast_types(
     frame: ArFrame,
     mapping: dict[str, str],

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -315,7 +315,6 @@ def rename_columns(
     return ArFrame(result)
 
 
-
 def trim_column_names(frame: ArFrame) -> ArFrame:
     """Strip leading and trailing whitespace from column names.
 

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -315,7 +315,7 @@ def rename_columns(
     return ArFrame(result)
 
 
-# changes done to trim white spaces.
+
 def trim_column_names(frame: ArFrame) -> ArFrame:
     """Strip leading and trailing whitespace from column names.
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -22,6 +22,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "rename_columns": cleaning.rename_columns,
     "cast_types": cleaning.cast_types,
     "round_numeric_columns": cleaning.round_numeric_columns,
+    "trim_column_names": cleaning.trim_column_names,
 }
 
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import arnio as ar
+from arnio import from_pandas, to_pandas
 
 
 class TestDropNulls:
@@ -299,6 +300,38 @@ class TestRenameColumns:
         assert "full_name" in result.columns
         assert "years" in result.columns
         assert "name" not in result.columns
+
+
+class TestTrimColumnNames:
+    def test_trim_column_names_basic(self):
+        df = pd.DataFrame({" name ": [1], " age ": [2]})
+        frame = from_pandas(df)
+        result = ar.trim_column_names(frame)
+        assert to_pandas(result).columns.tolist() == ["name", "age"]
+
+    def test_trim_column_names_already_clean(self):
+        df = pd.DataFrame({"name": [1], "age": [2]})
+        frame = from_pandas(df)
+        result = ar.trim_column_names(frame)
+        assert to_pandas(result).columns.tolist() == ["name", "age"]
+
+    def test_trim_column_names_mixed(self):
+        df = pd.DataFrame({" name": [1], "age ": [2], "score": [3]})
+        frame = from_pandas(df)
+        result = ar.trim_column_names(frame)
+        assert to_pandas(result).columns.tolist() == ["name", "age", "score"]
+
+    def test_trim_column_names_preserves_order(self):
+        df = pd.DataFrame({" c ": [1], " b ": [2], " a ": [3]})
+        frame = from_pandas(df)
+        result = ar.trim_column_names(frame)
+        assert to_pandas(result).columns.tolist() == ["c", "b", "a"]
+
+    def test_trim_column_names_duplicate_raises(self):
+        df = pd.DataFrame({" name": [1], "name ": [2]})
+        frame = from_pandas(df)
+        with pytest.raises(ValueError, match="duplicates"):
+            ar.trim_column_names(frame)
 
 
 class TestCastTypes:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -94,6 +94,7 @@ class TestPipeline:
 
         assert list(df.columns) == ["name", "age"]
 
+
 def test_pipeline_clip_numeric(self):
     import pandas as pd
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -72,28 +72,50 @@ class TestPipeline:
         assert list(df.columns) == ["value"]
         assert list(df["value"]) == [1, 2, 1]
 
-    def test_pipeline_clip_numeric(self):
-        import pandas as pd
+def test_pipeline_trim_column_names(self):
+    import pandas as pd
 
-        frame = ar.from_pandas(
-            pd.DataFrame(
-                {
-                    "value": [-5, 2, 10],
-                    "label": ["a", "b", "c"],
-                }
-            )
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                " name ": ["Alice"],
+                " age ": [30],
+            }
         )
+    )
 
-        result = ar.pipeline(
-            frame,
-            [
-                ("clip_numeric", {"lower": 0, "upper": 5}),
-            ],
+    result = ar.pipeline(
+        frame,
+        [
+            ("trim_column_names",),
+        ],
+    )
+    df = ar.to_pandas(result)
+
+    assert list(df.columns) == ["name", "age"]
+
+def test_pipeline_clip_numeric(self):
+    import pandas as pd
+
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "value": [-5, 2, 10],
+                "label": ["a", "b", "c"],
+            }
         )
-        df = ar.to_pandas(result)
+    )
 
-        assert list(df["value"]) == [0, 2, 5]
-        assert list(df["label"]) == ["a", "b", "c"]
+    result = ar.pipeline(
+        frame,
+        [
+            ("clip_numeric", {"lower": 0, "upper": 5}),
+        ],
+    )
+    df = ar.to_pandas(result)
+
+    assert list(df["value"]) == [0, 2, 5]
+    assert list(df["label"]) == ["a", "b", "c"]
 
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -72,27 +72,27 @@ class TestPipeline:
         assert list(df.columns) == ["value"]
         assert list(df["value"]) == [1, 2, 1]
 
-def test_pipeline_trim_column_names(self):
-    import pandas as pd
+    def test_pipeline_trim_column_names(self):
+        import pandas as pd
 
-    frame = ar.from_pandas(
-        pd.DataFrame(
-            {
-                " name ": ["Alice"],
-                " age ": [30],
-            }
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    " name ": ["Alice"],
+                    " age ": [30],
+                }
+            )
         )
-    )
 
-    result = ar.pipeline(
-        frame,
-        [
-            ("trim_column_names",),
-        ],
-    )
-    df = ar.to_pandas(result)
+        result = ar.pipeline(
+            frame,
+            [
+                ("trim_column_names",),
+            ],
+        )
+        df = ar.to_pandas(result)
 
-    assert list(df.columns) == ["name", "age"]
+        assert list(df.columns) == ["name", "age"]
 
 def test_pipeline_clip_numeric(self):
     import pandas as pd


### PR DESCRIPTION
## Summary
Adds `trim_column_names`, a new cleaning function that strips leading and 
trailing whitespace from DataFrame column names. Common in CSV exports where 
headers like ` name ` should be normalized to `name`.

## Linked issue
Fixes #138

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test`
- [x] `make lint`
- [ ] Other:

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Raises `ValueError` if trimming would create duplicate column names.