### PR TITLE
feat: add top_values summary for categorical columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,15 @@ DataQualityReport(
       "min": 85.5,
       "max": 90.0,
       "warnings": ["contains_nulls"]
+    },
+    "city": {
+      "dtype": "string",
+      "semantic_type": "categorical",
+      "null_count": 0,
+      "top_values": [
+        {"value": "London", "count": 3, "ratio": 0.5},
+        {"value": "Paris", "count": 2, "ratio": 0.333}
+      ]
     }
   }
 }

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -35,6 +35,7 @@ class ColumnProfile:
     mean: float | None = None
     sample_values: list[Any] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    top_values: list[tuple[Any, int, float]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
@@ -55,6 +56,14 @@ class ColumnProfile:
             "mean": self.mean,
             "sample_values": [_clean_scalar(value) for value in self.sample_values],
             "warnings": list(self.warnings),
+            "top_values": (
+                [
+                    {"value": _clean_scalar(v), "count": c, "ratio": r}
+                    for v, c, r in self.top_values
+                ]
+                if self.top_values is not None
+                else None
+            ),
         }
 
 
@@ -302,11 +311,13 @@ def _profile_column(
 
     empty_string_count = 0
     whitespace_count = 0
+    top_values = None
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
         as_text = non_null.astype("string")
         stripped = as_text.str.strip()
         empty_string_count = int((stripped == "").sum())
         whitespace_count = int((as_text != stripped).sum())
+        top_values = _top_values(non_null)
 
     numeric = pd.to_numeric(series, errors="coerce")
     numeric_non_null = numeric.dropna()
@@ -343,6 +354,7 @@ def _profile_column(
         mean=mean,
         sample_values=sample_values,
         warnings=warnings,
+        top_values=top_values,
     )
 
 
@@ -449,6 +461,24 @@ def _clean_scalar(value: Any) -> Any:
     if hasattr(value, "item"):
         return value.item()
     return value
+
+
+def _top_values(
+    series: pd.Series,
+    n: int = 5,
+) -> list[tuple[Any, int, float]]:
+    """Return top-N value frequencies for a non-null series.
+
+    Nulls are excluded. Percentages are based on the non-null total.
+    """
+    if len(series) == 0:
+        return []
+    counts = series.value_counts(dropna=True)
+    total = int(counts.sum())
+    return [
+        (val, int(cnt), _ratio(int(cnt), total))
+        for val, cnt in counts.head(n).items()
+    ]
 
 
 _EMAIL_PATTERN = r"[^@\s]+@[^@\s]+\.[^@\s]+"

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -133,6 +133,7 @@ class DataQualityReport:
                     "max": _clean_scalar(column.max),
                     "mean": column.mean,
                     "warnings": column.warnings,
+                    "top_values": column.top_values,
                 }
                 for column in self.columns.values()
             ]
@@ -476,8 +477,7 @@ def _top_values(
     counts = series.value_counts(dropna=True)
     total = int(counts.sum())
     return [
-        (val, int(cnt), _ratio(int(cnt), total))
-        for val, cnt in counts.head(n).items()
+        (val, int(cnt), _ratio(int(cnt), total)) for val, cnt in counts.head(n).items()
     ]
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,5 +1,6 @@
 """Tests for data quality profiling and smart cleaning."""
 
+import pytest
 import pandas as pd
 
 import arnio as ar
@@ -118,3 +119,91 @@ def test_profile_sample_size_validation(tmp_path):
         assert False, "Expected TypeError"
     except TypeError as exc:
         assert "sample_size must be an integer" in str(exc)
+
+
+# ── top_values tests ──────────────────────────────────────────────────────────
+
+
+def test_top_values_correct_order_and_ratio(tmp_path):
+    path = tmp_path / "tv.csv"
+    path.write_text("city\nLondon\nLondon\nLondon\nParis\nParis\nTokyo\n")
+    report = ar.profile(ar.read_csv(path))
+    tv = report.columns["city"].top_values
+
+    assert tv is not None
+    assert tv[0][0] == "London"
+    assert tv[0][1] == 3
+    assert tv[0][2] == pytest.approx(0.5, rel=1e-3)
+    assert tv[1][0] == "Paris"
+    assert tv[1][1] == 2
+    assert tv[2][0] == "Tokyo"
+    assert tv[2][1] == 1
+
+
+def test_top_values_nulls_excluded(tmp_path):
+    path = tmp_path / "nulls.csv"
+    path.write_text("city\nLondon\nLondon\n\nParis\n")
+    report = ar.profile(ar.read_csv(path))
+    tv = report.columns["city"].top_values
+
+    assert tv is not None
+    total_counts = sum(c for _, c, _ in tv)
+    # null row excluded — only 3 non-null rows
+    assert total_counts == 3
+    # ratios sum to 1.0 over non-null total
+    assert sum(r for _, _, r in tv) == pytest.approx(1.0, rel=1e-3)
+
+
+def test_top_values_all_unique(tmp_path):
+    path = tmp_path / "unique.csv"
+    path.write_text("code\nA\nB\nC\nD\n")
+    report = ar.profile(ar.read_csv(path))
+    tv = report.columns["code"].top_values
+
+    assert tv is not None
+    assert len(tv) == 4
+    for _, count, ratio in tv:
+        assert count == 1
+        assert ratio == pytest.approx(0.25, rel=1e-3)
+
+
+def test_top_values_single_value(tmp_path):
+    path = tmp_path / "single.csv"
+    path.write_text("status\nactive\nactive\nactive\n")
+    report = ar.profile(ar.read_csv(path))
+    tv = report.columns["status"].top_values
+
+    assert tv is not None
+    assert len(tv) == 1
+    assert tv[0] == ("active", 3, pytest.approx(1.0, rel=1e-3))
+
+
+def test_top_values_not_computed_for_numeric(tmp_path):
+    path = tmp_path / "numeric.csv"
+    path.write_text("score\n1\n2\n3\n")
+    report = ar.profile(ar.read_csv(path))
+
+    assert report.columns["score"].top_values is None
+
+
+def test_top_values_empty_column(tmp_path):
+    path = tmp_path / "empty.csv"
+    path.write_text("name\n\n\n\n")
+    report = ar.profile(ar.read_csv(path))
+    tv = report.columns["name"].top_values
+
+    # arnio parses blank rows as empty strings, not nulls
+    # top_values should still return without crashing
+    assert tv is not None
+    assert isinstance(tv, list)
+
+
+def test_top_values_in_to_dict(tmp_path):
+    path = tmp_path / "dict.csv"
+    path.write_text("city\nLondon\nParis\nLondon\n")
+    report = ar.profile(ar.read_csv(path))
+    d = report.columns["city"].to_dict()
+
+    assert "top_values" in d
+    assert d["top_values"][0]["value"] == "London"
+    assert d["top_values"][0]["count"] == 2

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,7 +1,7 @@
 """Tests for data quality profiling and smart cleaning."""
 
-import pytest
 import pandas as pd
+import pytest
 
 import arnio as ar
 


### PR DESCRIPTION
## Summary

Adds `top_values` to `ColumnProfile` for string and categorical columns — a ranked frequency list of `(value, count, ratio)` tuples computed during `ar.profile()`. Nulls are excluded from counts; ratios are based on the non-null total. Numeric and bool columns get `None`. Also surfaces in `to_dict()` for dashboard/API consumers.

## Linked issue

Fixes #173

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area

- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

```
make test
# 249 passed, 3 warnings
```

- [x] `make test`
- [ ] `make lint`
- [ ] Other:

New tests added in `tests/test_quality.py`:
- correct order and ratios
- nulls excluded, ratios sum to 1.0 over non-null total
- all-unique column
- single-value column (100%)
- numeric column returns `None`
- empty column returns list without crash
- `to_dict()` output shape

## Screenshots / Media

>
<img width="571" height="328" alt="Screenshot 2026-05-17 at 7 18 59 AM" src="https://github.com/user-attachments/assets/0786eb9b-44ee-4452-adc4-18e0b10f2171" />


## Performance Impact

None — `value_counts(dropna=True)` runs only on string/categorical columns and is bounded by the existing `sample_size` parameter.

## Contributor checklist

- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Only `arnio/quality.py`, `tests/test_quality.py`, and `README.md` touched. No C++ changes. No API surface removed or renamed — purely additive.