### PR TITLE
fix: validate missing columns in filter_rows

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -520,6 +520,9 @@ def filter_rows(frame, column, op, value):
     if op not in ops:
         raise ValueError(f"Unsupported operator: {op}")
 
+    if column not in df.columns:
+        raise ValueError(f"Unknown column: {column}")
+
     filtered = df[getattr(df[column], ops[op])(value)]
 
     return from_pandas(filtered) if is_arframe else filtered

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -428,6 +428,28 @@ class TestCleanAPI:
         assert len(result) < len(frame)
 
 
+class TestFilterRows:
+    def test_filter_rows_missing_column_raises_clear_error(self):
+        df = pd.DataFrame({"age": [20, 30]})
+
+        with pytest.raises(ValueError, match="Unknown column: missing"):
+            ar.filter_rows(df, "missing", ">", 10)
+
+    def test_filter_rows_missing_column_raises_clear_error_for_arframe(self):
+        frame = ar.from_pandas(pd.DataFrame({"age": [20, 30]}))
+
+        with pytest.raises(ValueError, match="Unknown column: missing"):
+            ar.filter_rows(frame, "missing", ">", 10)
+
+    def test_filter_rows_valid_column_still_works(self):
+        df = pd.DataFrame({"age": [20, 30]})
+
+        result = ar.filter_rows(df, "age", ">", 20)
+
+        assert len(result) == 1
+        assert result.iloc[0]["age"] == 30
+
+
 class TestRoundNumericColumns:
     def test_round_all_numeric(self):
         import pandas as pd


### PR DESCRIPTION
## Summary

Adds explicit column validation in `filter_rows()` before DataFrame indexing.

Previously, passing a missing column raised a raw pandas `KeyError`, which was inconsistent with Arnio's user-facing validation style.

This PR adds a clear validation message:

```python
Unknown column: <column_name>
```

## Changes made

* Added column existence validation in `arnio/cleaning.py`
* Added tests for:

  * Missing column handling for pandas DataFrame input
  * Missing column handling for ArFrame input
  * Existing valid behavior for filtering

## Why

This makes `filter_rows()` fail with a clearer, more consistent error message for invalid columns instead of exposing a raw pandas `KeyError`.

Fixes #468
