### PR TITLE
feat: add composite uniqueness validation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,17 @@ if not result.passed:
 ```
 
 `ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
+
+For multi-column uniqueness (composite keys):
+
+```python
+schema = ar.Schema({
+    "user_id": ar.Int64(nullable=False),
+    "course_id": ar.Int64(nullable=False),
+}, unique=["user_id", "course_id"])
+
+result = ar.validate(frame, schema)
+```
 Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
 
 For low-risk automatic cleanup:

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -44,6 +44,7 @@ class Schema:
 
     fields: dict[str, Field]
     strict: bool = False
+    unique: list[str] | tuple[str, ...] | None = None
 
     def validate(self, frame: ArFrame) -> ValidationResult:
         """Validate a frame against this schema."""
@@ -235,6 +236,42 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
                         message=f"Unexpected column: {name}",
                     )
                 )
+
+    if schema.unique is not None:
+        if isinstance(schema.unique, (list, tuple)) and len(schema.unique) == 0:
+            issues.append(
+                ValidationIssue(
+                    column=None,
+                    rule="composite_unique",
+                    message="Composite unique columns cannot be empty",
+                )
+            )
+        elif isinstance(schema.unique, (list, tuple)):
+            missing_cols = [c for c in schema.unique if c not in df.columns]
+            if missing_cols:
+                for col in missing_cols:
+                    issues.append(
+                        ValidationIssue(
+                            column=col,
+                            rule="missing_column",
+                            message=f"Column {col!r} not found",
+                        )
+                    )
+            else:
+                duplicate_mask = df.duplicated(subset=list(schema.unique), keep=False)
+                if duplicate_mask.any():
+                    for index in df[duplicate_mask].index:
+                        issues.append(
+                            ValidationIssue(
+                                column=None,
+                                rule="composite_unique",
+                                message=(
+                                    "Duplicate rows found for columns"
+                                    f" {list(schema.unique)}"
+                                ),
+                                row_index=int(index),
+                            )
+                        )
 
     bad_rows = sorted(
         {issue.row_index for issue in issues if issue.row_index is not None}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -363,3 +363,75 @@ def test_equal_string_length_bounds_are_valid():
 
     assert field.min_length == 3
     assert field.max_length == 3
+
+
+def test_schema_composite_unique_passes(tmp_path):
+    path = tmp_path / "composite.csv"
+    path.write_text("user_id,course_id\n1,101\n1,102\n2,101\n")
+    frame = ar.read_csv(path)
+    schema = ar.Schema(
+        {
+            "user_id": ar.Int64(),
+            "course_id": ar.Int64(),
+        },
+        unique=["user_id", "course_id"],
+    )
+    result = schema.validate(frame)
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_schema_composite_unique_fails(tmp_path):
+    path = tmp_path / "composite_bad.csv"
+    path.write_text("user_id,course_id\n1,101\n1,102\n1,101\n")
+    frame = ar.read_csv(path)
+    schema = ar.Schema(
+        {
+            "user_id": ar.Int64(),
+            "course_id": ar.Int64(),
+        },
+        unique=["user_id", "course_id"],
+    )
+    result = schema.validate(frame)
+    assert not result.passed
+    issues = [i for i in result.issues if i.rule == "composite_unique"]
+    assert len(issues) == 2
+    assert issues[0].row_index == 0
+    assert issues[1].row_index == 2
+    assert "['user_id', 'course_id']" in issues[0].message
+
+
+def test_schema_composite_unique_invalid_column(tmp_path):
+    path = tmp_path / "composite_invalid.csv"
+    path.write_text("user_id,course_id\n1,101\n")
+    frame = ar.read_csv(path)
+    schema = ar.Schema(
+        {
+            "user_id": ar.Int64(),
+            "course_id": ar.Int64(),
+        },
+        unique=["user_id", "bad_column"],
+    )
+    result = schema.validate(frame)
+    assert not result.passed
+    issues = [i for i in result.issues if i.rule == "missing_column"]
+    assert len(issues) == 1
+    assert issues[0].column == "bad_column"
+
+
+def test_schema_composite_unique_empty_columns(tmp_path):
+    path = tmp_path / "composite_empty.csv"
+    path.write_text("user_id,course_id\n1,101\n")
+    frame = ar.read_csv(path)
+    schema = ar.Schema(
+        {
+            "user_id": ar.Int64(),
+            "course_id": ar.Int64(),
+        },
+        unique=[],
+    )
+    result = schema.validate(frame)
+    assert not result.passed
+    issues = [i for i in result.issues if i.rule == "composite_unique"]
+    assert len(issues) == 1
+    assert "cannot be empty" in issues[0].message


### PR DESCRIPTION
## Summary

Adds schema-level composite uniqueness validation support using multi-column duplicate detection.

Users can now validate duplicate row combinations with:

```python id="vnl7ye"
Schema(..., unique=["user_id", "course_id"])
```

This removes the need for manual pandas duplicate handling for composite keys.

The implementation is minimal and backward compatible with existing field-level `unique=True` validation.

## Linked issue

Fixes #198

## Type of change

* [x] Feature
* [x] Documentation
* [x] Tests

## Area

* [x] Schema validation
* [x] Docs / website

## Testing

* [x] Other:

```bash id="9cwz10"
pytest tests/test_schema.py -v
```

Result:

* All schema tests passed successfully

## Screenshots / Media

N/A

## Performance Impact

No significant performance impact. Uses pandas `duplicated(subset=...)` for composite uniqueness validation.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR intentionally adds only:

* schema-level composite uniqueness validation
* focused composite uniqueness tests
* minimal README example

No existing schema functionality or public behaviors were removed or modified.