### PR TITLE
feat: implement transparent quality score components (Fixes #183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,8 @@ DataQualityReport(
     column_count=3,
     memory_usage=733,
     duplicate_rows=0,
+    quality_score=100.0,
+    score_components={},
     columns={
         'user_id': ColumnProfile(dtype='int64', semantic_type='identifier', unique_count=4),
         'email': ColumnProfile(dtype='string', semantic_type='categorical', null_count=1, unique_ratio=0.666667, min=13, max=13, mean=13.0),
@@ -866,6 +868,8 @@ DataQualityReport(
   "memory_usage": 733,
   "duplicate_rows": 0,
   "duplicate_ratio": 0.0,
+  "quality_score": 100.0,
+  "score_components": {},
   "columns": {
     "user_id": {
       "dtype": "int64",
@@ -914,6 +918,7 @@ DataQualityReport(
 | **Column Count** | 3 |
 | **Memory Usage** | 733 bytes |
 | **Duplicates** | 0 (0.0%) |
+| **Quality Score** | 100.0 |
 <br>
 
 ## 🗺️ Roadmap

--- a/README.md
+++ b/README.md
@@ -839,6 +839,8 @@ safe_report = report.to_dict(redact_sample_values=True)
 
 Use `report.to_dict(redact_sample_values=True)` when sharing reports outside your team and you want to avoid exposing raw example/sample values.
 
+> **Scoring Contract:** The `quality_score` starts at 100.0 and subtracts capped penalties for duplicates, nulls, and suggested dtype mismatches. The `score_components` field exposes these penalties as negative values. (Note: Semantic-validity penalties are intentionally out of scope for the current implementation.)
+
 ### 1. Terminal Representation (Simplified Example)
 *A simplified view of the standard string representation of the report object:*
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -296,7 +296,7 @@ def _calculate_quality_score(
         return 100.0, {}
 
     duplicate_penalty = round(min(duplicate_ratio * 100.0, 20.0), 2)
-    
+
     null_ratios = [c.null_ratio for c in columns.values()]
     avg_null_ratio = sum(null_ratios) / len(null_ratios) if null_ratios else 0.0
     null_penalty = round(min(avg_null_ratio * 100.0, 40.0), 2)

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -92,6 +92,8 @@ class DataQualityReport:
     duplicate_rows: int
     duplicate_ratio: float
     columns: dict[str, ColumnProfile]
+    quality_score: float = 100.0
+    score_components: dict[str, float] = field(default_factory=dict)
     suggestions: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
 
     def to_dict(self, *, redact_sample_values: bool = False) -> dict[str, Any]:
@@ -102,6 +104,8 @@ class DataQualityReport:
             "memory_usage": self.memory_usage,
             "duplicate_rows": self.duplicate_rows,
             "duplicate_ratio": self.duplicate_ratio,
+            "quality_score": self.quality_score,
+            "score_components": self.score_components,
             "columns": {
                 name: column.to_dict(redact_sample_values=redact_sample_values)
                 for name, column in self.columns.items()
@@ -170,6 +174,8 @@ class DataQualityReport:
     def summary(self) -> dict[str, Any]:
         """Return the highest-signal report fields."""
         return {
+            "quality_score": self.quality_score,
+            "score_components": self.score_components,
             "rows": self.row_count,
             "columns": self.column_count,
             "memory_usage": self.memory_usage,
@@ -264,15 +270,54 @@ def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
         suggestions=[],
     )
 
+    quality_score, score_components = _calculate_quality_score(
+        row_count, duplicate_ratio, columns
+    )
+
     return DataQualityReport(
         row_count=report.row_count,
         column_count=report.column_count,
         memory_usage=report.memory_usage,
         duplicate_rows=report.duplicate_rows,
         duplicate_ratio=report.duplicate_ratio,
+        quality_score=quality_score,
+        score_components=score_components,
         columns=report.columns,
         suggestions=suggest_cleaning(report),
     )
+
+
+def _calculate_quality_score(
+    row_count: int,
+    duplicate_ratio: float,
+    columns: dict[str, ColumnProfile],
+) -> tuple[float, dict[str, float]]:
+    if row_count == 0 or not columns:
+        return 100.0, {}
+
+    duplicate_penalty = round(min(duplicate_ratio * 100.0, 20.0), 2)
+    
+    null_ratios = [c.null_ratio for c in columns.values()]
+    avg_null_ratio = sum(null_ratios) / len(null_ratios) if null_ratios else 0.0
+    null_penalty = round(min(avg_null_ratio * 100.0, 40.0), 2)
+
+    type_mismatches = sum(1 for c in columns.values() if c.suggested_dtype is not None)
+    mismatch_ratio = type_mismatches / len(columns) if columns else 0.0
+    type_mismatch_penalty = round(min(mismatch_ratio * 100.0, 40.0), 2)
+
+    score_components: dict[str, float] = {}
+    if duplicate_penalty > 0:
+        score_components["duplicate_penalty"] = -duplicate_penalty
+    if null_penalty > 0:
+        score_components["null_penalty"] = -null_penalty
+    if type_mismatch_penalty > 0:
+        score_components["type_mismatch_penalty"] = -type_mismatch_penalty
+
+    quality_score = round(
+        100.0 - duplicate_penalty - null_penalty - type_mismatch_penalty, 2
+    )
+
+    return quality_score, score_components
 
 
 def suggest_cleaning(

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -427,3 +427,56 @@ def test_report_to_markdown_empty_sections():
     assert "## Overview" in md
     assert "## Columns" not in md
     assert "|---|---|" not in md
+
+
+# ── quality score tests ───────────────────────────────────────────────────────
+
+def test_quality_score_clean(tmp_path):
+    path = tmp_path / "clean.csv"
+    path.write_text("id,name\n1,Alice\n2,Bob\n3,Charlie\n")
+    report = ar.profile(ar.read_csv(path))
+    
+    assert report.quality_score == 100.0
+    assert not report.score_components
+
+
+def test_quality_score_empty(tmp_path):
+    path = tmp_path / "empty.csv"
+    path.write_text("id,name\n")
+    report = ar.profile(ar.read_csv(path))
+    
+    assert report.quality_score == 100.0
+    assert not report.score_components
+
+
+def test_quality_score_nulls(tmp_path):
+    path = tmp_path / "nulls.csv"
+    # id has 2 nulls, name has 1 null
+    path.write_text("id,name\n1,Alice\n,Bob\n,\n")
+    report = ar.profile(ar.read_csv(path))
+    
+    # 3 rows. id null_ratio ~0.66, name null_ratio ~0.33
+    # avg null ratio ~0.5 => 50 points penalty => capped at -40.0
+    assert report.score_components["null_penalty"] == -40.0
+    assert report.quality_score == 60.0
+
+
+def test_quality_score_duplicates(tmp_path):
+    path = tmp_path / "dup.csv"
+    path.write_text("id,name\n1,Alice\n1,Alice\n1,Alice\n")
+    report = ar.profile(ar.read_csv(path))
+    
+    # 3 rows, 2 duplicates. ratio = 0.66
+    # 0.66 * 100 = 66 points penalty => capped at -20.0
+    assert report.score_components["duplicate_penalty"] == -20.0
+
+
+def test_quality_score_type_mismatch(tmp_path):
+    path = tmp_path / "mismatch.csv"
+    # score column is read as string, but contains only numbers,
+    # which triggers a suggested_dtype of int64/float64.
+    path.write_text('id,score\n1,"10"\n2,"20"\n')
+    report = ar.profile(ar.read_csv(path))
+    
+    # 2 columns. 1 has type mismatch. ratio = 0.5 => 50 points => capped at -40.0
+    assert report.score_components["type_mismatch_penalty"] == -40.0

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -431,11 +431,12 @@ def test_report_to_markdown_empty_sections():
 
 # ── quality score tests ───────────────────────────────────────────────────────
 
+
 def test_quality_score_clean(tmp_path):
     path = tmp_path / "clean.csv"
     path.write_text("id,name\n1,Alice\n2,Bob\n3,Charlie\n")
     report = ar.profile(ar.read_csv(path))
-    
+
     assert report.quality_score == 100.0
     assert not report.score_components
 
@@ -444,7 +445,7 @@ def test_quality_score_empty(tmp_path):
     path = tmp_path / "empty.csv"
     path.write_text("id,name\n")
     report = ar.profile(ar.read_csv(path))
-    
+
     assert report.quality_score == 100.0
     assert not report.score_components
 
@@ -454,7 +455,7 @@ def test_quality_score_nulls(tmp_path):
     # id has 2 nulls, name has 1 null
     path.write_text("id,name\n1,Alice\n,Bob\n,\n")
     report = ar.profile(ar.read_csv(path))
-    
+
     # 3 rows. id null_ratio ~0.66, name null_ratio ~0.33
     # avg null ratio ~0.5 => 50 points penalty => capped at -40.0
     assert report.score_components["null_penalty"] == -40.0
@@ -465,7 +466,7 @@ def test_quality_score_duplicates(tmp_path):
     path = tmp_path / "dup.csv"
     path.write_text("id,name\n1,Alice\n1,Alice\n1,Alice\n")
     report = ar.profile(ar.read_csv(path))
-    
+
     # 3 rows, 2 duplicates. ratio = 0.66
     # 0.66 * 100 = 66 points penalty => capped at -20.0
     assert report.score_components["duplicate_penalty"] == -20.0
@@ -477,6 +478,6 @@ def test_quality_score_type_mismatch(tmp_path):
     # which triggers a suggested_dtype of int64/float64.
     path.write_text('id,score\n1,"10"\n2,"20"\n')
     report = ar.profile(ar.read_csv(path))
-    
+
     # 2 columns. 1 has type mismatch. ratio = 0.5 => 50 points => capped at -40.0
     assert report.score_components["type_mismatch_penalty"] == -40.0

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -470,14 +470,19 @@ def test_quality_score_duplicates(tmp_path):
     # 3 rows, 2 duplicates. ratio = 0.66
     # 0.66 * 100 = 66 points penalty => capped at -20.0
     assert report.score_components["duplicate_penalty"] == -20.0
+    assert report.quality_score == 80.0
 
 
-def test_quality_score_type_mismatch(tmp_path):
-    path = tmp_path / "mismatch.csv"
-    # score column is read as string, but contains only numbers,
-    # which triggers a suggested_dtype of int64/float64.
-    path.write_text('id,score\n1,"10"\n2,"20"\n')
-    report = ar.profile(ar.read_csv(path))
+def test_quality_score_type_mismatch():
+    df = pd.DataFrame(
+        {
+            "id": [1, 2],
+            "score": ["10", "20"],
+        }
+    )
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
 
     # 2 columns. 1 has type mismatch. ratio = 0.5 => 50 points => capped at -40.0
     assert report.score_components["type_mismatch_penalty"] == -40.0
+    assert report.quality_score == 60.0


### PR DESCRIPTION
Closes #183

### Description
Implemented a transparent 100-point data quality scoring system within `DataQualityReport` and added the `quality_score` and `score_components` to the serialization outputs. 

The score is calculated with the following penalties (bounded so they never exceed their max deduction):
- **Null Penalty**: Deducts up to 40 points based on the average `null_ratio`.
- **Duplicate Penalty**: Deducts up to 20 points based on the `duplicate_ratio`.
- **Type Mismatch Penalty**: Deducts up to 40 points based on columns that trigger a `suggested_dtype`.

- [x] `make test` (Verified through 5 new test cases)
- [x] `make lint`

## Screenshots / Media
N/A - Backend API enhancement.

## Performance Impact
No measurable impact. Score calculations are done in `O(C)` where C is the number of columns, using already-computed profile metrics.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
