### PR TITLE
feat: add CountryCode schema validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ For production data contracts:
 schema = ar.Schema({
     "id": ar.Int64(nullable=False, unique=True),
     "email": ar.Email(nullable=False),
+    "country": ar.CountryCode(nullable=False),
     "revenue": ar.Float64(nullable=True, min=0),
 })
 

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -43,6 +43,7 @@ from .quality import (
 from .schema import (
     URL,
     Bool,
+    CountryCode,
     Email,
     Field,
     Float64,
@@ -98,6 +99,7 @@ __all__ = [
     "Int64",
     "Float64",
     "String",
+    "CountryCode",
     "Bool",
     "Email",
     "URL",

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -482,4 +482,5 @@ _SEMANTIC_PATTERNS = {
     "email": r"[^@\s]+@[^@\s]+\.[^@\s]+",
     "url": r"https?://[^\s]+",
     "phone": r"\+?[0-9][0-9 .()\-]{6,}[0-9]",
+    "country_code": r"[A-Za-z]{2}",
 }

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -291,6 +291,15 @@ def URL(*, nullable: bool = True, unique: bool = False) -> Field:
     """Create a URL schema field."""
     return Field(dtype="string", nullable=nullable, semantic="url", unique=unique)
 
+def CountryCode(*, nullable: bool = True, unique: bool = False) -> Field:
+    """Create an ISO alpha-2 country-code schema field."""
+    return Field(
+        dtype="string",
+        nullable=nullable,
+        semantic="country_code",
+        unique=unique,
+    )
+
 
 def _validate_column(
     series: pd.Series,

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -324,6 +324,7 @@ def URL(*, nullable: bool = True, unique: bool = False) -> Field:
     """Create a URL schema field."""
     return Field(dtype="string", nullable=nullable, semantic="url", unique=unique)
 
+
 def CountryCode(*, nullable: bool = True, unique: bool = False) -> Field:
     """Create an uppercase ISO alpha-2 country-code schema field."""
     return Field(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -166,3 +166,31 @@ def test_custom_pattern_validation(tmp_path):
     assert not result.passed
     assert result.issues[0].rule == "pattern"
     assert result.issues[0].row_index == 1
+
+def test_country_code_validation_accepts_iso_alpha_2_codes(tmp_path):
+    path = tmp_path / "countries.csv"
+    path.write_text("country\nIN\nUS\ngb\nFr\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"country": ar.CountryCode(nullable=False)},
+    )
+
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_country_code_validation_rejects_invalid_codes(tmp_path):
+    path = tmp_path / "bad_countries.csv"
+    path.write_text("country\nIND\n1A\nA\nUSA\n\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"country": ar.CountryCode(nullable=False)},
+    )
+
+    assert not result.passed
+    assert result.issue_count > 0
+
+    rules = {issue.rule for issue in result.issues}
+    assert "country_code" in rules or "nullable" in rules

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -293,10 +293,10 @@ def test_country_code_validation_rejects_invalid_codes(tmp_path):
     )
 
     assert not result.passed
-    assert result.issue_count > 0
+    assert result.issue_count == 6
 
-    rules = {issue.rule for issue in result.issues}
-    assert "country_code" in rules or "nullable" in rules
+    assert [issue.row_index for issue in result.issues] == [0, 1, 2, 3, 4, 5]
+    assert {issue.rule for issue in result.issues} == {"country_code"}
 
 
 def test_string_min_length_boundary(tmp_path):
@@ -383,4 +383,3 @@ def test_equal_string_length_bounds_are_valid():
 
     assert field.min_length == 3
     assert field.max_length == 3
-


### PR DESCRIPTION
## Description

Adds a `CountryCode` schema validator for validating ISO alpha-2 country codes.

## Related Issue

Fixes Schema: Add CountryCode field #205

## Changes Made

* Added `CountryCode()` schema field
* Added semantic validation pattern for ISO alpha-2 country codes
* Exported `CountryCode` in the public API
* Added tests for:

  * valid country codes
  * invalid country codes
  * lowercase/mixed-case behavior
  * nullable handling
* Updated README schema validation example

## Testing

* `python -m pytest tests/test_schema.py`
* `python -m pytest`

All 220 tests pass locally.

## Screenshots

* scheme.py
<img width="1325" height="191" alt="Screenshot 2026-05-17 151806" src="https://github.com/user-attachments/assets/108eed18-58cf-4665-9a1e-5fe5921f4f4d" />

* test_schema.py
<img width="1347" height="345" alt="Screenshot 2026-05-17 151945" src="https://github.com/user-attachments/assets/5d09d35b-34aa-4a0d-b8a0-3484e7d50d23" />
