### PR TITLE
fix: preserve pandas nullable Int64 roundtrip

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -124,6 +124,12 @@ def to_pandas(frame: ArFrame) -> pd.DataFrame:
     return result
 
 
+def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
+    if dtype == pd.Int64Dtype():
+        return _DType.INT64
+    return None
+
+
 def from_pandas(df: pd.DataFrame) -> ArFrame:
     """Convert pandas.DataFrame to ArFrame.
 
@@ -149,10 +155,18 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
     >>> frame = ar.from_pandas(df)
     """
     columns = {}
+    dtype_hints = {}
+
     for col_name in df.columns:
         series = df[col_name]
-        columns[str(col_name)] = _series_to_python_values(series, col_name)
+        name = str(col_name)
 
-    cpp_frame = _Frame.from_dict(columns)
+        columns[name] = _series_to_python_values(series, col_name)
 
+        dtype_hint = _pandas_dtype_to_arnio(series.dtype)
+        if dtype_hint is not None:
+            dtype_hints[name] = dtype_hint
+
+    cpp_frame = _Frame.from_dict(columns, dtype_hints)
     return ArFrame(cpp_frame, attrs=copy.deepcopy(df.attrs))
+

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -154,49 +154,62 @@ PYBIND11_MODULE(_arnio_cpp, m) {
             py::return_value_policy::reference_internal)
         .def("add_column", &Frame::add_column)
         .def("clone", &Frame::clone)
-        .def_static("from_dict", [](py::dict cols_dict) {
-            Frame frame;
-            for (auto item : cols_dict) {
-                std::string name = py::cast<std::string>(item.first);
-                py::list values = py::cast<py::list>(item.second);
+        .def_static("from_dict",
+                    [](py::dict cols_dict, py::dict dtype_hints) {
+                        Frame frame;
 
-                DType dtype = DType::STRING;
-                for (auto val : values) {
-                    if (val.is_none()) continue;
-                    if (py::isinstance<py::bool_>(val)) {
-                        dtype = DType::BOOL;
-                        break;
-                    }
-                    if (py::isinstance<py::int_>(val)) {
-                        dtype = DType::INT64;
-                        break;
-                    }
-                    if (py::isinstance<py::float_>(val)) {
-                        dtype = DType::FLOAT64;
-                        break;
-                    }
-                    break;
-                }
+                        for (auto item : cols_dict) {
+                            std::string name = py::cast<std::string>(item.first);
+                            py::list values = py::cast<py::list>(item.second);
 
-                Column col(name, dtype);
-                for (auto val : values) {
-                    if (val.is_none()) {
-                        col.push_null();
-                        continue;
-                    }
-                    if (dtype == DType::BOOL)
-                        col.push_back(val.cast<bool>());
-                    else if (dtype == DType::INT64)
-                        col.push_back(val.cast<int64_t>());
-                    else if (dtype == DType::FLOAT64)
-                        col.push_back(val.cast<double>());
-                    else
-                        col.push_back(py::str(val).cast<std::string>());
-                }
-                frame.add_column(col);
-            }
-            return frame;
-        });
+                            DType dtype = DType::STRING;
+                            py::str py_name(name);
+
+                            if (dtype_hints.contains(py_name)) {
+                                dtype = dtype_hints[py_name].cast<DType>();
+                            } else {
+                                for (auto val : values) {
+                                    if (val.is_none()) continue;
+                                    if (py::isinstance<py::bool_>(val)) {
+                                        dtype = DType::BOOL;
+                                        break;
+                                    }
+                                    if (py::isinstance<py::int_>(val)) {
+                                        dtype = DType::INT64;
+                                        break;
+                                    }
+                                    if (py::isinstance<py::float_>(val)) {
+                                        dtype = DType::FLOAT64;
+                                        break;
+                                    }
+                                    break;
+                                }
+                            }
+
+                            Column col(name, dtype);
+                            for (auto val : values) {
+                                if (val.is_none()) {
+                                    col.push_null();
+                                    continue;
+                                }
+
+                                if (dtype == DType::BOOL)
+                                    col.push_back(val.cast<bool>());
+                                else if (dtype == DType::INT64)
+                                    col.push_back(val.cast<int64_t>());
+                                else if (dtype == DType::FLOAT64)
+                                    col.push_back(val.cast<double>());
+                                else
+                                    col.push_back(py::str(val).cast<std::string>());
+                            }
+
+                            frame.add_column(col);
+                        }
+
+                        return frame;
+                    },
+                    py::arg("cols_dict"),
+                    py::arg("dtype_hints") = py::dict());
 
     // --- CsvReader ---
     py::class_<CsvConfig>(m, "CsvConfig")

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -72,6 +72,36 @@ class TestFromPandas:
         assert "y" in frame.columns
         assert "z" in frame.columns
 
+    def test_nullable_int64_roundtrip_mixed_values(self):
+        df = pd.DataFrame(
+            {"id": pd.Series([1, pd.NA, 3], dtype=pd.Int64Dtype())}
+        )
+
+        result = ar.to_pandas(ar.from_pandas(df))
+
+        pd.testing.assert_series_equal(result["id"], df["id"])
+
+    def test_nullable_int64_roundtrip_all_nulls(self):
+        df = pd.DataFrame(
+            {"id": pd.Series([pd.NA, pd.NA], dtype=pd.Int64Dtype())}
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert frame.dtypes["id"] == "int64"
+        assert str(result["id"].dtype) == "Int64"
+        assert result["id"].isna().tolist() == [True, True]
+
+    def test_nullable_int64_roundtrip_without_nulls(self):
+        df = pd.DataFrame(
+            {"id": pd.Series([1, 2, 3], dtype=pd.Int64Dtype())}
+        )
+
+        result = ar.to_pandas(ar.from_pandas(df))
+
+        pd.testing.assert_series_equal(result["id"], df["id"])
+
     def test_roundtrip_values(self):
         df = pd.DataFrame(
             {
@@ -244,3 +274,4 @@ class TestAttrsPreservation:
         result = ar.to_pandas(frame)
         # stored copy must be unaffected
         assert result.attrs["meta"]["tags"] == ["a", "b"]
+


### PR DESCRIPTION
Fixes #235

## Summary
- Preserved pandas nullable `Int64` dtype during `from_pandas()` conversion
- Added dtype hints for all-null nullable integer columns so they do not fall back to string inference
- Added regression tests for mixed values, all-null values, and no-null `Int64` round-trips

## Testing
- [ ] `python -m pytest tests/test_convert.py -v`
- [ ] `python -m pytest tests/ -v`

## Notes
This keeps the change focused on pandas nullable integer round-trip behavior and avoids unrelated conversion refactors.

## Testing
- [ ] Not run locally: Windows environment is missing a C++ compiler required to build the Arnio extension.
