### PR TITLE
feat: add list_steps registry introspection

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -32,7 +32,7 @@ from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepErro
 from .frame import ArFrame
 from .integrations import ArnioPandasAccessor
 from .io import read_csv, scan_csv
-from .pipeline import pipeline, register_step
+from .pipeline import list_steps, pipeline, register_step
 from .quality import (
     ColumnProfile,
     DataQualityReport,
@@ -81,6 +81,7 @@ __all__ = [
     # Integrations
     "ArnioPandasAccessor",
     # Pipeline
+    "list_steps",
     "pipeline",
     "register_step",
     # Data quality

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -48,6 +48,24 @@ def register_step(name: str, fn: Callable):
     _PYTHON_STEP_REGISTRY[name] = fn
 
 
+def list_steps() -> list[str]:
+    """List all registered pipeline step names.
+
+    Returns built-in C++ backed steps and custom Python-registered steps.
+
+    Returns
+    -------
+    list[str]
+        Sorted list of all registered step names.
+
+    Examples
+    --------
+    >>> ar.list_steps()
+    ['cast_types', 'clip_numeric', 'drop_constant_columns', ...]
+    """
+    return sorted(set(_STEP_REGISTRY.keys()) | set(_PYTHON_STEP_REGISTRY.keys()))
+
+
 def pipeline(
     frame: ArFrame,
     steps: list[tuple],

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -191,6 +191,31 @@ class TestPipeline:
             assert "Expected a dict" in str(e)
 
 
+class TestListSteps:
+    def test_list_steps_includes_builtins(self):
+        steps = ar.list_steps()
+        assert "drop_nulls" in steps
+        assert "strip_whitespace" in steps
+        assert "cast_types" in steps
+
+    def test_list_steps_includes_custom_after_registration(self):
+        def dummy(df, **kwargs):
+            return df
+
+        ar.register_step("test_custom_step", dummy)
+        steps = ar.list_steps()
+        assert "test_custom_step" in steps
+
+    def test_list_steps_returns_sorted(self):
+        steps = ar.list_steps()
+        assert steps == sorted(steps)
+
+    def test_list_steps_does_not_mutate_registry(self):
+        before = ar.list_steps()
+        after = ar.list_steps()
+        assert before == after
+
+
 def test_filter_rows_greater_than():
     import pandas as pd
 


### PR DESCRIPTION
Adds a list_steps() function that returns all registered pipeline step names from both the built-in C++ backed registry and the custom Python registry. Useful for discovery in notebooks and docs.

Closes #157

## Changes
- rnio/pipeline.py — added list_steps() function
- rnio/__init__.py — exported list_steps
- 	ests/test_pipeline.py — tests for built-in steps, custom steps after registration, sorted output, and non-mutating behavior