### PR TITLE
fix: skip numeric cast suggestions for identifier-like columns

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -365,7 +365,13 @@ def _detect_semantic_type(name: str, series: pd.Series, dtype: str) -> str:
     if len(values) == 0:
         return "empty"
 
-    if lower_name in {"id", "uuid"} or lower_name.endswith("_id"):
+    if lower_name in {
+        "id",
+        "uuid",
+        "zip",
+        "zipcode",
+        "zip_code",
+    } or lower_name.endswith("_id"):
         return "identifier"
     if _is_numeric_dtype(dtype):
         return "numeric"
@@ -388,6 +394,12 @@ def _suggest_casts(report: DataQualityReport) -> dict[str, str]:
     mapping: dict[str, str] = {}
     for name, column in report.columns.items():
         if column.suggested_dtype is not None:
+            # Skip numeric casts for identifier-like columns to prevent data loss (e.g., leading zeros)
+            if column.semantic_type == "identifier" and column.suggested_dtype in {
+                "int64",
+                "float64",
+            }:
+                continue
             mapping[name] = column.suggested_dtype
     return mapping
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -207,3 +207,39 @@ def test_top_values_in_to_dict(tmp_path):
     assert "top_values" in d
     assert d["top_values"][0]["value"] == "London"
     assert d["top_values"][0]["count"] == 2
+
+
+def test_identifier_numeric_cast_prevention():
+    df = pd.DataFrame(
+        {
+            "id": ["001", "002", "003"],
+            "customer_id": ["00123", "00456", "00789"],
+            "zip_code": ["01234", "02345", "03456"],
+            "price": ["10.50", "20.00", "30.75"],
+            "quantity": ["1", "2", "3"],
+        }
+    )
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+
+    assert report.columns["id"].semantic_type == "identifier"
+    assert report.columns["customer_id"].semantic_type == "identifier"
+    assert report.columns["zip_code"].semantic_type == "identifier"
+
+    suggestions_list = ar.suggest_cleaning(frame)
+    suggestions = {}
+    for step, kwargs in suggestions_list:
+        if step == "cast_types":
+            suggestions.update(kwargs)
+
+    assert "price" in suggestions
+    assert "quantity" in suggestions
+    assert "id" not in suggestions
+    assert "customer_id" not in suggestions
+    assert "zip_code" not in suggestions
+
+    cleaned = ar.auto_clean(frame, mode="strict")
+    result = ar.to_pandas(cleaned)
+    assert list(result["id"]) == ["001", "002", "003"]
+    assert list(result["customer_id"]) == ["00123", "00456", "00789"]
+    assert list(result["zip_code"]) == ["01234", "02345", "03456"]


### PR DESCRIPTION
## Summary
- Prevent `suggest_cleaning()` / `auto_clean()` from proposing numeric casts on identifier columns (e.g. `id`, `customer_id`, `zip_code`), which could strip leading zeros and corrupt data
- `_suggest_casts()` now skips `int64`/`float64` suggestions when `semantic_type == "identifier"`

## Linked issue
Fixes #464

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [x] `make lint`
- [ ] Other:

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).