### PR TITLE
feat: added standardize_missing_tokens step

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Total avg (Read+Strict)       0.077             4.52
 
 ## 🧰 Cleaning primitives
 
-Most operations below run natively in C++. Currently, `filter_rows` and `replace_values` run via the Python (pandas) backend and may be optimized in C++ later.
+Most operations below run natively in C++. Currently, `filter_rows`, `replace_values` and `standardize_missing_tokens` run via the Python (pandas) backend and may be optimized in C++ later.
 
 | Primitive | What it does | Example |
 |:---|:---|:---|
@@ -429,6 +429,7 @@ Most operations below run natively in C++. Currently, `filter_rows` and `replace
 | `drop_constant_columns` | Remove columns with only one unique value | `ar.drop_constant_columns(frame)` |
 | `clip_numeric` | Clip numeric values to lower and/or upper bounds | `ar.clip_numeric(frame, lower=0, upper=100)` |
 | `strip_whitespace` | Trim leading/trailing spaces from strings | `ar.strip_whitespace(frame)` |
+| `standardize_missing_tokens` | Replace common missing-value strings with NaN | `ar.standardize_missing_tokens(frame)` |
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
@@ -466,6 +467,7 @@ Or compose them all into a **pipeline**:
 clean = ar.pipeline(frame, [
     ("validate_columns_exist", {"columns": ["name", "city", "revenue"]}),
     ("strip_whitespace",),
+    ("standardize_missing_tokens",),
     ("normalize_case", {"case_type": "lower"}),
     ("fill_nulls", {"value": "unknown", "subset": ["city"]}),
     ("drop_duplicates", {"keep": "first"}),

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -28,6 +28,7 @@ from .cleaning import (
     replace_values,
     round_numeric_columns,
     safe_divide_columns,
+    standardize_missing_tokens,
     strip_whitespace,
     trim_column_names,
     validate_columns_exist,
@@ -87,6 +88,7 @@ __all__ = [
     "clean",
     "safe_divide_columns",
     "trim_column_names",
+    "standardize_missing_tokens",
     # Conversion
     "to_pandas",
     "from_pandas",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -938,7 +938,27 @@ def replace_values(frame, mapping, column=None):
 
 
 def standardize_missing_tokens(frame, tokens=None, subset=None):
-    """Converting missing tokens in the DataFrame to the standard form NaN"""
+    """Converting missing tokens in the DataFrame to the standard form NaN
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    tokens : list[str], optional
+        List of strings to treat as missing. If None, then a built-in default tokens list is used
+    subset : list[str], optional
+        Column names to replace missing tokens in. If None, applies to all columns.
+
+    Returns
+    -------
+    ArFrame
+        New frame with missing token values replaced by NaN.
+
+    Examples
+    --------
+    >>> frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, "N/A"]}))
+    >>> result = ar.standardize_missing_tokens(frame)
+    """
 
     import pandas as pd
 
@@ -948,20 +968,21 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
     df = to_pandas(frame) if is_arframe else frame
 
     df = df.copy()
+    if isinstance(subset, str):
+        raise TypeError(
+            f"subset must be a list of column names, not a string. "
+            f"Did you mean subset=['{subset}']?"
+        )
 
     default_tokens = ["N/A", "NA", "n/a", "na", "-", "none", "nil", "null", "", "?"]
 
-    # check if the user has passed their own tokens or not
-    # Case 1 : when user does not pass a subset
     if subset is None:
         if tokens is None:
             df = df.replace(default_tokens, float("nan"))
         else:
             df = df.replace(tokens, float("nan"))
 
-    # Case 2 : when user passes a subset
     else:
-        # check if the subset column is valid or not
         unknown_columns = [column for column in subset if column not in df.columns]
         if unknown_columns:
             raise ValueError(f"Unknown columns in subset: {unknown_columns}")

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -935,8 +935,19 @@ def replace_values(frame, mapping, column=None):
             df = df.fillna(null_replacement)
 
     return from_pandas(df) if is_arframe else df
-def standardize_missing_tokens(df, tokens=None, subset=None):
+
+
+def standardize_missing_tokens(frame, tokens=None, subset=None):
     """Converting missing tokens in the DataFrame to the standard form NaN"""
+
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    is_arframe = not isinstance(frame, pd.DataFrame)
+    df = to_pandas(frame) if is_arframe else frame
+
+    df = df.copy()
 
     default_tokens = ["N/A", "NA", "n/a", "na", "-", "none", "nil", "null", "", "?"]
 
@@ -950,9 +961,13 @@ def standardize_missing_tokens(df, tokens=None, subset=None):
 
     # Case 2 : when user passes a subset
     else:
+        # check if the subset column is valid or not
+        unknown_columns = [column for column in subset if column not in df.columns]
+        if unknown_columns:
+            raise ValueError(f"Unknown columns in subset: {unknown_columns}")
         if tokens is None:
             df[subset] = df[subset].replace(default_tokens, float("nan"))
         else:
             df[subset] = df[subset].replace(tokens, float("nan"))
 
-    return df
+    return from_pandas(df) if is_arframe else df

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -935,3 +935,24 @@ def replace_values(frame, mapping, column=None):
             df = df.fillna(null_replacement)
 
     return from_pandas(df) if is_arframe else df
+def standardize_missing_tokens(df, tokens=None, subset=None):
+    """Converting missing tokens in the DataFrame to the standard form NaN"""
+
+    default_tokens = ["N/A", "NA", "n/a", "na", "-", "none", "nil", "null", "", "?"]
+
+    # check if the user has passed their own tokens or not
+    # Case 1 : when user does not pass a subset
+    if subset is None:
+        if tokens is None:
+            df = df.replace(default_tokens, float("nan"))
+        else:
+            df = df.replace(tokens, float("nan"))
+
+    # Case 2 : when user passes a subset
+    else:
+        if tokens is None:
+            df[subset] = df[subset].replace(default_tokens, float("nan"))
+        else:
+            df[subset] = df[subset].replace(tokens, float("nan"))
+
+    return df

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -30,9 +30,10 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "trim_column_names": cleaning.trim_column_names,
 }
 
-
-_PYTHON_STEP_REGISTRY: dict[str, Callable] = {}
 _REGISTRY_LOCK = Lock()
+_PYTHON_STEP_REGISTRY: dict[str, Callable] = {
+    "standardize_missing_tokens": cleaning.standardize_missing_tokens
+}
 
 
 def register_step(name: str, fn: Callable):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -377,7 +377,15 @@ class TestStandardizeMissingTokens:
     def test_normal_case(self):
         df = pd.DataFrame({"value": [1, 2, "N/A"]})
         result = ar.standardize_missing_tokens(df)
+        assert isinstance(result, pd.DataFrame)
         assert pd.isna(result["value"].iloc[2])
+
+    def test_normal_case_arframe(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, "N/A"]}))
+        result = ar.standardize_missing_tokens(frame)
+        df = ar.to_pandas(result)
+        assert isinstance(result, ar.ArFrame)
+        assert pd.isna(df["value"].iloc[2])
 
     def test_default_case(self):
         df = pd.DataFrame({"value": [1, 2, "-"]})
@@ -422,6 +430,11 @@ class TestStandardizeMissingTokens:
         df = pd.DataFrame({"value": [1, 2, "-"]})
         result = ar.standardize_missing_tokens(df, tokens=[])
         assert result["value"].iloc[2] == "-"
+
+    def test_standardize_missing_tokens_unknown_subset_column_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+        with pytest.raises(ValueError, match="Unknown columns in subset"):
+            ar.standardize_missing_tokens(frame, subset=["missing"])
 
 
 class TestStripWhitespace:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -373,6 +373,57 @@ class TestClipNumeric:
             ar.clip_numeric(frame, lower=5, upper=1)
 
 
+class TestStandardizeMissingTokens:
+    def test_normal_case(self):
+        df = pd.DataFrame({"value": [1, 2, "N/A"]})
+        result = ar.standardize_missing_tokens(df)
+        assert pd.isna(result["value"].iloc[2])
+
+    def test_default_case(self):
+        df = pd.DataFrame({"value": [1, 2, "-"]})
+        result = ar.standardize_missing_tokens(df)
+        assert pd.isna(result["value"].iloc[2])
+
+    def test_default_case_subset(self):
+        df = pd.DataFrame(
+            {
+                "roll_no": ["001", "002", "003"],
+                "name": ["Alice", "Bob", "Carter"],
+                "marks": [100, 90, "-"],
+            }
+        )
+        result = ar.standardize_missing_tokens(df, subset=["marks"])
+        assert pd.isna(result["marks"].iloc[2])
+        assert result["name"].iloc[2] == "Carter"
+
+    def test_custom_case(self):
+        df = pd.DataFrame({"value": [1, 2, "unknown"]})
+        result = ar.standardize_missing_tokens(df, tokens=["unknown"])
+        assert pd.isna(result["value"].iloc[2])
+
+    def test_custom_case_subset(self):
+        df = pd.DataFrame(
+            {
+                "roll_no": ["001", "002", "003"],
+                "name": ["Alice", "Bob", "Carter"],
+                "marks": [100, 90, "unknown"],
+            }
+        )
+        result = ar.standardize_missing_tokens(df, tokens=["unknown"], subset=["marks"])
+        assert pd.isna(result["marks"].iloc[2])
+        assert result["name"].iloc[2] == "Carter"
+
+    def test_non_string_columns(self):
+        df = pd.DataFrame({"value": [1, 2, 3]})
+        result = ar.standardize_missing_tokens(df)
+        assert result["value"].iloc[0] == 1
+
+    def test_unchanged_columns(self):
+        df = pd.DataFrame({"value": [1, 2, "-"]})
+        result = ar.standardize_missing_tokens(df, tokens=[])
+        assert result["value"].iloc[2] == "-"
+
+
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):
         frame = ar.read_csv(csv_with_whitespace)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,8 +4,8 @@ import importlib
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
-import pytest
 import pandas as pd
+import pytest
 
 import arnio as ar
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,6 +5,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+import pandas as pd
 
 import arnio as ar
 
@@ -144,8 +145,6 @@ class TestPipeline:
         assert list(df["label"]) == ["a", "b", "c"]
 
     def test_pipeline_standardize_missing_tokens(self):
-        import pandas as pd
-
         frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, "N/A"]}))
 
         result = ar.pipeline(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -143,6 +143,21 @@ class TestPipeline:
         assert list(df["value"]) == [0, 2, 5]
         assert list(df["label"]) == ["a", "b", "c"]
 
+    def test_pipeline_standardize_missing_tokens(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, "N/A"]}))
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("standardize_missing_tokens",),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert pd.isna(df["value"].iloc[2])
+
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(


### PR DESCRIPTION
## Summary
Added standardize_missing_tokens as a new Python pipeline cleaning step. The function replaces common missing-value strings such as "N/A", "none", "-" and others with float("nan") so downstream steps like drop_nulls can detect and handle them correctly. It accepts an optional tokens parameter for custom replacement lists and an optional subset parameter to target specific columns only. If neither is provided, a built-in default token list is applied across all columns.

## Linked issue
Fixes #137 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `python -m pytest tests/` — 118 passed, 0 failed

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).