### PR TITLE
updated benchmark_vs_pandas.py to include python + c++ process memory

### DIFF
--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -3,6 +3,7 @@ Reproducible benchmark: arnio vs pandas
 Run: python benchmarks/benchmark_vs_pandas.py
 """
 
+import sys
 import time
 import tracemalloc
 from dataclasses import dataclass
@@ -29,6 +30,54 @@ BENCHMARKS = (
 )
 
 
+_PSUTIL_PROCESS = None
+_PSUTIL_PROBED = False
+
+
+def _get_psutil_process():
+    global _PSUTIL_PROCESS
+    global _PSUTIL_PROBED
+
+    if _PSUTIL_PROBED:
+        return _PSUTIL_PROCESS
+
+    _PSUTIL_PROBED = True
+    try:
+        import psutil
+
+        _PSUTIL_PROCESS = psutil.Process()
+        return _PSUTIL_PROCESS
+    except Exception:
+        return None
+
+
+def get_rss_source():
+    if _get_psutil_process() is not None:
+        return "psutil"
+    try:
+        import resource
+
+        return "resource"
+    except Exception:
+        return "unavailable"
+
+
+def get_process_rss_mb():
+    process = _get_psutil_process()
+    if process is not None:
+        return process.memory_info().rss / 1024 / 1024
+
+    try:
+        import resource
+
+        rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if sys.platform == "darwin":
+            return rss_kb / 1024 / 1024
+        return rss_kb / 1024
+    except Exception:
+        return None
+
+
 def ensure_dataset_exists(path):
     if not Path(path).exists():
         raise FileNotFoundError(
@@ -41,26 +90,44 @@ def benchmark_pandas(path):
     ensure_dataset_exists(path)
     tracemalloc.start()
     t0 = time.perf_counter()
+    rss_samples = []
+    start_rss = get_process_rss_mb()
+    if start_rss is not None:
+        rss_samples.append(start_rss)
 
     df = pd.read_csv(path)
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
     df.columns = df.columns.str.strip()
     df = df.dropna()
     df = df.drop_duplicates()
     for col in df.select_dtypes(include=["object", "string"]).columns:
         df[col] = df[col].astype(str).str.strip().str.lower()
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
 
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+    peak_rss = max(rss_samples) if rss_samples else None
+    return elapsed, peak / 1024 / 1024, peak_rss
 
 
 def benchmark_arnio(path):
     ensure_dataset_exists(path)
     tracemalloc.start()
     t0 = time.perf_counter()
+    rss_samples = []
+    start_rss = get_process_rss_mb()
+    if start_rss is not None:
+        rss_samples.append(start_rss)
 
     frame = ar.read_csv(path)
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
     clean = ar.pipeline(
         frame,
         [
@@ -70,12 +137,19 @@ def benchmark_arnio(path):
             ("drop_duplicates",),
         ],
     )
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
     ar.to_pandas(clean)
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
 
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+    peak_rss = max(rss_samples) if rss_samples else None
+    return elapsed, peak / 1024 / 1024, peak_rss
 
 
 def avg(values):
@@ -88,24 +162,50 @@ def run_case(case):
     print("-" * 46)
 
     pd_times, ar_times = [], []
-    pd_rams, ar_rams = [], []
+    pd_trace_rams, ar_trace_rams = [], []
+    pd_rss_rams, ar_rss_rams = [], []
 
     for i in range(RUNS):
-        pt, pr = benchmark_pandas(case.path)
-        at, ar_r = benchmark_arnio(case.path)
+        pt, pr_trace, pr_rss = benchmark_pandas(case.path)
+        at, ar_trace, ar_rss = benchmark_arnio(case.path)
         pd_times.append(pt)
         ar_times.append(at)
-        pd_rams.append(pr)
-        ar_rams.append(ar_r)
+        pd_trace_rams.append(pr_trace)
+        ar_trace_rams.append(ar_trace)
+        if pr_rss is not None:
+            pd_rss_rams.append(pr_rss)
+        if ar_rss is not None:
+            ar_rss_rams.append(ar_rss)
 
     print(f"{'Exec Time (avg)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s")
-    print(f"{'Peak RAM':<20} {avg(pd_rams):>10.0f}MB {avg(ar_rams):>10.0f}MB")
+    if pd_rss_rams and ar_rss_rams:
+        pd_rss_avg = avg(pd_rss_rams)
+        ar_rss_avg = avg(ar_rss_rams)
+        print(f"{'Peak RSS (process)':<20} {pd_rss_avg:>10.0f}MB {ar_rss_avg:>10.0f}MB")
+    else:
+        pd_rss_avg = None
+        ar_rss_avg = None
+        print(f"{'Peak RSS (process)':<20} {'n/a':>12} {'n/a':>12}")
     print(
-        f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams)/avg(pd_rams))*100:.0f}% reduction"
+        f"{'Peak Python (trace)':<20} {avg(pd_trace_rams):>10.0f}MB {avg(ar_trace_rams):>10.0f}MB"
     )
+    if pd_rss_avg and ar_rss_avg:
+        ram_reduction = (1 - (ar_rss_avg / pd_rss_avg)) * 100
+        print(
+            f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x | RAM: {ram_reduction:.0f}% reduction (RSS)"
+        )
+    else:
+        print(f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x")
     print()
 
 
 if __name__ == "__main__":
+    rss_source = get_rss_source()
+    if rss_source == "resource":
+        print(
+            "Note: Peak RSS uses resource.getrusage; units are KB on Linux and bytes on macOS."
+        )
+    elif rss_source == "unavailable":
+        print("Note: Peak RSS unavailable (install psutil for process RSS).")
     for benchmark_case in BENCHMARKS:
         run_case(benchmark_case)

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -253,7 +253,9 @@ def run_child(engine, case_path):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Run Arnio vs pandas benchmarks")
-    parser.add_argument("--engine", choices=["pandas", "arnio"], help="Benchmark engine")
+    parser.add_argument(
+        "--engine", choices=["pandas", "arnio"], help="Benchmark engine"
+    )
     parser.add_argument("--case", help="CSV path for a single benchmark run")
     parser.add_argument("--json", action="store_true", help="Emit JSON result")
     return parser.parse_args()

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -3,6 +3,9 @@ Reproducible benchmark: arnio vs pandas
 Run: python benchmarks/benchmark_vs_pandas.py
 """
 
+import argparse
+import json
+import subprocess
 import sys
 import time
 import tracemalloc
@@ -51,12 +54,13 @@ def _get_psutil_process():
         return None
 
 
-def get_rss_source():
+def detect_rss_source():
     if _get_psutil_process() is not None:
         return "psutil"
     try:
         import resource
 
+        _ = resource.RUSAGE_SELF
         return "resource"
     except Exception:
         return "unavailable"
@@ -156,6 +160,28 @@ def avg(values):
     return sum(values) / len(values)
 
 
+def run_subprocess(engine, path):
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--engine",
+        engine,
+        "--case",
+        path,
+        "--json",
+    ]
+    completed = subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    output = completed.stdout.strip()
+    if not output:
+        raise RuntimeError(f"No output from benchmark subprocess ({engine}).")
+    return json.loads(output)
+
+
 def run_case(case):
     print(case.name)
     print(f"{'Metric':<20} {'pandas':>12} {'arnio':>12}")
@@ -166,8 +192,18 @@ def run_case(case):
     pd_rss_rams, ar_rss_rams = [], []
 
     for i in range(RUNS):
-        pt, pr_trace, pr_rss = benchmark_pandas(case.path)
-        at, ar_trace, ar_rss = benchmark_arnio(case.path)
+        pd_result = run_subprocess("pandas", case.path)
+        ar_result = run_subprocess("arnio", case.path)
+        pt, pr_trace, pr_rss = (
+            pd_result["elapsed"],
+            pd_result["peak_trace_mb"],
+            pd_result.get("peak_rss_mb"),
+        )
+        at, ar_trace, ar_rss = (
+            ar_result["elapsed"],
+            ar_result["peak_trace_mb"],
+            ar_result.get("peak_rss_mb"),
+        )
         pd_times.append(pt)
         ar_times.append(at)
         pd_trace_rams.append(pr_trace)
@@ -199,8 +235,39 @@ def run_case(case):
     print()
 
 
+def run_child(engine, case_path):
+    if engine == "pandas":
+        elapsed, peak_trace_mb, peak_rss_mb = benchmark_pandas(case_path)
+    elif engine == "arnio":
+        elapsed, peak_trace_mb, peak_rss_mb = benchmark_arnio(case_path)
+    else:
+        raise ValueError(f"Unknown engine: {engine}")
+
+    payload = {
+        "elapsed": elapsed,
+        "peak_trace_mb": peak_trace_mb,
+        "peak_rss_mb": peak_rss_mb,
+    }
+    print(json.dumps(payload))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run Arnio vs pandas benchmarks")
+    parser.add_argument("--engine", choices=["pandas", "arnio"], help="Benchmark engine")
+    parser.add_argument("--case", help="CSV path for a single benchmark run")
+    parser.add_argument("--json", action="store_true", help="Emit JSON result")
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
-    rss_source = get_rss_source()
+    args = parse_args()
+    if args.engine and args.case:
+        if not args.json:
+            raise SystemExit("Child mode requires --json output.")
+        run_child(args.engine, args.case)
+        raise SystemExit(0)
+
+    rss_source = detect_rss_source()
     if rss_source == "resource":
         print(
             "Note: Peak RSS uses resource.getrusage; units are KB on Linux and bytes on macOS."

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -55,18 +55,22 @@ def test_generate_wide_rejects_too_few_columns(tmp_path):
 
 
 def test_run_case_benchmarks_the_selected_case_path(monkeypatch):
-    seen_paths = []
+    seen_calls = []
 
-    def fake_benchmark(path):
-        seen_paths.append(path)
-        return 1.0, 1.0
+    def fake_run_subprocess(engine, path):
+        seen_calls.append((engine, path))
+        return {"elapsed": 1.0, "peak_trace_mb": 1.0, "peak_rss_mb": 2.0}
 
     monkeypatch.setattr(benchmark_vs_pandas, "RUNS", 2)
-    monkeypatch.setattr(benchmark_vs_pandas, "benchmark_pandas", fake_benchmark)
-    monkeypatch.setattr(benchmark_vs_pandas, "benchmark_arnio", fake_benchmark)
+    monkeypatch.setattr(benchmark_vs_pandas, "run_subprocess", fake_run_subprocess)
 
     benchmark_vs_pandas.run_case(
         benchmark_vs_pandas.BenchmarkCase("Wide fixture", "wide.csv")
     )
 
-    assert seen_paths == ["wide.csv", "wide.csv", "wide.csv", "wide.csv"]
+    assert seen_calls == [
+        ("pandas", "wide.csv"),
+        ("arnio", "wide.csv"),
+        ("pandas", "wide.csv"),
+        ("arnio", "wide.csv"),
+    ]


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->
Update the benchmark script to report process RSS alongside Python-only tracemalloc so memory numbers reflect native C++ allocations. Keeps output stable and adds a small platform caveat when RSS comes from [resource](vscode-file://vscode-app/app/extra/vscode/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
Fixes  #426

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
python benchmarks/generate_data.py
python benchmarks/benchmark_vs_pandas.py

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->
<img width="893" height="560" alt="image" src="https://github.com/user-attachments/assets/f0a8b575-d98d-44db-af11-3503b2014ebf" />

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->
Metric                     pandas        arnio
----------------------------------------------
Peak RSS (process)          549MB        805MB
Peak Python (trace)         189MB        184MB


## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
