### PR TITLE
feat: add Regex field validator to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ clean_df = df.arnio.clean(drop_duplicates=True)
 quality = clean_df.arnio.profile()
 validation = clean_df.arnio.validate({
     "email": ar.Email(nullable=False),
+    "user_code": ar.Regex(r"^USR-\d{4}$", nullable=False),
     "age": ar.Int64(nullable=True, min=0),
 })
 ```
@@ -626,6 +627,7 @@ schema = ar.Schema({
     # CountryCode expects uppercase ISO alpha-2 values, for example IN, US, GB.
     "country": ar.CountryCode(nullable=False),
     "username": ar.String(min_length=3, max_length=20),
+    "user_code": ar.Regex(r"^USR-\d{4}$", nullable=False),
     "revenue": ar.Float64(nullable=True, min=0),
     "created_at": ar.DateTime(nullable=False, format="%Y-%m-%d"),
 })

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -54,12 +54,12 @@ from .schema import (
     Field,
     Float64,
     Int64,
+    Regex,
     Schema,
     String,
     ValidationIssue,
     ValidationResult,
     validate,
-    Regex,
 )
 
 __all__ = [

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -59,6 +59,7 @@ from .schema import (
     ValidationIssue,
     ValidationResult,
     validate,
+    Regex,
 )
 
 __all__ = [
@@ -120,4 +121,5 @@ __all__ = [
     "CsvReadError",
     "TypeCastError",
     "normalize_unicode",
+    "Regex",
 ]

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -386,6 +386,44 @@ def CountryCode(*, nullable: bool = True, unique: bool = False) -> Field:
     )
 
 
+def Regex(
+    pattern: str,
+    *,
+    nullable: bool = True,
+    unique: bool = False,
+) -> Field:
+    """Create a regex-validated string schema field.
+
+    The pattern is compiled at call time so invalid expressions raise
+    ``re.error`` immediately rather than at validation time.
+
+    Parameters
+    ----------
+    pattern : str
+        Regular expression that every non-null value must fully match.
+    nullable : bool, default True
+        Whether null values are allowed.
+    unique : bool, default False
+        Whether all non-null values must be unique.
+
+    Examples
+    --------
+    >>> schema = ar.Schema({
+    ...     "user_id": ar.Regex(r"^USR-\\d{4}$", nullable=False),
+    ...     "zip_code": ar.Regex(r"^\\d{5}(-\\d{4})?$", nullable=True),
+    ... })
+    """
+    import re
+
+    re.compile(pattern)  # fail fast on invalid pattern
+    return Field(
+        dtype="string",
+        nullable=nullable,
+        pattern=pattern,
+        unique=unique,
+    )
+
+
 def DateTime(
     *,
     nullable: bool = True,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -609,3 +609,85 @@ def test_bad_rows_reflects_one_based_indexes(tmp_path):
     result = ar.validate(frame, {"age": ar.Int64(min=0)})
 
     assert result.bad_rows == [1, 3]
+    assert result.issues[0].row_index == 1
+
+
+def test_regex_valid_match(tmp_path):
+    path = tmp_path / "ids.csv"
+    path.write_text("user_id\nUSR-1234\nUSR-5678\n")
+    result = ar.validate(
+        ar.read_csv(path),
+        {"user_id": ar.Regex(r"^USR-\d{4}$", nullable=False)},
+    )
+
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_regex_mismatch_reports_pattern_rule(tmp_path):
+    path = tmp_path / "ids.csv"
+    path.write_text("user_id\nUSR-1234\nbadvalue\n")
+    result = ar.validate(
+        ar.read_csv(path),
+        {"user_id": ar.Regex(r"^USR-\d{4}$", nullable=False)},
+    )
+
+    assert not result.passed
+    assert result.issues[0].rule == "pattern"
+    assert result.issues[0].row_index == 2
+
+
+def test_regex_null_allowed(tmp_path):
+    path = tmp_path / "ids.csv"
+    path.write_text("user_id\nUSR-1234\n\n")
+    result = ar.validate(
+        ar.read_csv(path),
+        {"user_id": ar.Regex(r"^USR-\d{4}$", nullable=True)},
+    )
+
+    assert result.passed
+
+
+def test_regex_null_not_allowed(tmp_path):
+    path = tmp_path / "ids.csv"
+    path.write_text("user_id,other\nUSR-1234,a\n,b\n")
+    result = ar.validate(
+        ar.read_csv(path),
+        {"user_id": ar.Regex(r"^USR-\d{4}$", nullable=False)},
+    )
+
+    assert not result.passed
+    assert result.issues[0].rule == "nullable"
+
+
+def test_regex_invalid_pattern_raises_at_construction():
+    try:
+        ar.Regex(r"[invalid")
+        assert False, "Expected re.error"
+    except Exception as exc:
+        assert (
+            "unterminated" in str(exc).lower() or "error" in type(exc).__name__.lower()
+        )
+
+
+def test_regex_numeric_column_coerces_to_string(tmp_path):
+    path = tmp_path / "codes.csv"
+    path.write_text("code\n123\n456\n")
+    result = ar.validate(
+        ar.read_csv(path),
+        {"code": ar.Regex(r"^\d+$")},
+    )
+
+    assert result.issues[0].rule == "dtype"
+
+
+def test_regex_fullmatch_not_partial(tmp_path):
+    path = tmp_path / "ids.csv"
+    path.write_text("user_id\nUSR-1234-EXTRA\n")
+    result = ar.validate(
+        ar.read_csv(path),
+        {"user_id": ar.Regex(r"^USR-\d{4}$")},
+    )
+
+    assert not result.passed
+    assert result.issues[0].rule == "pattern"


### PR DESCRIPTION
## Summary

Adds `ar.Regex(pattern, nullable, unique)` as a first-class schema field validator for IDs, codes, and formatted text columns. The pattern is compiled at call time so invalid regex raises `re.error` immediately. Validation uses `fullmatch` so the entire value must match, not just a prefix. Reuses the existing `Field.pattern` mechanism — no new validation logic needed.

## Linked issue

Fixes #193

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area

- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

```
make test
# 256 passed, 3 warnings
```

- [x] `make test`
- [ ] `make lint`
- [ ] Other:

New tests added in `tests/test_schema.py`:
- valid match — passes with no issues
- pattern mismatch — reports `pattern` rule with correct row index
- null allowed — passes when `nullable=True`
- null not allowed — reports `nullable` rule
- invalid pattern — raises `re.error` at construction
- fullmatch not partial — `USR-1234-EXTRA` fails `^USR-\d{4}$`
- numeric column — reports `dtype` mismatch (Regex requires string columns)

## Screenshots / Media

<img width="1108" height="280" alt="Screenshot 2026-05-18 at 2 13 31 AM" src="https://github.com/user-attachments/assets/6f0cdee5-536a-4ac3-8f0b-76c62ca9ee13" />
<img width="599" height="155" alt="Screenshot 2026-05-18 at 2 15 01 AM" src="https://github.com/user-attachments/assets/5da54c35-b704-4205-9618-88af1a1a0efc" />
<img width="2280" height="656" alt="image" src="https://github.com/user-attachments/assets/a832d0f9-551c-4c1d-8903-3dbb07fb03a5" />

## Performance Impact

None — purely additive Python change. Pattern is compiled once at schema construction, not per row.

## Contributor checklist

- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Only `arnio/schema.py`, `arnio/__init__.py`, `tests/test_schema.py`, and `README.md` touched. No C++ changes. Purely additive — no existing API surface changed or removed.