### PR TITLE
docs: document pandas index conversion behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ If a dtype is partially supported, users may need conversion before processing. 
 - String columns require Python string object creation during `to_pandas()` conversion.
 - Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
 - Unsupported dtypes should raise clear user-facing errors instead of silent failures.
+> **Note:** pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion. Converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
 
 <br>
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -341,6 +341,12 @@ class TestFromPandas:
         assert list(result["flag"]) == [True, False, pd.NA]
 
 
+    def test_dataframe_index_is_dropped(self):
+        """pandas index is not preserved during from_pandas conversion."""
+        df = pd.DataFrame({"a": [1, 2, 3]}, index=["x", "y", "z"])
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert isinstance(result.index, pd.RangeIndex)
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):
         """attrs set on input DataFrame survive from_pandas -> to_pandas."""

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -340,13 +340,14 @@ class TestFromPandas:
 
         assert list(result["flag"]) == [True, False, pd.NA]
 
-
     def test_dataframe_index_is_dropped(self):
         """pandas index is not preserved during from_pandas conversion."""
         df = pd.DataFrame({"a": [1, 2, 3]}, index=["x", "y", "z"])
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
         assert isinstance(result.index, pd.RangeIndex)
+
+
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):
         """attrs set on input DataFrame survive from_pandas -> to_pandas."""


### PR DESCRIPTION
## Summary
- Added a regression test verifying pandas indexes are dropped during conversion
- Documented the current index handling behavior
- Clarified that converted DataFrames receive a default RangeIndex

Fixes #238