### PR TITLE
test: add bool null-mask conversion tests

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -161,3 +161,19 @@ class TestFromPandas:
         result_df = ar.to_pandas(result)
 
         assert list(result_df.columns) == ["name", "age", "city"]
+
+    def test_nullable_boolean_roundtrip(self):
+        df = pd.DataFrame(
+            {
+                "active": pd.Series(
+                    [True, False, pd.NA],
+                    dtype="boolean",
+                )
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert str(result["active"].dtype) == "boolean"
+        assert list(result["active"]) == [True, False, pd.NA]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -202,12 +202,12 @@ class TestFromPandas:
 
     def test_nullable_boolean_roundtrip(self):
         df = pd.DataFrame(
-        {
-            "active": pd.Series(
-                [True, False, pd.NA],
-                dtype="boolean",
-            )
-        }
+            {
+                "active": pd.Series(
+                    [True, False, pd.NA],
+                    dtype="boolean",
+                )
+            }
         )
 
         frame = ar.from_pandas(df)
@@ -215,7 +215,6 @@ class TestFromPandas:
 
         assert str(result["active"].dtype) == "boolean"
         assert list(result["active"]) == [True, False, pd.NA]
-
 
     def test_bool_null_mask_roundtrip(self):
         df = pd.DataFrame(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -177,3 +177,18 @@ class TestFromPandas:
 
         assert str(result["active"].dtype) == "boolean"
         assert list(result["active"]) == [True, False, pd.NA]
+
+    def test_bool_null_mask_roundtrip(self):
+        df = pd.DataFrame(
+            {
+                "flag": pd.Series(
+                    [True, False, pd.NA],
+                    dtype="boolean",
+                )
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert list(result["flag"]) == [True, False, pd.NA]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -200,6 +200,23 @@ class TestFromPandas:
 
         assert list(result_df.columns) == ["name", "age", "city"]
 
+    def test_nullable_boolean_roundtrip(self):
+        df = pd.DataFrame(
+        {
+            "active": pd.Series(
+                [True, False, pd.NA],
+                dtype="boolean",
+            )
+        }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert str(result["active"].dtype) == "boolean"
+        assert list(result["active"]) == [True, False, pd.NA]
+
+
     def test_bool_null_mask_roundtrip(self):
         df = pd.DataFrame(
             {


### PR DESCRIPTION
## Summary

Adds focused regression tests for nullable boolean columns with null masks during pandas ↔ Arnio conversions.

The tests verify that boolean columns preserve values and null semantics during round-trip conversion.

## Linked issue

Fixes #243

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:

```bash
python -m pytest tests/test_convert.py -q
python -m black --check arnio tests