### PR TITLE
ci: keep wheel package precedence in release tests

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: >-
-            python -c "import pathlib, sys, pytest; sys.path.insert(0, str(pathlib.Path(r'{project}'))); raise SystemExit(pytest.main([str(pathlib.Path(r'{project}') / 'tests'), '-v', '--tb=short', '-x']))"
+            python -c "import pathlib, sys, pytest; sys.path.append(str(pathlib.Path(r'{project}'))); raise SystemExit(pytest.main([str(pathlib.Path(r'{project}') / 'tests'), '-v', '--tb=short', '-x']))"
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- append the repo root during cibuildwheel tests instead of prepending it
- keep the installed wheel first on Python's import path while still making benchmark helpers importable

## Why
The v1.2.0 wheel publish workflow failed after the previous fix because adding the project root at the front caused tests to import the source package instead of the built wheel. This keeps the wheel test faithful to the installed package.