### PR TITLE
test: add sdist build smoke test

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,6 +18,13 @@ jobs:
           ref: ${{ inputs.tag_name || github.ref }}
       - name: Build sdist
         run: pipx run build --sdist
+      
+      - name: Install package from sdist
+        run: pip install dist/*.tar.gz
+
+      - name: Smoke test import
+        run: python -c "import arnio"
+
       - uses: actions/upload-artifact@v4
         with:
           name: sdist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,13 +18,10 @@ jobs:
           ref: ${{ inputs.tag_name || github.ref }}
       - name: Build sdist
         run: pipx run build --sdist
-      
       - name: Install package from sdist
         run: pip install dist/*.tar.gz
-
       - name: Smoke test import
         run: python -c "import arnio"
-
       - uses: actions/upload-artifact@v4
         with:
           name: sdist


### PR DESCRIPTION
## Summary

Adds a source distribution (sdist) smoke test to the CI workflow.

### Changes

* Build the source distribution in CI
* Install the generated sdist package
* Run a minimal import smoke test using `import arnio`

This helps verify that source-based installations work correctly before publishing artifacts.

Fixes #263
