### PR TITLE
fix: raise ValueError for duplicate column labels in from_pandas()

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -249,7 +249,7 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
         seen.add(label)
     if dupes:
         raise ValueError(
-            f"from_pandas() does not support duplicate column labels: {[repr(l) for l in dupes]}"
+            f"from_pandas() does not support duplicate column labels: {[repr(label) for label in dupes]}"
         )
 
     columns = {}

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -241,10 +241,15 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
     >>> df = pd.DataFrame({"name": ["Alice"], "age": [25]})
     >>> frame = ar.from_pandas(df)
     """
-    dupes = df.columns[df.columns.duplicated()].tolist()
+    seen: set[object] = set()
+    dupes: list[object] = []
+    for label in df.columns:
+        if label in seen and label not in dupes:
+            dupes.append(label)
+        seen.add(label)
     if dupes:
         raise ValueError(
-            f"from_pandas() does not support duplicate column labels: {sorted(set(dupes))}"
+            f"from_pandas() does not support duplicate column labels: {[repr(l) for l in dupes]}"
         )
 
     columns = {}

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -241,6 +241,12 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
     >>> df = pd.DataFrame({"name": ["Alice"], "age": [25]})
     >>> frame = ar.from_pandas(df)
     """
+    dupes = df.columns[df.columns.duplicated()].tolist()
+    if dupes:
+        raise ValueError(
+            f"from_pandas() does not support duplicate column labels: {sorted(set(dupes))}"
+        )
+
     columns = {}
     dtype_hints = {}
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -397,6 +397,24 @@ class TestFromPandas:
         with pytest.raises(TypeError, match="Column 'joined'"):
             ar.from_pandas(df)
 
+    def test_duplicate_single_label_raises(self):
+        df = pd.DataFrame([[1, 2]], columns=["id", "id"])
+        with pytest.raises(ValueError, match="duplicate column labels") as exc_info:
+            ar.from_pandas(df)
+        assert "id" in str(exc_info.value)
+
+    def test_duplicate_multiple_labels_raises(self):
+        df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "a", "b"])
+        with pytest.raises(ValueError, match="duplicate column labels") as exc_info:
+            ar.from_pandas(df)
+        assert "a" in str(exc_info.value)
+        assert "b" in str(exc_info.value)
+
+    def test_unique_labels_converts_cleanly(self):
+        df = pd.DataFrame({"x": [1], "y": [2]})
+        frame = ar.from_pandas(df)
+        assert frame.columns == ["x", "y"]
+
 
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -415,6 +415,12 @@ class TestFromPandas:
         frame = ar.from_pandas(df)
         assert frame.columns == ["x", "y"]
 
+    def test_duplicate_non_string_labels_raises(self):
+        df = pd.DataFrame([[1, 2, 3]], columns=[0, 1, 0])
+        with pytest.raises(ValueError, match="duplicate column labels") as exc_info:
+            ar.from_pandas(df)
+        assert "0" in str(exc_info.value)
+
 
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):


### PR DESCRIPTION

Add an upfront duplicate-column guard in `from_pandas()`. Before this fix, passing a pandas DataFrame with duplicate column labels (e.g. after a join or manual assignment) caused an unclear internal error because `df["col"]` returns a DataFrame instead of a Series when labels are duplicated. Now `from_pandas()` detects this immediately and raises a clear `ValueError` listing the offending labels.

## Linked issue
Fixes #463 

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] pandas interoperability

## Testing
```bash
pytest tests/test_convert.py::TestFromPandas::test_duplicate_single_label_raises tests/test_convert.py::TestFromPandas::test_duplicate_multiple_labels_raises tests/test_convert.py::TestFromPandas::test_unique_labels_converts_cleanly -v
# 3 passed

pytest tests/ -v
# 467 passed, 0 failures

Contributor checklist
 I read the contributing guide.
 I kept the PR focused on one issue or one logical change.
 I added or updated tests for behavior changes.
 I added or updated docs/examples for public API changes.
 I checked that generated files, logs, and local build artifacts are not committed.
 My PR title uses Conventional Commits (feat:, fix:, docs:, test:, refactor:, chore:).
