### PR TITLE
feat: Benchmark strip_whitespace string allocation behavior

### DIFF
--- a/benchmarks/benchmark_strip_whitespace.py
+++ b/benchmarks/benchmark_strip_whitespace.py
@@ -1,0 +1,51 @@
+"""
+Reproducible Benchmark: strip_whitespace string allocation behavior.
+Run: python benchmarks/benchmark_strip_whitespace.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+
+import time
+import tracemalloc
+
+from generate_data import generate
+
+import arnio as ar
+
+ROWS = 100_000
+RUNS = 3
+
+
+def benchmark_strip_whitespace(frame):
+    tracemalloc.start()
+    t0 = time.perf_counter()
+
+    ar.strip_whitespace(frame)
+
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+if __name__ == "__main__":
+    generate(rows=ROWS, path="benchmarks/benchmark_strip_whitespace.csv")
+    frame = ar.read_csv("benchmarks/benchmark_strip_whitespace.csv")
+
+    times, rams = [], []
+    for _ in range(RUNS):
+        t, r = benchmark_strip_whitespace(frame)
+        times.append(t)
+        rams.append(r)
+
+    def avg(x):
+        return sum(x) / len(x)
+
+    print(f"strip_whitespace - {ROWS:,} rows, {RUNS} runs")
+    print(f"{'Metric':<20} {'avg':>12}")
+    print("-" * 34)
+    print(f"{'Exec Time':<20} {avg(times):>11.4f}s")
+    print(f"{'Peak RAM':<20} {avg(rams):>10.2f}MB")

--- a/benchmarks/benchmark_strip_whitespace.py
+++ b/benchmarks/benchmark_strip_whitespace.py
@@ -1,6 +1,7 @@
 """
 Reproducible Benchmark: strip_whitespace string allocation behavior.
-Run: python benchmarks/benchmark_strip_whitespace.py
+Run from repo root: python benchmarks/benchmark_strip_whitespace.py
+Run from current file location: python benchmark_strip_whitespace.py
 """
 
 import os

--- a/benchmarks/benchmark_strip_whitespace.py
+++ b/benchmarks/benchmark_strip_whitespace.py
@@ -1,7 +1,6 @@
 """
 Reproducible Benchmark: strip_whitespace string allocation behavior.
 Run from repo root: python benchmarks/benchmark_strip_whitespace.py
-Run from current file location: python benchmark_strip_whitespace.py
 """
 
 import os


### PR DESCRIPTION
**Added Benchmark for strip_whitespace, Fixes #250, Rebased branch, made a few fixes, and redid commit**

**Initial fixes**

Adds a focused before/after benchmark for `strip_whitespace` to capture its string allocation behavior on padded string columns.
**Changes:**
`benchmarks/benchmark_strip_whitespace.py` — measures peak RAM and execution time across 3 runs on 100k rows of padded string data using the existing `generate_data.generate()` helper and `tracemalloc`

**Few extra small fixes:**

-    Behaviour in the docstring → ASCII-only so just drop the stylised spelling, and the run command needs to work from the repo root meaning generate_data needs to be imported as benchmarks.generate_data or you add the path explicitly
-    The print line `strip_whitespace - {ROWS:,} rows`  - the `—` em dash is non-ASCII, swap it for `-`
- Fixed Spelling-Error
- Added instructions for running the command from repo root, and current file location
