### PR TITLE
Add markdown export support for DataQualityReport

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -135,22 +135,14 @@ class DataQualityReport:
             lines.append("## Columns")
             lines.append("")
 
-            lines.append(
-                "| Name | Dtype | Semantic Type | Nulls | Unique | Warnings |"
-            )
+            lines.append("| Name | Dtype | Semantic Type | Nulls | Unique | Warnings |")
 
-            lines.append(
-                "|---|---|---|---|---|---|"
-            )
+            lines.append("|---|---|---|---|---|---|")
 
             for name in sorted(self.columns):
                 column = self.columns[name]
 
-                warnings = (
-                    ", ".join(column.warnings)
-                    if column.warnings
-                    else "-"
-                )
+                warnings = ", ".join(column.warnings) if column.warnings else "-"
 
                 lines.append(
                     f"| {column.name} "

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -135,24 +135,33 @@ class DataQualityReport:
             lines.append("## Columns")
             lines.append("")
 
-            lines.append("| Name | Dtype | Semantic Type | Nulls | Unique | Warnings |")
-        lines.append("|---|---|---|---|---|---|")
-
-        for name in sorted(self.columns):
-            column = self.columns[name]
-
-            warnings = ", ".join(column.warnings) if column.warnings else "-"
-
             lines.append(
-                f"| {column.name} "
-                f"| {column.dtype} "
-                f"| {column.semantic_type} "
-                f"| {column.null_count} "
-                f"| {column.unique_count} "
-                f"| {warnings} |"
+                "| Name | Dtype | Semantic Type | Nulls | Unique | Warnings |"
             )
 
-        lines.append("")
+            lines.append(
+                "|---|---|---|---|---|---|"
+            )
+
+            for name in sorted(self.columns):
+                column = self.columns[name]
+
+                warnings = (
+                    ", ".join(column.warnings)
+                    if column.warnings
+                    else "-"
+                )
+
+                lines.append(
+                    f"| {column.name} "
+                    f"| {column.semantic_type} "
+                    f"| {column.dtype} "
+                    f"| {column.null_count} "
+                    f"| {column.unique_count} "
+                    f"| {warnings} |"
+                )
+
+            lines.append("")
 
         # Suggestions
         if self.suggestions:

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -112,6 +112,60 @@ class DataQualityReport:
             ],
         }
 
+    def to_markdown(self) -> str:
+        """Return a GitHub-friendly Markdown report."""
+
+        lines: list[str] = []
+
+        lines.append("# Data Quality Report")
+        lines.append("")
+
+        # Overview
+        lines.append("## Overview")
+        lines.append("")
+        lines.append(f"- Rows: {self.row_count}")
+        lines.append(f"- Columns: {self.column_count}")
+        lines.append(f"- Memory Usage: {self.memory_usage}")
+        lines.append(f"- Duplicate Rows: {self.duplicate_rows}")
+        lines.append(f"- Duplicate Ratio: {self.duplicate_ratio:.2%}")
+        lines.append("")
+
+        # Columns
+        if self.columns:
+            lines.append("## Columns")
+            lines.append("")
+
+            lines.append("| Name | Dtype | Semantic Type | Nulls | Unique | Warnings |")
+        lines.append("|---|---|---|---|---|---|")
+
+        for name in sorted(self.columns):
+            column = self.columns[name]
+
+            warnings = ", ".join(column.warnings) if column.warnings else "-"
+
+            lines.append(
+                f"| {column.name} "
+                f"| {column.dtype} "
+                f"| {column.semantic_type} "
+                f"| {column.null_count} "
+                f"| {column.unique_count} "
+                f"| {warnings} |"
+            )
+
+        lines.append("")
+
+        # Suggestions
+        if self.suggestions:
+            lines.append("## Suggested Cleaning Steps")
+            lines.append("")
+
+            for step, kwargs in self.suggestions:
+                lines.append(f"- `{step}`: `{kwargs}`")
+
+            lines.append("")
+
+        return "\n".join(lines)
+
     def summary(self) -> dict[str, Any]:
         """Return the highest-signal report fields."""
         return {

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -146,8 +146,8 @@ class DataQualityReport:
 
                 lines.append(
                     f"| {column.name} "
-                    f"| {column.semantic_type} "
                     f"| {column.dtype} "
+                    f"| {column.semantic_type} "
                     f"| {column.null_count} "
                     f"| {column.unique_count} "
                     f"| {warnings} |"

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -383,3 +383,44 @@ def test_profile_string_metrics_to_pandas():
     assert row["min"] == 1
     assert row["max"] == 10
     assert row["mean"] == 5.0 + 1 / 3
+
+
+def test_report_to_markdown_basic(tmp_path):
+    path = tmp_path / "report.csv"
+
+    path.write_text("id,name\n" "1,Alice\n" "2,Bob\n")
+
+    report = ar.profile(ar.read_csv(path))
+
+    md = report.to_markdown()
+
+    assert "# Data Quality Report" in md
+    assert "## Overview" in md
+    assert "## Columns" in md
+
+
+def test_report_to_markdown_deterministic(tmp_path):
+    path = tmp_path / "stable.csv"
+
+    path.write_text("id,name\n" "1,Alice\n" "2,Bob\n")
+
+    report = ar.profile(ar.read_csv(path))
+
+    assert report.to_markdown() == report.to_markdown()
+
+
+def test_report_to_markdown_empty_sections():
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[],
+    )
+
+    md = report.to_markdown()
+
+    assert "# Data Quality Report" in md
+    assert "## Overview" in md

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -424,3 +424,5 @@ def test_report_to_markdown_empty_sections():
 
     assert "# Data Quality Report" in md
     assert "## Overview" in md
+    assert "## Columns" not in md
+    assert "|---|---|" not in md

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -397,6 +397,7 @@ def test_report_to_markdown_basic(tmp_path):
     assert "# Data Quality Report" in md
     assert "## Overview" in md
     assert "## Columns" in md
+    assert "| id | int64 | identifier |" in md
 
 
 def test_report_to_markdown_deterministic(tmp_path):


### PR DESCRIPTION
## Changes

* Added `DataQualityReport.to_markdown()`
* Added deterministic GitHub-friendly Markdown formatting
* Added graceful handling for empty or missing sections
* Added tests for:

  * markdown generation
  * deterministic output
  * empty section handling

## Test Results

* Ran `pytest tests/test_quality.py`
* All tests passing
