### PR TITLE
feat: add pandas accessor and integration direction

### DIFF
--- a/PROJECT_DIRECTION.md
+++ b/PROJECT_DIRECTION.md
@@ -1,0 +1,64 @@
+# Arnio Project Direction
+
+Arnio is a fast data-preparation layer for the Python data ecosystem.
+
+The project is not trying to replace pandas, NumPy, scikit-learn, DuckDB, or
+Arrow. Arnio should make those tools easier to use by handling the messy,
+repetitive, and risky preparation work before data reaches analysis, modeling,
+or storage workflows.
+
+## Core Identity
+
+Arnio focuses on:
+
+- fast CSV ingestion and schema scanning
+- predictable cleaning pipelines
+- data quality profiling
+- schema validation and data contracts
+- safe pandas interoperability
+- integrations that fit existing data workflows
+
+The existing C++ runtime, `ArFrame`, cleaning primitives, and schema layer
+remain the foundation. Integrations are the next layer built on top of that
+foundation.
+
+## Product Positioning
+
+Use this framing when writing docs, issues, release notes, or examples:
+
+> Arnio prepares messy data for the Python data stack.
+
+Good examples:
+
+- Clean with Arnio, analyze with pandas.
+- Validate with Arnio, train with scikit-learn.
+- Profile with Arnio, query with DuckDB.
+- Prepare with Arnio, exchange with Arrow.
+
+Avoid framing Arnio as a pandas replacement. Arnio should be useful to people
+who already love pandas and simply want fewer fragile preprocessing chains.
+
+## Contributor Guidance
+
+Existing issues around parsing, cleaning, schema validation, profiling,
+performance, and packaging are still important. They directly improve the
+foundation that integrations rely on.
+
+New integration work should be:
+
+- small and focused
+- compatible with existing public APIs
+- tested against real user workflows
+- documented with short examples
+- careful about optional dependencies
+
+Prefer additive APIs over breaking changes.
+
+## Near-Term Integration Roadmap
+
+1. Pandas accessor: `df.arnio.clean()`, `df.arnio.profile()`,
+   `df.arnio.validate()`.
+2. scikit-learn transformer for preprocessing pipelines.
+3. Arrow bridge for DuckDB, Polars, and PyArrow workflows.
+4. NumPy preparation helpers for numeric/modeling workflows.
+5. Interoperability examples that show Arnio working with popular libraries.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 <br><br>
 
-### Your CSV hits C++ before Python even wakes up.
+### Fast data preparation for the Python data stack.
 
 <br>
 
-**Arnio** is a compiled C++ data cleaning engine that slots in _before_ pandas.<br>
-It parses, infers types, strips whitespace, deduplicates, and normalizes —<br>
-all natively, in columnar memory — then hands you a pristine `DataFrame`.<br>
-No `.apply()`. No lambda chains. No spaghetti.
+**Arnio** is a compiled C++ data preparation engine for messy CSV and pandas workflows.<br>
+It parses, infers types, strips whitespace, deduplicates, validates, and profiles data —<br>
+then hands clean results back to the tools you already use.<br>
+Use Arnio _before_ and _alongside_ pandas, NumPy, scikit-learn, DuckDB, and Arrow.
 
 <br>
 
@@ -37,7 +37,7 @@ pip install arnio
 
 <br>
 
-<a href="#-quickstart">Quickstart</a>&ensp;·&ensp;<a href="#-why-arnio-exists">Why Arnio</a>&ensp;·&ensp;<a href="#%EF%B8%8F-architecture">Architecture</a>&ensp;·&ensp;<a href="#-benchmarks">Benchmarks</a>&ensp;·&ensp;<a href="#-community">Community</a>&ensp;·&ensp;<a href="#-contribute">Contribute</a>
+<a href="#-quickstart">Quickstart</a>&ensp;·&ensp;<a href="#-integrations">Integrations</a>&ensp;·&ensp;<a href="#-why-arnio-exists">Why Arnio</a>&ensp;·&ensp;<a href="#%EF%B8%8F-architecture">Architecture</a>&ensp;·&ensp;<a href="#-benchmarks">Benchmarks</a>&ensp;·&ensp;<a href="#-community">Community</a>&ensp;·&ensp;<a href="#-contribute">Contribute</a>
 
 </div>
 
@@ -69,6 +69,25 @@ clean = ar.pipeline(frame, [
 # Out comes a standard pandas DataFrame — use it like you always have
 df = ar.to_pandas(clean)
 ```
+
+Already have a pandas `DataFrame`? Use Arnio in-place in your existing pandas
+workflow:
+
+```python
+import pandas as pd
+import arnio as ar
+
+df = pd.read_csv("messy_sales_data.csv")
+
+clean_df = df.arnio.clean([
+    ("strip_whitespace",),
+    ("normalize_case", {"case_type": "lower"}),
+    ("drop_duplicates",),
+])
+
+report = clean_df.arnio.profile()
+```
+
 ### Select specific columns
 
 Use `select_columns()` to create a new `ArFrame` with only the required columns before converting to pandas.
@@ -144,6 +163,43 @@ Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Pyth
 
 <br>
 
+## 🔗 Integrations
+
+Arnio is designed to make the rest of the Python data stack more productive,
+not to replace it.
+
+| Workflow | How Arnio helps |
+|:---|:---|
+| **pandas** | Clean, validate, and profile messy `DataFrame`s through `df.arnio`. |
+| **NumPy** | Prepare typed numeric data before array/modeling workflows. |
+| **scikit-learn** | Use Arnio cleaning as a preprocessing layer before model training. |
+| **DuckDB / Arrow** | Validate and prepare data before analytics and columnar exchange. |
+| **notebooks** | Inspect quality issues and cleaning suggestions before analysis. |
+
+### Pandas accessor
+
+```python
+df = pd.read_csv("raw_customers.csv")
+
+clean_df = df.arnio.clean(drop_duplicates=True)
+quality = clean_df.arnio.profile()
+validation = clean_df.arnio.validate({
+    "email": ar.Email(nullable=False),
+    "age": ar.Int64(nullable=True, min=0),
+})
+```
+
+This keeps pandas as the analysis tool while Arnio handles the preparation,
+quality, and validation layer.
+
+> Product direction: **[PROJECT_DIRECTION.md](PROJECT_DIRECTION.md)**
+
+<br>
+
+---
+
+<br>
+
 ## 🔍 Why Arnio exists
 
 Every data project starts the same way:
@@ -159,7 +215,7 @@ df = df.drop_duplicates()                  # Another pass
 
 Six lines. Four full-data passes. All in interpreted Python. This is fine for a Jupyter demo — but it doesn't scale, it doesn't compose, and it definitely doesn't belong in production.
 
-**Arnio intercepts this entire pattern.** It moves the heavy lifting to C++, replaces imperative chains with a declarative pipeline, and gives you a clean `DataFrame` in one shot.
+**Arnio intercepts this entire pattern.** It moves the preparation layer into a predictable pipeline, accelerates supported operations in C++, and gives you clean data for pandas, NumPy, scikit-learn, DuckDB, or notebooks.
 
 <table>
 <tr>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,7 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 
 - Make CSV parsing and cleaning behavior predictable across platforms.
 - Expand the data quality and schema validation layer.
+- Make Arnio useful inside existing pandas and Python data-stack workflows.
 - Improve contributor onboarding for GSSoC 2026.
 - Increase unit, integration, packaging, and benchmark coverage.
 - Keep PyPI releases reliable and easy to verify.
@@ -15,6 +16,7 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 - Harden CSV edge cases: row width validation, comments, encodings, malformed quotes, delimiter detection, and better diagnostics.
 - Make `ArFrame` easier to inspect and test with row previews, column access, equality, and copy behavior.
 - Expand pipeline ergonomics with validation, registry introspection, and safer custom step execution.
+- Add focused interoperability features, starting with the pandas `df.arnio` accessor.
 - Add more schema validators for real-world data contracts.
 - Build reproducible performance baselines and regression checks.
 
@@ -23,6 +25,7 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 - Chunked and streaming processing for datasets that do not fit comfortably in memory.
 - Native writers for CSV and other common export formats.
 - Better pandas interoperability for datetime, categorical, nullable, and timedelta types.
+- Add scikit-learn, Arrow, DuckDB, and NumPy integration paths where they make existing workflows easier.
 - More automatic data quality suggestions with confidence levels and explainable actions.
 - Documentation site with API reference, tutorials, recipes, and contribution tracks.
 
@@ -36,4 +39,6 @@ This roadmap is a maintainer-level guide for contributors. It is intentionally p
 
 ## Product Direction
 
-Arnio should become the fast, explicit preparation layer before pandas: inspect messy data, clean it predictably, validate it against contracts, and hand a trustworthy DataFrame to the rest of the Python ecosystem.
+Arnio should become the fast, explicit preparation layer for the Python data ecosystem: inspect messy data, clean it predictably, validate it against contracts, and hand trustworthy results to pandas, NumPy, scikit-learn, DuckDB, Arrow, and notebooks.
+
+For the full positioning, see [PROJECT_DIRECTION.md](PROJECT_DIRECTION.md).

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -30,6 +30,7 @@ from .cleaning import (
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame
+from .integrations import ArnioPandasAccessor
 from .io import read_csv, scan_csv
 from .pipeline import pipeline, register_step
 from .quality import (
@@ -77,6 +78,8 @@ __all__ = [
     # Conversion
     "to_pandas",
     "from_pandas",
+    # Integrations
+    "ArnioPandasAccessor",
     # Pipeline
     "pipeline",
     "register_step",

--- a/arnio/integrations/__init__.py
+++ b/arnio/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Integration helpers for the Python data ecosystem."""
+
+from .pandas import ArnioPandasAccessor
+
+__all__ = ["ArnioPandasAccessor"]

--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -1,0 +1,88 @@
+"""Pandas DataFrame accessor for Arnio workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import pandas as pd
+
+from arnio.convert import from_pandas, to_pandas
+from arnio.frame import ArFrame
+from arnio.pipeline import pipeline as run_pipeline
+from arnio.quality import DataQualityReport, auto_clean, profile, suggest_cleaning
+from arnio.schema import Schema, ValidationResult, validate
+
+
+@pd.api.extensions.register_dataframe_accessor("arnio")
+class ArnioPandasAccessor:
+    """Run Arnio preparation helpers from an existing pandas DataFrame."""
+
+    def __init__(self, pandas_obj: pd.DataFrame) -> None:
+        self._df = pandas_obj
+
+    def to_arframe(self) -> ArFrame:
+        """Convert the DataFrame into an Arnio frame."""
+        return from_pandas(self._df)
+
+    def pipeline(self, steps: Sequence[Any]) -> pd.DataFrame:
+        """Run an Arnio pipeline and return a pandas DataFrame."""
+        frame = self.to_arframe()
+        return to_pandas(run_pipeline(frame, steps))
+
+    def clean(
+        self,
+        steps: Sequence[Any] | None = None,
+        *,
+        strip_whitespace: bool = True,
+        drop_nulls: bool = False,
+        drop_duplicates: bool = False,
+    ) -> pd.DataFrame:
+        """Clean a DataFrame with Arnio and return pandas output.
+
+        When ``steps`` is provided, it is passed directly to ``ar.pipeline``.
+        Otherwise this uses Arnio's convenience ``clean`` behavior.
+        """
+        if steps is not None:
+            return self.pipeline(steps)
+
+        from arnio.cleaning import clean
+
+        frame = clean(
+            self.to_arframe(),
+            strip_whitespace=strip_whitespace,
+            drop_nulls=drop_nulls,
+            drop_duplicates=drop_duplicates,
+        )
+        return to_pandas(frame)
+
+    def profile(self, *, sample_size: int = 5) -> DataQualityReport:
+        """Profile DataFrame quality with Arnio."""
+        return profile(self.to_arframe(), sample_size=sample_size)
+
+    def suggest_cleaning(self) -> list[tuple[str, dict[str, Any]]]:
+        """Return Arnio pipeline-compatible cleaning suggestions."""
+        return suggest_cleaning(self.to_arframe())
+
+    def auto_clean(
+        self,
+        *,
+        mode: str = "safe",
+        return_report: bool = False,
+    ) -> pd.DataFrame | tuple[pd.DataFrame, DataQualityReport]:
+        """Run Arnio's automatic cleaning and return pandas output."""
+        result = auto_clean(
+            self.to_arframe(),
+            mode=mode,
+            return_report=return_report,
+        )
+
+        if return_report:
+            frame, report = result
+            return to_pandas(frame), report
+
+        return to_pandas(result)
+
+    def validate(self, schema: Schema | dict[str, Any]) -> ValidationResult:
+        """Validate the DataFrame against an Arnio schema."""
+        return validate(self.to_arframe(), schema)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "arnio"
 version = "1.2.0"
-description = "C++ accelerated CSV preprocessing and data cleaning for pandas"
+description = "C++ accelerated data preparation for pandas and the Python data stack"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9"
 authors = [
     { name = "Anish Raj", email = "anishrajyadav97@gmail.com" }
 ]
-keywords = ["pandas", "csv", "data-cleaning", "preprocessing", "c++", "performance"]
+keywords = ["pandas", "csv", "data-cleaning", "preprocessing", "data-quality", "schema-validation", "c++", "performance"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -1,0 +1,70 @@
+"""Tests for the pandas DataFrame accessor."""
+
+import pandas as pd
+
+import arnio as ar
+
+
+def test_pandas_accessor_converts_to_arframe():
+    df = pd.DataFrame({"name": ["Alice"], "age": [30]})
+
+    frame = df.arnio.to_arframe()
+
+    assert isinstance(frame, ar.ArFrame)
+    assert frame.shape == (1, 2)
+    assert frame.columns == ["name", "age"]
+
+
+def test_pandas_accessor_runs_explicit_pipeline_without_mutating_source():
+    df = pd.DataFrame({"name": [" Alice ", " Bob "], "age": [30, 40]})
+
+    result = df.arnio.clean(
+        [
+            ("strip_whitespace", {"subset": ["name"]}),
+            ("normalize_case", {"subset": ["name"], "case_type": "lower"}),
+        ]
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["alice", "bob"]
+    assert list(df["name"]) == [" Alice ", " Bob "]
+
+
+def test_pandas_accessor_runs_convenience_clean():
+    df = pd.DataFrame({"name": [" Alice ", " Alice "], "score": [10, 10]})
+
+    result = df.arnio.clean(drop_duplicates=True)
+
+    assert list(result["name"]) == ["Alice"]
+    assert list(result["score"]) == [10]
+
+
+def test_pandas_accessor_profiles_dataframe_quality():
+    df = pd.DataFrame({"name": [" Alice ", "Bob"], "score": [1.5, None]})
+
+    report = df.arnio.profile()
+
+    assert isinstance(report, ar.DataQualityReport)
+    assert report.row_count == 2
+    assert report.columns["name"].whitespace_count == 1
+    assert report.columns["score"].null_count == 1
+
+
+def test_pandas_accessor_auto_clean_returns_dataframe_and_report():
+    df = pd.DataFrame({"name": [" Alice ", "Bob"]})
+
+    result, report = df.arnio.auto_clean(return_report=True)
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["Alice", "Bob"]
+    assert isinstance(report, ar.DataQualityReport)
+
+
+def test_pandas_accessor_validates_dataframe():
+    df = pd.DataFrame({"email": ["alice@example.com", "bad"]})
+
+    result = df.arnio.validate({"email": ar.Email(nullable=False)})
+
+    assert isinstance(result, ar.ValidationResult)
+    assert not result.passed
+    assert result.issues[0].rule == "email"


### PR DESCRIPTION
## Summary

This PR adds the first concrete interoperability layer for Arnio and clarifies the product direction.

### What changed

- Adds `PROJECT_DIRECTION.md` to explain Arnio as a fast data-preparation layer for the Python data ecosystem.
- Updates README and ROADMAP positioning around pandas, NumPy, scikit-learn, DuckDB, Arrow, and notebooks.
- Adds a pandas DataFrame accessor: `df.arnio`.
- Supports:
  - `df.arnio.to_arframe()`
  - `df.arnio.pipeline(...)`
  - `df.arnio.clean(...)`
  - `df.arnio.profile()`
  - `df.arnio.suggest_cleaning()`
  - `df.arnio.auto_clean(...)`
  - `df.arnio.validate(...)`
- Adds focused accessor tests.

## Why

This keeps Arnio positioned as a companion to pandas and the wider Python data stack, not a replacement. Users can keep their existing pandas workflows while using Arnio for preparation, quality checks, and validation.

Fixes #398.

## Verification

- `python -m black --check arnio\integrations tests\test_pandas_accessor.py`
- `python -m ruff check arnio\integrations tests\test_pandas_accessor.py`
- `python -m py_compile arnio\integrations\__init__.py arnio\integrations\pandas.py tests\test_pandas_accessor.py`
- `git diff --cached --check`
- Pre-commit on commit: Black passed, Ruff passed

Note: local pytest could not run because this Windows environment is missing the C++ build toolchain (`nmake` / MSVC), so `_arnio_cpp` cannot be built/imported locally. GitHub CI should be the runtime gate.