### PR TITLE
ci: smoke test sdist import outside checkout

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,21 @@ jobs:
       - name: Install package from sdist
         run: pip install dist/*.tar.gz
       - name: Smoke test import
-        run: python -c "import arnio"
+        run: |
+          python - <<'PY'
+          import os
+          import subprocess
+          import sys
+          import tempfile
+
+          with tempfile.TemporaryDirectory() as tmp:
+              subprocess.run(
+                  [sys.executable, "-c", "import arnio"],
+                  cwd=tmp,
+                  check=True,
+                  env={**os.environ, "PYTHONPATH": ""},
+              )
+          PY
       - uses: actions/upload-artifact@v4
         with:
           name: sdist


### PR DESCRIPTION
## Summary
- run the sdist import smoke test from a temporary directory outside the repository checkout
- clear `PYTHONPATH` for the smoke import so Python imports the installed sdist package, not the raw source tree

## Why
The release workflow currently installs the sdist successfully, then runs `python -c "import arnio"` from the checkout. Python puts the current working directory first on `sys.path`, so it imports the raw `arnio/` package without the compiled extension and fails with `ModuleNotFoundError: arnio._arnio_cpp`.

## Testing
- `git diff --check`
