### PR TITLE
feat: add clip numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `fill_nulls` | Replace nulls with a scalar | `ar.fill_nulls(frame, 0, subset=["revenue"])` |
 | `drop_duplicates` | Deduplicate rows (first/last/none) | `ar.drop_duplicates(frame, keep="first")` |
 | `drop_constant_columns` | Remove columns with only one unique value | `ar.drop_constant_columns(frame)` |
+| `clip_numeric` | Clip numeric values to lower and/or upper bounds | `ar.clip_numeric(frame, lower=0, upper=100)` |
 | `strip_whitespace` | Trim leading/trailing spaces from strings | `ar.strip_whitespace(frame)` |
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -14,6 +14,7 @@ except Exception:
 from .cleaning import (
     cast_types,
     clean,
+    clip_numeric,
     drop_constant_columns,
     drop_duplicates,
     drop_nulls,
@@ -61,6 +62,7 @@ __all__ = [
     "filter_rows",
     "drop_duplicates",
     "drop_constant_columns",
+    "clip_numeric",
     "strip_whitespace",
     "normalize_case",
     "rename_columns",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -152,6 +152,83 @@ def drop_constant_columns(frame: ArFrame) -> ArFrame:
     return from_pandas(df.drop(columns=constant_columns))
 
 
+def clip_numeric(
+    frame: ArFrame,
+    *,
+    lower: int | float | None = None,
+    upper: int | float | None = None,
+    subset: list[str] | None = None,
+) -> ArFrame:
+    """Clip numeric columns to lower and/or upper bounds.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    lower : int or float, optional
+        Lower bound. Values below this are raised to the bound.
+    upper : int or float, optional
+        Upper bound. Values above this are lowered to the bound.
+    subset : list[str], optional
+        Numeric columns to clip. If None, applies to all numeric columns except bools.
+
+    Returns
+    -------
+    ArFrame
+        New frame with clipped numeric values.
+
+    Raises
+    ------
+    ValueError
+        If no bounds are provided, bounds are inverted, subset contains unknown
+        columns, or subset contains non-numeric columns.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> clipped = ar.clip_numeric(frame, lower=0, upper=100)
+    """
+    from pandas.api.types import is_bool_dtype, is_numeric_dtype
+
+    from .convert import from_pandas, to_pandas
+
+    if lower is None and upper is None:
+        raise ValueError("At least one of 'lower' or 'upper' must be provided")
+    if lower is not None and upper is not None and lower > upper:
+        raise ValueError("lower cannot be greater than upper")
+
+    df = to_pandas(frame)
+
+    def _is_supported_numeric(column_name: str) -> bool:
+        series = df[column_name]
+        return is_numeric_dtype(series) and not is_bool_dtype(series)
+
+    if subset is None:
+        target_columns = [
+            column for column in df.columns if _is_supported_numeric(column)
+        ]
+    else:
+        unknown_columns = [column for column in subset if column not in df.columns]
+        if unknown_columns:
+            raise ValueError(f"Unknown columns in subset: {unknown_columns}")
+
+        non_numeric_columns = [
+            column for column in subset if not _is_supported_numeric(column)
+        ]
+        if non_numeric_columns:
+            raise ValueError(
+                "clip_numeric only supports numeric columns: " f"{non_numeric_columns}"
+            )
+        target_columns = subset
+
+    if not target_columns:
+        return frame
+
+    clipped = df.copy()
+    clipped[target_columns] = clipped[target_columns].clip(lower=lower, upper=upper)
+    return from_pandas(clipped)
+
+
 def strip_whitespace(
     frame: ArFrame,
     *,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -16,6 +16,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "fill_nulls": cleaning.fill_nulls,
     "drop_duplicates": cleaning.drop_duplicates,
     "drop_constant_columns": cleaning.drop_constant_columns,
+    "clip_numeric": cleaning.clip_numeric,
     "strip_whitespace": cleaning.strip_whitespace,
     "normalize_case": cleaning.normalize_case,
     "rename_columns": cleaning.rename_columns,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -158,6 +158,105 @@ class TestDropConstantColumns:
         assert result.shape[1] == 0
 
 
+class TestClipNumeric:
+    def test_clip_numeric_lower_only(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [-5, 0, 10]}))
+
+        result = ar.clip_numeric(frame, lower=1)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [1, 1, 10]
+
+    def test_clip_numeric_upper_only(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [-5, 0, 10]}))
+
+        result = ar.clip_numeric(frame, upper=3)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [-5, 0, 3]
+
+    def test_clip_numeric_both_bounds(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [-5, 2, 10]}))
+
+        result = ar.clip_numeric(frame, lower=0, upper=5)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [0, 2, 5]
+
+    def test_clip_numeric_all_numeric_subset_skips_non_numeric_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [-5, 5, 20],
+                    "label": ["low", "ok", "high"],
+                }
+            )
+        )
+
+        result = ar.clip_numeric(frame, lower=0, upper=10)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [0, 5, 10]
+        assert list(df["label"]) == ["low", "ok", "high"]
+
+    def test_clip_numeric_subset_only_requested_numeric_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [-5, 0, 10],
+                    "b": [-10, 5, 20],
+                    "label": ["x", "y", "z"],
+                }
+            )
+        )
+
+        result = ar.clip_numeric(frame, lower=0, upper=8, subset=["b"])
+        df = ar.to_pandas(result)
+
+        assert list(df["a"]) == [-5, 0, 10]
+        assert list(df["b"]) == [0, 5, 8]
+        assert list(df["label"]) == ["x", "y", "z"]
+
+    def test_clip_numeric_keeps_missing_values(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [None, -5.0, 10.0]}))
+
+        result = ar.clip_numeric(frame, lower=0, upper=5)
+        df = ar.to_pandas(result)
+
+        assert pd.isna(df["value"].iloc[0])
+        assert list(df["value"].iloc[1:]) == [0.0, 5.0]
+
+    def test_clip_numeric_unknown_subset_column_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(ValueError, match="Unknown columns in subset"):
+            ar.clip_numeric(frame, lower=0, subset=["missing"])
+
+    def test_clip_numeric_non_numeric_subset_column_raises(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"value": [1, 2, 3], "label": ["x", "y", "z"]})
+        )
+
+        with pytest.raises(
+            ValueError, match="clip_numeric only supports numeric columns"
+        ):
+            ar.clip_numeric(frame, lower=0, subset=["label"])
+
+    def test_clip_numeric_no_bounds_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(
+            ValueError, match="At least one of 'lower' or 'upper' must be provided"
+        ):
+            ar.clip_numeric(frame)
+
+    def test_clip_numeric_inverted_bounds_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(ValueError, match="lower cannot be greater than upper"):
+            ar.clip_numeric(frame, lower=5, upper=1)
+
+
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):
         frame = ar.read_csv(csv_with_whitespace)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -72,6 +72,29 @@ class TestPipeline:
         assert list(df.columns) == ["value"]
         assert list(df["value"]) == [1, 2, 1]
 
+    def test_pipeline_clip_numeric(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [-5, 2, 10],
+                    "label": ["a", "b", "c"],
+                }
+            )
+        )
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("clip_numeric", {"lower": 0, "upper": 5}),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [0, 2, 5]
+        assert list(df["label"]) == ["a", "b", "c"]
+
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(


### PR DESCRIPTION
## Summary

- Added `clip_numeric` cleaning helper for clipping numeric columns to lower and/or upper bounds.
- Registered `clip_numeric` for pipeline usage.
- Exported `clip_numeric` through the public API.
- Added a README entry for the new cleaning primitive.
- Added focused tests for direct and pipeline usage.

## Linked issue

Fixes #143

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [x] `make lint`
- [x] Other:
  - `git diff --check` — passed
  - `pytest tests/test_cleaning.py -v` — 37 passed
  - `pytest tests/test_pipeline.py -v` — 17 passed

## Screenshots / Media

N/A — no UI or visual changes.

## Performance Impact

N/A — no benchmark run. This is a Python-backed cleaning helper and no C++/engine performance path was changed.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

- Focused only on `clip_numeric`.
- No C++ files changed.
- Supports lower-only, upper-only, and both-bound clipping.
- Supports `subset` for selected numeric columns.
- Applies to numeric non-bool columns when `subset=None`.
- Preserves non-numeric columns and missing values.
- Raises `ValueError` for missing bounds, inverted bounds, unknown subset columns, and non-numeric subset columns.
- I used AI assistance to inspect repo patterns and draft changes, then reviewed, formatted, and tested locally.