### PR TITLE
docs: add interoperability examples for pandas, NumPy, scikit-learn, and DuckDB

### DIFF
--- a/examples/arnio_with_duckdb.py
+++ b/examples/arnio_with_duckdb.py
@@ -1,0 +1,74 @@
+"""
+Arnio + DuckDB: Clean/validate data before querying.
+----------------------------------------------------
+This example shows how to use Arnio to clean messy data and
+then load it into DuckDB for SQL-based analytics.
+
+Run:
+    python examples/arnio_with_duckdb.py
+
+Requires:
+    pip install duckdb
+"""
+
+import io
+
+try:
+    import duckdb
+except ImportError:
+    print("DuckDB is not installed. Run: pip install duckdb")
+    raise SystemExit(0)
+
+import arnio as ar
+
+
+def main():
+    # 1. Synthetic messy CSV: sales records
+    raw_csv = (
+        "order_id,product,quantity,unit_price,region\n"
+        "O1, Widget A ,10,5.99, North \n"
+        "O2,Widget B,,3.49,South\n"   # missing quantity
+        "O3, Gadget C ,5,12.00,EAST\n"
+        "O1, Widget A ,10,5.99,North\n"  # duplicate
+        "O4,Gadget D,2,,West\n"          # missing unit_price
+        "O5,Widget E,7,8.50,South\n"
+    )
+
+    # 2. Load and clean with Arnio
+    frame = ar.read_csv(io.StringIO(raw_csv))
+    clean_frame = ar.pipeline(
+        frame,
+        [
+            ("strip_whitespace",),
+            ("normalize_case", {"case_type": "title"}),
+            ("fill_nulls", {"value": 0.0, "subset": ["quantity", "unit_price"]}),
+            ("drop_duplicates",),
+        ],
+    )
+    df = ar.to_pandas(clean_frame)
+    print("--- Cleaned Data ---")
+    print(df)
+
+    # 3. Register the cleaned DataFrame with DuckDB and run SQL queries
+    con = duckdb.connect()
+    con.register("sales", df)
+
+    print("\n--- Total Revenue by Region ---")
+    result = con.execute(
+        "SELECT region, ROUND(SUM(quantity * unit_price), 2) AS total_revenue "
+        "FROM sales GROUP BY region ORDER BY total_revenue DESC"
+    ).df()
+    print(result)
+
+    print("\n--- Top Products by Quantity Sold ---")
+    result2 = con.execute(
+        "SELECT product, SUM(quantity) AS total_qty "
+        "FROM sales GROUP BY product ORDER BY total_qty DESC LIMIT 5"
+    ).df()
+    print(result2)
+
+    con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/arnio_with_numpy.py
+++ b/examples/arnio_with_numpy.py
@@ -1,0 +1,58 @@
+"""
+Arnio + NumPy: Prepare numeric arrays safely.
+---------------------------------------------
+This example shows how to use Arnio to clean numeric columns
+and export them as NumPy arrays for further computation.
+
+Run:
+    python examples/arnio_with_numpy.py
+"""
+
+import io
+import arnio as ar
+import numpy as np
+
+
+def main():
+    # 1. Synthetic CSV with messy numeric data
+    raw_csv = (
+        "sensor_id,temperature,humidity\n"
+        "S1, 22.5 ,60.0\n"
+        "S2,,55.0\n"         # missing temperature
+        "S3,19.0, 80.0 \n"
+        "S4,150.0,70.0\n"    # outlier temperature (will be clipped)
+        "S5,21.0,\n"         # missing humidity
+    )
+
+    # 2. Load through Arnio's C++ core
+    frame = ar.read_csv(io.StringIO(raw_csv))
+    print("--- Raw Data ---")
+    print(ar.to_pandas(frame))
+
+    # 3. Clean: fill missing values, clip outliers, strip whitespace
+    clean_frame = ar.pipeline(
+        frame,
+        [
+            ("strip_whitespace",),
+            ("fill_nulls", {"value": 0.0, "subset": ["temperature", "humidity"]}),
+            ("clip_numeric", {"column": "temperature", "min": -40.0, "max": 100.0}),
+        ],
+    )
+
+    # 4. Convert to pandas then extract NumPy arrays
+    df = ar.to_pandas(clean_frame)
+    print("\n--- Cleaned DataFrame ---")
+    print(df)
+
+    temps = df["temperature"].to_numpy(dtype=np.float64)
+    humidity = df["humidity"].to_numpy(dtype=np.float64)
+
+    # 5. NumPy analysis
+    print("\n--- NumPy Statistics ---")
+    print(f"Temperature  -> mean: {np.mean(temps):.2f}, std: {np.std(temps):.2f}")
+    print(f"Humidity     -> mean: {np.mean(humidity):.2f}, std: {np.std(humidity):.2f}")
+    print(f"Correlation  -> {np.corrcoef(temps, humidity)[0, 1]:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/arnio_with_pandas.py
+++ b/examples/arnio_with_pandas.py
@@ -1,0 +1,54 @@
+"""
+Arnio + pandas: Clean a messy CSV, then analyze with pandas.
+-------------------------------------------------------------
+This example shows how to use Arnio to clean raw data and then
+hand the result off to pandas for analysis.
+
+Run:
+    python examples/arnio_with_pandas.py
+"""
+
+import io
+import arnio as ar
+
+
+def main():
+    # 1. Synthetic messy CSV (inline, no external file needed)
+    raw_csv = (
+        "product,price,category\n"
+        " Widget A ,12.5,electronics\n"
+        "Widget B,,electronics\n"   # missing price
+        " Widget A ,12.5,electronics\n"  # duplicate
+        "Gadget C,8.0, TOOLS \n"
+        "Gadget D,0.0,tools\n"  # zero price (valid)
+    )
+
+    # 2. Load raw data through Arnio's C++ core
+    frame = ar.read_csv(io.StringIO(raw_csv))
+    print("--- Raw Data ---")
+    print(ar.to_pandas(frame))
+
+    # 3. Clean with an Arnio pipeline
+    clean_frame = ar.pipeline(
+        frame,
+        [
+            ("strip_whitespace",),
+            ("normalize_case", {"case_type": "title"}),
+            ("fill_nulls", {"value": 0.0, "subset": ["price"]}),
+            ("drop_duplicates",),
+        ],
+    )
+
+    # 4. Convert to pandas for analysis
+    df = ar.to_pandas(clean_frame)
+    print("\n--- Cleaned DataFrame ---")
+    print(df)
+
+    # 5. Analyze with pandas
+    print("\n--- Average price by category ---")
+    summary = df.groupby("category")["price"].mean().reset_index()
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/arnio_with_sklearn.py
+++ b/examples/arnio_with_sklearn.py
@@ -1,0 +1,71 @@
+"""
+Arnio + scikit-learn: Prepare data before a small ML pipeline.
+--------------------------------------------------------------
+This example shows how to use Arnio to clean and validate a
+dataset before feeding it into a scikit-learn machine learning
+pipeline.
+
+Run:
+    python examples/arnio_with_sklearn.py
+"""
+
+import io
+import arnio as ar
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+from sklearn.preprocessing import LabelEncoder
+
+
+def main():
+    # 1. Synthetic CSV: predict churn based on usage & tenure
+    raw_csv = (
+        "customer_id,monthly_usage,tenure_months,churned\n"
+        "C1, 120 ,24,no\n"
+        "C2,45,6,yes\n"
+        "C3,,12,yes\n"       # missing usage
+        "C4,200,36,no\n"
+        "C5,80,3,yes\n"
+        "C6,150, ,24,no\n"   # extra comma / bad row -> Arnio handles
+        "C7,60,9,yes\n"
+        "C8,180,30,no\n"
+        "C9,90,15,no\n"
+        "C10,30,2,yes\n"
+    )
+
+    # 2. Load and clean with Arnio
+    frame = ar.read_csv(io.StringIO(raw_csv))
+    clean_frame = ar.pipeline(
+        frame,
+        [
+            ("strip_whitespace",),
+            ("fill_nulls", {"value": 0.0, "subset": ["monthly_usage", "tenure_months"]}),
+            ("drop_nulls",),
+        ],
+    )
+    df = ar.to_pandas(clean_frame)
+    print("--- Cleaned Data ---")
+    print(df)
+
+    # 3. Encode target and prepare features
+    le = LabelEncoder()
+    df["churned"] = le.fit_transform(df["churned"])  # yes=1, no=0
+
+    X = df[["monthly_usage", "tenure_months"]].astype(float)
+    y = df["churned"]
+
+    # 4. Train / test split and fit a simple logistic regression
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.3, random_state=42
+    )
+    model = LogisticRegression()
+    model.fit(X_train, y_train)
+
+    # 5. Evaluate
+    preds = model.predict(X_test)
+    print(f"\n--- Model Accuracy: {accuracy_score(y_test, preds):.2%} ---")
+    print("Coefficients:", dict(zip(X.columns, model.coef_[0])))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds 4 self-contained interoperability example scripts under `examples/` that show Arnio working alongside the Python data stack. Each script uses only synthetic inline data, requires no external files, and is runnable from a fresh checkout.

## Linked issue

Fixes #397

## Type of change

- [x] Documentation
- [x] Feature (new examples)

## Files added

| File | Demonstrates |
|---|---|
| `examples/arnio_with_pandas.py` | Clean a messy CSV with Arnio, then analyze with pandas (groupby) |
| `examples/arnio_with_numpy.py` | Clean numeric sensor data with Arnio, extract NumPy arrays, compute stats |
| `examples/arnio_with_sklearn.py` | Clean customer data with Arnio, then train a scikit-learn LogisticRegression |
| `examples/arnio_with_duckdb.py` | Clean sales records with Arnio, then query with DuckDB SQL |

## Checklist

- [x] Examples use synthetic/inline datasets only (no external files)
- [x] All examples are runnable from a fresh checkout (`pip install arnio`)
- [x] DuckDB example gracefully skips if `duckdb` is not installed
- [x] Code follows the style of existing examples (`basic_usage.py`, `custom_step.py`)
- [x] Each file has a clear docstring with a `Run:` instruction