### PR TITLE
test(csv): add regression coverage for signed integer inference

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
-#include <charconv>
 #include <cstddef>
 #include <cstdlib>
 #include <fstream>
@@ -14,21 +13,9 @@
 namespace arnio {
 
 namespace {
-
-static std::string trim_whitespace(const std::string& s) {
-    auto start = s.find_first_not_of(" \t\n\r\f\v");
-    if (start == std::string::npos) {
-        return "";
-    }
-
-    auto end = s.find_last_not_of(" \t\n\r\f\v");
-    return s.substr(start, end - start + 1);
-}
-
 inline void trim_in_place(std::string& s) {
     s.erase(s.begin(),
             std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
-
     s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); })
                 .base(),
             s.end());
@@ -257,57 +244,47 @@ DType CsvReader::infer_type(const std::string& value) const {
     std::string cleaned = normalize_numeric(value, config_);
 
     // Try int64
-    std::string trimmed = trim_whitespace(cleaned);
-    std::string int_candidate = trimmed;
-
-    if (!int_candidate.empty() && int_candidate[0] == '+') {
-        int_candidate.erase(0, 1);
+    {
+        const char* start = cleaned.c_str();
+        char* end = nullptr;
+        errno = 0;
+        long long val = std::strtoll(start, &end, 10);
+        (void)val;
+        if (end != start && *end == '\0') {
+            if (errno == ERANGE) return DType::STRING;
+            return DType::INT64;
+        }
     }
 
-    long long val = 0;
+    if (looks_like_integer_literal(cleaned)) return DType::STRING;
 
-    const char* start = int_candidate.data();
-    const char* end = start + int_candidate.size();
-
-    const char* start = int_candidate.data();
-    const char* end = int_candidate.data() + int_candidate.size();
-
-    long long val = 0;
-
-    auto [ptr, ec] = std::from_chars(start, end, val);
-
-    if (ec == std::errc() && ptr == end) {
-        return DType::INT64;
+    // Try float64
+    {
+        const char* start = cleaned.c_str();
+        char* end = nullptr;
+        double val = std::strtod(start, &end);
+        (void)val;
+        if (end != start && *end == '\0') return DType::FLOAT64;
     }
-}
 
-// Try float64
-{
-    const char* start = trimmed.c_str();
-    char* end = nullptr;
-    double val = std::strtod(start, &end);
-    (void)val;
-    if (end != start && *end == '\0') return DType::FLOAT64;
-}
-
-// If thousands separator is set and value contains it but failed
-// grouping validation, it's a malformed numeric — treat as NULL_TYPE
-// so it doesn't poison the whole column's dtype to STRING.
-if (config_.thousands_separator.has_value()) {
-    char sep = config_.thousands_separator.value();
-    if (value.find(sep) != std::string::npos && !has_valid_thousands_grouping(value, sep)) {
-        std::string check = value;
-        trim_in_place(check);
-        if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
-        bool looks_numeric =
-            !check.empty() && std::all_of(check.begin(), check.end(), [sep](char c) {
-                return std::isdigit((unsigned char)c) || c == sep || c == '.';
-            });
-        if (looks_numeric) return DType::NULL_TYPE;
+    // If thousands separator is set and value contains it but failed
+    // grouping validation, it's a malformed numeric — treat as NULL_TYPE
+    // so it doesn't poison the whole column's dtype to STRING.
+    if (config_.thousands_separator.has_value()) {
+        char sep = config_.thousands_separator.value();
+        if (value.find(sep) != std::string::npos && !has_valid_thousands_grouping(value, sep)) {
+            std::string check = value;
+            trim_in_place(check);
+            if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
+            bool looks_numeric =
+                !check.empty() && std::all_of(check.begin(), check.end(), [sep](char c) {
+                    return std::isdigit((unsigned char)c) || c == sep || c == '.';
+                });
+            if (looks_numeric) return DType::NULL_TYPE;
+        }
     }
-}
 
-return DType::STRING;
+    return DType::STRING;
 }
 
 DType CsvReader::promote_type(DType current, DType incoming) {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -5,10 +5,25 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdlib>
+#include <charconv>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
 #include <unordered_set>
+
+static std::string trim_whitespace(const std::string& s) {
+    size_t start = 0;
+    while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start]))) {
+        ++start;
+    }
+
+    size_t end = s.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) {
+        --end;
+    }
+
+    return s.substr(start, end - start);
+}
 
 namespace arnio {
 
@@ -244,20 +259,24 @@ DType CsvReader::infer_type(const std::string& value) const {
     std::string cleaned = normalize_numeric(value, config_);
 
     // Try int64
-    {
-        const char* start = cleaned.c_str();
-        char* end = nullptr;
-        errno = 0;
-        long long val = std::strtoll(start, &end, 10);
-        (void)val;
-        if (end != start && *end == '\0') {
-            if (errno == ERANGE) return DType::STRING;
-            return DType::INT64;
-        }
+    std::string trimmed = trim_whitespace(cleaned);
+    std::string int_candidate = trimmed;
+
+    if (!int_candidate.empty() && int_candidate[0] == '+') {
+        int_candidate.erase(0, 1);
     }
 
-    if (looks_like_integer_literal(cleaned)) return DType::STRING;
+    long long val = 0;
+    const char* start = int_candidate.data();
+    const char* end = start + int_candidate.size();
 
+    auto [ptr, ec] = std::from_chars(start, end, val);
+
+    if (ec == std::errc() && ptr == end) {
+       return DType::INT64;
+
+    }
+    
     // Try float64
     {
         const char* start = cleaned.c_str();

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -11,29 +11,28 @@
 #include <stdexcept>
 #include <unordered_set>
 
-static std::string trim_whitespace(const std::string& s) {
-    size_t start = 0;
-    while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start]))) {
-        ++start;
-    }
-
-    size_t end = s.size();
-    while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) {
-        --end;
-    }
-
-    return s.substr(start, end - start);
-}
-
 namespace arnio {
 
 namespace {
+
+static std::string trim_whitespace(const std::string& s) {
+    auto start = s.find_first_not_of(" \t\n\r\f\v");
+    if (start == std::string::npos) {
+        return "";
+    }
+
+    auto end = s.find_last_not_of(" \t\n\r\f\v");
+    return s.substr(start, end - start + 1);
+}
+
 inline void trim_in_place(std::string& s) {
     s.erase(s.begin(),
             std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+
     s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); })
                 .base(),
             s.end());
+}
 }
 
 inline void strip_utf8_bom(std::string& s) {
@@ -260,11 +259,14 @@ DType CsvReader::infer_type(const std::string& value) const {
 
     // Try int64
     std::string trimmed = trim_whitespace(cleaned);
+<<<<<<< HEAD
     std::string int_candidate = trimmed;
 
     if (!int_candidate.empty() && int_candidate[0] == '+') {
         int_candidate.erase(0, 1);
     }
+=======
+>>>>>>> a0aa2bf (fix(csv): address review feedback for integer inference)
 
     long long val = 0;
 

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -3,9 +3,9 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <charconv>
 #include <cstddef>
 #include <cstdlib>
-#include <charconv>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
@@ -258,65 +258,56 @@ DType CsvReader::infer_type(const std::string& value) const {
 
     // Try int64
     std::string trimmed = trim_whitespace(cleaned);
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 15fd88b (Handle signed integer inference with leading plus sign)
     std::string int_candidate = trimmed;
 
     if (!int_candidate.empty() && int_candidate[0] == '+') {
         int_candidate.erase(0, 1);
     }
-<<<<<<< HEAD
-=======
->>>>>>> a0aa2bf (fix(csv): address review feedback for integer inference)
 
     long long val = 0;
 
     const char* start = int_candidate.data();
     const char* end = start + int_candidate.size();
-=======
 
     const char* start = int_candidate.data();
     const char* end = int_candidate.data() + int_candidate.size();
 
     long long val = 0;
->>>>>>> 15fd88b (Handle signed integer inference with leading plus sign)
 
     auto [ptr, ec] = std::from_chars(start, end, val);
 
     if (ec == std::errc() && ptr == end) {
         return DType::INT64;
     }
-    }
+}
 
-    // Try float64
-    {
-        const char* start = trimmed.c_str();
-        char* end = nullptr;
-        double val = std::strtod(start, &end);
-        (void)val;
-        if (end != start && *end == '\0') return DType::FLOAT64;
-    }
+// Try float64
+{
+    const char* start = trimmed.c_str();
+    char* end = nullptr;
+    double val = std::strtod(start, &end);
+    (void)val;
+    if (end != start && *end == '\0') return DType::FLOAT64;
+}
 
-    // If thousands separator is set and value contains it but failed
-    // grouping validation, it's a malformed numeric — treat as NULL_TYPE
-    // so it doesn't poison the whole column's dtype to STRING.
-    if (config_.thousands_separator.has_value()) {
-        char sep = config_.thousands_separator.value();
-        if (value.find(sep) != std::string::npos && !has_valid_thousands_grouping(value, sep)) {
-            std::string check = value;
-            trim_in_place(check);
-            if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
-            bool looks_numeric =
-                !check.empty() && std::all_of(check.begin(), check.end(), [sep](char c) {
-                    return std::isdigit((unsigned char)c) || c == sep || c == '.';
-                });
-            if (looks_numeric) return DType::NULL_TYPE;
-        }
+// If thousands separator is set and value contains it but failed
+// grouping validation, it's a malformed numeric — treat as NULL_TYPE
+// so it doesn't poison the whole column's dtype to STRING.
+if (config_.thousands_separator.has_value()) {
+    char sep = config_.thousands_separator.value();
+    if (value.find(sep) != std::string::npos && !has_valid_thousands_grouping(value, sep)) {
+        std::string check = value;
+        trim_in_place(check);
+        if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
+        bool looks_numeric =
+            !check.empty() && std::all_of(check.begin(), check.end(), [sep](char c) {
+                return std::isdigit((unsigned char)c) || c == sep || c == '.';
+            });
+        if (looks_numeric) return DType::NULL_TYPE;
     }
+}
 
-    return DType::STRING;
+return DType::STRING;
 }
 
 DType CsvReader::promote_type(DType current, DType incoming) {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -267,16 +267,17 @@ DType CsvReader::infer_type(const std::string& value) const {
     }
 
     long long val = 0;
+
     const char* start = int_candidate.data();
     const char* end = start + int_candidate.size();
 
     auto [ptr, ec] = std::from_chars(start, end, val);
 
     if (ec == std::errc() && ptr == end) {
-       return DType::INT64;
-
+        return DType::INT64;
     }
-    
+    }
+
     // Try float64
     {
         const char* start = cleaned.c_str();

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -33,7 +33,6 @@ inline void trim_in_place(std::string& s) {
                 .base(),
             s.end());
 }
-}
 
 inline void strip_utf8_bom(std::string& s) {
     if (s.size() >= 3 && static_cast<unsigned char>(s[0]) == 0xEF &&
@@ -260,11 +259,15 @@ DType CsvReader::infer_type(const std::string& value) const {
     // Try int64
     std::string trimmed = trim_whitespace(cleaned);
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 15fd88b (Handle signed integer inference with leading plus sign)
     std::string int_candidate = trimmed;
 
     if (!int_candidate.empty() && int_candidate[0] == '+') {
         int_candidate.erase(0, 1);
     }
+<<<<<<< HEAD
 =======
 >>>>>>> a0aa2bf (fix(csv): address review feedback for integer inference)
 
@@ -272,6 +275,13 @@ DType CsvReader::infer_type(const std::string& value) const {
 
     const char* start = int_candidate.data();
     const char* end = start + int_candidate.size();
+=======
+
+    const char* start = int_candidate.data();
+    const char* end = int_candidate.data() + int_candidate.size();
+
+    long long val = 0;
+>>>>>>> 15fd88b (Handle signed integer inference with leading plus sign)
 
     auto [ptr, ec] = std::from_chars(start, end, val);
 
@@ -282,7 +292,7 @@ DType CsvReader::infer_type(const std::string& value) const {
 
     // Try float64
     {
-        const char* start = cleaned.c_str();
+        const char* start = trimmed.c_str();
         char* end = nullptr;
         double val = std::strtod(start, &end);
         (void)val;

--- a/tests/test_csv_numeric_parsing.py
+++ b/tests/test_csv_numeric_parsing.py
@@ -1,0 +1,37 @@
+from arnio import read_csv
+
+
+def test_int_inference_valid(tmp_path):
+    csv_file = tmp_path / "valid.csv"
+    csv_file.write_text("a\n123\n456\n")
+
+    df = read_csv(str(csv_file))
+
+    assert df.dtypes["a"] == "int64"
+
+
+def test_float_inference_valid(tmp_path):
+    csv_file = tmp_path / "float.csv"
+    csv_file.write_text("a\n1.5\n2.75\n")
+
+    df = read_csv(str(csv_file))
+
+    assert df.dtypes["a"] == "float64"
+
+
+def test_invalid_numeric_falls_back_to_string(tmp_path):
+    csv_file = tmp_path / "invalid.csv"
+    csv_file.write_text("a\n123abc\n")
+
+    df = read_csv(str(csv_file))
+
+    assert df.dtypes["a"] == "string"
+
+
+def test_whitespace_numeric_current_behavior(tmp_path):
+    csv_file = tmp_path / "space.csv"
+    csv_file.write_text("a\n 123\n")
+
+    df = read_csv(str(csv_file))
+
+    assert df.dtypes["a"] == "int64"

--- a/tests/test_csv_numeric_parsing.py
+++ b/tests/test_csv_numeric_parsing.py
@@ -10,6 +10,15 @@ def test_int_inference_valid(tmp_path):
     assert df.dtypes["a"] == "int64"
 
 
+def test_signed_integer_inference(tmp_path):
+    csv_file = tmp_path / "signed.csv"
+    csv_file.write_text("value\n+123\n+456\n")
+
+    df = read_csv(str(csv_file))
+
+    assert df.dtypes["value"] == "int64"
+
+
 def test_float_inference_valid(tmp_path):
     csv_file = tmp_path / "float.csv"
     csv_file.write_text("a\n1.5\n2.75\n")


### PR DESCRIPTION
## Summary

This PR now focuses on regression coverage for CSV numeric type inference behavior.

### Included

* Signed integer inference coverage
* Leading `+` handling tests
* Numeric parsing regression tests
* Validation of existing integer inference behavior

### Notes

The earlier `std::from_chars` performance-path implementation changes were dropped during conflict cleanup/rebase resolution, so this PR has been narrowed to test coverage only.
