### PR TITLE
Add Decimal conversion support for pandas objects columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ df = ar.to_pandas(clean)
 # Use copy=True when you need defensive pandas-owned buffers
 safe_df = ar.to_pandas(clean, copy=True)
 ```
+- Decimal values in pandas object columns are preserved as strings during `from_pandas()` conversion to avoid silent precision loss from float conversion.
 
 Already have a pandas `DataFrame`? Use Arnio in-place in your existing pandas
 workflow:

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -6,7 +6,7 @@ Pandas conversion functions.
 from __future__ import annotations
 
 import copy as copylib
-
+from decimal import Decimal
 import numpy as np
 import pandas as pd
 
@@ -23,10 +23,14 @@ def _normalize_scalar(value: object) -> object:
         return None
     if isinstance(value, np.generic):
         return value.item()
+
+    if isinstance(value, Decimal):
+        return float(value)
+
     if not isinstance(value, (bool, int, float, str)):
         return str(value)
-    return value
 
+    return value
 
 def _scalar_kind(value: object) -> str:
     if isinstance(value, bool):

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import copy as copylib
 from decimal import Decimal
+
 import numpy as np
 import pandas as pd
 
@@ -25,12 +26,13 @@ def _normalize_scalar(value: object) -> object:
         return value.item()
 
     if isinstance(value, Decimal):
-        return float(value)
+        return str(value)
 
     if not isinstance(value, (bool, int, float, str)):
         return str(value)
 
     return value
+
 
 def _scalar_kind(value: object) -> str:
     if isinstance(value, bool):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -343,6 +343,22 @@ class TestFromPandas:
 
         assert result["amount"].tolist() == ["10.5", "20.25", "30.75"]
 
+    def test_high_precision_decimal_preserved_as_string(self):
+        from decimal import Decimal
+
+        df = pd.DataFrame(
+            {
+                "amount": [
+                    Decimal("0.123456789123456789"),
+                ]
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert result["amount"].tolist() == ["0.123456789123456789"]
+
     def test_decimal_values_with_nulls(self):
         from decimal import Decimal
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -325,20 +325,59 @@ class TestFromPandas:
         assert pd.isna(result["score"].tolist()[1])
         assert result["score"].tolist()[2] == 3.7
 
-    def test_bool_null_mask_roundtrip(self):
+
+    def test_decimal_values_convert_to_float(self):
+        from decimal import Decimal
+
         df = pd.DataFrame(
             {
-                "flag": pd.Series(
-                    [True, False, pd.NA],
-                    dtype="boolean",
-                )
+                "amount": [
+                    Decimal("10.5"),
+                    Decimal("20.25"),
+                    Decimal("30.75"),
+                ]
             }
         )
 
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
 
-        assert list(result["flag"]) == [True, False, pd.NA]
+        assert result["amount"].tolist() == [10.5, 20.25, 30.75]
+
+
+    def test_decimal_values_with_nulls(self):
+        from decimal import Decimal
+
+        df = pd.DataFrame(
+            {
+                "amount": [
+                    Decimal("10.5"),
+                    None,
+                    Decimal("30.75"),
+                ]
+            },
+            dtype = object,
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert result["amount"].tolist()[0] == 10.5
+        assert pd.isna(result["amount"].tolist()[1])
+        assert result["amount"].tolist()[2] == 30.75
+
+    def test_bool_null_mask_roundtrip(self):
+        df = pd.DataFrame(
+            {
+                "flag": pd.Series(
+                    [True,False,pd.NA],
+                    dtype="boolean",
+                )
+            }
+        )
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert list(result["flag"]) == [True,False,pd.NA]
 
     def test_dataframe_index_is_dropped(self):
         """pandas index is not preserved during from_pandas conversion."""

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -325,8 +325,7 @@ class TestFromPandas:
         assert pd.isna(result["score"].tolist()[1])
         assert result["score"].tolist()[2] == 3.7
 
-
-    def test_decimal_values_convert_to_float(self):
+    def test_decimal_values_convert_to_string(self):
         from decimal import Decimal
 
         df = pd.DataFrame(
@@ -342,8 +341,7 @@ class TestFromPandas:
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
 
-        assert result["amount"].tolist() == [10.5, 20.25, 30.75]
-
+        assert result["amount"].tolist() == ["10.5", "20.25", "30.75"]
 
     def test_decimal_values_with_nulls(self):
         from decimal import Decimal
@@ -356,28 +354,28 @@ class TestFromPandas:
                     Decimal("30.75"),
                 ]
             },
-            dtype = object,
+            dtype=object,
         )
 
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
 
-        assert result["amount"].tolist()[0] == 10.5
+        assert result["amount"].tolist()[0] == "10.5"
         assert pd.isna(result["amount"].tolist()[1])
-        assert result["amount"].tolist()[2] == 30.75
+        assert result["amount"].tolist()[2] == "30.75"
 
     def test_bool_null_mask_roundtrip(self):
         df = pd.DataFrame(
             {
                 "flag": pd.Series(
-                    [True,False,pd.NA],
+                    [True, False, pd.NA],
                     dtype="boolean",
                 )
             }
         )
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
-        assert list(result["flag"]) == [True,False,pd.NA]
+        assert list(result["flag"]) == [True, False, pd.NA]
 
     def test_dataframe_index_is_dropped(self):
         """pandas index is not preserved during from_pandas conversion."""


### PR DESCRIPTION
Summary

This PR adds a focused Decimal conversion policy for pandas object columns during "from_pandas()" conversion.

Changes made

- Added Decimal normalization support in "arnio/convert.py"
- Preserved "decimal.Decimal" values as strings during conversion to avoid silent precision loss from float coercion
- Preserved existing null handling behavior
- Added regression tests for:
  - Decimal values preserved as strings
  - Decimal values with nulls
  - High-precision Decimal preservation

Validation

Ran:

python -m pytest tests/test_convert.py

All tests passed successfully.

Test Output

Screenshot of successful pytest execution attached below.
<img width="1919" height="1008" alt="image" src="https://github.com/user-attachments/assets/a60614a5-a0da-44ff-b97f-0a44aac5c612" />
