### PR TITLE
fix: reject impossible schema bounds

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -244,7 +244,17 @@ def Int64(
     unique: bool = False,
 ) -> Field:
     """Create an int64 schema field."""
-    return Field(dtype="int64", nullable=nullable, min=min, max=max, unique=unique)
+
+    if min is not None and max is not None and min > max:
+        raise ValueError("min must be less than or equal to max")
+
+    return Field(
+        dtype="int64",
+        nullable=nullable,
+        min=min,
+        max=max,
+        unique=unique,
+    )
 
 
 def Float64(
@@ -255,7 +265,17 @@ def Float64(
     unique: bool = False,
 ) -> Field:
     """Create a float64 schema field."""
-    return Field(dtype="float64", nullable=nullable, min=min, max=max, unique=unique)
+
+    if min is not None and max is not None and min > max:
+        raise ValueError("min must be less than or equal to max")
+
+    return Field(
+        dtype="float64",
+        nullable=nullable,
+        min=min,
+        max=max,
+        unique=unique,
+    )
 
 
 def String(
@@ -268,7 +288,12 @@ def String(
     max_length: int | None = None,
 ) -> Field:
     """Create a string schema field."""
+
+    if min_length is not None and max_length is not None and min_length > max_length:
+        raise ValueError("min_length must be less than or equal to max_length")
+
     allowed_set = set(allowed) if allowed is not None else None
+
     return Field(
         dtype="string",
         nullable=nullable,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -313,3 +313,44 @@ def test_null_values_skip_length_validation(tmp_path):
     assert result.issue_count == 1
     assert result.issues[0].rule == "min_length"
     assert result.issues[0].row_index == 0
+
+
+def test_int64_rejects_impossible_bounds():
+    try:
+        ar.Int64(min=10, max=1)
+    except ValueError as exc:
+        assert "min must be less than or equal to max" in str(exc)
+    else:
+        raise AssertionError("Expected invalid Int64 bounds to raise")
+
+
+def test_float64_rejects_impossible_bounds():
+    try:
+        ar.Float64(min=10.0, max=1.0)
+    except ValueError as exc:
+        assert "min must be less than or equal to max" in str(exc)
+    else:
+        raise AssertionError("Expected invalid Float64 bounds to raise")
+
+
+def test_string_rejects_impossible_length_bounds():
+    try:
+        ar.String(min_length=5, max_length=2)
+    except ValueError as exc:
+        assert "min_length must be less than or equal to max_length" in str(exc)
+    else:
+        raise AssertionError("Expected invalid String bounds to raise")
+
+
+def test_equal_numeric_bounds_are_valid():
+    field = ar.Int64(min=5, max=5)
+
+    assert field.min == 5
+    assert field.max == 5
+
+
+def test_equal_string_length_bounds_are_valid():
+    field = ar.String(min_length=3, max_length=3)
+
+    assert field.min_length == 3
+    assert field.max_length == 3


### PR DESCRIPTION
## Summary

Adds validation for impossible schema bounds in schema field constructors.

Previously, invalid configurations such as:

```python
ar.Int64(min=10, max=1)
ar.Float64(min=10.0, max=1.0)
ar.String(min_length=5, max_length=2)
```

were accepted successfully.

This PR adds early validation and raises clear `ValueError`s for impossible bounds.

## Changes made

* Added validation in `Int64()` and `Float64()` to reject `min > max`
* Added validation in `String()` to reject `min_length > max_length`
* Added focused tests for:

  * invalid numeric bounds
  * invalid string length bounds
  * valid equal bounds (`min == max`, `min_length == max_length`)

## Why

Invalid schema definitions should fail early at construction time instead of creating confusing downstream validation behavior.

Fixes #466
