### PR TITLE
fix: standardize roadmap versioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,11 +613,11 @@ DataQualityReport(
 
 | Version | Focus | Status |
 |:---:|:---|:---:|
-| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
-| **v1.1** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
-| **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
-| **v1.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
-| **v1.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
+| **v1.0.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
+| **v1.1.0** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
+| **v1.2.0** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
+| **v1.3.0** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
+| **v1.4.0** | Parallel column processing · SIMD string operations | 💭 Exploring |
 
 <br>
 


### PR DESCRIPTION
Fixes inconsistent roadmap version formatting in the README by aligning all entries to semantic versioning (v1.0.0 format).

This improves clarity, removes ambiguity in version progression, and ensures consistency across documentation.

No functional changes were made — only documentation updates.

Fixes #103