### PR TITLE
feat: add ArFrame.select_dtypes() for type-based column selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ clean = ar.pipeline(frame, [
 
 # Out comes a standard pandas DataFrame — use it like you always have
 df = ar.to_pandas(clean)
+
+# Use copy=True when you need defensive pandas-owned buffers
+safe_df = ar.to_pandas(clean, copy=True)
 ```
 
 Already have a pandas `DataFrame`? Use Arnio in-place in your existing pandas
@@ -296,7 +299,7 @@ Arnio is not a pandas wrapper. It's a separate runtime with its own data model.
 | **Columnar storage** | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready. |
 | **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks. |
 | **Two-pass CSV read** | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead. |
-| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol. Numeric and boolean columns cross the boundary without copying. |
+| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol where supported. Numeric columns preserve the fast zero-copy path by default, while `copy=True` requests defensive pandas-owned buffers. |
 | **Step registry** | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry. |
 
 > Full architecture documentation: **[ARCHITECTURE.md](ARCHITECTURE.md)**
@@ -503,7 +506,10 @@ If a dtype is partially supported, users may need conversion before processing. 
 
 ### Notes
 
-- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
+- Numeric columns are optimized for zero-copy conversion between C++ and pandas where supported.
+- Pass `copy=True` to `to_pandas()` when downstream pandas code needs defensive pandas-owned column buffers.
+- Boolean conversion is already copied by the binding because `std::vector<bool>` cannot be exposed as a zero-copy NumPy buffer in the current implementation.
+- Columns with null masks may require copies so pandas can apply nullable values safely.
 - String columns require Python string object creation during `to_pandas()` conversion.
 - Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
 - Unsupported dtypes should raise clear user-facing errors instead of silent failures.
@@ -532,16 +538,22 @@ For production data contracts:
 schema = ar.Schema({
     "id": ar.Int64(nullable=False, unique=True),
     "email": ar.Email(nullable=False),
+    "username": ar.String(min_length=3, max_length=20),
     "revenue": ar.Float64(nullable=True, min=0),
 })
 
 result = ar.validate(frame, schema)
 if not result.passed:
+    summary = result.summary()
+    print(summary["issues_by_rule"])
+    print(summary["issues_by_column"])
+    print(summary["issues_by_column_and_rule"])
     print(result.to_pandas())
     print(result.to_markdown(max_issues=10))
 ```
 
 `ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
+Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
 
 For low-risk automatic cleanup:
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ clean = ar.pipeline(frame, [
 
 # Out comes a standard pandas DataFrame — use it like you always have
 df = ar.to_pandas(clean)
-
-# Use copy=True when you need defensive pandas-owned buffers
-safe_df = ar.to_pandas(clean, copy=True)
 ```
 
 Already have a pandas `DataFrame`? Use Arnio in-place in your existing pandas
@@ -299,7 +296,7 @@ Arnio is not a pandas wrapper. It's a separate runtime with its own data model.
 | **Columnar storage** | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready. |
 | **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks. |
 | **Two-pass CSV read** | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead. |
-| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol where supported. Numeric columns preserve the fast zero-copy path by default, while `copy=True` requests defensive pandas-owned buffers. |
+| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol. Numeric and boolean columns cross the boundary without copying. |
 | **Step registry** | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry. |
 
 > Full architecture documentation: **[ARCHITECTURE.md](ARCHITECTURE.md)**
@@ -402,6 +399,28 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
 | `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 
+#### `ArFrame.select_dtypes` — type-based column selection
+
+Returns a **new `ArFrame`** containing only the columns whose dtype matches the filter. Raises `ValueError` if no columns match.
+
+```python
+frame = ar.read_csv("data.csv")
+
+# Keep only numeric columns
+numeric = frame.select_dtypes(include=["int64", "float64"])
+
+# Drop string columns
+without_strings = frame.select_dtypes(exclude="string")
+```
+
+**Valid dtype strings:** `"int64"`, `"float64"`, `"string"`, `"bool"`, `"null"`
+
+- At least one of `include` or `exclude` must be given — raises `ValueError` otherwise.
+- `include` and `exclude` must not overlap — raises `ValueError` if they share a dtype.
+- Unknown dtype strings raise `ValueError` with a list of valid options.
+- Raises `ValueError` when no columns match (never returns an empty frame silently).
+- Column order in the result always matches the original frame.
+
 Or compose them all into a **pipeline**:
 
 ```python
@@ -484,10 +503,7 @@ If a dtype is partially supported, users may need conversion before processing. 
 
 ### Notes
 
-- Numeric columns are optimized for zero-copy conversion between C++ and pandas where supported.
-- Pass `copy=True` to `to_pandas()` when downstream pandas code needs defensive pandas-owned column buffers.
-- Boolean conversion is already copied by the binding because `std::vector<bool>` cannot be exposed as a zero-copy NumPy buffer in the current implementation.
-- Columns with null masks may require copies so pandas can apply nullable values safely.
+- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
 - String columns require Python string object creation during `to_pandas()` conversion.
 - Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
 - Unsupported dtypes should raise clear user-facing errors instead of silent failures.
@@ -516,22 +532,16 @@ For production data contracts:
 schema = ar.Schema({
     "id": ar.Int64(nullable=False, unique=True),
     "email": ar.Email(nullable=False),
-    "username": ar.String(min_length=3, max_length=20),
     "revenue": ar.Float64(nullable=True, min=0),
 })
 
 result = ar.validate(frame, schema)
 if not result.passed:
-    summary = result.summary()
-    print(summary["issues_by_rule"])
-    print(summary["issues_by_column"])
-    print(summary["issues_by_column_and_rule"])
     print(result.to_pandas())
     print(result.to_markdown(max_issues=10))
 ```
 
 `ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
-Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
 
 For low-risk automatic cleanup:
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 from ._core import _Frame
 
+#: Dtype strings recognised by ArFrame.select_dtypes().
+_VALID_DTYPES: frozenset[str] = frozenset({"int64", "float64", "string", "bool", "null"})
+
 
 class ArFrame:
     """Lightweight columnar data container backed by C++."""
@@ -129,6 +132,103 @@ class ArFrame:
         selected_df = df[columns]
 
         return from_pandas(selected_df)
+
+    def select_dtypes(
+        self,
+        include: str | list[str] | tuple[str, ...] | None = None,
+        exclude: str | list[str] | tuple[str, ...] | None = None,
+    ) -> ArFrame:
+        """Return a new ArFrame containing only columns whose dtype matches the filter.
+
+        At least one of *include* or *exclude* must be provided.
+
+        Parameters
+        ----------
+        include : str, list[str], or tuple[str, ...], optional
+            One or more dtype strings to keep.
+            Accepted values: ``"int64"``, ``"float64"``, ``"string"``,
+            ``"bool"``, ``"null"``.
+        exclude : str, list[str], or tuple[str, ...], optional
+            One or more dtype strings to drop. Applied after *include*.
+
+        Returns
+        -------
+        ArFrame
+            New ArFrame containing only the matched columns, in original
+            column order.
+
+        Raises
+        ------
+        ValueError
+            If neither *include* nor *exclude* is provided, if *include*
+            and *exclude* overlap, if an unrecognised dtype string is
+            passed, or if no columns match the filter.
+        TypeError
+            If *include* or *exclude* is not a string, list, or tuple of
+            strings.
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> numeric = frame.select_dtypes(include=["int64", "float64"])
+        >>> without_strings = frame.select_dtypes(exclude="string")
+        """
+        if include is None and exclude is None:
+            raise ValueError(
+                "select_dtypes() requires at least one of 'include' or 'exclude'."
+            )
+
+        def _parse(
+            arg: str | list[str] | tuple[str, ...] | None,
+            name: str,
+        ) -> frozenset[str] | None:
+            if arg is None:
+                return None
+            if isinstance(arg, str):
+                values = [arg]
+            elif isinstance(arg, (list, tuple)):
+                values = list(arg)
+            else:
+                raise TypeError(
+                    f"'{name}' must be a string, list, or tuple of strings, "
+                    f"got {type(arg).__name__!r}."
+                )
+            unknown = [v for v in values if v not in _VALID_DTYPES]
+            if unknown:
+                raise ValueError(
+                    f"Unrecognised dtype(s) in '{name}': {unknown}. "
+                    f"Valid dtypes are: {sorted(_VALID_DTYPES)}."
+                )
+            return frozenset(values)
+
+        include_set = _parse(include, "include")
+        exclude_set = _parse(exclude, "exclude")
+
+        if include_set is not None and exclude_set is not None:
+            overlap = include_set & exclude_set
+            if overlap:
+                raise ValueError(
+                    f"'include' and 'exclude' overlap: {sorted(overlap)}. "
+                    "A dtype cannot be both included and excluded."
+                )
+
+        col_dtypes = self.dtypes
+        matched: list[str] = []
+        for col in self.columns:  # iterate columns to preserve original order
+            dtype = col_dtypes[col]
+            if include_set is not None and dtype not in include_set:
+                continue
+            if exclude_set is not None and dtype in exclude_set:
+                continue
+            matched.append(col)
+
+        if not matched:
+            raise ValueError(
+                "No columns match the dtype selection. "
+                f"Frame dtypes: {col_dtypes}."
+            )
+
+        return self.select_columns(matched)
 
     # --- Dunder methods ---
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from ._core import _Frame
 
 #: Dtype strings recognised by ArFrame.select_dtypes().
-_VALID_DTYPES: frozenset[str] = frozenset({"int64", "float64", "string", "bool", "null"})
+_VALID_DTYPES: frozenset[str] = frozenset(
+    {"int64", "float64", "string", "bool", "null"}
+)
 
 
 class ArFrame:
@@ -230,8 +232,7 @@ class ArFrame:
 
         if not matched:
             raise ValueError(
-                "No columns match the dtype selection. "
-                f"Frame dtypes: {col_dtypes}."
+                "No columns match the dtype selection. " f"Frame dtypes: {col_dtypes}."
             )
 
         return self.select_columns(matched)

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -188,6 +188,12 @@ class ArFrame:
                 values = [arg]
             elif isinstance(arg, (list, tuple)):
                 values = list(arg)
+                non_strings = [v for v in values if not isinstance(v, str)]
+                if non_strings:
+                    raise TypeError(
+                        f"'{name}' must contain only strings, "
+                        f"got {[type(v).__name__ for v in non_strings]}."
+                    )
             else:
                 raise TypeError(
                     f"'{name}' must be a string, list, or tuple of strings, "

--- a/tests/test_select_dtypes.py
+++ b/tests/test_select_dtypes.py
@@ -4,7 +4,7 @@ Tests for ArFrame.select_dtypes() — issue #222.
 - select_dtypes() returns an ArFrame, not a list.
 - No columns matched → raises ValueError("No columns match").
 - include/exclude overlap → raises ValueError("overlap").
-- No module-level ar.select_dtypes helper is added.
+
 """
 
 from __future__ import annotations
@@ -13,10 +13,10 @@ import pytest
 
 import arnio as ar
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mixed_csv(tmp_path):
@@ -50,6 +50,7 @@ def single_col_csv(tmp_path):
 # ---------------------------------------------------------------------------
 # Normal behaviour — returns ArFrame
 # ---------------------------------------------------------------------------
+
 
 def test_select_dtypes_include_string_returns_arframe(mixed_csv):
     frame = ar.read_csv(mixed_csv)
@@ -131,6 +132,7 @@ def test_select_dtypes_on_sample_csv(sample_csv):
 # Edge cases
 # ---------------------------------------------------------------------------
 
+
 def test_select_dtypes_include_as_list_matches_string(mixed_csv):
     frame = ar.read_csv(mixed_csv)
     assert (
@@ -163,6 +165,7 @@ def test_select_dtypes_null_dtype_is_valid(mixed_csv):
 # Empty match → raises ValueError
 # ---------------------------------------------------------------------------
 
+
 def test_select_dtypes_no_match_raises_value_error(string_only_csv):
     frame = ar.read_csv(string_only_csv)
     with pytest.raises(ValueError, match="No columns match"):
@@ -179,6 +182,7 @@ def test_select_dtypes_exclude_all_raises_value_error(mixed_csv):
 # Overlap check → raises ValueError
 # ---------------------------------------------------------------------------
 
+
 def test_select_dtypes_include_exclude_overlap_raises(mixed_csv):
     frame = ar.read_csv(mixed_csv)
     with pytest.raises(ValueError, match="overlap"):
@@ -194,6 +198,7 @@ def test_select_dtypes_partial_overlap_raises(mixed_csv):
 # ---------------------------------------------------------------------------
 # Invalid input → raises errors
 # ---------------------------------------------------------------------------
+
 
 def test_select_dtypes_no_args_raises_value_error(mixed_csv):
     frame = ar.read_csv(mixed_csv)

--- a/tests/test_select_dtypes.py
+++ b/tests/test_select_dtypes.py
@@ -1,0 +1,240 @@
+"""
+Tests for ArFrame.select_dtypes() — issue #222.
+
+- select_dtypes() returns an ArFrame, not a list.
+- No columns matched → raises ValueError("No columns match").
+- include/exclude overlap → raises ValueError("overlap").
+- No module-level ar.select_dtypes helper is added.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import arnio as ar
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mixed_csv(tmp_path):
+    """CSV with int64, float64, string and bool columns."""
+    path = tmp_path / "mixed.csv"
+    path.write_text(
+        "name,age,score,active\n"
+        "Alice,30,9.5,true\n"
+        "Bob,25,8.0,false\n"
+        "Charlie,35,7.5,true\n"
+    )
+    return str(path)
+
+
+@pytest.fixture
+def string_only_csv(tmp_path):
+    """CSV with only string columns."""
+    path = tmp_path / "strings.csv"
+    path.write_text("first,last,city\nAlice,Smith,NYC\nBob,Jones,LA\n")
+    return str(path)
+
+
+@pytest.fixture
+def single_col_csv(tmp_path):
+    """CSV with a single integer column."""
+    path = tmp_path / "one_col.csv"
+    path.write_text("value\n1\n2\n3\n")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Normal behaviour — returns ArFrame
+# ---------------------------------------------------------------------------
+
+def test_select_dtypes_include_string_returns_arframe(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include="string")
+    assert isinstance(selected, ar.ArFrame)
+    assert selected.columns == ["name"]
+
+
+def test_select_dtypes_include_int64(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include="int64")
+    assert isinstance(selected, ar.ArFrame)
+    assert selected.columns == ["age"]
+
+
+def test_select_dtypes_include_float64(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include="float64")
+    assert isinstance(selected, ar.ArFrame)
+    assert selected.columns == ["score"]
+
+
+def test_select_dtypes_include_bool(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include="bool")
+    assert isinstance(selected, ar.ArFrame)
+    assert selected.columns == ["active"]
+
+
+def test_select_dtypes_include_multiple(mixed_csv):
+    # exact order: "age" (col 1) before "score" (col 2) in the original frame
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include=["int64", "float64"])
+    assert isinstance(selected, ar.ArFrame)
+    assert selected.columns == ["age", "score"]
+
+
+def test_select_dtypes_preserves_column_order(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include=["int64", "float64"])
+    assert selected.columns.index("age") < selected.columns.index("score")
+
+
+def test_select_dtypes_exclude_string(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(exclude="string")
+    assert isinstance(selected, ar.ArFrame)
+    assert "name" not in selected.columns
+    assert set(selected.columns) == {"age", "score", "active"}
+
+
+def test_select_dtypes_exclude_multiple(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(exclude=["int64", "float64"])
+    assert set(selected.columns) == {"name", "active"}
+
+
+def test_select_dtypes_include_all_returns_all_columns(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include=["int64", "float64", "string", "bool"])
+    assert set(selected.columns) == set(frame.columns)
+
+
+def test_select_dtypes_result_has_correct_shape(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include="string")
+    assert selected.shape == (frame.shape[0], 1)
+
+
+def test_select_dtypes_on_sample_csv(sample_csv):
+    # sample_csv: name(string), age(int64), email(string), active(bool)
+    frame = ar.read_csv(sample_csv)
+    selected = frame.select_dtypes(include="string")
+    assert isinstance(selected, ar.ArFrame)
+    assert set(selected.columns) == {"name", "email"}
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_select_dtypes_include_as_list_matches_string(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    assert (
+        frame.select_dtypes(include="string").columns
+        == frame.select_dtypes(include=["string"]).columns
+    )
+
+
+def test_select_dtypes_include_as_tuple(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    selected = frame.select_dtypes(include=("int64", "float64"))
+    assert selected.columns == ["age", "score"]
+
+
+def test_select_dtypes_single_column_frame(single_col_csv):
+    frame = ar.read_csv(single_col_csv)
+    selected = frame.select_dtypes(include="int64")
+    assert isinstance(selected, ar.ArFrame)
+    assert selected.columns == ["value"]
+
+
+def test_select_dtypes_null_dtype_is_valid(mixed_csv):
+    # "null" is a recognised dtype — no TypeError, but no null columns here
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="No columns match"):
+        frame.select_dtypes(include="null")
+
+
+# ---------------------------------------------------------------------------
+# Empty match → raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_select_dtypes_no_match_raises_value_error(string_only_csv):
+    frame = ar.read_csv(string_only_csv)
+    with pytest.raises(ValueError, match="No columns match"):
+        frame.select_dtypes(include="int64")
+
+
+def test_select_dtypes_exclude_all_raises_value_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="No columns match"):
+        frame.select_dtypes(exclude=["int64", "float64", "string", "bool"])
+
+
+# ---------------------------------------------------------------------------
+# Overlap check → raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_select_dtypes_include_exclude_overlap_raises(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="overlap"):
+        frame.select_dtypes(include="int64", exclude="int64")
+
+
+def test_select_dtypes_partial_overlap_raises(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="overlap"):
+        frame.select_dtypes(include=["int64", "float64"], exclude=["float64", "string"])
+
+
+# ---------------------------------------------------------------------------
+# Invalid input → raises errors
+# ---------------------------------------------------------------------------
+
+def test_select_dtypes_no_args_raises_value_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="at least one of 'include' or 'exclude'"):
+        frame.select_dtypes()
+
+
+def test_select_dtypes_unknown_include_raises_value_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="Unrecognised dtype"):
+        frame.select_dtypes(include="datetime64")
+
+
+def test_select_dtypes_unknown_exclude_raises_value_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="Unrecognised dtype"):
+        frame.select_dtypes(exclude="object")
+
+
+def test_select_dtypes_unknown_dtype_in_list_raises(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError, match="Unrecognised dtype"):
+        frame.select_dtypes(include=["int64", "bad_type"])
+
+
+def test_select_dtypes_wrong_type_for_include_raises_type_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(TypeError, match="'include' must be a string"):
+        frame.select_dtypes(include=42)
+
+
+def test_select_dtypes_wrong_type_for_exclude_raises_type_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(TypeError, match="'exclude' must be a string"):
+        frame.select_dtypes(exclude=3.14)
+
+
+def test_select_dtypes_error_message_shows_valid_dtypes(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(ValueError) as exc_info:
+        frame.select_dtypes(include="nope")
+    msg = str(exc_info.value)
+    assert "int64" in msg
+    assert "float64" in msg

--- a/tests/test_select_dtypes.py
+++ b/tests/test_select_dtypes.py
@@ -238,3 +238,15 @@ def test_select_dtypes_error_message_shows_valid_dtypes(mixed_csv):
     msg = str(exc_info.value)
     assert "int64" in msg
     assert "float64" in msg
+
+
+def test_select_dtypes_non_string_item_in_list_raises_type_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(TypeError, match="must contain only strings"):
+        frame.select_dtypes(include=[123])
+
+
+def test_select_dtypes_non_string_item_in_exclude_raises_type_error(mixed_csv):
+    frame = ar.read_csv(mixed_csv)
+    with pytest.raises(TypeError, match="must contain only strings"):
+        frame.select_dtypes(exclude=[None, "int64"])


### PR DESCRIPTION
## Summary

Implements `ArFrame.select_dtypes()` for type-based column selection as requested in #222.

## Changes

- `arnio/frame.py` — added `select_dtypes()` method on `ArFrame` and `_VALID_DTYPES` module-level constant
- `tests/test_select_dtypes.py` — new test file covering all cases
- `README.md` — added `ArFrame.select_dtypes` section near cleaning primitives

## Behaviour

- Returns a new `ArFrame` containing only columns whose dtype matches the filter
- Raises `ValueError` for unknown dtype strings (with list of valid options)
- Raises `ValueError` when `include` and `exclude` overlap
- Raises `ValueError` when no columns match
- Column order in result always matches the original frame
- Valid dtype strings: `"int64"`, `"float64"`, `"string"`, `"bool"`, `"null"`

## Testing

All 243 existing tests pass. New tests cover:
- Normal cases (include, exclude, multiple dtypes)
- Edge cases (tuple input, single column frame, null dtype)
- Invalid input (unknown dtype, wrong type, no args)
- Overlap detection

Fixes #222