### PR TITLE
perf: release GIL around long C++ operations (fixes #256)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,4 @@ _arnio_cpp*
 
 # csv
 /*.csv
+benchmarks/benchmark_gil_temp.csv

--- a/benchmarks/benchmark_gil_threading.py
+++ b/benchmarks/benchmark_gil_threading.py
@@ -1,0 +1,75 @@
+"""
+GIL release benchmark: single-threaded vs multi-threaded performance.
+Demonstrates that GIL is released during long C++ operations.
+
+Run: python benchmarks/benchmark_gil_threading.py
+"""
+
+import threading
+import time
+from pathlib import Path
+
+import arnio as ar
+
+CSV_FILE = "benchmarks/benchmark_1m.csv"
+FALLBACK_ROWS = 500_000
+
+
+def ensure_or_generate(path, tmp_path):
+    if Path(path).exists():
+        return path
+    print(f"[info] {path} not found, generating {FALLBACK_ROWS} rows...")
+    lines = ["id,name,value,category"]
+    for i in range(FALLBACK_ROWS):
+        lines.append(f"{i},  name_{i}  ,{i * 1.5},cat_{i % 10}")
+    Path(tmp_path).write_text("\n".join(lines))
+    return tmp_path
+
+
+def run_single_threaded(path, n=4):
+    """Run n read+clean ops sequentially."""
+    t0 = time.perf_counter()
+    for _ in range(n):
+        frame = ar.read_csv(path)
+        ar.drop_nulls(frame)
+        ar.drop_duplicates(frame)
+        ar.strip_whitespace(frame)
+    return time.perf_counter() - t0
+
+
+def run_multi_threaded(path, n=4):
+    """Run n read+clean ops concurrently across threads."""
+    def task():
+        frame = ar.read_csv(path)
+        ar.drop_nulls(frame)
+        ar.drop_duplicates(frame)
+        ar.strip_whitespace(frame)
+
+    t0 = time.perf_counter()
+    threads = [threading.Thread(target=task) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return time.perf_counter() - t0
+
+
+if __name__ == "__main__":
+    path = ensure_or_generate(CSV_FILE, "benchmarks/benchmark_gil_temp.csv")
+
+    N = 4
+    print(f"\nGIL Release Threading Benchmark ({N} concurrent operations)")
+    print("=" * 52)
+
+    single = run_single_threaded(path, N)
+    print(f"Single-threaded ({N} sequential ops): {single:.2f}s")
+
+    multi = run_multi_threaded(path, N)
+    print(f"Multi-threaded  ({N} concurrent ops): {multi:.2f}s")
+
+    speedup = single / multi
+    print(f"\nSpeedup: {speedup:.2f}x")
+    if speedup > 1.3:
+        print("GIL is being released correctly (concurrent ops faster than sequential)")
+    else:
+        print("Note: Speedup may vary based on system load and CSV size")

--- a/benchmarks/benchmark_gil_threading.py
+++ b/benchmarks/benchmark_gil_threading.py
@@ -39,6 +39,7 @@ def run_single_threaded(path, n=4):
 
 def run_multi_threaded(path, n=4):
     """Run n read+clean ops concurrently across threads."""
+
     def task():
         frame = ar.read_csv(path)
         ar.drop_nulls(frame)

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -223,9 +223,16 @@ PYBIND11_MODULE(_arnio_cpp, m) {
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})
-        .def("read", &CsvReader::read)
+        .def("read", [](const CsvReader& reader, const std::string& path) {
+            py::gil_scoped_release release;
+            return reader.read(path);
+        })
         .def("scan_schema", [](const CsvReader& reader, const std::string& path) {
-            auto result = reader.scan_schema(path);
+            std::vector<std::pair<std::string, std::string>> result;
+            {
+                py::gil_scoped_release release;
+                result = reader.scan_schema(path);
+            }
             py::dict schema;
             for (const auto& pair : result) {
                 schema[py::str(pair.first)] = py::str(pair.second);
@@ -234,7 +241,10 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         });
 
     // --- Cleaning functions ---
-    m.def("drop_nulls", &drop_nulls, py::arg("frame"), py::arg("subset") = std::nullopt);
+    m.def("drop_nulls", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset) {
+        py::gil_scoped_release release;
+        return drop_nulls(frame, subset);
+    }, py::arg("frame"), py::arg("subset") = std::nullopt);
 
     m.def(
         "fill_nulls",
@@ -256,14 +266,20 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         },
         py::arg("frame"), py::arg("value"), py::arg("subset") = std::nullopt);
 
-    m.def("drop_duplicates", &drop_duplicates, py::arg("frame"), py::arg("subset") = std::nullopt,
-          py::arg("keep") = "first");
+    m.def("drop_duplicates", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset, const std::string& keep) {
+        py::gil_scoped_release release;
+        return drop_duplicates(frame, subset, keep);
+    }, py::arg("frame"), py::arg("subset") = std::nullopt, py::arg("keep") = "first");
 
-    m.def("strip_whitespace", &strip_whitespace, py::arg("frame"),
-          py::arg("subset") = std::nullopt);
+    m.def("strip_whitespace", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset) {
+        py::gil_scoped_release release;
+        return strip_whitespace(frame, subset);
+    }, py::arg("frame"), py::arg("subset") = std::nullopt);
 
-    m.def("normalize_case", &normalize_case, py::arg("frame"), py::arg("subset") = std::nullopt,
-          py::arg("case_type") = "lower");
+    m.def("normalize_case", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset, const std::string& case_type) {
+        py::gil_scoped_release release;
+        return normalize_case(frame, subset, case_type);
+    }, py::arg("frame"), py::arg("subset") = std::nullopt, py::arg("case_type") = "lower");
 
     m.def("rename_columns", &rename_columns, py::arg("frame"), py::arg("mapping"));
 

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -223,10 +223,11 @@ PYBIND11_MODULE(_arnio_cpp, m) {
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})
-        .def("read", [](const CsvReader& reader, const std::string& path) {
-            py::gil_scoped_release release;
-            return reader.read(path);
-        })
+        .def("read",
+             [](const CsvReader& reader, const std::string& path) {
+                 py::gil_scoped_release release;
+                 return reader.read(path);
+             })
         .def("scan_schema", [](const CsvReader& reader, const std::string& path) {
             std::vector<std::pair<std::string, std::string>> result;
             {
@@ -241,10 +242,13 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         });
 
     // --- Cleaning functions ---
-    m.def("drop_nulls", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset) {
-        py::gil_scoped_release release;
-        return drop_nulls(frame, subset);
-    }, py::arg("frame"), py::arg("subset") = std::nullopt);
+    m.def(
+        "drop_nulls",
+        [](const Frame& frame, const std::optional<std::vector<std::string>>& subset) {
+            py::gil_scoped_release release;
+            return drop_nulls(frame, subset);
+        },
+        py::arg("frame"), py::arg("subset") = std::nullopt);
 
     m.def(
         "fill_nulls",
@@ -266,20 +270,31 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         },
         py::arg("frame"), py::arg("value"), py::arg("subset") = std::nullopt);
 
-    m.def("drop_duplicates", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset, const std::string& keep) {
-        py::gil_scoped_release release;
-        return drop_duplicates(frame, subset, keep);
-    }, py::arg("frame"), py::arg("subset") = std::nullopt, py::arg("keep") = "first");
+    m.def(
+        "drop_duplicates",
+        [](const Frame& frame, const std::optional<std::vector<std::string>>& subset,
+           const std::string& keep) {
+            py::gil_scoped_release release;
+            return drop_duplicates(frame, subset, keep);
+        },
+        py::arg("frame"), py::arg("subset") = std::nullopt, py::arg("keep") = "first");
 
-    m.def("strip_whitespace", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset) {
-        py::gil_scoped_release release;
-        return strip_whitespace(frame, subset);
-    }, py::arg("frame"), py::arg("subset") = std::nullopt);
+    m.def(
+        "strip_whitespace",
+        [](const Frame& frame, const std::optional<std::vector<std::string>>& subset) {
+            py::gil_scoped_release release;
+            return strip_whitespace(frame, subset);
+        },
+        py::arg("frame"), py::arg("subset") = std::nullopt);
 
-    m.def("normalize_case", [](const Frame& frame, const std::optional<std::vector<std::string>>& subset, const std::string& case_type) {
-        py::gil_scoped_release release;
-        return normalize_case(frame, subset, case_type);
-    }, py::arg("frame"), py::arg("subset") = std::nullopt, py::arg("case_type") = "lower");
+    m.def(
+        "normalize_case",
+        [](const Frame& frame, const std::optional<std::vector<std::string>>& subset,
+           const std::string& case_type) {
+            py::gil_scoped_release release;
+            return normalize_case(frame, subset, case_type);
+        },
+        py::arg("frame"), py::arg("subset") = std::nullopt, py::arg("case_type") = "lower");
 
     m.def("rename_columns", &rename_columns, py::arg("frame"), py::arg("mapping"));
 

--- a/tests/test_gil.py
+++ b/tests/test_gil.py
@@ -21,11 +21,17 @@ class TestGILReleaseCsvRead:
 
         results = [None, None]
 
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 0)
+        )
+        t2 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 1)
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         assert results[0].shape[0] == 500
         assert results[1].shape[0] == 500
@@ -37,11 +43,15 @@ class TestGILReleaseCsvRead:
 
         results = [None, None, None]
         threads = [
-            threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, i))
+            threading.Thread(
+                target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, i)
+            )
             for i in range(3)
         ]
-        for t in threads: t.start()
-        for t in threads: t.join()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
 
         for r in results:
             assert r.shape == (3, 2)
@@ -55,11 +65,17 @@ class TestGILReleaseCleaningOps:
         frame = ar.read_csv(str(path))
 
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 0)
+        )
+        t2 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 1)
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         assert results[0].shape[0] == 2
         assert results[1].shape[0] == 2
@@ -71,11 +87,17 @@ class TestGILReleaseCleaningOps:
         frame = ar.read_csv(str(path))
 
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 0)
+        )
+        t2 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 1)
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         assert results[0].shape[0] == 2
         assert results[1].shape[0] == 2
@@ -87,11 +109,17 @@ class TestGILReleaseCleaningOps:
         frame = ar.read_csv(str(path))
 
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 0)
+        )
+        t2 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 1)
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         df0 = ar.to_pandas(results[0])
         df1 = ar.to_pandas(results[1])
@@ -105,24 +133,41 @@ class TestGILReleaseCleaningOps:
         frame = ar.read_csv(str(path))
 
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.normalize_case(frame, subset=["name"]), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.normalize_case(frame, subset=["name"]), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread,
+            args=(lambda: ar.normalize_case(frame, subset=["name"]), results, 0),
+        )
+        t2 = threading.Thread(
+            target=run_in_thread,
+            args=(lambda: ar.normalize_case(frame, subset=["name"]), results, 1),
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         df0 = ar.to_pandas(results[0])
         assert df0["name"].iloc[0] == "alice"
+
 
 class TestGILReleaseEdgeCases:
     def test_concurrent_read_invalid_path(self):
         """Concurrent reads with invalid path should raise errors safely."""
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv("nonexistent.csv"), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv("nonexistent.csv"), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread,
+            args=(lambda: ar.read_csv("nonexistent.csv"), results, 0),
+        )
+        t2 = threading.Thread(
+            target=run_in_thread,
+            args=(lambda: ar.read_csv("nonexistent.csv"), results, 1),
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         assert isinstance(results[0], Exception)
         assert isinstance(results[1], Exception)
@@ -133,11 +178,17 @@ class TestGILReleaseEdgeCases:
         path.write_text("name,age\n")
 
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 0)
+        )
+        t2 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 1)
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         assert results[0].shape[0] == 0
         assert results[1].shape[0] == 0
@@ -148,11 +199,17 @@ class TestGILReleaseEdgeCases:
         path.write_text("name,age,score\nAlice,30,95.5\nBob,25,88.0\n")
 
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.scan_csv(str(path)), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.scan_csv(str(path)), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.scan_csv(str(path)), results, 0)
+        )
+        t2 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.scan_csv(str(path)), results, 1)
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         assert isinstance(results[0], dict)
         assert isinstance(results[1], dict)
@@ -165,15 +222,22 @@ class TestGILReleaseEdgeCases:
         frame = ar.read_csv(str(path))
 
         results = [None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame, subset=["name"]), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame, subset=["name"]), results, 1))
+        t1 = threading.Thread(
+            target=run_in_thread,
+            args=(lambda: ar.drop_nulls(frame, subset=["name"]), results, 0),
+        )
+        t2 = threading.Thread(
+            target=run_in_thread,
+            args=(lambda: ar.drop_nulls(frame, subset=["name"]), results, 1),
+        )
 
-        t1.start(); t2.start()
-        t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         assert results[0].shape[0] == 3
         assert results[1].shape[0] == 3
-
 
     def test_mixed_concurrent_operations(self, tmp_path):
         """Different GIL-releasing ops should run concurrently without interference."""
@@ -182,11 +246,21 @@ class TestGILReleaseEdgeCases:
         frame = ar.read_csv(str(path))
 
         results = [None, None, None]
-        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 0))
-        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 1))
-        t3 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 2))
+        t1 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 0)
+        )
+        t2 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 1)
+        )
+        t3 = threading.Thread(
+            target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 2)
+        )
 
-        t1.start(); t2.start(); t3.start()
-        t1.join(); t2.join(); t3.join()
+        t1.start()
+        t2.start()
+        t3.start()
+        t1.join()
+        t2.join()
+        t3.join()
 
         assert results[2].shape[0] == 4

--- a/tests/test_gil.py
+++ b/tests/test_gil.py
@@ -1,0 +1,192 @@
+"""Tests to verify GIL is released around long C++ operations."""
+
+import threading
+
+import arnio as ar
+
+
+def run_in_thread(fn, results, index):
+    try:
+        results[index] = fn()
+    except Exception as e:
+        results[index] = e
+
+
+class TestGILReleaseCsvRead:
+    def test_concurrent_csv_reads(self, tmp_path):
+        """Multiple threads should be able to read CSVs concurrently."""
+        path = tmp_path / "data.csv"
+        lines = ["id,value"] + [f"{i},{i*1.5}" for i in range(500)]
+        path.write_text("\n".join(lines))
+
+        results = [None, None]
+
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert results[0].shape[0] == 500
+        assert results[1].shape[0] == 500
+
+    def test_concurrent_read_does_not_corrupt_data(self, tmp_path):
+        """Concurrent reads should return correct data."""
+        path = tmp_path / "data.csv"
+        path.write_text("name,age\nAlice,30\nBob,25\nCharlie,35\n")
+
+        results = [None, None, None]
+        threads = [
+            threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, i))
+            for i in range(3)
+        ]
+        for t in threads: t.start()
+        for t in threads: t.join()
+
+        for r in results:
+            assert r.shape == (3, 2)
+
+
+class TestGILReleaseCleaningOps:
+    def test_concurrent_drop_nulls(self, tmp_path):
+        """drop_nulls should run concurrently across threads."""
+        path = tmp_path / "nulls.csv"
+        path.write_text("name,age\nAlice,30\n,25\nCharlie,\nDiana,28\n")
+        frame = ar.read_csv(str(path))
+
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert results[0].shape[0] == 2
+        assert results[1].shape[0] == 2
+
+    def test_concurrent_drop_duplicates(self, tmp_path):
+        """drop_duplicates should run concurrently."""
+        path = tmp_path / "dupes.csv"
+        path.write_text("name,age\nAlice,30\nAlice,30\nBob,25\n")
+        frame = ar.read_csv(str(path))
+
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert results[0].shape[0] == 2
+        assert results[1].shape[0] == 2
+
+    def test_concurrent_strip_whitespace(self, tmp_path):
+        """strip_whitespace should run concurrently."""
+        path = tmp_path / "ws.csv"
+        path.write_text("name,city\n  Alice  , New York\n  Bob ,London\n")
+        frame = ar.read_csv(str(path))
+
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        df0 = ar.to_pandas(results[0])
+        df1 = ar.to_pandas(results[1])
+        assert df0["name"].iloc[0] == "Alice"
+        assert df1["name"].iloc[0] == "Alice"
+
+    def test_concurrent_normalize_case(self, tmp_path):
+        """normalize_case should run concurrently."""
+        path = tmp_path / "case.csv"
+        path.write_text("name\nALICE\nBOB\nCHARLIE\n")
+        frame = ar.read_csv(str(path))
+
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.normalize_case(frame, subset=["name"]), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.normalize_case(frame, subset=["name"]), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        df0 = ar.to_pandas(results[0])
+        assert df0["name"].iloc[0] == "alice"
+
+class TestGILReleaseEdgeCases:
+    def test_concurrent_read_invalid_path(self):
+        """Concurrent reads with invalid path should raise errors safely."""
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv("nonexistent.csv"), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv("nonexistent.csv"), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert isinstance(results[0], Exception)
+        assert isinstance(results[1], Exception)
+
+    def test_concurrent_read_empty_csv(self, tmp_path):
+        """Concurrent reads on empty CSV should not crash."""
+        path = tmp_path / "empty.csv"
+        path.write_text("name,age\n")
+
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.read_csv(str(path)), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert results[0].shape[0] == 0
+        assert results[1].shape[0] == 0
+
+    def test_concurrent_scan_schema(self, tmp_path):
+        """scan_schema should run concurrently without errors."""
+        path = tmp_path / "schema.csv"
+        path.write_text("name,age,score\nAlice,30,95.5\nBob,25,88.0\n")
+
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.scan_csv(str(path)), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.scan_csv(str(path)), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert isinstance(results[0], dict)
+        assert isinstance(results[1], dict)
+        assert results[0]["name"] == results[1]["name"]
+
+    def test_concurrent_drop_nulls_subset(self, tmp_path):
+        """drop_nulls with subset should work concurrently."""
+        path = tmp_path / "nulls.csv"
+        path.write_text("name,age\nAlice,30\n,25\nCharlie,\nDiana,28\n")
+        frame = ar.read_csv(str(path))
+
+        results = [None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame, subset=["name"]), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame, subset=["name"]), results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        assert results[0].shape[0] == 3
+        assert results[1].shape[0] == 3
+
+
+    def test_mixed_concurrent_operations(self, tmp_path):
+        """Different GIL-releasing ops should run concurrently without interference."""
+        path = tmp_path / "data.csv"
+        path.write_text("name,age\n  Alice  ,30\nAlice,30\nBob,25\n,20\n")
+        frame = ar.read_csv(str(path))
+
+        results = [None, None, None]
+        t1 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_nulls(frame), results, 0))
+        t2 = threading.Thread(target=run_in_thread, args=(lambda: ar.strip_whitespace(frame), results, 1))
+        t3 = threading.Thread(target=run_in_thread, args=(lambda: ar.drop_duplicates(frame), results, 2))
+
+        t1.start(); t2.start(); t3.start()
+        t1.join(); t2.join(); t3.join()
+
+        assert results[2].shape[0] == 4


### PR DESCRIPTION
## Summary
Releases the GIL around confirmed pure C++ operations in the binding layer so unrelated Python threads are not blocked during CSV parsing and data cleaning operations.

Fixes #256

## Type of change
- [x] Performance improvement
- [x] Tests

## Area
- [x] CSV parser / I/O
- [x] C++ cleaning engine

## Testing
Ran the full test suite locally:

python -m pytest tests/ -q
386 passed, 4 warnings

New file tests/test_gil.py adds 11 concurrent correctness tests covering CSV reads, all GIL-releasing cleaning operations, edge cases (invalid path, empty CSV, scan_schema), and mixed concurrent operations across different functions.

## Performance Impact
Added benchmarks/benchmark_gil_threading.py showing single-threaded vs multi-threaded performance across 4 concurrent operations.

On Windows/MSVC, thread startup and scheduling overhead can dominate for moderate dataset sizes, so wall-clock numbers may appear slower than sequential execution. This is a known platform characteristic and not a regression — performance gains from GIL release will be more visible on Linux in CI with larger datasets. The benchmark is included as supporting evidence only with no timing-sensitive assertions in CI, as discussed in the issue thread.

## GIL Coverage

GIL released in these bindings (confirmed pure C++ sections, no Python objects touched during execution):

CsvReader::read — pure file I/O and C++ parsing
CsvReader::scan_schema — pure file I/O and type inference
drop_nulls — pure C++ Frame operation
drop_duplicates — pure C++ Frame operation
strip_whitespace — pure C++ string operation
normalize_case — pure C++ string operation

Intentionally excluded (Python objects accessed in the binding layer):

fill_nulls — py::object conversion happens before the C++ call
cast_types — interacts with a Python dict in the binding layer
rename_columns — interacts with a Python dict in the binding layer
from_dict — iterates over py::dict and py::list throughout

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (perf:).