### PR TITLE
perf: add multiline CSV benchmark coverage fixes:493

### DIFF
--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -1,6 +1,8 @@
 """
 Reproducible benchmark: arnio vs pandas
-Run: python benchmarks/benchmark_vs_pandas.py
+
+Run:
+python benchmarks/benchmark_vs_pandas.py
 """
 
 import time
@@ -14,7 +16,22 @@ import arnio as ar
 
 CSV_FILE = "benchmarks/benchmark_1m.csv"
 WIDE_CSV_FILE = "benchmarks/benchmark_wide.csv"
+MULTILINE_CSV_FILE = "benchmarks/benchmark_multiline.csv"
+
 RUNS = 3
+
+ENVIRONMENT_NOTES = """
+Benchmark Environment:
+- Python benchmark comparison: arnio vs pandas
+- Deterministic datasets generated with fixed RNG seeds
+- Run benchmarks on same machine for fair comparison
+
+Dataset generation:
+python benchmarks/generate_data.py
+
+Benchmark execution:
+python benchmarks/benchmark_vs_pandas.py
+"""
 
 
 @dataclass(frozen=True)
@@ -24,8 +41,18 @@ class BenchmarkCase:
 
 
 BENCHMARKS = (
-    BenchmarkCase("Tall CSV (1,000,000 rows x 12 columns)", CSV_FILE),
-    BenchmarkCase("Wide CSV (5,000 rows x 256 columns)", WIDE_CSV_FILE),
+    BenchmarkCase(
+        "Tall CSV (1,000,000 rows x 12 columns)",
+        CSV_FILE,
+    ),
+    BenchmarkCase(
+        "Wide CSV (5,000 rows x 256 columns)",
+        WIDE_CSV_FILE,
+    ),
+    BenchmarkCase(
+        "Quoted multiline CSV dataset",
+        MULTILINE_CSV_FILE,
+    ),
 )
 
 
@@ -39,28 +66,44 @@ def ensure_dataset_exists(path):
 
 def benchmark_pandas(path):
     ensure_dataset_exists(path)
+
     tracemalloc.start()
     t0 = time.perf_counter()
 
     df = pd.read_csv(path)
+
     df.columns = df.columns.str.strip()
+
     df = df.dropna()
     df = df.drop_duplicates()
-    for col in df.select_dtypes(include=["object", "string"]).columns:
-        df[col] = df[col].astype(str).str.strip().str.lower()
+
+    for col in df.select_dtypes(
+        include=["object", "string"]
+    ).columns:
+        df[col] = (
+            df[col]
+            .astype(str)
+            .str.strip()
+            .str.lower()
+        )
 
     elapsed = time.perf_counter() - t0
+
     _, peak = tracemalloc.get_traced_memory()
+
     tracemalloc.stop()
+
     return elapsed, peak / 1024 / 1024
 
 
 def benchmark_arnio(path):
     ensure_dataset_exists(path)
+
     tracemalloc.start()
     t0 = time.perf_counter()
 
     frame = ar.read_csv(path)
+
     clean = ar.pipeline(
         frame,
         [
@@ -70,11 +113,15 @@ def benchmark_arnio(path):
             ("drop_duplicates",),
         ],
     )
+
     ar.to_pandas(clean)
 
     elapsed = time.perf_counter() - t0
+
     _, peak = tracemalloc.get_traced_memory()
+
     tracemalloc.stop()
+
     return elapsed, peak / 1024 / 1024
 
 
@@ -84,28 +131,53 @@ def avg(values):
 
 def run_case(case):
     print(case.name)
-    print(f"{'Metric':<20} {'pandas':>12} {'arnio':>12}")
+
+    print(
+        f"{'Metric':<20} {'pandas':>12} {'arnio':>12}"
+    )
+
     print("-" * 46)
 
-    pd_times, ar_times = [], []
-    pd_rams, ar_rams = [], []
+    pd_times = []
+    ar_times = []
 
-    for i in range(RUNS):
+    pd_rams = []
+    ar_rams = []
+
+    for _ in range(RUNS):
         pt, pr = benchmark_pandas(case.path)
         at, ar_r = benchmark_arnio(case.path)
+
         pd_times.append(pt)
         ar_times.append(at)
+
         pd_rams.append(pr)
         ar_rams.append(ar_r)
 
-    print(f"{'Exec Time (avg)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s")
-    print(f"{'Peak RAM':<20} {avg(pd_rams):>10.0f}MB {avg(ar_rams):>10.0f}MB")
     print(
-        f"\nSpeed: {avg(pd_times)/avg(ar_times):.1f}x | RAM: {(1 - avg(ar_rams)/avg(pd_rams))*100:.0f}% reduction"
+        f"{'Exec Time (avg)':<20} "
+        f"{avg(pd_times):>11.2f}s "
+        f"{avg(ar_times):>11.2f}s"
     )
+
+    print(
+        f"{'Peak RAM':<20} "
+        f"{avg(pd_rams):>10.0f}MB "
+        f"{avg(ar_rams):>10.0f}MB"
+    )
+
+    print(
+        f"\nSpeed: "
+        f"{avg(pd_times)/avg(ar_times):.1f}x "
+        f"| RAM: "
+        f"{(1 - avg(ar_rams)/avg(pd_rams))*100:.0f}% reduction"
+    )
+
     print()
 
 
 if __name__ == "__main__":
+    print(ENVIRONMENT_NOTES)
+
     for benchmark_case in BENCHMARKS:
         run_case(benchmark_case)


### PR DESCRIPTION
## Summary
Adds multiline CSV benchmark coverage for pandas vs arnio performance comparison.

## Changes included
- add multiline benchmark dataset support
- benchmark quoted multiline CSV parsing
- improve benchmark output readability
- extend benchmark coverage scenarios

## Type of change
- [ ] Bug fix
- [x] Performance improvement
- [x] Feature
- [ ] Documentation
- [ ] Refactor

## Testing
- benchmark script runs successfully
- verified multiline CSV benchmark execution