### PR TITLE
docs: Add Google Colab install smoke test guide

### DIFF
--- a/COLAB_SMOKE_TEST.md
+++ b/COLAB_SMOKE_TEST.md
@@ -1,0 +1,56 @@
+# Google Colab install smoke test
+
+This is a lightweight, copy-pasteable smoke test to verify that `pip install arnio` works in a fresh Google Colab runtime.
+
+## 1) Install
+
+Run this in a new Colab notebook cell:
+
+```python
+!pip install arnio
+```
+
+## 2) Verify import
+
+```python
+import arnio as ar
+
+print("arnio version:", ar.__version__)
+print("arnio imported successfully")
+```
+
+## 3) Create a tiny CSV
+
+This creates a small file directly in Colab (no uploads needed):
+
+```python
+from pathlib import Path
+
+csv_text = """name,revenue,city
+ Ishan ,10,London
+ Pranay, ,Paris
+ Ishan ,10,London
+"""
+
+Path("sample.csv").write_text(csv_text, encoding="utf-8")
+print("wrote sample.csv")
+```
+
+## 4) Minimal validation
+
+```python
+import arnio as ar
+
+print("scan_csv:", ar.scan_csv("sample.csv"))
+
+frame = ar.read_csv("sample.csv")
+df = ar.to_pandas(frame)
+
+print("shape:", df.shape)
+df
+```
+
+## Troubleshooting
+
+- If you get unexpected import errors after re-running cells, use **Runtime → Restart runtime**, then re-run the notebook top to bottom.
+- If `pip install arnio` fails, copy the full error output into a GitHub issue and include your Colab runtime type (Python version) and the exact install commands you ran.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ No `.apply()`. No lambda chains. No spaghetti.
 pip install arnio
 ```
 
+Colab install smoke test: **[COLAB_SMOKE_TEST.md](COLAB_SMOKE_TEST.md)**
+
 <br>
 
 <a href="#-quickstart">Quickstart</a>&ensp;·&ensp;<a href="#-why-arnio-exists">Why Arnio</a>&ensp;·&ensp;<a href="#%EF%B8%8F-architecture">Architecture</a>&ensp;·&ensp;<a href="#-benchmarks">Benchmarks</a>&ensp;·&ensp;<a href="#-community">Community</a>&ensp;·&ensp;<a href="#-contribute">Contribute</a>


### PR DESCRIPTION
## Summary
Adds a lightweight Google Colab install smoke-test guide (Markdown only) with a tiny inline CSV example and a minimal `arnio` verification flow. Links the guide from the README.

## Linked issue
Fixes #264

## Type of change
- [x] Documentation

## Area
- [x] Docs / website

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: Verified `pip install arnio` in a clean venv and confirmed `scan_csv`, `read_csv`, and `to_pandas` work on a tiny CSV.

## Screenshots / Media
N/A (docs-only)

## Performance Impact
N/A

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Docs-only PR limited to Colab install smoke-test documentation; no CI/packaging changes.