### PR TITLE
fix: preserve row count for zero-column frames

### DIFF
--- a/cpp/include/arnio/frame.h
+++ b/cpp/include/arnio/frame.h
@@ -12,7 +12,7 @@ namespace arnio {
 class Frame {
    public:
     Frame() = default;
-    explicit Frame(std::vector<Column> columns);
+    explicit Frame(std::vector<Column> columns, size_t row_count = 0);
 
     // Accessors
     std::pair<size_t, size_t> shape() const;

--- a/cpp/include/arnio/frame.h
+++ b/cpp/include/arnio/frame.h
@@ -39,6 +39,7 @@ class Frame {
 
    private:
     std::vector<Column> columns_;
+    size_t row_count_ = 0;
     std::unordered_map<std::string, size_t> name_index_;
     void rebuild_index();
 };

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -9,7 +9,7 @@ Frame::Frame(std::vector<Column> columns) : columns_(std::move(columns)) { rebui
 std::pair<size_t, size_t> Frame::shape() const { return {num_rows(), num_cols()}; }
 
 size_t Frame::num_rows() const {
-    if (columns_.empty()) return 0;
+    if (columns_.empty()) return row_count_;
     return columns_[0].size();
 }
 

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -74,6 +74,10 @@ size_t Frame::column_index(const std::string& name) const {
 void Frame::add_column(Column col) {
     name_index_[col.name()] = columns_.size();
     columns_.push_back(std::move(col));
+
+    if (columns_.size() == 1) {
+        row_count_ = columns_[0].size();
+    }
 }
 
 const std::vector<Column>& Frame::columns() const { return columns_; }

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -4,7 +4,11 @@
 
 namespace arnio {
 
-Frame::Frame(std::vector<Column> columns) : columns_(std::move(columns)) { rebuild_index(); }
+Frame::Frame(std::vector<Column> columns, size_t row_count)
+    : columns_(std::move(columns)),
+      row_count_(columns_.empty() ? row_count : columns_[0].size()) {
+    rebuild_index();
+    }
 
 std::pair<size_t, size_t> Frame::shape() const { return {num_rows(), num_cols()}; }
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -206,7 +206,7 @@ class TestDropConstantColumns:
         result = ar.drop_constant_columns(frame)
 
         assert result.columns == []
-        assert result.shape[0] == 0
+        assert result.shape[0] == 1
         assert result.shape[1] == 0
 
 


### PR DESCRIPTION
Summary

Preserve row cardinality for zero-column frames by adding explicit row count tracking to "Frame" and updating "num_rows()" to return the stored row count when columns are empty.

Linked issue

Fixes #423

Type of change

- [x] Bug fix

Area

- [x] Python API / ArFrame
- [x] pandas interoperability

Testing

- [ ] "make test"
- [ ] "make lint"
- [x] Other:
  - verified "num_rows()" no longer returns "0" only because "columns_" is empty

Screenshots / Media

N/A

Performance Impact

No expected performance impact. Change only adds explicit row count preservation for zero-column frames.

Contributor checklist

- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits ("feat:", "fix:", "docs:", "test:", "refactor:", "chore:").

Maintainer notes

This change preserves existing behavior for non-empty frames while allowing future support for valid "(n, 0)" frame shapes.