### PR TITLE
feat: add validation summary counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,11 +515,16 @@ schema = ar.Schema({
 
 result = ar.validate(frame, schema)
 if not result.passed:
+    summary = result.summary()
+    print(summary["issues_by_rule"])
+    print(summary["issues_by_column"])
+    print(summary["issues_by_column_and_rule"])
     print(result.to_pandas())
     print(result.to_markdown(max_issues=10))
 ```
 
 `ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
+Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
 
 For low-risk automatic cleanup:
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -88,19 +88,27 @@ class ValidationResult:
         }
 
     def summary(self) -> dict[str, Any]:
-        """Return a compact validation summary."""
+        """Return a compact validation summary.
+
+        Severity counts are not included because ``ValidationIssue`` does not
+        currently carry severity information.
+        """
         by_rule: dict[str, int] = {}
         by_column: dict[str, int] = {}
+        by_column_and_rule: dict[str, dict[str, int]] = {}
         for issue in self.issues:
             by_rule[issue.rule] = by_rule.get(issue.rule, 0) + 1
             if issue.column is not None:
                 by_column[issue.column] = by_column.get(issue.column, 0) + 1
+                column_rules = by_column_and_rule.setdefault(issue.column, {})
+                column_rules[issue.rule] = column_rules.get(issue.rule, 0) + 1
         return {
             "passed": self.passed,
             "issue_count": self.issue_count,
             "bad_row_count": len(self.bad_rows),
             "issues_by_rule": by_rule,
             "issues_by_column": by_column,
+            "issues_by_column_and_rule": by_column_and_rule,
         }
 
     def to_pandas(self) -> pd.DataFrame:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -71,6 +71,108 @@ def test_validation_result_to_pandas(sample_csv):
     assert list(df["row_index"]) == [0, 1]
 
 
+def test_validation_result_summary_counts_repeated_issues_in_one_column():
+    result = ar.ValidationResult(
+        row_count=3,
+        issue_count=3,
+        issues=[
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=0
+            ),
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=1
+            ),
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=2
+            ),
+        ],
+        bad_rows=[0, 1, 2],
+    )
+
+    summary = result.summary()
+
+    assert summary["issues_by_rule"] == {"min": 3}
+    assert summary["issues_by_column"] == {"age": 3}
+    assert summary["issues_by_column_and_rule"] == {"age": {"min": 3}}
+
+
+def test_validation_result_summary_counts_issues_across_multiple_columns():
+    result = ar.ValidationResult(
+        row_count=3,
+        issue_count=4,
+        issues=[
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=0
+            ),
+            ar.ValidationIssue(
+                column="status", rule="allowed", message="bad status", row_index=1
+            ),
+            ar.ValidationIssue(
+                column="email", rule="email", message="bad email", row_index=1
+            ),
+            ar.ValidationIssue(
+                column=None, rule="required_column", message="missing column"
+            ),
+        ],
+        bad_rows=[0, 1],
+    )
+
+    summary = result.summary()
+
+    assert summary["issues_by_rule"] == {
+        "min": 1,
+        "allowed": 1,
+        "email": 1,
+        "required_column": 1,
+    }
+    assert summary["issues_by_column"] == {"age": 1, "status": 1, "email": 1}
+    assert summary["issues_by_column_and_rule"] == {
+        "age": {"min": 1},
+        "status": {"allowed": 1},
+        "email": {"email": 1},
+    }
+
+
+def test_validation_result_summary_counts_grouped_rules_under_one_column():
+    result = ar.ValidationResult(
+        row_count=2,
+        issue_count=3,
+        issues=[
+            ar.ValidationIssue(
+                column="age", rule="min", message="too small", row_index=0
+            ),
+            ar.ValidationIssue(
+                column="age", rule="max", message="too large", row_index=1
+            ),
+            ar.ValidationIssue(
+                column="age", rule="numeric", message="not numeric", row_index=1
+            ),
+        ],
+        bad_rows=[0, 1],
+    )
+
+    summary = result.summary()
+
+    assert summary["issues_by_rule"] == {"min": 1, "max": 1, "numeric": 1}
+    assert summary["issues_by_column"] == {"age": 3}
+    assert summary["issues_by_column_and_rule"] == {
+        "age": {"min": 1, "max": 1, "numeric": 1}
+    }
+
+
+def test_validation_result_summary_counts_no_issue_result():
+    result = ar.ValidationResult(row_count=3, issue_count=0, issues=[], bad_rows=[])
+
+    summary = result.summary()
+
+    assert summary["passed"] is True
+    assert summary["issue_count"] == 0
+    assert summary["bad_row_count"] == 0
+    assert summary["issues_by_rule"] == {}
+    assert summary["issues_by_column"] == {}
+    assert summary["issues_by_column_and_rule"] == {}
+
+
 def test_validation_result_to_markdown_for_success(sample_csv):
     result = ar.validate(ar.read_csv(sample_csv), {"age": ar.Int64()})
 


### PR DESCRIPTION
## Summary

- Extended `ValidationResult.summary()` with compact grouped issue counts.
- Added counts grouped by rule, column, and column + rule.
- Documented that severity counts are not included yet because `ValidationIssue` does not currently carry severity information.
- Added focused tests for repeated issues, multiple columns, grouped rules, and no-issue results.
- Added a short README example for using summary count keys.

## Linked issue

Fixes #210

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `pytest tests/test_schema.py -v` — 15 passed
  - `git diff --check` — passed
  - `ruff check README.md arnio/schema.py tests/test_schema.py` — passed
  - `black --check arnio/schema.py tests/test_schema.py` — passed

Note: `make lint` currently fails on upstream formatting in `arnio/convert.py`, which is unrelated to this PR and was intentionally not included to keep this change focused.

## Screenshots / Media

N/A — no UI or visual changes.

## Performance Impact

N/A — summary counts are computed from existing validation issues and do not change validation behavior.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

- Existing validation behavior is unchanged.
- `issues_by_rule` counts every issue by rule.
- `issues_by_column` counts issues with a non-`None` column.
- `issues_by_column_and_rule` groups counts by column first, then rule.
- `column=None` issues are skipped from column-based groupings but still counted by rule.
- Severity counts are not added because severity is not represented in the current `ValidationIssue` model.
- I used AI assistance to inspect repo patterns and draft changes, then reviewed, formatted, and tested locally.