### PR TITLE
perf: stream transcode and sample rows for scan_csv schema inference (#467)

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -6,6 +6,7 @@ CSV reading functions.
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -21,7 +22,12 @@ def _is_utf8_encoding(encoding: str) -> bool:
 
 
 @contextmanager
-def _utf8_csv_path(path: str, encoding: str, sample_rows: int | None = None) -> Iterator[str]:
+def _utf8_csv_path(
+    path: str,
+    encoding: str,
+    delimiter: str = ",",
+    sample_rows: int | None = None,
+) -> Iterator[str]:
     """Return a UTF-8 file path for the C++ reader.
 
     The native reader currently consumes UTF-8 bytes. For other encodings,
@@ -39,12 +45,16 @@ def _utf8_csv_path(path: str, encoding: str, sample_rows: int | None = None) -> 
                 "w", encoding="utf-8", newline="", suffix=".csv", delete=False
             ) as tmp:
                 if sample_rows is not None:
-                    for i, line in enumerate(src):
-                        if i >= sample_rows:
-                            break
+                    in_quote = False
+                    row_count = 0
+                    for line in src:
                         tmp.write(line)
+                        in_quote ^= line.count('"') % 2 == 1
+                        if not in_quote:
+                            row_count += 1
+                            if row_count >= sample_rows:
+                                break
                 else:
-                    import shutil
                     shutil.copyfileobj(src, tmp)
                 tmp_name = tmp.name
         yield tmp_name
@@ -150,7 +160,9 @@ def read_csv(
 
     reader = _CsvReader(config)
     try:
-        with _utf8_csv_path(path, encoding) as native_path:
+        with _utf8_csv_path(
+            path, encoding, delimiter=delimiter
+        ) as native_path:
             cpp_frame = reader.read(native_path)
     except ValueError:
         raise
@@ -158,6 +170,7 @@ def read_csv(
         raise
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e
+
     return ArFrame(cpp_frame)
 
 
@@ -223,7 +236,6 @@ def scan_csv(
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")
-
     except FileNotFoundError:
         pass
 
@@ -234,7 +246,9 @@ def scan_csv(
     reader = _CsvReader(config)
     try:
         # Schema inference only needs a sample, avoiding full-file transcode
-        with _utf8_csv_path(path, encoding, sample_rows=10000) as native_path:
+        with _utf8_csv_path(
+            path, encoding, delimiter=delimiter, sample_rows=10000
+        ) as native_path:
             return reader.scan_schema(native_path)
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -5,6 +5,7 @@ CSV reading functions.
 
 from __future__ import annotations
 
+import csv
 import os
 import shutil
 import tempfile
@@ -45,15 +46,16 @@ def _utf8_csv_path(
                 "w", encoding="utf-8", newline="", suffix=".csv", delete=False
             ) as tmp:
                 if sample_rows is not None:
-                    in_quote = False
-                    row_count = 0
-                    for line in src:
-                        tmp.write(line)
-                        in_quote ^= line.count('"') % 2 == 1
-                        if not in_quote:
-                            row_count += 1
-                            if row_count >= sample_rows:
-                                break
+                    # Use csv.reader so we advance through complete CSV records
+                    # rather than raw physical lines. This prevents a quoted
+                    # multiline field from being split at the sampling boundary,
+                    # which would produce an invalid partial CSV for scan_schema.
+                    reader = csv.reader(src, delimiter=delimiter)
+                    writer = csv.writer(tmp, delimiter=delimiter)
+                    for row_count, row in enumerate(reader):
+                        writer.writerow(row)
+                        if row_count >= sample_rows:
+                            break
                 else:
                     shutil.copyfileobj(src, tmp)
                 tmp_name = tmp.name
@@ -160,9 +162,7 @@ def read_csv(
 
     reader = _CsvReader(config)
     try:
-        with _utf8_csv_path(
-            path, encoding, delimiter=delimiter
-        ) as native_path:
+        with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
             cpp_frame = reader.read(native_path)
     except ValueError:
         raise
@@ -190,7 +190,8 @@ def scan_csv(
     delimiter : str, default ","
         Field delimiter character.
     encoding : str, default "utf-8"
-        File encoding. For non-UTF-8 inputs, a sample of the file is transcoded to infer the schema.
+        File encoding. For non-UTF-8 inputs, a sample of the file is
+        transcoded to infer the schema.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.
 
@@ -233,6 +234,7 @@ def scan_csv(
                     )
         except FileNotFoundError:
             pass  # Let C++ backend handle or raise standard error
+
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")
@@ -245,9 +247,15 @@ def scan_csv(
     config.trim_headers = trim_headers
     reader = _CsvReader(config)
     try:
-        # Schema inference only needs a sample, avoiding full-file transcode
+        # Schema inference only needs a sample, avoiding full-file transcode.
+        # sample_rows is passed so _utf8_csv_path uses record-aware sampling
+        # via csv.reader, which correctly handles quoted multiline fields that
+        # straddle the boundary.
         with _utf8_csv_path(
-            path, encoding, delimiter=delimiter, sample_rows=10000
+            path,
+            encoding,
+            delimiter=delimiter,
+            sample_rows=10000,
         ) as native_path:
             return reader.scan_schema(native_path)
     except RuntimeError as e:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -21,7 +21,7 @@ def _is_utf8_encoding(encoding: str) -> bool:
 
 
 @contextmanager
-def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
+def _utf8_csv_path(path: str, encoding: str, sample_rows: int | None = None) -> Iterator[str]:
     """Return a UTF-8 file path for the C++ reader.
 
     The native reader currently consumes UTF-8 bytes. For other encodings,
@@ -38,7 +38,14 @@ def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
             with tempfile.NamedTemporaryFile(
                 "w", encoding="utf-8", newline="", suffix=".csv", delete=False
             ) as tmp:
-                tmp.write(src.read())
+                if sample_rows is not None:
+                    for i, line in enumerate(src):
+                        if i >= sample_rows:
+                            break
+                        tmp.write(line)
+                else:
+                    import shutil
+                    shutil.copyfileobj(src, tmp)
                 tmp_name = tmp.name
         yield tmp_name
     except LookupError as e:
@@ -170,7 +177,7 @@ def scan_csv(
     delimiter : str, default ","
         Field delimiter character.
     encoding : str, default "utf-8"
-        File encoding. Non-UTF-8 inputs are transcoded before native scanning.
+        File encoding. For non-UTF-8 inputs, a sample of the file is transcoded to infer the schema.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.
 
@@ -226,7 +233,8 @@ def scan_csv(
     config.trim_headers = trim_headers
     reader = _CsvReader(config)
     try:
-        with _utf8_csv_path(path, encoding) as native_path:
+        # Schema inference only needs a sample, avoiding full-file transcode
+        with _utf8_csv_path(path, encoding, sample_rows=10000) as native_path:
             return reader.scan_schema(native_path)
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -56,7 +56,6 @@ class TestReadCsv:
         assert len(frame) == 3
 
     def test_header_whitespace(self, tmp_path):
-
         csv_path = str(tmp_path / "whitespace.csv")
         with open(csv_path, "w") as f:
             f.write("name ,  age\nAlice,25\n")
@@ -268,3 +267,46 @@ class TestScanCsv:
         frame = ar.read_csv(sample_csv)
 
         assert list(schema.keys()) == list(frame.columns)
+
+    def test_scan_csv_non_utf8_multiline_boundary(self, tmp_path):
+        # Create a non-UTF-8 (latin-1) file with 10,000 rows, plus a quoted multiline row at the boundary.
+        csv_file = tmp_path / "test_multiline_boundary.csv"
+
+        # Row index 0 is header. Rows 1 to 9999 are simple rows.
+        # Row 10000 (at the sampling limit) is a multiline row containing a latin-1 char (café).
+        content_lines = ["id,text"]
+        for i in range(1, 9999):
+            content_lines.append(f"{i},value")
+
+        content_lines.append('9999,"multiline\nrecord\ncafé"')
+        content_lines.append("10000,end")
+
+        csv_content = "\n".join(content_lines)
+
+        # Write as latin-1
+        csv_file.write_bytes(csv_content.encode("latin-1"))
+
+        # Now scan_csv should successfully parse the schema without throwing CsvReadError or decoding errors
+        schema = ar.scan_csv(str(csv_file), encoding="latin-1")
+        assert schema == {"id": "int64", "text": "string"}
+
+    def test_scan_csv_type_evidence_after_limit(self, tmp_path):
+        # Create a non-UTF-8 (latin-1) file where a column has only integers
+        # in the first 10,000 rows, but a float appears after the sample limit.
+        csv_file = tmp_path / "test_type_evidence.csv"
+
+        content_lines = ["id,value"]
+        for i in range(1, 10005):
+            content_lines.append(f"{i},100")
+
+        # Row after the 10,000 sample limit has float type evidence (3.14)
+        content_lines.append("10006,3.14")
+
+        csv_content = "\n".join(content_lines)
+
+        # Write as latin-1
+        csv_file.write_bytes(csv_content.encode("latin-1"))
+
+        # scan_csv should infer 'value' as 'int64' because the float appears after the sample limit
+        schema = ar.scan_csv(str(csv_file), encoding="latin-1")
+        assert schema["value"] == "int64"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -269,44 +269,58 @@ class TestScanCsv:
         assert list(schema.keys()) == list(frame.columns)
 
     def test_scan_csv_non_utf8_multiline_boundary(self, tmp_path):
-        # Create a non-UTF-8 (latin-1) file with 10,000 rows, plus a quoted multiline row at the boundary.
+        """scan_csv must not split a quoted multiline record at the sample boundary.
+
+        Previously the sampling path iterated raw physical lines, which could
+        cut through a quoted field that contained an embedded newline. The result
+        was an invalid partial CSV fed to scan_schema, causing either a parse
+        error or wrong type inference. With record-aware sampling (csv.reader)
+        the boundary always falls between complete records.
+        """
         csv_file = tmp_path / "test_multiline_boundary.csv"
 
-        # Row index 0 is header. Rows 1 to 9999 are simple rows.
-        # Row 10000 (at the sampling limit) is a multiline row containing a latin-1 char (café).
+        # Build ~10 000 rows so the multiline record sits right at the limit.
         content_lines = ["id,text"]
         for i in range(1, 9999):
             content_lines.append(f"{i},value")
 
+        # Row 9999 — a quoted field containing embedded newlines and a
+        # latin-1 character (é). This record straddles the old line-count
+        # boundary and would have been split by the previous implementation.
         content_lines.append('9999,"multiline\nrecord\ncafé"')
         content_lines.append("10000,end")
 
         csv_content = "\n".join(content_lines)
 
-        # Write as latin-1
+        # Write as latin-1 so the non-UTF-8 transcode path is exercised.
         csv_file.write_bytes(csv_content.encode("latin-1"))
 
-        # Now scan_csv should successfully parse the schema without throwing CsvReadError or decoding errors
         schema = ar.scan_csv(str(csv_file), encoding="latin-1")
         assert schema == {"id": "int64", "text": "string"}
 
     def test_scan_csv_type_evidence_after_limit(self, tmp_path):
-        # Create a non-UTF-8 (latin-1) file where a column has only integers
-        # in the first 10,000 rows, but a float appears after the sample limit.
+        """Type evidence that appears after the sample window must not affect inference.
+
+        scan_csv is documented to infer types from a leading sample. A float
+        value that appears only beyond row 10 000 should not change the inferred
+        type of a column that looks like int64 within the sample. This test pins
+        that contract so future changes to the sample size don't silently break
+        the documented behaviour.
+        """
         csv_file = tmp_path / "test_type_evidence.csv"
 
         content_lines = ["id,value"]
         for i in range(1, 10005):
             content_lines.append(f"{i},100")
 
-        # Row after the 10,000 sample limit has float type evidence (3.14)
+        # Row 10 006 — float evidence that falls outside the 10 000-row sample.
         content_lines.append("10006,3.14")
 
         csv_content = "\n".join(content_lines)
 
-        # Write as latin-1
+        # latin-1 encoding so the transcode + sampling path is exercised.
         csv_file.write_bytes(csv_content.encode("latin-1"))
 
-        # scan_csv should infer 'value' as 'int64' because the float appears after the sample limit
         schema = ar.scan_csv(str(csv_file), encoding="latin-1")
+        # The float is outside the sample; 'value' must be inferred as int64.
         assert schema["value"] == "int64"


### PR DESCRIPTION
## Summary
This PR resolves a performance bottleneck where `scan_csv()` was transcoding the entire file into memory before native scanning for non-UTF-8 inputs. 

Changes included:
1. Updated `_utf8_csv_path` to stream the transcode using `shutil.copyfileobj` instead of reading the entire file into memory at once (`src.read()`).
2. Added a `sample_rows` parameter to `_utf8_csv_path`.
3. Updated `scan_csv()` to pass `sample_rows=10000`, so it only transcodes a small sample to infer the schema, keeping the function lightweight as documented.
4. Updated the `scan_csv` docstring to reflect this behavior.

## Linked issue
Fixes #467

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [x] `make lint`
- [ ] Other: 

## Screenshots / Media
N/A

## Performance Impact
Substantially reduces memory consumption and execution time when running `scan_csv()` on massive non-UTF-8 (e.g., Latin-1, UTF-16) CSV files, as it no longer reads the entire file into memory or writes the full file to disk before schema inference.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The `sample_rows` default for `scan_csv` is set to `10000`, which should be plenty for robust schema inference while avoiding the full-file transcode penalty.
