### PR TITLE
feat: add optional pipeline step timing metadata (#162)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -271,6 +271,11 @@ ops = [
 df = ar.pipeline(df, ops)
 ```
 
+```python
+clean, metadata = ar.pipeline(df, ops, return_metadata=True)
+print(metadata["step_timings"])
+```
+
 ### register_step
 
 Extend the pipeline by adding your own custom Python functions.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ df = ar.to_pandas(clean)
 safe_df = ar.to_pandas(clean, copy=True)
 ```
 
+Need step timings for debugging? Opt in without changing the default pipeline return type:
+
+```python
+clean, metadata = ar.pipeline(
+    frame,
+    [("strip_whitespace",), ("drop_duplicates",)],
+    return_metadata=True,
+)
+
+print(metadata["step_timings"])
+```
+
 Already have a pandas `DataFrame`? Use Arnio in-place in your existing pandas
 workflow:
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -6,7 +6,8 @@ Chained cleaning pipeline.
 from __future__ import annotations
 
 from threading import Lock
-from typing import Callable
+from time import perf_counter
+from typing import Any, Callable
 
 from . import cleaning
 from .frame import ArFrame
@@ -60,7 +61,9 @@ def register_step(name: str, fn: Callable):
 def pipeline(
     frame: ArFrame,
     steps: list[tuple],
-) -> ArFrame:
+    *,
+    return_metadata: bool = False,
+) -> ArFrame | tuple[ArFrame, dict[str, Any]]:
     """Apply a list of cleaning steps sequentially.
 
     Each step is a tuple of (step_name,) or (step_name, kwargs_dict).
@@ -73,6 +76,9 @@ def pipeline(
         Input data frame.
     steps : list[tuple]
         List of steps to apply. Each step is (name,) or (name, kwargs).
+    return_metadata : bool, default False
+        When True, also return a metadata dictionary with per-step timing
+        information in execution order.
 
     Returns
     -------
@@ -102,6 +108,7 @@ def pipeline(
         python_step_registry = dict(_PYTHON_STEP_REGISTRY)
 
     result = frame
+    step_timings: list[dict[str, Any]] = []
     for step in steps:
         if len(step) == 1:
             name = step[0]
@@ -120,19 +127,37 @@ def pipeline(
         if name in _STEP_REGISTRY:
             # C++ backed step - fast path
             fn = _STEP_REGISTRY[name]
+            started_at = perf_counter()
             if name in {"rename_columns", "cast_types"} and "mapping" not in kwargs:
                 result = fn(result, kwargs)
             else:
                 result = fn(result, **kwargs)
+            if return_metadata:
+                step_timings.append(
+                    {
+                        "step": name,
+                        "seconds": round(perf_counter() - started_at, 9),
+                    }
+                )
         elif name in python_step_registry:
             # Pure Python step - slower but contributor-friendly
+            started_at = perf_counter()
             df = to_pandas(result)
             df = python_step_registry[name](df, **kwargs)
             result = from_pandas(df)
+            if return_metadata:
+                step_timings.append(
+                    {
+                        "step": name,
+                        "seconds": round(perf_counter() - started_at, 9),
+                    }
+                )
         else:
             available = list(_STEP_REGISTRY.keys()) + list(python_step_registry.keys())
             raise UnknownStepError(name, available)
 
+    if return_metadata:
+        return result, {"step_timings": step_timings}
     return result
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -214,6 +214,60 @@ class TestPipeline:
         result = ar.pipeline(frame, [])
         assert result.shape == frame.shape
 
+    def test_pipeline_return_metadata_disabled_by_default(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("strip_whitespace",),
+            ],
+        )
+
+        assert isinstance(result, ar.ArFrame)
+
+    def test_pipeline_return_metadata_includes_step_timings(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result, metadata = ar.pipeline(
+            frame,
+            [
+                ("strip_whitespace",),
+                ("normalize_case", {"case_type": "lower"}),
+            ],
+            return_metadata=True,
+        )
+
+        assert isinstance(result, ar.ArFrame)
+        assert list(metadata.keys()) == ["step_timings"]
+        assert len(metadata["step_timings"]) == 2
+        assert metadata["step_timings"][0]["step"] == "strip_whitespace"
+        assert metadata["step_timings"][1]["step"] == "normalize_case"
+        assert all(item["seconds"] >= 0 for item in metadata["step_timings"])
+
+    def test_pipeline_return_metadata_handles_python_steps(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        def add_marker(df, value="ok"):
+            df["marker"] = value
+            return df
+
+        ar.register_step("timed_python_step", add_marker)
+
+        result, metadata = ar.pipeline(
+            frame,
+            [
+                ("timed_python_step", {"value": "done"}),
+            ],
+            return_metadata=True,
+        )
+
+        df = ar.to_pandas(result)
+        assert set(df["marker"]) == {"done"}
+        assert len(metadata["step_timings"]) == 1
+        assert metadata["step_timings"][0]["step"] == "timed_python_step"
+        assert metadata["step_timings"][0]["seconds"] >= 0
+
     def test_register_python_step(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 


### PR DESCRIPTION
## Summary
- add an opt-in `return_metadata` flag to `ar.pipeline()` while preserving the default return type
- capture per-step execution timings for both built-in and custom Python pipeline steps
- document the metadata shape in the README and API reference
- add regression tests covering default behavior, metadata shape, and Python-step timing

## Testing
- `python -m pytest tests/test_pipeline.py`
- `python -m ruff check arnio/pipeline.py tests/test_pipeline.py`
- `python -m black --check arnio/pipeline.py tests/test_pipeline.py`

Fixes #162