### PR TITLE
fix: allow encoded csv nul handling

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -15,6 +15,11 @@ from .exceptions import CsvReadError
 from .frame import ArFrame
 
 
+def _is_utf8_encoding(encoding: str) -> bool:
+    """Return whether the encoding should be treated as raw UTF-8 input."""
+    return encoding.lower().replace("_", "-") in {"utf-8", "utf8"}
+
+
 @contextmanager
 def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
     """Return a UTF-8 file path for the C++ reader.
@@ -23,7 +28,7 @@ def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
     transcode through a temporary UTF-8 file so the public encoding parameter is
     honored without leaking platform-specific decoding behavior through pybind.
     """
-    if encoding.lower().replace("_", "-") in {"utf-8", "utf8"}:
+    if _is_utf8_encoding(encoding):
         yield path
         return
 
@@ -109,14 +114,15 @@ def read_csv(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
 
-    try:
-        with open(path, "rb") as f:
-            if b"\0" in f.read(1024):
-                raise CsvReadError(
-                    "CSV input contains NUL bytes and appears to be binary or corrupted"
-                )
-    except FileNotFoundError:
-        pass  # Let C++ backend handle or raise standard error
+    if _is_utf8_encoding(encoding):
+        try:
+            with open(path, "rb") as f:
+                if b"\0" in f.read(1024):
+                    raise CsvReadError(
+                        "CSV input contains NUL bytes and appears to be binary or corrupted"
+                    )
+        except FileNotFoundError:
+            pass  # Let C++ backend handle or raise standard error
 
     try:
         if os.path.getsize(path) == 0:
@@ -198,14 +204,15 @@ def scan_csv(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
 
-    try:
-        with open(path, "rb") as f:
-            if b"\0" in f.read(1024):
-                raise CsvReadError(
-                    "CSV input contains NUL bytes and appears to be binary or corrupted"
-                )
-    except FileNotFoundError:
-        pass  # Let C++ backend handle or raise standard error
+    if _is_utf8_encoding(encoding):
+        try:
+            with open(path, "rb") as f:
+                if b"\0" in f.read(1024):
+                    raise CsvReadError(
+                        "CSV input contains NUL bytes and appears to be binary or corrupted"
+                    )
+        except FileNotFoundError:
+            pass  # Let C++ backend handle or raise standard error
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -159,6 +159,18 @@ class TestReadCsv:
 
         assert df["name"].iloc[0] == "André"
 
+    def test_utf16_encoding_with_nul_bytes_reads_successfully(self, tmp_path):
+        csv_path = tmp_path / "utf16.csv"
+        csv_path.write_text("name,age\nAlice,30\n", encoding="utf-16")
+
+        frame = ar.read_csv(csv_path, encoding="utf-16")
+        df = ar.to_pandas(frame)
+
+        assert frame.columns == ["name", "age"]
+        assert frame.shape == (1, 2)
+        assert df["name"].iloc[0] == "Alice"
+        assert df["age"].iloc[0] == 30
+
     def test_quoted_newline_record(self, tmp_path):
         csv_path = tmp_path / "quoted_newline.csv"
         csv_path.write_text('id,text\n1,"hello\nworld"\n2,ok\n')
@@ -210,6 +222,14 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, encoding="latin-1")
 
         assert schema == {"name": "string"}
+
+    def test_scan_utf16_encoding_with_nul_bytes_reads_successfully(self, tmp_path):
+        csv_path = tmp_path / "utf16.csv"
+        csv_path.write_text("name,age\nAlice,30\n", encoding="utf-16")
+
+        schema = ar.scan_csv(csv_path, encoding="utf-16")
+
+        assert schema == {"name": "string", "age": "int64"}
 
     def test_scan_binary_file_rejection(self, tmp_path):
         file_path = str(tmp_path / "data.csv")


### PR DESCRIPTION
## Summary

- Made the CSV NUL-byte binary guard encoding-aware.
- Preserved existing binary/corrupted-file rejection behavior for default UTF-8 reads.
- Allowed explicitly requested non-UTF-8 text encodings like UTF-16 to decode before raw NUL-byte rejection.
- Added focused UTF-16 coverage for both `read_csv()` and `scan_csv()`.

## Linked issue

Fixes #422

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `pytest tests/test_csv.py -v` — 32 passed
  - `git diff --check` — passed
  - `ruff check arnio/io.py tests/test_csv.py` — passed
  - `black --check arnio/io.py tests/test_csv.py` — passed

Note: `make lint` currently fails on unrelated upstream formatting in `arnio/convert.py`, which is not part of this PR and was intentionally not included to keep this change focused.

## Screenshots / Media

N/A — no UI or visual changes.

## Performance Impact

N/A — this only changes when the raw NUL-byte guard runs before encoding-aware transcoding.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

- The raw NUL-byte guard still runs for UTF-8/default reads.
- Explicit non-UTF-8 encodings now go through `_utf8_csv_path()` first, allowing valid UTF-16 text to decode successfully.
- Existing corrupted binary rejection tests for `read_csv()` and `scan_csv()` are preserved.
- Added focused UTF-16 tests for both `read_csv()` and `scan_csv()`.
- No C++ files were changed.
- I used AI assistance to inspect repo patterns and draft changes, then reviewed, formatted, and tested locally.