### PR TITLE
feat: add thousands separator option

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -169,4 +169,3 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
 
     cpp_frame = _Frame.from_dict(columns, dtype_hints)
     return ArFrame(cpp_frame, attrs=copy.deepcopy(df.attrs))
-

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -61,6 +61,7 @@ def read_csv(
     nrows: int | None = None,
     encoding: str = "utf-8",
     trim_headers: bool = True,
+    thousands_separator: str | None = None,
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -80,6 +81,14 @@ def read_csv(
         File encoding.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.
+    thousands_separator : str, optional
+        Single non-alphanumeric character used as a thousands separator
+        during numeric parsing.
+
+        Values containing delimiter characters must still be quoted
+        properly in the CSV input. For example, when using a comma
+        delimiter, the value "1,234" must be quoted, while unquoted
+        1,234 is interpreted as two separate fields.
 
     Returns
     -------
@@ -89,7 +98,10 @@ def read_csv(
     Raises
     ------
     ValueError
-        If file format is unsupported.
+        If file format is unsupported or if thousands_separator is invalid.
+
+    TypeError
+        If thousands_separator is not a string or None.
 
     CsvReadError
         If CSV input contains NUL bytes and appears binary or corrupted.
@@ -124,11 +136,22 @@ def read_csv(
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
 
+    if thousands_separator is not None:
+        if not isinstance(thousands_separator, str):
+            raise TypeError("thousands_separator must be a string or None")
+        if len(thousands_separator) != 1:
+            raise ValueError("thousands_separator must be a single character")
+        if thousands_separator.isalnum() or thousands_separator in ['"', "\n", "\r"]:
+            raise ValueError(
+                "thousands_separator must be a single non-alphanumeric character excluding quotes and newlines"
+            )
+
     config = _CsvConfig()
     config.delimiter = delimiter
     config.has_header = has_header
     config.encoding = encoding
     config.trim_headers = trim_headers
+    config.thousands_separator = thousands_separator
 
     if usecols is not None:
         config.usecols = usecols
@@ -154,6 +177,7 @@ def scan_csv(
     delimiter: str = ",",
     encoding: str = "utf-8",
     trim_headers: bool = True,
+    thousands_separator: str | None = None,
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
 
@@ -167,6 +191,14 @@ def scan_csv(
         File encoding. Non-UTF-8 inputs are transcoded before native scanning.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.
+    thousands_separator : str, optional
+        Single non-alphanumeric character used as a thousands separator
+        during numeric parsing.
+
+        Values containing delimiter characters must still be quoted
+        properly in the CSV input. For example, when using a comma
+        delimiter, the value "1,234" must be quoted, while unquoted
+        1,234 is interpreted as two separate fields.
 
     Returns
     -------
@@ -176,7 +208,10 @@ def scan_csv(
     Raises
     ------
     ValueError
-        If file format is unsupported.
+        If file format is unsupported or if thousands_separator is invalid.
+
+    TypeError
+        If thousands_separator is not a string or None.
 
     CsvReadError
         If CSV input contains NUL bytes and appears binary or corrupted.
@@ -213,10 +248,21 @@ def scan_csv(
     except FileNotFoundError:
         pass
 
+    if thousands_separator is not None:
+        if not isinstance(thousands_separator, str):
+            raise TypeError("thousands_separator must be a string or None")
+        if len(thousands_separator) != 1:
+            raise ValueError("thousands_separator must be a single character")
+        if thousands_separator.isalnum() or thousands_separator in ['"', "\n", "\r"]:
+            raise ValueError(
+                "thousands_separator must be a single non-alphanumeric character excluding quotes and newlines"
+            )
+
     config = _CsvConfig()
     config.delimiter = delimiter
     config.encoding = encoding
     config.trim_headers = trim_headers
+    config.thousands_separator = thousands_separator
     reader = _CsvReader(config)
     try:
         with _utf8_csv_path(path, encoding) as native_path:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -52,6 +52,21 @@ def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
                 pass
 
 
+def _validate_thousands_separator(
+    thousands_separator: str | None,
+) -> None:
+    if thousands_separator is None:
+        return
+    if not isinstance(thousands_separator, str):
+        raise TypeError("thousands_separator must be a string or None")
+    if len(thousands_separator) != 1:
+        raise ValueError("thousands_separator must be a single character")
+    if thousands_separator.isalnum() or thousands_separator in {'"', "\n", "\r"}:
+        raise ValueError(
+            "thousands_separator must be a single non-alphanumeric character"
+        )
+
+
 def read_csv(
     path: str | os.PathLike[str],
     *,
@@ -136,15 +151,7 @@ def read_csv(
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
 
-    if thousands_separator is not None:
-        if not isinstance(thousands_separator, str):
-            raise TypeError("thousands_separator must be a string or None")
-        if len(thousands_separator) != 1:
-            raise ValueError("thousands_separator must be a single character")
-        if thousands_separator.isalnum() or thousands_separator in ['"', "\n", "\r"]:
-            raise ValueError(
-                "thousands_separator must be a single non-alphanumeric character excluding quotes and newlines"
-            )
+    _validate_thousands_separator(thousands_separator)
 
     config = _CsvConfig()
     config.delimiter = delimiter
@@ -248,21 +255,14 @@ def scan_csv(
     except FileNotFoundError:
         pass
 
-    if thousands_separator is not None:
-        if not isinstance(thousands_separator, str):
-            raise TypeError("thousands_separator must be a string or None")
-        if len(thousands_separator) != 1:
-            raise ValueError("thousands_separator must be a single character")
-        if thousands_separator.isalnum() or thousands_separator in ['"', "\n", "\r"]:
-            raise ValueError(
-                "thousands_separator must be a single non-alphanumeric character excluding quotes and newlines"
-            )
+    _validate_thousands_separator(thousands_separator)
 
     config = _CsvConfig()
     config.delimiter = delimiter
     config.encoding = encoding
     config.trim_headers = trim_headers
     config.thousands_separator = thousands_separator
+
     reader = _CsvReader(config)
     try:
         with _utf8_csv_path(path, encoding) as native_path:

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -101,7 +101,7 @@ def run_case(case):
     print(f"{'Exec Time (avg)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s")
     print(f"{'Peak RAM':<20} {avg(pd_rams):>10.0f}MB {avg(ar_rams):>10.0f}MB")
     print(
-        f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams)/avg(pd_rams))*100:.0f}% reduction"
+        f"\nSpeed: {avg(pd_times) / avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams) / avg(pd_rams)) * 100:.0f}% reduction"
     )
     print()
 

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -101,7 +101,7 @@ def run_case(case):
     print(f"{'Exec Time (avg)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s")
     print(f"{'Peak RAM':<20} {avg(pd_rams):>10.0f}MB {avg(ar_rams):>10.0f}MB")
     print(
-        f"\nSpeed: {avg(pd_times) / avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams) / avg(pd_rams)) * 100:.0f}% reduction"
+        f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams)/avg(pd_rams))*100:.0f}% reduction"
     )
     print()
 

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -154,62 +154,62 @@ PYBIND11_MODULE(_arnio_cpp, m) {
             py::return_value_policy::reference_internal)
         .def("add_column", &Frame::add_column)
         .def("clone", &Frame::clone)
-        .def_static("from_dict",
-                    [](py::dict cols_dict, py::dict dtype_hints) {
-                        Frame frame;
+        .def_static(
+            "from_dict",
+            [](py::dict cols_dict, py::dict dtype_hints) {
+                Frame frame;
 
-                        for (auto item : cols_dict) {
-                            std::string name = py::cast<std::string>(item.first);
-                            py::list values = py::cast<py::list>(item.second);
+                for (auto item : cols_dict) {
+                    std::string name = py::cast<std::string>(item.first);
+                    py::list values = py::cast<py::list>(item.second);
 
-                            DType dtype = DType::STRING;
-                            py::str py_name(name);
+                    DType dtype = DType::STRING;
+                    py::str py_name(name);
 
-                            if (dtype_hints.contains(py_name)) {
-                                dtype = dtype_hints[py_name].cast<DType>();
-                            } else {
-                                for (auto val : values) {
-                                    if (val.is_none()) continue;
-                                    if (py::isinstance<py::bool_>(val)) {
-                                        dtype = DType::BOOL;
-                                        break;
-                                    }
-                                    if (py::isinstance<py::int_>(val)) {
-                                        dtype = DType::INT64;
-                                        break;
-                                    }
-                                    if (py::isinstance<py::float_>(val)) {
-                                        dtype = DType::FLOAT64;
-                                        break;
-                                    }
-                                    break;
-                                }
+                    if (dtype_hints.contains(py_name)) {
+                        dtype = dtype_hints[py_name].cast<DType>();
+                    } else {
+                        for (auto val : values) {
+                            if (val.is_none()) continue;
+                            if (py::isinstance<py::bool_>(val)) {
+                                dtype = DType::BOOL;
+                                break;
                             }
-
-                            Column col(name, dtype);
-                            for (auto val : values) {
-                                if (val.is_none()) {
-                                    col.push_null();
-                                    continue;
-                                }
-
-                                if (dtype == DType::BOOL)
-                                    col.push_back(val.cast<bool>());
-                                else if (dtype == DType::INT64)
-                                    col.push_back(val.cast<int64_t>());
-                                else if (dtype == DType::FLOAT64)
-                                    col.push_back(val.cast<double>());
-                                else
-                                    col.push_back(py::str(val).cast<std::string>());
+                            if (py::isinstance<py::int_>(val)) {
+                                dtype = DType::INT64;
+                                break;
                             }
+                            if (py::isinstance<py::float_>(val)) {
+                                dtype = DType::FLOAT64;
+                                break;
+                            }
+                            break;
+                        }
+                    }
 
-                            frame.add_column(col);
+                    Column col(name, dtype);
+                    for (auto val : values) {
+                        if (val.is_none()) {
+                            col.push_null();
+                            continue;
                         }
 
-                        return frame;
-                    },
-                    py::arg("cols_dict"),
-                    py::arg("dtype_hints") = py::dict());
+                        if (dtype == DType::BOOL)
+                            col.push_back(val.cast<bool>());
+                        else if (dtype == DType::INT64)
+                            col.push_back(val.cast<int64_t>());
+                        else if (dtype == DType::FLOAT64)
+                            col.push_back(val.cast<double>());
+                        else
+                            col.push_back(py::str(val).cast<std::string>());
+                    }
+
+                    frame.add_column(col);
+                }
+
+                return frame;
+            },
+            py::arg("cols_dict"), py::arg("dtype_hints") = py::dict());
 
     // --- CsvReader ---
     py::class_<CsvConfig>(m, "CsvConfig")
@@ -219,7 +219,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("usecols", &CsvConfig::usecols)
         .def_readwrite("nrows", &CsvConfig::nrows)
         .def_readwrite("encoding", &CsvConfig::encoding)
-        .def_readwrite("trim_headers", &CsvConfig::trim_headers);
+        .def_readwrite("trim_headers", &CsvConfig::trim_headers)
+        .def_readwrite("thousands_separator", &CsvConfig::thousands_separator);
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -17,6 +17,7 @@ struct CsvConfig {
     std::optional<size_t> nrows = std::nullopt;
     std::string encoding = "utf-8";  // Currently only utf-8 supported
     bool trim_headers = true;        // for implementing the trim_headers option
+    std::optional<char> thousands_separator = std::nullopt;
 };
 
 class CsvReader {
@@ -36,13 +37,13 @@ class CsvReader {
     std::vector<std::string> parse_line(const std::string& line) const;
 
     // Infer DType from a string value
-    static DType infer_type(const std::string& value);
+    DType infer_type(const std::string& value) const;
 
     // Promote dtype when merging inferences
     static DType promote_type(DType current, DType incoming);
 
     // Parse a string value into a CellValue given a target dtype
-    static CellValue parse_value(const std::string& raw, DType dtype);
+    CellValue parse_value(const std::string& raw, DType dtype) const;
 };
 
 }  // namespace arnio

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -74,6 +74,16 @@ void validate_header(const std::vector<std::string>& header) {
         }
     }
 }
+
+std::string strip_thousands_separator(const std::string& value, const CsvConfig& config) {
+    if (!config.thousands_separator.has_value()) {
+        return value;
+    }
+    std::string cleaned = value;
+    cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), config.thousands_separator.value()),
+                  cleaned.end());
+    return cleaned;
+}
 }  // namespace
 
 CsvReader::CsvReader(const CsvConfig& config) : config_(config) {}
@@ -113,7 +123,7 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
     return fields;
 }
 
-DType CsvReader::infer_type(const std::string& value) {
+DType CsvReader::infer_type(const std::string& value) const {
     if (value.empty()) return DType::NULL_TYPE;
 
     // Try bool
@@ -121,9 +131,11 @@ DType CsvReader::infer_type(const std::string& value) {
     std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
     if (lower == "true" || lower == "false") return DType::BOOL;
 
+    std::string cleaned = strip_thousands_separator(value, config_);
+
     // Try int64
     {
-        const char* start = value.c_str();
+        const char* start = cleaned.c_str();
         char* end = nullptr;
         long long val = std::strtoll(start, &end, 10);
         (void)val;
@@ -132,7 +144,7 @@ DType CsvReader::infer_type(const std::string& value) {
 
     // Try float64
     {
-        const char* start = value.c_str();
+        const char* start = cleaned.c_str();
         char* end = nullptr;
         double val = std::strtod(start, &end);
         (void)val;
@@ -157,7 +169,7 @@ DType CsvReader::promote_type(DType current, DType incoming) {
     return DType::STRING;
 }
 
-CellValue CsvReader::parse_value(const std::string& raw, DType dtype) {
+CellValue CsvReader::parse_value(const std::string& raw, DType dtype) const {
     if (raw.empty()) return std::monostate{};
 
     switch (dtype) {
@@ -168,14 +180,16 @@ CellValue CsvReader::parse_value(const std::string& raw, DType dtype) {
         }
         case DType::INT64: {
             try {
-                return static_cast<int64_t>(std::stoll(raw));
+                std::string cleaned = strip_thousands_separator(raw, config_);
+                return static_cast<int64_t>(std::stoll(cleaned));
             } catch (...) {
                 return std::monostate{};
             }
         }
         case DType::FLOAT64: {
             try {
-                return std::stod(raw);
+                std::string cleaned = strip_thousands_separator(raw, config_);
+                return std::stod(cleaned);
             } catch (...) {
                 return std::monostate{};
             }

--- a/cpp/tests/test_column_consistency.cpp
+++ b/cpp/tests/test_column_consistency.cpp
@@ -1,10 +1,10 @@
-#include "arnio/column.h"
-
 #include <cstdlib>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+#include "arnio/column.h"
 
 static int failures = 0;
 
@@ -20,8 +20,7 @@ int main() {
 
     // Construct an inconsistent column: dtype=INT64 but data holds strings.
     ColumnData bad_data = std::vector<std::string>{"hello"};
-    Column inconsistent("test", DType::INT64, std::move(bad_data),
-                        std::vector<bool>{false});
+    Column inconsistent("test", DType::INT64, std::move(bad_data), std::vector<bool>{false});
 
     // -- clone() ----------------------------------------------------------
     {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -38,6 +38,48 @@ class TestReadCsv:
         assert dtypes["name"] == "string"
         assert dtypes["active"] == "bool"
 
+    def test_thousands_separator_comma(self, tmp_path):
+        csv_path = tmp_path / "comma_thousands.csv"
+        csv_path.write_text('value\n"1,234"\n')
+        frame = ar.read_csv(csv_path, thousands_separator=",")
+        df = ar.to_pandas(frame)
+        assert df["value"].iloc[0] == 1234
+
+    def test_thousands_separator_space(self, tmp_path):
+        csv_path = tmp_path / "space_thousands.csv"
+        csv_path.write_text("value\n1 234\n")
+        frame = ar.read_csv(csv_path, thousands_separator=" ")
+        df = ar.to_pandas(frame)
+        assert df["value"].iloc[0] == 1234
+
+    def test_default_behavior_without_thousands_separator(self, tmp_path):
+        csv_path = tmp_path / "default_behavior.csv"
+        csv_path.write_text('value\n"1,234"\n')
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+        assert df["value"].iloc[0] == "1,234"
+
+    @pytest.mark.parametrize("separator", ["", "a", "3", "ab", "\n", '"'])
+    def test_invalid_thousands_separator(self, tmp_path, separator):
+        csv_path = tmp_path / "default_behavior.csv"
+        csv_path.write_text("value\n1234\n")
+        with pytest.raises(ValueError):
+            ar.read_csv(csv_path, thousands_separator=separator)
+
+    def test_thousands_separator_not_applied_to_strings(self, tmp_path):
+        csv_path = tmp_path / "string.csv"
+        csv_path.write_text('message\n"hello,world"\n')
+        frame = ar.read_csv(csv_path, thousands_separator=",")
+        df = ar.to_pandas(frame)
+        assert df["message"].iloc[0] == "hello,world"
+
+    def test_unquoted_comma_value_with_comma_delimeter(self, tmp_path):
+        csv_path = tmp_path / "delimiter_interaction.csv"
+        csv_path.write_text("value\n1,234\n")
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+        assert df["value"].iloc[0] == 1
+
     def test_large_csv(self, large_csv):
         frame = ar.read_csv(large_csv)
         assert frame.shape == (1000, 3)
@@ -210,6 +252,12 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, encoding="latin-1")
 
         assert schema == {"name": "string"}
+
+    def test_scan_csv_with_thousands_separator(self, tmp_path):
+        csv_path = tmp_path / "scan_thousands.csv"
+        csv_path.write_text('value\n"1,234"\n')
+        schema = ar.scan_csv(csv_path, thousands_separator=",")
+        assert schema["value"] == "int64"
 
     def test_scan_binary_file_rejection(self, tmp_path):
         file_path = str(tmp_path / "data.csv")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -66,6 +66,15 @@ class TestReadCsv:
         with pytest.raises(ValueError):
             ar.read_csv(csv_path, thousands_separator=separator)
 
+    @pytest.mark.parametrize("separator", [1, 1.5, True, [], {}])
+    def test_invalid_non_string_thousands_separator(self, tmp_path, separator):
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text("value\n1234\n")
+        with pytest.raises(TypeError):
+            ar.read_csv(csv_path, thousands_separator=separator)
+        with pytest.raises(TypeError):
+            ar.scan_csv(csv_path, thousands_separator=separator)
+
     def test_thousands_separator_not_applied_to_strings(self, tmp_path):
         csv_path = tmp_path / "string.csv"
         csv_path.write_text('message\n"hello,world"\n')
@@ -73,7 +82,7 @@ class TestReadCsv:
         df = ar.to_pandas(frame)
         assert df["message"].iloc[0] == "hello,world"
 
-    def test_unquoted_comma_value_with_comma_delimeter(self, tmp_path):
+    def test_unquoted_comma_value_with_comma_delimiter(self, tmp_path):
         csv_path = tmp_path / "delimiter_interaction.csv"
         csv_path.write_text("value\n1,234\n")
         frame = ar.read_csv(csv_path)


### PR DESCRIPTION

### Summary

Adds support for thousands_separator in read_csv() and scan_csv() for improved numeric parsing of formatted numbers.

**Example:**
`ar.read_csv("data.csv", thousands_separator=",")`

This allows values such as "1,234" to be parsed as numeric values instead of strings.

### Linked issue
Fixes #135 

### Type of change
- [x] Feature

### Area
- [x] CSV parser

### Changes made

### Python API
Added thousands_separator parameter to:
- read_csv()
- scan_csv()

### Validation
Restricted thousands_separator to a single non-alphanumeric character.
Rejects:

- empty strings
- multi-character values
- letters/digits
- newline characters
- quote characters

### C++ backend

- Added thousands_separator support to CsvConfig
- Exposed the field through pybind bindings
- Applied separator stripping during:
-- type inference
-- numeric parsing

### Documentation

- Added delimiter interaction note:
- values like "1,234" must be quoted in comma-delimited CSVs
- unquoted 1,234 is still treated as two CSV fields

### Tests

Added tests for:
- quoted comma-separated thousands values
- space-separated thousands values
- default behavior without separator
- invalid separator values
- schema scanning with separator
- delimiter interaction behavior
- string values remaining unchanged

### Contributor checklist

- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (feat:).

###  Maintainer notes
This change improves CSV numeric parsing robustness for real-world datasets containing formatted numbers (e.g., "1,000", "10,000").

No breaking changes introduced