### PR TITLE
Fix filter_rows crash on missing values

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -661,7 +661,9 @@ def filter_rows(frame, column, op, value):
     if column not in df.columns:
         raise ValueError(f"Unknown column: {column}")
 
-    filtered = df[getattr(df[column], ops[op])(value)]
+    mask = getattr(df[column], ops[op])(value)
+    mask = mask.fillna(False).astype(bool)
+    filtered = df[mask]
 
     return from_pandas(filtered) if is_arframe else filtered
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -562,6 +562,17 @@ class TestFilterRows:
         assert len(result) == 1
         assert result.iloc[0]["age"] == 30
 
+    def test_filter_rows_with_missing_values_does_not_crash(self):
+        import pandas as pd
+        import numpy as np
+
+        df = pd.DataFrame({"age": [20, 30, np.nan, pd.NA, None]})
+
+        result = ar.filter_rows(df, "age", ">", 25)
+
+        assert len(result) == 1
+        assert result.iloc[0]["age"] == 30
+
 
 class TestRoundNumericColumns:
     def test_round_all_numeric(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -563,8 +563,8 @@ class TestFilterRows:
         assert result.iloc[0]["age"] == 30
 
     def test_filter_rows_with_missing_values_does_not_crash(self):
-        import pandas as pd
         import numpy as np
+        import pandas as pd
 
         df = pd.DataFrame({"age": [20, 30, np.nan, pd.NA, None]})
 


### PR DESCRIPTION
Fixes #528 

### Summary of Changes
- Added `.fillna(False).astype(bool)` to the boolean mask in `filter_rows`.
- This ensures that filtering handles missing values gracefully (evaluating them to `False`) instead of crashing with a `ValueError` when pandas encounters `NaN`, `None`, or `pd.NA`.
- Included a regression test to verify this behavior.