### PR TITLE
fix: preserve pandas StringDtype during roundtrip conversion

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -26,7 +26,7 @@ class TestToPandas:
     def test_nulls_converted(self, csv_with_nulls):
         frame = ar.read_csv(csv_with_nulls)
         df = ar.to_pandas(frame)
-        assert df.isna().any().any()  # Should have some NaN/NA values
+        assert df.isna().any().any()
 
     def test_copy_option_returns_equivalent_dataframe(self, sample_csv):
         frame = ar.read_csv(sample_csv)
@@ -148,6 +148,44 @@ class TestFromPandas:
         assert "x" in frame.columns
         assert "y" in frame.columns
         assert "z" in frame.columns
+
+    def test_string_dtype_roundtrip_with_missing_value(self):
+        df = pd.DataFrame(
+            {
+                "name": pd.Series(
+                    ["a", pd.NA],
+                    dtype=pd.StringDtype(),
+                )
+            }
+        )
+
+        result = ar.to_pandas(ar.from_pandas(df))
+
+        assert str(result["name"].dtype) == "string"
+        assert list(result["name"]) == ["a", pd.NA]
+
+    def test_string_dtype_roundtrip_all_nulls(self):
+        df = pd.DataFrame(
+            {
+                "name": pd.Series(
+                    [pd.NA, pd.NA],
+                    dtype=pd.StringDtype(),
+                )
+            }
+        )
+
+        result = ar.to_pandas(ar.from_pandas(df))
+
+        assert str(result["name"].dtype) == "string"
+        assert result["name"].isna().tolist() == [True, True]
+
+    def test_plain_object_string_column_behavior_unchanged(self):
+        df = pd.DataFrame({"name": ["a", "b"]}, dtype=object)
+
+        result = ar.to_pandas(ar.from_pandas(df))
+
+        assert list(result["name"]) == ["a", "b"]
+        assert str(result["name"].dtype) == "string"
 
     def test_nullable_int64_roundtrip_mixed_values(self):
         df = pd.DataFrame({"id": pd.Series([1, pd.NA, 3], dtype=pd.Int64Dtype())})
@@ -465,7 +503,6 @@ class TestDecimalConversion:
         )
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
-        # Result should be preserved as exact strings
         assert list(result["price"]) == ["19.99", "29.95", "15.50"]
         assert result["price"].dtype == "string"
 
@@ -521,10 +558,8 @@ class TestDecimalConversion:
         df = pd.DataFrame({"x": [1, 2]})
         df.attrs = {"meta": {"version": 1, "tags": ["a", "b"]}}
         frame = ar.from_pandas(df)
-        # mutate the original nested object
         df.attrs["meta"]["tags"].append("c")
         result = ar.to_pandas(frame)
-        # stored copy must be unaffected
         assert result.attrs["meta"]["tags"] == ["a", "b"]
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -26,7 +26,7 @@ class TestToPandas:
     def test_nulls_converted(self, csv_with_nulls):
         frame = ar.read_csv(csv_with_nulls)
         df = ar.to_pandas(frame)
-        assert df.isna().any().any()
+        assert df.isna().any().any()  # Should have some NaN/NA values
 
     def test_copy_option_returns_equivalent_dataframe(self, sample_csv):
         frame = ar.read_csv(sample_csv)
@@ -503,6 +503,7 @@ class TestDecimalConversion:
         )
         frame = ar.from_pandas(df)
         result = ar.to_pandas(frame)
+        # Result should be preserved as exact strings
         assert list(result["price"]) == ["19.99", "29.95", "15.50"]
         assert result["price"].dtype == "string"
 
@@ -558,8 +559,10 @@ class TestDecimalConversion:
         df = pd.DataFrame({"x": [1, 2]})
         df.attrs = {"meta": {"version": 1, "tags": ["a", "b"]}}
         frame = ar.from_pandas(df)
+        # mutate the original nested object
         df.attrs["meta"]["tags"].append("c")
         result = ar.to_pandas(frame)
+        # stored copy must be unaffected
         assert result.attrs["meta"]["tags"] == ["a", "b"]
 
 


### PR DESCRIPTION
## Summary

Adds focused regression coverage for pandas `StringDtype()` roundtrip behavior through `from_pandas()` → `to_pandas()` conversions.

This PR:

* adds regression tests for nullable string roundtrips
* verifies all-null string columns retain pandas string dtype
* verifies plain object/string column behavior remains unchanged

No implementation changes are included in this PR.

## Linked issue

Refs #243

## Type of change

* [ ] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash
python3 -m black tests/test_convert.py
pytest tests/test_convert.py
```

## Screenshots / Media

N/A

## Performance Impact

No expected performance impact.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Rebuilt cleanly from the latest upstream `main` branch to keep the PR focused only on StringDtype regression coverage and avoid unrelated merge/release changes.
