### PR TITLE
fix: preserve column order in scan_csv() schema

### DIFF
--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -224,7 +224,15 @@ PYBIND11_MODULE(_arnio_cpp, m) {
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})
         .def("read", &CsvReader::read)
-        .def("scan_schema", &CsvReader::scan_schema);
+        .def("scan_schema",
+             [](const CsvReader& reader, const std::string& path) {
+                 auto result = reader.scan_schema(path);
+                 py::dict schema;
+                 for (const auto& pair : result) {
+                     schema[py::str(pair.first)] = py::str(pair.second);
+                 }
+                 return schema;
+             });
 
     // --- Cleaning functions ---
     m.def("drop_nulls", &drop_nulls, py::arg("frame"), py::arg("subset") = std::nullopt);

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -2,8 +2,7 @@
 
 #include <optional>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "frame.h"
@@ -27,7 +26,7 @@ class CsvReader {
     Frame read(const std::string& path) const;
 
     // Scan schema only (column names + inferred types)
-    std::unordered_map<std::string, std::string> scan_schema(const std::string& path) const;
+    std::vector<std::pair<std::string, std::string>> scan_schema(const std::string& path) const;
 
    private:
     CsvConfig config_;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -277,7 +277,7 @@ Frame CsvReader::read(const std::string& path) const {
     return Frame(std::move(columns));
 }
 
-std::unordered_map<std::string, std::string> CsvReader::scan_schema(const std::string& path) const {
+std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(const std::string& path) const {
     std::ifstream file(path);
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
@@ -313,9 +313,10 @@ std::unordered_map<std::string, std::string> CsvReader::scan_schema(const std::s
         if (dt == DType::NULL_TYPE) dt = DType::STRING;
     }
 
-    std::unordered_map<std::string, std::string> schema;
+    std::vector<std::pair<std::string, std::string>> schema;
+    schema.reserve(num_cols);
     for (size_t i = 0; i < num_cols; ++i) {
-        schema[header[i]] = dtype_to_string(col_types[i]);
+        schema.emplace_back(header[i], dtype_to_string(col_types[i]));
     }
     return schema;
 }

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -44,7 +44,7 @@ def test_generate_wide_benchmark_csv_round_trips_through_arnio(tmp_path):
     assert frame.shape == (4, 9)
     assert arnio_df.shape == (4, 9)
     assert arnio_df.columns.tolist() == pandas_df.columns.tolist()
-    assert ar.scan_csv(csv_path).keys() == set(pandas_df.columns)
+    assert list(ar.scan_csv(csv_path).keys()) == list(pandas_df.columns)
 
 
 def test_generate_wide_rejects_too_few_columns(tmp_path):

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -232,3 +232,19 @@ class TestScanCsv:
     def test_scan_missing_file_passthrough(self, tmp_path):
         with pytest.raises(ar.CsvReadError):
             ar.scan_csv(str(tmp_path / "nonexistent.csv"))
+
+    def test_scan_schema_preserves_column_order(self, tmp_path):
+        csv_path = tmp_path / "order_test.csv"
+        csv_path.write_text("z,a,m\n1,2,3\n")
+
+        schema = ar.scan_csv(str(csv_path))
+        frame = ar.read_csv(str(csv_path))
+
+        assert list(schema.keys()) == ["z", "a", "m"]
+        assert list(frame.columns) == ["z", "a", "m"]
+
+    def test_scan_schema_order_matches_read_csv(self, sample_csv):
+        schema = ar.scan_csv(sample_csv)
+        frame = ar.read_csv(sample_csv)
+
+        assert list(schema.keys()) == list(frame.columns)


### PR DESCRIPTION
## Summary
Changes `scan_schema()` return type from `std::unordered_map` to `std::vector<std::pair<std::string, std::string>>` to preserve CSV column order.

## Problem
`scan_csv()` used `std::unordered_map` which doesn't guarantee insertion order, causing the returned Python dict to have columns in arbitrary order rather than the original CSV header order.

## Solution
- Changed C++ return type to ordered vector of pairs
- Updated pybind11 binding to convert vector to insertion-ordered Python dict
- Added tests verifying `scan_csv()` column order matches `read_csv()`

## Test Plan
- New tests verify `list(scan_csv(path).keys())` matches file header order
- Verified order matches `read_csv(path).columns`

Fixes #424 