### PR TITLE
feat: add quality sample redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,10 @@ data = {
 df = ar.from_pandas(pd.DataFrame(data))
 # Bounded profiling for large datasets (controls how many sample values are kept)
 report = ar.profile(df, sample_size=5)
+safe_report = report.to_dict(redact_sample_values=True)
 ```
+
+Use `report.to_dict(redact_sample_values=True)` when sharing reports outside your team and you want to avoid exposing raw example/sample values.
 
 ### 1. Terminal Representation (Simplified Example)
 *A simplified view of the standard string representation of the report object:*

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -37,8 +37,13 @@ class ColumnProfile:
     warnings: list[str] = field(default_factory=list)
     top_values: list[tuple[Any, int, float]] | None = None
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, *, redact_sample_values: bool = False) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
+        sample_values = (
+            ["[REDACTED]" for _ in self.sample_values]
+            if redact_sample_values
+            else [_clean_scalar(value) for value in self.sample_values]
+        )
         return {
             "name": self.name,
             "dtype": self.dtype,
@@ -54,7 +59,7 @@ class ColumnProfile:
             "min": _clean_scalar(self.min),
             "max": _clean_scalar(self.max),
             "mean": self.mean,
-            "sample_values": [_clean_scalar(value) for value in self.sample_values],
+            "sample_values": sample_values,
             "warnings": list(self.warnings),
             "top_values": (
                 [
@@ -79,7 +84,7 @@ class DataQualityReport:
     columns: dict[str, ColumnProfile]
     suggestions: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, *, redact_sample_values: bool = False) -> dict[str, Any]:
         """Return a JSON-friendly dictionary representation."""
         return {
             "row_count": self.row_count,
@@ -88,7 +93,8 @@ class DataQualityReport:
             "duplicate_rows": self.duplicate_rows,
             "duplicate_ratio": self.duplicate_ratio,
             "columns": {
-                name: column.to_dict() for name, column in self.columns.items()
+                name: column.to_dict(redact_sample_values=redact_sample_values)
+                for name, column in self.columns.items()
             },
             "suggestions": [
                 {"step": step, "kwargs": dict(kwargs)}

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -103,6 +103,61 @@ def test_profile_sample_size_small_dataset_and_nulls(tmp_path):
     assert report.columns["id"].sample_values == [1.0, 3.0]
 
 
+def test_quality_to_dict_default_preserves_sample_values(tmp_path):
+    path = tmp_path / "dict_default.csv"
+    path.write_text("name\nAlice\nBob\n")
+    report = ar.profile(ar.read_csv(path), sample_size=2)
+
+    d = report.to_dict()
+
+    assert d["columns"]["name"]["sample_values"] == ["Alice", "Bob"]
+
+
+def test_quality_to_dict_redacts_sample_values(tmp_path):
+    path = tmp_path / "dict_redacted.csv"
+    path.write_text("name\nAlice\nBob\n")
+    report = ar.profile(ar.read_csv(path), sample_size=2)
+
+    d = report.to_dict(redact_sample_values=True)
+
+    assert d["columns"]["name"]["sample_values"] == ["[REDACTED]", "[REDACTED]"]
+    assert report.columns["name"].sample_values == ["Alice", "Bob"]
+
+
+def test_quality_to_dict_redacts_multiple_columns_and_preserves_lengths(tmp_path):
+    path = tmp_path / "dict_multi.csv"
+    path.write_text("name,city\nAlice,Paris\nBob,London\n")
+    report = ar.profile(ar.read_csv(path), sample_size=2)
+
+    d = report.to_dict(redact_sample_values=True)
+
+    assert d["columns"]["name"]["sample_values"] == ["[REDACTED]", "[REDACTED]"]
+    assert d["columns"]["city"]["sample_values"] == ["[REDACTED]", "[REDACTED]"]
+    assert len(d["columns"]["name"]["sample_values"]) == 2
+    assert len(d["columns"]["city"]["sample_values"]) == 2
+
+
+def test_quality_to_dict_redaction_keeps_no_example_cases_empty(tmp_path):
+    path = tmp_path / "dict_empty_samples.csv"
+    path.write_text("id\n1\n2\n")
+    report = ar.profile(ar.read_csv(path), sample_size=0)
+
+    d = report.to_dict(redact_sample_values=True)
+
+    assert d["columns"]["id"]["sample_values"] == []
+
+
+def test_column_profile_to_dict_redacts_sample_values_direct(tmp_path):
+    path = tmp_path / "column_redacted.csv"
+    path.write_text("name\nAlice\nBob\n")
+    report = ar.profile(ar.read_csv(path), sample_size=2)
+
+    d = report.columns["name"].to_dict(redact_sample_values=True)
+
+    assert d["sample_values"] == ["[REDACTED]", "[REDACTED]"]
+    assert report.columns["name"].sample_values == ["Alice", "Bob"]
+
+
 def test_profile_sample_size_validation(tmp_path):
     path = tmp_path / "sample.csv"
     path.write_text("id\n1\n")


### PR DESCRIPTION
## Summary

- Added `redact_sample_values` controls for quality report serialization.
- Preserved current behavior by default.
- Redacts `sample_values` as `"[REDACTED]"` when `report.to_dict(redact_sample_values=True)` is used.
- Threaded the redaction flag through `DataQualityReport.to_dict()` and `ColumnProfile.to_dict()`.
- Added focused tests for default output, redacted output, multiple columns, no-example cases, and direct column profile serialization.
- Added a short README example for sharing redacted quality reports.

## Linked issue

Fixes #188

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `pytest tests/test_quality.py -v` — 22 passed
  - `git diff --check` — passed
  - `ruff check arnio/quality.py tests/test_quality.py` — passed
  - `black --check arnio/quality.py tests/test_quality.py` — passed

Note: `make lint` currently fails on unrelated upstream notebook lint in `examples/financial_csv_example.ipynb`, which is not part of this PR and was intentionally not changed to keep this PR focused.

## Screenshots / Media

N/A — no UI or visual changes.

## Performance Impact

N/A — redaction only affects report serialization and does not change profiling logic or quality scoring.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

- Current behavior is preserved by default.
- `sample_values` are redacted only when `redact_sample_values=True` is passed to `to_dict(...)`.
- Redaction uses the stable placeholder `"[REDACTED]"`.
- Empty sample lists remain `[]`.
- Stored in-memory `sample_values` are not mutated.
- No quality scoring, profiling, suggestion, auto-clean, or schema behavior was changed.
- I used AI assistance to inspect repo patterns and draft changes, then reviewed, formatted, and tested locally.