### PR TITLE
feat: implement schema bootstrap from data quality report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,28 @@ DataQualityReport(
 | **Quality Score** | 100.0 |
 <br>
 
+### Bootstrapping a Schema from a Quality Report
+
+After profiling a dataset, you can automatically generate a validation schema
+directly from the report:
+
+```python
+import arnio as ar
+
+frame = ar.from_pandas(df)
+report = ar.profile(frame)
+
+schema = ar.Schema.bootstrap_from_report(report)
+result = schema.validate(frame)
+
+print(result.passed)
+print(result.summary())
+```
+
+The inferred schema uses conservative defaults: column dtypes are mapped
+directly from the report, and a column is marked `nullable=True` if any
+null values were observed during profiling.
+
 ## 🗺️ Roadmap
 
 | Version | Focus | Status |

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -35,6 +35,21 @@ def _validate_severity(severity: str) -> None:
         raise ValueError("severity must be 'error' or 'warning'")
 
 
+_DTYPE_MAP = {
+    "int": "int64",
+    "int64": "int64",
+    "int32": "int64",
+    "float": "float64",
+    "float64": "float64",
+    "float32": "float64",
+    "bool": "bool",
+    "object": "string",
+    "string": "string",
+    "str": "string",
+    "null": "null",
+}
+
+
 @dataclass(frozen=True)
 class Field:
     """Validation rules for one column."""
@@ -71,6 +86,50 @@ class Schema:
     def validate(self, frame: ArFrame) -> ValidationResult:
         """Validate a frame against this schema."""
         return validate(frame, self)
+
+    @classmethod
+    def bootstrap_from_report(cls, report: Any) -> Schema:
+        """Create a Schema from a DataQualityReport.
+
+        Args:
+            report: A DataQualityReport produced by arnio.profile().
+
+        Returns:
+            Schema: A new Schema inferred from the report's column profiles.
+
+        Raises:
+            TypeError: If the input is not a DataQualityReport.
+            ValueError: If the report has no columns, or any column profile
+                is missing a dtype.
+
+        Example:
+            >>> report = ar.profile(frame)
+            >>> schema = ar.Schema.bootstrap_from_report(report)
+            >>> result = schema.validate(frame)
+        """
+        from .quality import DataQualityReport
+
+        if not isinstance(report, DataQualityReport):
+            raise TypeError(f"Expected DataQualityReport, got {type(report).__name__}")
+        if not report.columns:
+            raise ValueError(
+                "Cannot bootstrap schema from an empty report (no columns)."
+            )
+
+        fields = {}
+        for col_name, profile in report.columns.items():
+            dtype_val = getattr(profile, "dtype", None)
+            null_count = getattr(profile, "null_count", 0)
+
+            if not dtype_val:
+                raise ValueError(
+                    f"Column profile for {col_name!r} is missing 'dtype' key."
+                )
+
+            arnio_dtype = _DTYPE_MAP.get(str(dtype_val).lower(), "string")
+            fields[col_name] = Field(dtype=arnio_dtype, nullable=null_count > 0)
+
+        return cls(fields=fields)
 
 
 @dataclass(frozen=True)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -382,6 +382,60 @@ def test_raise_for_errors_multiple_issues(tmp_path):
     assert "row 1" in msg and "row 2" in msg
 
 
+def test_schema_bootstrap_from_report_infers_dtype_and_nullable(tmp_path):
+    path = tmp_path / "quality.csv"
+    path.write_text(
+        "id,name,score,active\n"
+        "1,Alice,9.5,true\n"
+        "2,Bob,,false\n"
+        "3,Carol,7.25,true\n"
+    )
+    report = ar.profile(ar.read_csv(path))
+
+    schema = ar.Schema.bootstrap_from_report(report)
+
+    assert schema.fields == {
+        "id": ar.Field(dtype="int64", nullable=False),
+        "name": ar.Field(dtype="string", nullable=False),
+        "score": ar.Field(dtype="float64", nullable=True),
+        "active": ar.Field(dtype="bool", nullable=False),
+    }
+
+
+def test_schema_bootstrap_from_report_validates_source_frame(tmp_path):
+    path = tmp_path / "quality.csv"
+    path.write_text("id,name\n1,Alice\n2,Bob\n")
+    frame = ar.read_csv(path)
+    report = ar.profile(frame)
+
+    schema = ar.Schema.bootstrap_from_report(report)
+    result = schema.validate(frame)
+
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_schema_bootstrap_from_report_rejects_non_report():
+    with pytest.raises(TypeError, match="Expected DataQualityReport"):
+        ar.Schema.bootstrap_from_report({"columns": {}})
+
+
+def test_schema_bootstrap_from_report_rejects_empty_report():
+    from arnio.quality import DataQualityReport
+
+    report = DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+    )
+
+    with pytest.raises(ValueError, match="empty report"):
+        ar.Schema.bootstrap_from_report(report)
+
+
 def test_email_validation_rejects_invalid_validation_mode():
     with pytest.raises(ValueError):
         ar.Email(validation="banana")


### PR DESCRIPTION


## Summary
Adds `Schema.bootstrap_from_report(report)` — a class method that automatically generates a validation schema directly from an Arnio `DataQualityReport`. This streamlines the workflow: inspect a dataset, review the quality report, and immediately bootstrap a functional schema for continuous validation.

## Linked issue
Fixes #208

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- Ran `python -m black --check arnio/schema.py tests/test_schema.py` — no changes needed
- Ran `python -m ruff check arnio/schema.py tests/test_schema.py` — no issues
- Ran `python -m compileall -q arnio/schema.py tests/test_schema.py` — clean
- Added 4 new tests covering normal inference, nullable columns, string-like fallbacks, and malformed/empty inputs

## Screenshots / Media
N/A

## Performance Impact
N/A — schema bootstrapping is a one-time utility method, not a hot path.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
This is a clean rebased version of #454 on top of latest upstream main. Single commit, no conflicts. Previous PR had repeated rebase conflicts due to multiple commits each touching `tests/test_schema.py`  resolved by creating this clean branch.

---