### PR TITLE
fix: add YAML validation for GitHub workflow files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,22 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.1
     hooks:
       - id: ruff
         args: [--fix]
+
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v17.0.6
     hooks:
       - id: clang-format
         types_or: [c++, c]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        files: ^\.github/
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,3 @@ repos:
     hooks:
       - id: check-yaml
         files: ^\.github/
-


### PR DESCRIPTION
Addressed the requested review changes:

* Preserved the existing Black, Ruff, and clang-format hooks
* Added `check-yaml` as an additional hook scoped to `.github/`
* Removed unrelated changes from the PR
* Fixed the whitespace / EOF issue reported by `git diff --check`

Validation performed:

* `pre-commit run check-yaml --all-files`
* `pre-commit run --files .pre-commit-config.yaml`

`pre-commit run check-yaml --all-files`
This is the hook command,
as check-yaml is the specific hook ID that was introduced
--all-files runs it against all matching YAML files in the repo

I also reran `pre-commit run --all-files`. The YAML hook passes successfully, but my local clang-format setup reformats an unrelated existing C++ test file outside the scope of this PR, so those unrelated formatting changes were intentionally not included to keep the diff focused on YAML/pre-commit validation only.

Ready for re-review. Thanks!
<img width="554" height="175" alt="Screenshot 2026-05-16 at 12 52 50 PM" src="https://github.com/user-attachments/assets/2f8aa7b2-300b-41b4-8a19-ddfd1bd8fc8d" />
