### PR TITLE
feat: add string length statistics to quality profile (resolves #174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ DataQualityReport(
     duplicate_rows=0,
     columns={
         'user_id': ColumnProfile(dtype='int64', semantic_type='identifier', unique_count=4),
-        'email': ColumnProfile(dtype='string', semantic_type='categorical', null_count=1, unique_ratio=0.666667),
+        'email': ColumnProfile(dtype='string', semantic_type='categorical', null_count=1, unique_ratio=0.666667, min=13, max=13, mean=13.0),
         'score': ColumnProfile(dtype='float64', semantic_type='numeric', mean=87.9, min=85.5, max=90.0)
     }
 )
@@ -777,6 +777,9 @@ DataQualityReport(
       "semantic_type": "categorical",
       "null_count": 1,
       "unique_ratio": 0.666667,
+      "min": 13,
+      "max": 13,
+      "mean": 13.0,
       "warnings": ["contains_nulls"]
     },
     "score": {

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -17,7 +17,17 @@ from .frame import ArFrame
 
 @dataclass(frozen=True)
 class ColumnProfile:
-    """Quality profile for one column."""
+    """Quality profile for one column.
+
+    For numeric columns ``min``, ``max``, and ``mean`` report **value**
+    statistics.  For string columns the same fields report **string-length**
+    statistics (minimum length, maximum length, and mean length of non-null
+    values).
+
+    ``empty_string_count`` is the number of non-null values that become empty
+    after stripping leading/trailing whitespace — whitespace-only strings are
+    therefore counted as empty.
+    """
 
     name: str
     dtype: str
@@ -320,13 +330,21 @@ def _profile_column(
         whitespace_count = int((as_text != stripped).sum())
         top_values = _top_values(non_null)
 
-    numeric = pd.to_numeric(series, errors="coerce")
-    numeric_non_null = numeric.dropna()
     min_value = max_value = mean = None
-    if len(numeric_non_null) and _is_numeric_dtype(dtype):
-        min_value = numeric_non_null.min()
-        max_value = numeric_non_null.max()
-        mean = float(numeric_non_null.mean())
+    if len(non_null) and _is_numeric_dtype(dtype):
+        numeric = pd.to_numeric(series, errors="coerce")
+        numeric_non_null = numeric.dropna()
+        if len(numeric_non_null):
+            min_value = numeric_non_null.min()
+            max_value = numeric_non_null.max()
+            mean = float(numeric_non_null.mean())
+    elif len(non_null) and (
+        dtype == "string" or pd.api.types.is_string_dtype(series.dtype)
+    ):
+        lengths = non_null.astype("string").str.len()
+        min_value = int(lengths.min())
+        max_value = int(lengths.max())
+        mean = float(lengths.mean())
 
     semantic_type = _detect_semantic_type(name, series, dtype)
     suggested_dtype = _suggest_column_dtype(series, dtype)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -243,3 +243,88 @@ def test_identifier_numeric_cast_prevention():
     assert list(result["id"]) == ["001", "002", "003"]
     assert list(result["customer_id"]) == ["00123", "00456", "00789"]
     assert list(result["zip_code"]) == ["01234", "02345", "03456"]
+
+
+# ── string length statistics tests ───────────────────────────────────────────
+
+
+def test_profile_string_metrics():
+    df = pd.DataFrame({"text": ["a", "abc", "abcde", "", "  ", None]})
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+
+    profile = report.columns["text"]
+    assert profile.dtype == "string"
+    assert profile.min == 0
+    assert profile.max == 5
+    assert profile.mean == 2.2
+    assert profile.empty_string_count == 2
+    assert profile.whitespace_count == 1
+    assert "empty_strings" in profile.warnings
+
+
+def test_profile_empty_and_null_strings():
+    df = pd.DataFrame(
+        {
+            "all_null": [None, None],
+            "all_empty": ["", ""],
+        }
+    )
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+
+    # All null
+    p_null = report.columns["all_null"]
+    assert p_null.min is None
+    assert p_null.max is None
+    assert p_null.mean is None
+    assert p_null.null_count == 2
+
+    # All empty
+    p_empty = report.columns["all_empty"]
+    assert p_empty.min == 0
+    assert p_empty.max == 0
+    assert p_empty.mean == 0.0
+    assert p_empty.empty_string_count == 2
+
+
+def test_profile_string_clean_happy_path():
+    """Clean string column with no nulls, no empties — simplest case."""
+    df = pd.DataFrame({"name": ["hello", "hi", "hey"]})
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+
+    p = report.columns["name"]
+    assert p.dtype == "string"
+    assert p.min == 2
+    assert p.max == 5
+    assert p.mean == 10 / 3
+    assert p.null_count == 0
+    assert p.empty_string_count == 0
+    assert p.whitespace_count == 0
+
+
+def test_profile_string_metrics_to_dict():
+    """String length values appear correctly in to_dict() output."""
+    df = pd.DataFrame({"label": ["short", "medium-ish", "x"]})
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+    d = report.to_dict()
+
+    col = d["columns"]["label"]
+    assert col["min"] == 1
+    assert col["max"] == 10
+    assert col["mean"] == 5.0 + 1 / 3
+
+
+def test_profile_string_metrics_to_pandas():
+    """String length values appear correctly in to_pandas() output."""
+    df = pd.DataFrame({"label": ["short", "medium-ish", "x"]})
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+    result_df = report.to_pandas()
+
+    row = result_df[result_df["name"] == "label"].iloc[0]
+    assert row["min"] == 1
+    assert row["max"] == 10
+    assert row["mean"] == 5.0 + 1 / 3


### PR DESCRIPTION
## Summary

Closes #174

String columns in `ar.profile()` now report **string-length statistics** (`min`, `max`, `mean`) alongside the existing `empty_string_count` and `whitespace_count` fields. The implementation reuses the existing `min`/`max`/`mean` fields on `ColumnProfile` — no model schema changes were needed.

---

## What changed

### `arnio/quality.py`
- `_profile_column` now computes string-length stats for string columns using an `elif` branch after the numeric path.
- Stats are computed only on non-null values (consistent with the numeric path).
- Removes an unnecessary `pd.to_numeric()` call for non-numeric columns (minor perf improvement).
- Expanded `ColumnProfile` docstring to clarify:
  - `min`/`max`/`mean` = **value stats** for numeric columns, **length stats** for string columns.
  - `empty_string_count` is computed **after stripping whitespace** — whitespace-only strings count as empty.

### `tests/test_quality.py`
Five new tests added under the `# string length statistics tests` section:

| Test | Covers |
|:--|:--|
| `test_profile_string_metrics` | Mixed input: normal strings, empty string, whitespace-only, `None` |
| `test_profile_empty_and_null_strings` | Edge cases: all-null column (stats are `None`) and all-empty column (stats are `0`) |
| `test_profile_string_clean_happy_path` | Happy path: clean column with no nulls or empties |
| `test_profile_string_metrics_to_dict` | Serialisation: length values appear correctly in `to_dict()` |
| `test_profile_string_metrics_to_pandas` | Serialisation: length values appear correctly in `to_pandas()` |

### `README.md`
- Terminal representation example updated to show `min=13, max=13, mean=13.0` for the `email` string column.
- JSON example below it updated to match (was inconsistent — missing the new fields).

---

## PR checklist

- [x] The behavior is implemented or clearly documented as unsupported.
- [x] Tests cover the new behavior or regression.
- [x] Errors, outputs, or reports are clear for users.
- [x] Existing tests pass locally.

---

## Test output

```
============================= test session starts =============================
collected 22 items

tests/test_quality.py::test_profile_reports_quality_signals PASSED
tests/test_quality.py::test_report_summary_and_pandas_output PASSED
tests/test_quality.py::test_suggest_cleaning_returns_pipeline_compatible_steps PASSED
tests/test_quality.py::test_auto_clean_safe_trims_without_dropping_duplicates PASSED
tests/test_quality.py::test_auto_clean_strict_applies_exact_deduplication PASSED
tests/test_quality.py::test_auto_clean_rejects_unknown_mode PASSED
tests/test_quality.py::test_profile_sample_size PASSED
tests/test_quality.py::test_profile_sample_size_small_dataset_and_nulls PASSED
tests/test_quality.py::test_profile_sample_size_validation PASSED
tests/test_quality.py::test_top_values_correct_order_and_ratio PASSED
tests/test_quality.py::test_top_values_nulls_excluded PASSED
tests/test_quality.py::test_top_values_all_unique PASSED
tests/test_quality.py::test_top_values_single_value PASSED
tests/test_quality.py::test_top_values_not_computed_for_numeric PASSED
tests/test_quality.py::test_top_values_empty_column PASSED
tests/test_quality.py::test_top_values_in_to_dict PASSED
tests/test_quality.py::test_identifier_numeric_cast_prevention PASSED
tests/test_quality.py::test_profile_string_metrics PASSED
tests/test_quality.py::test_profile_empty_and_null_strings PASSED
tests/test_quality.py::test_profile_string_clean_happy_path PASSED
tests/test_quality.py::test_profile_string_metrics_to_dict PASSED
tests/test_quality.py::test_profile_string_metrics_to_pandas PASSED

22 passed in 1.13s
```
