### PR TITLE
feat: truncate long column names in ArFrame display

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -258,8 +258,8 @@ class ArFrame:
         """Return a detailed string summary of the ArFrame."""
         lines = [f"ArFrame: {self.shape[0]} rows × {self.shape[1]} columns"]
         lines.append(f"Columns: {self._truncate_column_names()}")
-        lines.append(f"DTypes: {self.dtypes}")
-        lines.append(f"Memory: {self.memory_usage()} bytes")
+        lines.append(f"DTypes:  {self.dtypes}")
+        lines.append(f"Memory:  {self.memory_usage()} bytes")
         return "\n".join(lines)
 
     def preview(self, n: int = 5) -> str:

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -237,6 +237,12 @@ class ArFrame:
 
         return self.select_columns(matched)
 
+    def _truncate_column_names(self, max_length=20):
+        return [
+            col[:max_length] + "..." if len(col) > max_length else col
+            for col in self.columns
+        ]
+
     # --- Dunder methods ---
 
     def __len__(self) -> int:
@@ -251,9 +257,9 @@ class ArFrame:
     def __str__(self) -> str:
         """Return a detailed string summary of the ArFrame."""
         lines = [f"ArFrame: {self.shape[0]} rows × {self.shape[1]} columns"]
-        lines.append(f"Columns: {self.columns}")
-        lines.append(f"DTypes:  {self.dtypes}")
-        lines.append(f"Memory:  {self.memory_usage()} bytes")
+        lines.append(f"Columns: {self._truncate_column_names()}")
+        lines.append(f"DTypes: {self.dtypes}")
+        lines.append(f"Memory: {self.memory_usage()} bytes")
         return "\n".join(lines)
 
     def preview(self, n: int = 5) -> str:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -251,3 +251,14 @@ def test_str_truncates_long_column_names():
     assert "very_very_very_long_column_name_for_testing" not in columns_line
 
     assert frame.columns == ["very_very_very_long_column_name_for_testing"]
+
+
+def test_str_keeps_normal_column_names():
+    df = pd.DataFrame({"name": [1, 2]})
+
+    frame = ar.from_pandas(df)
+
+    result = str(frame)
+
+    assert "name" in result
+    assert "..." not in result

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -235,11 +235,19 @@ class TestArFrame:
         assert len(frame) == 1
 
 
-def test_repr_returns_string():
+def test_str_truncates_long_column_names():
     df = pd.DataFrame({"very_very_very_long_column_name_for_testing": [1, 2]})
 
     frame = ar.from_pandas(df)
 
-    result = repr(frame)
+    result = str(frame)
 
-    assert isinstance(result, str)
+    assert "very_very_very_long_..." in result
+
+    columns_line = [line for line in result.split("\n") if line.startswith("Columns:")][
+        0
+    ]
+
+    assert "very_very_very_long_column_name_for_testing" not in columns_line
+
+    assert frame.columns == ["very_very_very_long_column_name_for_testing"]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -233,3 +233,13 @@ class TestArFrame:
         frame = ar.read_csv(str(csv_path))
         assert frame.is_empty is False
         assert len(frame) == 1
+
+
+def test_repr_returns_string():
+    df = pd.DataFrame({"very_very_very_long_column_name_for_testing": [1, 2]})
+
+    frame = ar.from_pandas(df)
+
+    result = repr(frame)
+
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary

Implemented display-only truncation of long column names in `ArFrame` string output to improve terminal readability for wide/messy datasets while preserving original column names internally.

Added/updated tests to verify truncation behavior and ensure underlying column names remain unchanged.

## Linked issue

Fixes #227

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

Commands run:
`python -m pytest tests/test_frame.py -v`

Result:

* All relevant tests passed successfully
* Verified manually using a dataframe with long column names
* Confirmed displayed names are truncated while `frame.columns` preserves original names

## Screenshots / Media

N/A

## Performance Impact

No expected performance impact. Change only affects display formatting.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Display-only change; no underlying data or API behavior modified.
