### PR TITLE
Add numeric quantiles to profile reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,25 @@ report = ar.profile(df, sample_size=5)
 safe_report = report.to_dict(redact_sample_values=True)
 ```
 
+Sample output now includes quantiles for numeric columns:
+
+```json
+{
+  "age": {
+    "dtype": "float64",
+    "mean": 35.2,
+    "std": 10.1,
+    "min": 18.0,
+    "max": 60.0,
+    "q25": 27.5,
+    "q50": 35.0,
+    "q75": 44.0,
+    "q95": 57.0,
+    "null_count": 0
+  }
+}
+```
+
 Use `report.to_dict(redact_sample_values=True)` when sharing reports outside your team and you want to avoid exposing raw example/sample values.
 
 > **Scoring Contract:** The `quality_score` starts at 100.0 and subtracts capped penalties for duplicates, nulls, and suggested dtype mismatches. The `score_components` field exposes these penalties as negative values. (Note: Semantic-validity penalties are intentionally out of scope for the current implementation.)

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -214,6 +214,8 @@ def to_pandas(frame: ArFrame, *, copy: bool = False) -> pd.DataFrame:
 def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
     if dtype == pd.Int64Dtype():
         return _DType.INT64
+    if str(dtype) == "float64":
+        return _DType.FLOAT64
     return None
 
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -47,7 +47,6 @@ class ColumnProfile:
     q50: float | None = None
     q75: float | None = None
     q95: float | None = None
-    has_quantiles: bool = field(default=False, repr=False, compare=False)
     sample_values: list[Any] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     top_values: list[tuple[Any, int, float]] | None = None
@@ -81,7 +80,7 @@ class ColumnProfile:
                     "q75": _clean_scalar(self.q75),
                     "q95": _clean_scalar(self.q95),
                 }
-                if self.has_quantiles
+                if _is_numeric_dtype(self.dtype)
                 else {}
             ),
             "sample_values": sample_values,
@@ -224,10 +223,16 @@ class DataQualityReport:
                     "min": _clean_scalar(column.min),
                     "max": _clean_scalar(column.max),
                     "mean": column.mean,
-                    "q25": _clean_scalar(column.q25),
-                    "q50": _clean_scalar(column.q50),
-                    "q75": _clean_scalar(column.q75),
-                    "q95": _clean_scalar(column.q95),
+                    **(
+                        {
+                            "q25": _clean_scalar(column.q25),
+                            "q50": _clean_scalar(column.q50),
+                            "q75": _clean_scalar(column.q75),
+                            "q95": _clean_scalar(column.q95),
+                        }
+                        if _is_numeric_dtype(column.dtype)
+                        else {}
+                    ),
                     "warnings": column.warnings,
                     "top_values": column.top_values,
                 }
@@ -449,7 +454,6 @@ def _profile_column(
     whitespace_count = 0
     top_values = None
     q25 = q50 = q75 = q95 = None
-    has_quantiles = _is_numeric_dtype(dtype) or pd.api.types.is_numeric_dtype(series.dtype)
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
         as_text = non_null.astype("string")
         stripped = as_text.str.strip()
@@ -507,7 +511,6 @@ def _profile_column(
         q50=q50,
         q75=q75,
         q95=q95,
-        has_quantiles=has_quantiles,
         sample_values=sample_values,
         warnings=warnings,
         top_values=top_values,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -43,6 +43,11 @@ class ColumnProfile:
     min: Any = None
     max: Any = None
     mean: float | None = None
+    q25: float | None = None
+    q50: float | None = None
+    q75: float | None = None
+    q95: float | None = None
+    has_quantiles: bool = field(default=False, repr=False, compare=False)
     sample_values: list[Any] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     top_values: list[tuple[Any, int, float]] | None = None
@@ -69,6 +74,16 @@ class ColumnProfile:
             "min": _clean_scalar(self.min),
             "max": _clean_scalar(self.max),
             "mean": self.mean,
+            **(
+                {
+                    "q25": _clean_scalar(self.q25),
+                    "q50": _clean_scalar(self.q50),
+                    "q75": _clean_scalar(self.q75),
+                    "q95": _clean_scalar(self.q95),
+                }
+                if self.has_quantiles
+                else {}
+            ),
             "sample_values": sample_values,
             "warnings": list(self.warnings),
             "top_values": (
@@ -209,6 +224,10 @@ class DataQualityReport:
                     "min": _clean_scalar(column.min),
                     "max": _clean_scalar(column.max),
                     "mean": column.mean,
+                    "q25": _clean_scalar(column.q25),
+                    "q50": _clean_scalar(column.q50),
+                    "q75": _clean_scalar(column.q75),
+                    "q95": _clean_scalar(column.q95),
                     "warnings": column.warnings,
                     "top_values": column.top_values,
                 }
@@ -429,6 +448,8 @@ def _profile_column(
     empty_string_count = 0
     whitespace_count = 0
     top_values = None
+    q25 = q50 = q75 = q95 = None
+    has_quantiles = _is_numeric_dtype(dtype) or pd.api.types.is_numeric_dtype(series.dtype)
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
         as_text = non_null.astype("string")
         stripped = as_text.str.strip()
@@ -444,6 +465,11 @@ def _profile_column(
             min_value = numeric_non_null.min()
             max_value = numeric_non_null.max()
             mean = float(numeric_non_null.mean())
+            quantiles = numeric_non_null.quantile([0.25, 0.50, 0.75, 0.95])
+            q25 = round(float(quantiles.loc[0.25]), 4)
+            q50 = round(float(quantiles.loc[0.50]), 4)
+            q75 = round(float(quantiles.loc[0.75]), 4)
+            q95 = round(float(quantiles.loc[0.95]), 4)
     elif len(non_null) and (
         dtype == "string" or pd.api.types.is_string_dtype(series.dtype)
     ):
@@ -477,6 +503,11 @@ def _profile_column(
         min=min_value,
         max=max_value,
         mean=mean,
+        q25=q25,
+        q50=q50,
+        q75=q75,
+        q95=q95,
+        has_quantiles=has_quantiles,
         sample_values=sample_values,
         warnings=warnings,
         top_values=top_values,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -50,7 +50,9 @@ def test_profile_numeric_quantiles():
 
 
 def test_profile_all_null_numeric_quantiles():
-    frame = ar.from_pandas(pd.DataFrame({"score": pd.Series([None, None], dtype="float64")}))
+    frame = ar.from_pandas(
+        pd.DataFrame({"score": pd.Series([None, None], dtype="float64")})
+    )
 
     report = ar.profile(frame)
     profile = report.columns["score"].to_dict()

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -37,6 +37,42 @@ def test_report_summary_and_pandas_output(csv_with_whitespace):
     assert set(df["name"]) == {"name", "city"}
 
 
+def test_profile_numeric_quantiles():
+    frame = ar.from_pandas(pd.DataFrame({"age": [1.0, 2.0, 3.0, 4.0, 5.0]}))
+
+    report = ar.profile(frame)
+    profile = report.columns["age"].to_dict()
+
+    assert profile["q25"] == 2.0
+    assert profile["q50"] == 3.0
+    assert profile["q75"] == 4.0
+    assert profile["q95"] == 4.8
+
+
+def test_profile_all_null_numeric_quantiles():
+    frame = ar.from_pandas(pd.DataFrame({"score": pd.Series([None, None], dtype="float64")}))
+
+    report = ar.profile(frame)
+    profile = report.columns["score"].to_dict()
+
+    assert profile["q25"] is None
+    assert profile["q50"] is None
+    assert profile["q75"] is None
+    assert profile["q95"] is None
+
+
+def test_profile_non_numeric_no_quantiles():
+    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob", "Cara"]}))
+
+    report = ar.profile(frame)
+    profile = report.columns["name"].to_dict()
+
+    assert "q25" not in profile
+    assert "q50" not in profile
+    assert "q75" not in profile
+    assert "q95" not in profile
+
+
 def test_suggest_cleaning_returns_pipeline_compatible_steps(csv_with_duplicates):
     frame = ar.read_csv(csv_with_duplicates)
     suggestions = ar.suggest_cleaning(frame)


### PR DESCRIPTION
## Summary

Adds q25, q50, q75, and q95 quantile fields to `profile()` output for numeric columns.

Fixes #172

## Changes

- `arnio/quality.py`
  - compute quantiles in `_profile_column()` for numeric columns
  - expose quantile fields via `ColumnProfile`
  - include quantiles in `to_dict()` and `to_pandas()`

- `tests/test_quality.py`
  - added tests for:
    - normal numeric columns
    - all-null numeric columns
    - non-numeric columns

- `README.md`
  - updated profile output examples with quantile fields

## Test Plan

- All existing tests pass
- Added 3 new tests covering quantile behavior and edge cases