### PR TITLE
feat: add to_pandas copy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ clean = ar.pipeline(frame, [
 
 # Out comes a standard pandas DataFrame — use it like you always have
 df = ar.to_pandas(clean)
+
+# Use copy=True when you need defensive pandas-owned buffers
+safe_df = ar.to_pandas(clean, copy=True)
 ```
 
 Already have a pandas `DataFrame`? Use Arnio in-place in your existing pandas
@@ -296,7 +299,7 @@ Arnio is not a pandas wrapper. It's a separate runtime with its own data model.
 | **Columnar storage** | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready. |
 | **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks. |
 | **Two-pass CSV read** | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead. |
-| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol. Numeric and boolean columns cross the boundary without copying. |
+| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol. Numeric and boolean columns cross the boundary without copying unless `copy=True` is requested. |
 | **Step registry** | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry. |
 
 > Full architecture documentation: **[ARCHITECTURE.md](ARCHITECTURE.md)**
@@ -482,6 +485,7 @@ If a dtype is partially supported, users may need conversion before processing. 
 ### Notes
 
 - Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
+- Pass `copy=True` to `to_pandas()` when downstream pandas code needs defensive column buffers.
 - String columns require Python string object creation during `to_pandas()` conversion.
 - Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
 - Unsupported dtypes should raise clear user-facing errors instead of silent failures.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Arnio is not a pandas wrapper. It's a separate runtime with its own data model.
 | **Columnar storage** | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready. |
 | **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks. |
 | **Two-pass CSV read** | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead. |
-| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol. Numeric and boolean columns cross the boundary without copying unless `copy=True` is requested. |
+| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol where supported. Numeric columns preserve the fast zero-copy path by default, while `copy=True` requests defensive pandas-owned buffers. |
 | **Step registry** | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry. |
 
 > Full architecture documentation: **[ARCHITECTURE.md](ARCHITECTURE.md)**
@@ -484,8 +484,10 @@ If a dtype is partially supported, users may need conversion before processing. 
 
 ### Notes
 
-- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
-- Pass `copy=True` to `to_pandas()` when downstream pandas code needs defensive column buffers.
+- Numeric columns are optimized for zero-copy conversion between C++ and pandas where supported.
+- Pass `copy=True` to `to_pandas()` when downstream pandas code needs defensive pandas-owned column buffers.
+- Boolean conversion is already copied by the binding because `std::vector<bool>` cannot be exposed as a zero-copy NumPy buffer in the current implementation.
+- Columns with null masks may require copies so pandas can apply nullable values safely.
 - String columns require Python string object creation during `to_pandas()` conversion.
 - Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
 - Unsupported dtypes should raise clear user-facing errors instead of silent failures.

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -5,7 +5,7 @@ Pandas conversion functions.
 
 from __future__ import annotations
 
-import copy
+import copy as copylib
 
 import numpy as np
 import pandas as pd
@@ -67,13 +67,17 @@ def _series_to_python_values(series: pd.Series, col_name: object) -> list[object
     return values
 
 
-def to_pandas(frame: ArFrame) -> pd.DataFrame:
+def to_pandas(frame: ArFrame, *, copy: bool = False) -> pd.DataFrame:
     """Convert ArFrame to pandas.DataFrame.
 
     Parameters
     ----------
     frame : ArFrame
         Input ArFrame to convert.
+    copy : bool, default False
+        When False, use zero-copy buffers for supported numeric and boolean
+        columns where possible. When True, return defensive copies of
+        supported column buffers.
 
     Returns
     -------
@@ -86,7 +90,11 @@ def to_pandas(frame: ArFrame) -> pd.DataFrame:
     --------
     >>> frame = ar.read_csv("data.csv")
     >>> df = ar.to_pandas(frame)
+    >>> defensive_df = ar.to_pandas(frame, copy=True)
     """
+    if not isinstance(copy, bool):
+        raise TypeError("copy must be a bool")
+
     cpp_frame = frame._frame
     data = {}
 
@@ -98,16 +106,23 @@ def to_pandas(frame: ArFrame) -> pd.DataFrame:
 
         if dtype == _DType.INT64:
             arr = col.to_numpy_int()
+            if copy:
+                arr = arr.copy()
             # pandas Int64Dtype handles nulls via mask
             series = pd.Series(arr, dtype=pd.Int64Dtype())
             series[mask] = pd.NA
             data[name] = series
         elif dtype == _DType.FLOAT64:
-            arr = col.to_numpy_float().copy()
-            arr[mask] = np.nan
+            arr = col.to_numpy_float()
+            if copy or mask.any():
+                arr = arr.copy()
+            if mask.any():
+                arr[mask] = np.nan
             data[name] = arr
         elif dtype == _DType.BOOL:
             arr = col.to_numpy_bool()
+            if copy:
+                arr = arr.copy()
             series = pd.Series(arr, dtype=pd.BooleanDtype())
             series[mask] = pd.NA
             data[name] = series
@@ -120,7 +135,7 @@ def to_pandas(frame: ArFrame) -> pd.DataFrame:
 
     result = pd.DataFrame(data)
     if frame._attrs:
-        result.attrs = copy.deepcopy(frame._attrs)
+        result.attrs = copylib.deepcopy(frame._attrs)
     return result
 
 
@@ -168,5 +183,4 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
             dtype_hints[name] = dtype_hint
 
     cpp_frame = _Frame.from_dict(columns, dtype_hints)
-    return ArFrame(cpp_frame, attrs=copy.deepcopy(df.attrs))
-
+    return ArFrame(cpp_frame, attrs=copylib.deepcopy(df.attrs))

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -75,9 +75,10 @@ def to_pandas(frame: ArFrame, *, copy: bool = False) -> pd.DataFrame:
     frame : ArFrame
         Input ArFrame to convert.
     copy : bool, default False
-        When False, use zero-copy buffers for supported numeric and boolean
-        columns where possible. When True, return defensive copies of
-        supported column buffers.
+        When False, preserve the fast zero-copy path where supported. Some
+        columns still require copies because of null-mask handling, Python
+        object creation, or binding limitations. When True, return defensive
+        pandas-owned copies of supported column buffers.
 
     Returns
     -------

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,6 @@
 """Tests for pandas conversion."""
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -45,6 +46,57 @@ class TestToPandas:
         df = ar.to_pandas(frame, copy=True)
 
         assert df.isna().any().any()
+
+    def test_copy_option_isolates_integer_buffers(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        zero_copy = ar.to_pandas(frame)
+        defensive = ar.to_pandas(frame, copy=True)
+        original_age = zero_copy.loc[0, "age"]
+
+        assert not np.shares_memory(
+            zero_copy["age"].to_numpy(copy=False),
+            defensive["age"].to_numpy(copy=False),
+        )
+
+        defensive.loc[0, "age"] = 99
+
+        assert zero_copy.loc[0, "age"] == original_age
+        assert ar.to_pandas(frame).loc[0, "age"] == original_age
+
+    def test_copy_option_isolates_float_buffers(self, tmp_path):
+        csv_path = tmp_path / "floats.csv"
+        csv_path.write_text("score\n1.5\n2.5\n3.5\n")
+        frame = ar.read_csv(csv_path)
+
+        zero_copy = ar.to_pandas(frame)
+        defensive = ar.to_pandas(frame, copy=True)
+
+        assert not np.shares_memory(
+            zero_copy["score"].to_numpy(copy=False),
+            defensive["score"].to_numpy(copy=False),
+        )
+
+        defensive.loc[0, "score"] = 99.5
+
+        assert zero_copy.loc[0, "score"] == 1.5
+        assert ar.to_pandas(frame).loc[0, "score"] == 1.5
+
+    def test_boolean_conversion_is_already_isolated(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        first = ar.to_pandas(frame)
+        second = ar.to_pandas(frame)
+
+        assert not np.shares_memory(
+            first["active"].to_numpy(copy=False),
+            second["active"].to_numpy(copy=False),
+        )
+
+        second.loc[0, "active"] = False
+
+        assert first.loc[0, "active"] is np.True_
+        assert ar.to_pandas(frame).loc[0, "active"] is np.True_
 
     def test_to_python_list_with_nulls(self):
         frame = ar.from_pandas(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -24,6 +24,28 @@ class TestToPandas:
         df = ar.to_pandas(frame)
         assert df.isna().any().any()  # Should have some NaN/NA values
 
+    def test_copy_option_returns_equivalent_dataframe(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        zero_copy = ar.to_pandas(frame)
+        defensive = ar.to_pandas(frame, copy=True)
+
+        pd.testing.assert_frame_equal(defensive, zero_copy)
+        assert defensive is not zero_copy
+
+    def test_copy_option_rejects_non_bool(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="copy must be a bool"):
+            ar.to_pandas(frame, copy="yes")
+
+    def test_copy_option_preserves_null_masks(self, csv_with_nulls):
+        frame = ar.read_csv(csv_with_nulls)
+
+        df = ar.to_pandas(frame, copy=True)
+
+        assert df.isna().any().any()
+
     def test_to_python_list_with_nulls(self):
         frame = ar.from_pandas(
             pd.DataFrame(


### PR DESCRIPTION
## Summary
- add a keyword-only `copy` option to `to_pandas()`
- keep the default fast/zero-copy behavior for supported buffers
- return defensive copies for supported numeric/bool buffers when `copy=True`
- validate invalid `copy` values with a clear `TypeError`
- document the new option in README quickstart and interop notes

Fixes #241

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_convert.py::TestToPandas::test_basic_conversion tests/test_convert.py::TestToPandas::test_types_preserved tests/test_convert.py::TestToPandas::test_nulls_converted tests/test_convert.py::TestToPandas::test_copy_option_returns_equivalent_dataframe tests/test_convert.py::TestToPandas::test_copy_option_rejects_non_bool tests/test_convert.py::TestToPandas::test_copy_option_preserves_null_masks -q` ✅ 6 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check arnio/convert.py tests/test_convert.py` ✅
- `git diff --check` ✅

## Note
I also ran `pytest tests/test_convert.py -q`; it currently fails outside this PR's `to_pandas(copy=...)` path because the local compiled extension exposes `_Frame.from_dict(dict)` only, while current `origin/main` Python code calls `_Frame.from_dict(columns, dtype_hints)` from `from_pandas()`. The focused `to_pandas` regression tests pass.

## GSSoC labels requested
Please add `gssoc:approved`, `level:intermediate`, `quality:clean`, and `type:feature` if this PR meets the project criteria.
