### PR TITLE
Add Python-side validation for CSV read options (delimiter, usecols, nrows)

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import os
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+
 
 from ._core import _CsvConfig, _CsvReader
 from .exceptions import CsvReadError
@@ -51,6 +52,48 @@ def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
             except OSError:
                 pass
 
+def _validate_delimiter(delimiter: str) -> str:
+    """Validate CSV delimiter."""
+    if not isinstance(delimiter, str):
+        raise TypeError("delimiter must be a string")
+
+    if len(delimiter) != 1:
+        raise ValueError("delimiter must be exactly one character")
+
+    return delimiter
+
+
+def _validate_usecols(usecols: Sequence[str]) -> list[str]:
+    """Validate usecols parameter."""
+    if isinstance(usecols, str):
+        raise TypeError(
+            "usecols must be a sequence of column names, not a string"
+        )
+
+    if not isinstance(usecols, Sequence):
+        raise TypeError("usecols must be a sequence of strings")
+
+    for col in usecols:
+        if not isinstance(col, str):
+            raise TypeError("usecols must contain only strings")
+
+    if len(set(usecols)) != len(usecols):
+        raise ValueError(
+            "usecols must not contain duplicate column names"
+        )
+
+    return list(usecols)
+
+
+def _validate_nrows(nrows: int) -> int:
+    """Validate nrows parameter."""
+    if isinstance(nrows, bool) or not isinstance(nrows, int):
+        raise TypeError("nrows must be an integer")
+
+    if nrows < 0:
+        raise ValueError("nrows must be non-negative")
+
+    return nrows
 
 def read_csv(
     path: str | os.PathLike[str],
@@ -124,6 +167,8 @@ def read_csv(
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
 
+    delimiter = _validate_delimiter(delimiter)
+
     config = _CsvConfig()
     config.delimiter = delimiter
     config.has_header = has_header
@@ -131,9 +176,10 @@ def read_csv(
     config.trim_headers = trim_headers
 
     if usecols is not None:
-        config.usecols = usecols
+        config.usecols = _validate_usecols(usecols)
+
     if nrows is not None:
-        config.nrows = nrows
+        config.nrows = _validate_nrows(nrows)
 
     reader = _CsvReader(config)
     try:
@@ -212,6 +258,8 @@ def scan_csv(
 
     except FileNotFoundError:
         pass
+
+    delimiter = _validate_delimiter(delimiter)
 
     config = _CsvConfig()
     config.delimiter = delimiter

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -10,7 +10,6 @@ import tempfile
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 
-
 from ._core import _CsvConfig, _CsvReader
 from .exceptions import CsvReadError
 from .frame import ArFrame
@@ -52,6 +51,7 @@ def _utf8_csv_path(path: str, encoding: str) -> Iterator[str]:
             except OSError:
                 pass
 
+
 def _validate_delimiter(delimiter: str) -> str:
     """Validate CSV delimiter."""
     if not isinstance(delimiter, str):
@@ -66,9 +66,7 @@ def _validate_delimiter(delimiter: str) -> str:
 def _validate_usecols(usecols: Sequence[str]) -> list[str]:
     """Validate usecols parameter."""
     if isinstance(usecols, str):
-        raise TypeError(
-            "usecols must be a sequence of column names, not a string"
-        )
+        raise TypeError("usecols must be a sequence of column names, not a string")
 
     if not isinstance(usecols, Sequence):
         raise TypeError("usecols must be a sequence of strings")
@@ -78,9 +76,7 @@ def _validate_usecols(usecols: Sequence[str]) -> list[str]:
             raise TypeError("usecols must contain only strings")
 
     if len(set(usecols)) != len(usecols):
-        raise ValueError(
-            "usecols must not contain duplicate column names"
-        )
+        raise ValueError("usecols must not contain duplicate column names")
 
     return list(usecols)
 
@@ -94,6 +90,7 @@ def _validate_nrows(nrows: int) -> int:
         raise ValueError("nrows must be non-negative")
 
     return nrows
+
 
 def read_csv(
     path: str | os.PathLike[str],

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -26,6 +26,54 @@ class TestReadCsv:
         frame = ar.read_csv(sample_csv, nrows=2)
         assert frame.shape == (2, 4)
 
+    def test_invalid_delimiter(self, tmp_path):
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text("a,b\n1,2\n")
+
+        with pytest.raises(ValueError, match="delimiter must be exactly one character"):
+            ar.read_csv(csv_path, delimiter="::")
+
+        with pytest.raises(ValueError, match="delimiter must be exactly one character"):
+            ar.read_csv(csv_path, delimiter="")
+
+        with pytest.raises(TypeError, match="delimiter must be a string"):
+            ar.read_csv(csv_path, delimiter=1)
+
+    def test_invalid_usecols(self, tmp_path):
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text("id,name\n1,Alice\n")
+
+        with pytest.raises(
+            TypeError,
+            match="usecols must be a sequence of column names, not a string",
+        ):
+            ar.read_csv(csv_path, usecols="name")
+
+        with pytest.raises(
+            TypeError,
+            match="usecols must contain only strings",
+        ):
+            ar.read_csv(csv_path, usecols=[123])
+
+        with pytest.raises(
+            ValueError,
+            match="usecols must not contain duplicate column names",
+        ):
+            ar.read_csv(csv_path, usecols=["id", "id"])
+
+    def test_invalid_nrows(self, tmp_path):
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text("a,b\n1,2\n")
+
+        with pytest.raises(TypeError, match="nrows must be an integer"):
+            ar.read_csv(csv_path, nrows=True)
+
+        with pytest.raises(TypeError, match="nrows must be an integer"):
+            ar.read_csv(csv_path, nrows=1.5)
+
+        with pytest.raises(ValueError, match="nrows must be non-negative"):
+            ar.read_csv(csv_path, nrows=-1)
+
     def test_no_header(self, csv_no_header):
         frame = ar.read_csv(csv_no_header, has_header=False)
         assert frame.shape == (2, 3)
@@ -222,6 +270,19 @@ class TestScanCsv:
             match="CSV input contains NUL bytes and appears to be binary or corrupted",
         ):
             ar.scan_csv(file_path)
+
+    def test_scan_invalid_delimiter(self, tmp_path):
+        csv_path = tmp_path / "test.csv"
+        csv_path.write_text("a,b\n1,2\n")
+
+        with pytest.raises(ValueError, match="delimiter must be exactly one character"):
+            ar.scan_csv(csv_path, delimiter="::")
+
+        with pytest.raises(ValueError, match="delimiter must be exactly one character"):
+            ar.scan_csv(csv_path, delimiter="")
+
+        with pytest.raises(TypeError, match="delimiter must be a string"):
+            ar.scan_csv(csv_path, delimiter=1)
 
     def test_scan_empty_file_raises(self, tmp_path):
         csv_path = tmp_path / "empty.csv"


### PR DESCRIPTION
Description

This PR adds Python-side validation for CSV reading options in read_csv() and scan_csv() to ensure invalid inputs are caught early with clear, consistent error messages before reaching the C++ backend.

Changes made:
  Added validation helpers:
    _validate_delimiter: ensures delimiter is a single-character string
    _validate_usecols: ensures usecols is a sequence of strings with no duplicates
    _validate_nrows: ensures nrows is a non-negative integer and rejects bool/float
    Applied validations in both:
    read_csv()
    scan_csv()
Why this change:

  Previously, invalid arguments were passed directly to the C++ layer, which could result in unclear or inconsistent runtime  errors. This made debugging harder for users and did not guarantee a stable public API behavior.

Improvements:
  Clear and early error handling at Python level
  Consistent behavior across read_csv() and scan_csv()
  Better developer experience with descriptive exceptions
Testing:
  Added tests for invalid:
  delimiter values (non-string, multi-character, empty string)
  usecols (string input, non-string elements, duplicates)
  nrows (bool, float, negative values)
  Ensured all valid cases continue to work without changes
Notes:
  No changes to C++ backend
  No breaking changes for valid inputs
  Focused purely on input validation layer