### PR TITLE
feat: add scikit-learn ArnioCleaner transformer

### DIFF
--- a/arnio/integrations/sklearn.py
+++ b/arnio/integrations/sklearn.py
@@ -15,6 +15,7 @@ except ImportError:
 from arnio.convert import from_pandas, to_pandas
 from arnio.pipeline import pipeline as run_pipeline
 
+
 class ArnioCleaner(BaseEstimator, TransformerMixin):
     """
     A scikit-learn compatible transformer that wraps the Arnio C++ pipeline.
@@ -74,4 +75,3 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
             )
 
         return np.asarray(input_features, dtype=object)
-    

--- a/arnio/integrations/sklearn.py
+++ b/arnio/integrations/sklearn.py
@@ -1,0 +1,63 @@
+"""Scikit-learn integration for Arnio's data preparation engine."""
+
+import pandas as pd
+
+# Fail gracefully if scikit-learn isn't installed in the current environment
+try:
+    from sklearn.base import BaseEstimator, TransformerMixin
+except ImportError:
+    raise ImportError(
+        "The 'scikit-learn' package is required to use ArnioCleaner. "
+        "Install it with: pip install scikit-learn"
+    )
+
+from arnio.convert import from_pandas, to_pandas
+from arnio.pipeline import pipeline as run_pipeline
+
+class ArnioCleaner(BaseEstimator, TransformerMixin):
+    """
+    A scikit-learn compatible transformer that wraps the Arnio C++ pipeline.
+    
+    Example:
+        >>> import pandas as pd
+        >>> from sklearn.pipeline import Pipeline
+        >>> from arnio.integrations.sklearn import ArnioCleaner
+        >>> 
+        >>> df = pd.DataFrame({"A": [" dirty ", "data "], "B": [1, 2]})
+        >>> pipe = Pipeline([("arnio_prep", ArnioCleaner(steps=[]))])
+        >>> X_clean = pipe.fit_transform(df)
+    """
+    
+    def __init__(self, steps=None, copy=True):
+        self.steps = steps if steps is not None else []
+        self.copy = copy
+        self.feature_names_in_ = None
+        
+    def fit(self, X, y=None):
+        if not isinstance(X, pd.DataFrame):
+            raise TypeError(f"ArnioCleaner requires a pandas DataFrame, got {type(X)}")
+            
+        # Store input features for get_feature_names_out compliance
+        self.feature_names_in_ = X.columns.tolist()
+        return self
+        
+    def transform(self, X, y=None):
+        if not isinstance(X, pd.DataFrame):
+            raise TypeError(f"ArnioCleaner requires a pandas DataFrame, got {type(X)}")
+            
+        # Prevent mutating the user's original data
+        X_in = X.copy() if self.copy else X
+        
+        # Execute the Arnio C++ pipeline
+        ar_frame = from_pandas(X_in)
+        cleaned_ar_frame = run_pipeline(ar_frame, self.steps)
+        X_out = to_pandas(cleaned_ar_frame)
+            
+        # Ensure the pandas index survives the C++ conversion roundtrip
+        if not X_out.index.equals(X.index):
+            X_out.index = X.index
+            
+        return X_out
+
+    def get_feature_names_out(self, input_features=None):
+        return self.feature_names_in_

--- a/arnio/integrations/sklearn.py
+++ b/arnio/integrations/sklearn.py
@@ -1,14 +1,15 @@
 """Scikit-learn integration for Arnio's data preparation engine."""
 
+import numpy as np
 import pandas as pd
 
-# Fail gracefully if scikit-learn isn't installed in the current environment
 try:
     from sklearn.base import BaseEstimator, TransformerMixin
+    from sklearn.utils.validation import check_is_fitted
 except ImportError:
     raise ImportError(
         "The 'scikit-learn' package is required to use ArnioCleaner. "
-        "Install it with: pip install scikit-learn"
+        "Install it with: pip install arnio[sklearn]"
     )
 
 from arnio.convert import from_pandas, to_pandas
@@ -17,47 +18,60 @@ from arnio.pipeline import pipeline as run_pipeline
 class ArnioCleaner(BaseEstimator, TransformerMixin):
     """
     A scikit-learn compatible transformer that wraps the Arnio C++ pipeline.
-    
+
     Example:
         >>> import pandas as pd
         >>> from sklearn.pipeline import Pipeline
         >>> from arnio.integrations.sklearn import ArnioCleaner
-        >>> 
+        >>>
         >>> df = pd.DataFrame({"A": [" dirty ", "data "], "B": [1, 2]})
         >>> pipe = Pipeline([("arnio_prep", ArnioCleaner(steps=[]))])
         >>> X_clean = pipe.fit_transform(df)
     """
-    
+
     def __init__(self, steps=None, copy=True):
         self.steps = steps if steps is not None else []
         self.copy = copy
-        self.feature_names_in_ = None
-        
+
     def fit(self, X, y=None):
         if not isinstance(X, pd.DataFrame):
             raise TypeError(f"ArnioCleaner requires a pandas DataFrame, got {type(X)}")
-            
-        # Store input features for get_feature_names_out compliance
-        self.feature_names_in_ = X.columns.tolist()
+
+        # Scikit-learn expectation: store feature names as a numpy array and track feature count
+        self.feature_names_in_ = np.array(X.columns, dtype=object)
+        self.n_features_in_ = X.shape[1]
         return self
-        
+
     def transform(self, X, y=None):
+        # Scikit-learn expectation: ensure the estimator was fitted
+        check_is_fitted(self, "n_features_in_")
+
         if not isinstance(X, pd.DataFrame):
             raise TypeError(f"ArnioCleaner requires a pandas DataFrame, got {type(X)}")
-            
-        # Prevent mutating the user's original data
+
         X_in = X.copy() if self.copy else X
-        
-        # Execute the Arnio C++ pipeline
+
         ar_frame = from_pandas(X_in)
         cleaned_ar_frame = run_pipeline(ar_frame, self.steps)
         X_out = to_pandas(cleaned_ar_frame)
-            
-        # Ensure the pandas index survives the C++ conversion roundtrip
+
         if not X_out.index.equals(X.index):
             X_out.index = X.index
-            
+
         return X_out
 
     def get_feature_names_out(self, input_features=None):
-        return self.feature_names_in_
+        """Enable compatibility with ColumnTransformer workflows."""
+        check_is_fitted(self, "n_features_in_")
+
+        if input_features is None:
+            return self.feature_names_in_
+
+        if len(input_features) != self.n_features_in_:
+            raise ValueError(
+                f"input_features should have length equal to number of features "
+                f"({self.n_features_in_}), got {len(input_features)}"
+            )
+
+        return np.asarray(input_features, dtype=object)
+    

--- a/examples/sklearn_pipeline.py
+++ b/examples/sklearn_pipeline.py
@@ -1,36 +1,45 @@
 """
 Scikit-learn Pipeline Example for Arnio
 """
+
 import pandas as pd
 
 try:
     from sklearn.pipeline import Pipeline
 except ImportError:
-    print("This example requires scikit-learn. Install it with: pip install scikit-learn")
+    print(
+        "This example requires scikit-learn. Install it with: pip install scikit-learn"
+    )
     exit(1)
 
 from arnio.integrations.sklearn import ArnioCleaner
 
+
 def main():
-    df = pd.DataFrame({
-        "name": ["  Alice  ", "Bob"],
-        "age": [30, None]
-    })
+    df = pd.DataFrame({"name": ["  Alice  ", "Bob"], "age": [30, None]})
 
     print("--- Original DataFrame ---")
     print(df)
 
-    pipe = Pipeline([
-        ("arnio_prep", ArnioCleaner(steps=[
-            ("strip_whitespace",),
-            ("fill_nulls", {"value": 0, "subset": ["age"]})
-        ])),
-    ])
+    pipe = Pipeline(
+        [
+            (
+                "arnio_prep",
+                ArnioCleaner(
+                    steps=[
+                        ("strip_whitespace",),
+                        ("fill_nulls", {"value": 0, "subset": ["age"]}),
+                    ]
+                ),
+            ),
+        ]
+    )
 
     clean_df = pipe.fit_transform(df)
-    
+
     print("\n--- Cleaned DataFrame ---")
     print(clean_df)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/sklearn_pipeline.py
+++ b/examples/sklearn_pipeline.py
@@ -1,0 +1,36 @@
+"""
+Scikit-learn Pipeline Example for Arnio
+"""
+import pandas as pd
+
+try:
+    from sklearn.pipeline import Pipeline
+except ImportError:
+    print("This example requires scikit-learn. Install it with: pip install scikit-learn")
+    exit(1)
+
+from arnio.integrations.sklearn import ArnioCleaner
+
+def main():
+    df = pd.DataFrame({
+        "name": ["  Alice  ", "Bob"],
+        "age": [30, None]
+    })
+
+    print("--- Original DataFrame ---")
+    print(df)
+
+    pipe = Pipeline([
+        ("arnio_prep", ArnioCleaner(steps=[
+            ("strip_whitespace",),
+            ("fill_nulls", {"value": 0, "subset": ["age"]})
+        ])),
+    ])
+
+    clean_df = pipe.fit_transform(df)
+    
+    print("\n--- Cleaned DataFrame ---")
+    print(clean_df)
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dev = [
     "ruff>=0.4.0",
     "pre-commit>=3.0",
 ]
+sklearn = [
+    "scikit-learn>=1.0",
+]
 
 [tool.setuptools.package-data]
 arnio = ["py.typed"]

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+# Skip this entire test suite if scikit-learn isn't installed
+pytest.importorskip("sklearn")
+
+from sklearn.pipeline import Pipeline
+from arnio.integrations.sklearn import ArnioCleaner
+
+def test_arniocleaner_dataframe_validation():
+    cleaner = ArnioCleaner()
+    
+    with pytest.raises(TypeError):
+        cleaner.fit([1, 2, 3])
+        
+    with pytest.raises(TypeError):
+        cleaner.transform([1, 2, 3])
+
+def test_arniocleaner_in_pipeline():
+    df = pd.DataFrame({"A": [" data ", "here "], "B": [1, 2]})
+    cleaner = ArnioCleaner(steps=[])
+    pipe = Pipeline([("arnio_prep", cleaner)])
+    
+    result = pipe.fit_transform(df)
+    
+    assert isinstance(result, pd.DataFrame)
+    assert result.index.equals(df.index)

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1,27 +1,48 @@
+import numpy as np
 import pandas as pd
 import pytest
 
-# Skip this entire test suite if scikit-learn isn't installed
 pytest.importorskip("sklearn")
 
 from sklearn.pipeline import Pipeline
 from arnio.integrations.sklearn import ArnioCleaner
 
-def test_arniocleaner_dataframe_validation():
+def test_arniocleaner_non_dataframe_input():
     cleaner = ArnioCleaner()
-    
-    with pytest.raises(TypeError):
-        cleaner.fit([1, 2, 3])
-        
-    with pytest.raises(TypeError):
-        cleaner.transform([1, 2, 3])
+    # Test lists and numpy arrays fail safely
+    with pytest.raises(TypeError, match="requires a pandas DataFrame"):
+        cleaner.fit([[1, 2], [3, 4]])
+
+    cleaner.fit(pd.DataFrame({"A": [1]}))
+    with pytest.raises(TypeError, match="requires a pandas DataFrame"):
+        cleaner.transform(np.array([[1], [2]]))
+
+def test_arniocleaner_configured_steps():
+    df = pd.DataFrame({"A": ["  dirty  ", "data "], "B": [1, 2]})
+
+    cleaner = ArnioCleaner(steps=[("strip_whitespace",)])
+    result = cleaner.fit_transform(df)
+
+    assert result["A"].tolist() == ["dirty", "data"]
+
+def test_arniocleaner_copy_behavior():
+    df = pd.DataFrame({"A": ["  dirty  ", "data "]})
+
+    # Test copy=True (default) ensures the original dataframe isn't mutated
+    cleaner = ArnioCleaner(steps=[("strip_whitespace",)], copy=True)
+    cleaner.fit_transform(df)
+
+    # Original should still have spaces
+    assert df.iloc[0, 0] == "  dirty  "
 
 def test_arniocleaner_in_pipeline():
     df = pd.DataFrame({"A": [" data ", "here "], "B": [1, 2]})
     cleaner = ArnioCleaner(steps=[])
     pipe = Pipeline([("arnio_prep", cleaner)])
-    
+
     result = pipe.fit_transform(df)
-    
+
     assert isinstance(result, pd.DataFrame)
     assert result.index.equals(df.index)
+    assert list(result.columns) == ["A", "B"]
+    

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -5,7 +5,9 @@ import pytest
 pytest.importorskip("sklearn")
 
 from sklearn.pipeline import Pipeline
+
 from arnio.integrations.sklearn import ArnioCleaner
+
 
 def test_arniocleaner_non_dataframe_input():
     cleaner = ArnioCleaner()
@@ -17,6 +19,7 @@ def test_arniocleaner_non_dataframe_input():
     with pytest.raises(TypeError, match="requires a pandas DataFrame"):
         cleaner.transform(np.array([[1], [2]]))
 
+
 def test_arniocleaner_configured_steps():
     df = pd.DataFrame({"A": ["  dirty  ", "data "], "B": [1, 2]})
 
@@ -24,6 +27,7 @@ def test_arniocleaner_configured_steps():
     result = cleaner.fit_transform(df)
 
     assert result["A"].tolist() == ["dirty", "data"]
+
 
 def test_arniocleaner_copy_behavior():
     df = pd.DataFrame({"A": ["  dirty  ", "data "]})
@@ -35,6 +39,7 @@ def test_arniocleaner_copy_behavior():
     # Original should still have spaces
     assert df.iloc[0, 0] == "  dirty  "
 
+
 def test_arniocleaner_in_pipeline():
     df = pd.DataFrame({"A": [" data ", "here "], "B": [1, 2]})
     cleaner = ArnioCleaner(steps=[])
@@ -45,4 +50,3 @@ def test_arniocleaner_in_pipeline():
     assert isinstance(result, pd.DataFrame)
     assert result.index.equals(df.index)
     assert list(result.columns) == ["A", "B"]
-    


### PR DESCRIPTION
Fixes #395

Hi @im-anishraj, here is the initial implementation for the `ArnioCleaner` scikit-learn transformer, following the structure we discussed.

**Key implementations:**
* Added the integration under the `arnio.integrations.sklearn` module.
* Validates and strictly expects pandas `DataFrame` input/output.
* Implemented `fit()`, `transform()`, and `get_feature_names_out()`, including logic to restore the pandas index after the C++ roundtrip.
* Uses `.copy()` to avoid mutating the caller's input.
* Guarded the sklearn imports with a clear `ImportError` fallback.
* Added tests in `test_sklearn.py` utilizing `pytest.importorskip("sklearn")`.
* Included a Pipeline usage example in the class docstring and added a standalone runnable script in `examples/sklearn_pipeline.py`.

*(Note: I am pushing this to utilize the CI pipeline for the C++ build and test formatting, as I am temporarily away from my local build environment!)*