### PR TITLE
feat: add deterministic multiline CSV benchmark dataset generation

### DIFF
--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 DEFAULT_TALL_PATH = "benchmarks/benchmark_1m.csv"
 DEFAULT_WIDE_PATH = "benchmarks/benchmark_wide.csv"
-
+DEFAULT_MULTILINE_PATH = "benchmarks/benchmark_multiline.csv"
 
 def generate(rows=1_000_000, path=DEFAULT_TALL_PATH):
     rng = np.random.default_rng(42)
@@ -71,7 +71,73 @@ def generate_wide(rows=5_000, columns=256, path=DEFAULT_WIDE_PATH):
     df.to_csv(path, index=False, lineterminator="\n")
     print(f"Generated {rows:,} row x {columns:,} column CSV -> {path}")
 
+def generate_multiline(
+    rows=100_000,
+    path=DEFAULT_MULTILINE_PATH,
+    multiline_ratio=0.3,
+):
+    """
+    Generate deterministic CSV containing quoted multiline fields.
+    Used for benchmarking multiline CSV parsing performance.
+    """
 
+    if rows < 1:
+        raise ValueError("multiline benchmark requires at least 1 row")
+
+    rng = np.random.default_rng(512)
+
+    multiline_templates = [
+        "First line\nSecond line",
+        "hello world\nthis is multiline text",
+        "alpha\nbeta\ngamma",
+        "quoted field\nwith embedded newline",
+        "line1\nline2\nline3",
+    ]
+
+    singleline_templates = [
+        "simple text",
+        "benchmark row",
+        "plain csv value",
+        "single line content",
+        "normal parser row",
+    ]
+
+    descriptions = []
+
+    for _ in range(rows):
+        if rng.random() < multiline_ratio:
+            descriptions.append(rng.choice(multiline_templates))
+        else:
+            descriptions.append(rng.choice(singleline_templates))
+
+    df = pd.DataFrame(
+        {
+            "id": np.arange(rows),
+            "name": rng.choice(
+                ["Alice", "Bob", "Charlie", "Diana"],
+                rows,
+            ),
+            "description": descriptions,
+            "score": rng.uniform(0, 100, rows).round(4),
+            "active": rng.choice(
+                ["true", "false", "TRUE", "FALSE"],
+                rows,
+            ),
+        }
+    )
+
+    df.to_csv(
+        path,
+        index=False,
+        lineterminator="\n",
+        quoting=1,  # csv.QUOTE_ALL
+    )
+
+    print(
+        f"Generated multiline benchmark CSV "
+        f"({rows:,} rows, ratio={multiline_ratio:.0%}) -> {path}"
+    )
 if __name__ == "__main__":
     generate()
     generate_wide()
+    generate_multiline()


### PR DESCRIPTION
## Summary
Adds deterministic quoted multiline CSV dataset generation for reproducible parser benchmarking.

## Changes
- Added `generate_multiline()` benchmark dataset generator
- Added deterministic RNG seed for reproducibility
- Added quoted multiline field templates
- Added mixed single-line and multiline dataset coverage
- Added validation for multiline benchmark generation
- Added dedicated multiline benchmark CSV output path

## Benchmark Goals
- Benchmark multiline CSV parsing performance
- Preserve consistent dataset shape across runs
- Improve reproducibility of parser benchmarks
- Support quoted newline edge cases

## Notes
- No parser behavior changes
- Benchmark-only scoped changes
- Dataset generation remains deterministic

Fixes #251