### PR TITLE
perf: add deterministic multiline benchmark dataset generation

### DIFF
--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 DEFAULT_TALL_PATH = "benchmarks/benchmark_1m.csv"
 DEFAULT_WIDE_PATH = "benchmarks/benchmark_wide.csv"
+DEFAULT_MULTILINE_PATH = "benchmarks/benchmark_multiline.csv"
 
 
 def generate(rows=1_000_000, path=DEFAULT_TALL_PATH):
@@ -70,8 +71,77 @@ def generate_wide(rows=5_000, columns=256, path=DEFAULT_WIDE_PATH):
     df = pd.DataFrame(data)
     df.to_csv(path, index=False, lineterminator="\n")
     print(f"Generated {rows:,} row x {columns:,} column CSV -> {path}")
+def generate_multiline(
+    rows=100_000,
+    path=DEFAULT_MULTILINE_PATH,
+    multiline_ratio=0.3,
+):
+    """
+    Generate deterministic multiline benchmark CSV.
 
+    Used for benchmarking quoted multiline CSV parsing.
+    """
 
+    if rows < 1:
+        raise ValueError(
+            "multiline benchmark requires at least 1 row"
+        )
+
+    rng = np.random.default_rng(512)
+
+    multiline_templates = [
+        "First line\nSecond line",
+        "hello world\nthis is multiline text",
+        "alpha\nbeta\ngamma",
+        "quoted field\nwith embedded newline",
+        "line1\nline2\nline3",
+    ]
+
+    singleline_templates = [
+        "simple text",
+        "benchmark row",
+        "plain csv value",
+        "single line content",
+    ]
+
+    descriptions = []
+
+    for _ in range(rows):
+        if rng.random() < multiline_ratio:
+            descriptions.append(
+                rng.choice(multiline_templates)
+            )
+        else:
+            descriptions.append(
+                rng.choice(singleline_templates)
+            )
+
+    df = pd.DataFrame(
+        {
+            "id": np.arange(rows),
+            "description": descriptions,
+            "category": rng.choice(
+                ["A", "B", "C"],
+                rows,
+            ),
+            "value": rng.uniform(
+                0,
+                1000,
+                rows,
+            ).round(2),
+        }
+    )
+
+    df.to_csv(
+        path,
+        index=False,
+        lineterminator="\n",
+    )
+
+    print(
+        f"Generated multiline benchmark CSV -> {path}"
+    )
 if __name__ == "__main__":
     generate()
     generate_wide()
+    generate_multiline()


### PR DESCRIPTION
## Summary

Adds deterministic multiline CSV benchmark dataset generation for reproducible quoted multiline parsing benchmarks.

## Changes

- added `DEFAULT_MULTILINE_PATH`
- added deterministic `generate_multiline()` dataset generator
- added quoted multiline CSV benchmark fixtures
- added configurable multiline ratio support
- added reproducible RNG seed for stable benchmark runs
- updated generation flow to automatically create multiline benchmark datasets

## Benchmark Dataset Coverage

The generated dataset now includes:

- quoted multiline fields
- embedded newline content
- mixed single-line and multiline rows
- deterministic dataset structure across runs

## Reproduction

Generate all benchmark datasets:

```bash
python benchmarks/generate_data.py