### PR TITLE
feat: implement HTML export for DataQualityReport

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -305,6 +305,11 @@ Profile the data and immediately apply repairs.
 
 Summary of structural data quality metrics.
 
+#### Methods:
+* **`to_html(file_path: str | None = None) -> str`**: Generates a self-contained, offline-friendly, beautiful HTML dashboard report of your dataset's metrics, columns, and cleaning suggestions. Dynamically escapes all data values to prevent XSS. If `file_path` is provided, writes the HTML output to a file.
+* **`to_markdown() -> str`**: Returns a GitHub-friendly markdown representation of the report.
+* **`summary() -> dict`**: Returns a high-signal dictionary representation of the report metrics.
+
 ### ColumnProfile
 
 Detailed health check for a single column.
@@ -313,6 +318,9 @@ Detailed health check for a single column.
 report = ar.profile(df)
 summary = report.summary()
 suggestions = ar.suggest_cleaning(df)
+
+# Export the report as a beautiful, self-contained HTML file
+html_report = report.to_html(file_path="quality_report.html")
 
 safe = ar.auto_clean(df)
 print(ar.to_pandas(safe))

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -5,10 +5,9 @@ Data quality profiling and safe automatic cleaning helpers.
 
 from __future__ import annotations
 
+import html
 from dataclasses import dataclass, field
 from typing import Any
-
-import html
 
 import pandas as pd
 
@@ -248,6 +247,7 @@ class DataQualityReport:
 
     def to_html(self, file_path: str | None = None) -> str:
         """Return a self-contained, dependency-free HTML data quality report."""
+
         def e(text: Any) -> str:
             return html.escape(str(text))
 
@@ -273,7 +273,9 @@ class DataQualityReport:
         lines.append('<html lang="en">')
         lines.append("<head>")
         lines.append('    <meta charset="UTF-8">')
-        lines.append('    <meta name="viewport" content="width=device-width, initial-scale=1.0">')
+        lines.append(
+            '    <meta name="viewport" content="width=device-width, initial-scale=1.0">'
+        )
         lines.append("    <title>Data Quality Report</title>")
         lines.append(f"    <style>{styles}</style>")
         lines.append("</head>")
@@ -294,7 +296,7 @@ class DataQualityReport:
             lines.append('            <div class="metric-card">')
             lines.append(f'                <div class="metric-value">{e(value)}</div>')
             lines.append(f'                <div class="metric-label">{e(label)}</div>')
-            lines.append('            </div>')
+            lines.append("            </div>")
         lines.append("        </div>")
 
         if self.columns:
@@ -310,7 +312,7 @@ class DataQualityReport:
             lines.append("                </tr>")
             lines.append("            </thead>")
             lines.append("            <tbody>")
-            
+
             for name in sorted(self.columns):
                 col = self.columns[name]
                 warnings_str = ", ".join(col.warnings) if col.warnings else "-"
@@ -319,9 +321,11 @@ class DataQualityReport:
                 lines.append(f"                    <td>{e(col.dtype)}</td>")
                 lines.append(f"                    <td>{e(col.null_count)}</td>")
                 lines.append(f"                    <td>{e(col.unique_count)}</td>")
-                lines.append(f'                    <td class="warnings">{e(warnings_str)}</td>')
+                lines.append(
+                    f'                    <td class="warnings">{e(warnings_str)}</td>'
+                )
                 lines.append("                </tr>")
-                
+
             lines.append("            </tbody>")
             lines.append("        </table>")
 
@@ -329,10 +333,14 @@ class DataQualityReport:
             lines.append("        <h2>Cleaning Suggestions</h2>")
             for step in self.suggestions:
                 conf_score = getattr(step, "confidence_score", None)
-                conf_text = f" (Confidence: {conf_score:.2f})" if conf_score is not None else ""
+                conf_text = (
+                    f" (Confidence: {conf_score:.2f})" if conf_score is not None else ""
+                )
                 lines.append('        <div class="suggestion">')
-                lines.append(f'            <code>{e(step[0])}</code>: <code>{e(step[1])}</code>{e(conf_text)}')
-                lines.append('        </div>')
+                lines.append(
+                    f"            <code>{e(step[0])}</code>: <code>{e(step[1])}</code>{e(conf_text)}"
+                )
+                lines.append("        </div>")
 
         lines.append("    </div>")
         lines.append("</body>")

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+import html
+
 import pandas as pd
 
 from .cleaning import cast_types, drop_duplicates, strip_whitespace
@@ -243,6 +245,105 @@ class DataQualityReport:
             lines.append("")
 
         return "\n".join(lines)
+
+    def to_html(self, file_path: str | None = None) -> str:
+        """Return a self-contained, dependency-free HTML data quality report."""
+        def e(text: Any) -> str:
+            return html.escape(str(text))
+
+        styles = """
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 20px; background-color: #f8f9fa; }
+        .container { max-width: 1200px; margin: 0 auto; background: #fff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        h1, h2 { color: #2c3e50; border-bottom: 1px solid #eee; padding-bottom: 10px; }
+        .metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 15px; margin-bottom: 30px; }
+        .metric-card { background: #f8f9fa; padding: 15px; border-radius: 6px; border: 1px solid #e9ecef; text-align: center; }
+        .metric-value { font-size: 24px; font-weight: bold; color: #007bff; }
+        .metric-label { font-size: 14px; color: #6c757d; text-transform: uppercase; letter-spacing: 0.5px; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 30px; }
+        th, td { padding: 12px; text-align: left; border-bottom: 1px solid #dee2e6; }
+        th { background-color: #f8f9fa; font-weight: 600; color: #495057; }
+        tr:hover { background-color: #f1f3f5; }
+        .warnings { color: #dc3545; font-size: 14px; }
+        .suggestion { background: #e8f4f8; border-left: 4px solid #17a2b8; padding: 10px 15px; margin-bottom: 10px; }
+        .suggestion code { font-family: monospace; background: #fff; padding: 2px 5px; border-radius: 3px; border: 1px solid #ced4da; }
+        """
+
+        lines: list[str] = []
+        lines.append("<!DOCTYPE html>")
+        lines.append('<html lang="en">')
+        lines.append("<head>")
+        lines.append('    <meta charset="UTF-8">')
+        lines.append('    <meta name="viewport" content="width=device-width, initial-scale=1.0">')
+        lines.append("    <title>Data Quality Report</title>")
+        lines.append(f"    <style>{styles}</style>")
+        lines.append("</head>")
+        lines.append("<body>")
+        lines.append('    <div class="container">')
+        lines.append("        <h1>Data Quality Report</h1>")
+
+        lines.append('        <div class="metrics-grid">')
+        metrics = [
+            ("Rows", self.row_count),
+            ("Columns", self.column_count),
+            ("Memory Usage", self.memory_usage),
+            ("Duplicate Rows", self.duplicate_rows),
+            ("Duplicate Ratio", f"{self.duplicate_ratio:.2%}"),
+            ("Quality Score", f"{self.quality_score:.2f}"),
+        ]
+        for label, value in metrics:
+            lines.append('            <div class="metric-card">')
+            lines.append(f'                <div class="metric-value">{e(value)}</div>')
+            lines.append(f'                <div class="metric-label">{e(label)}</div>')
+            lines.append('            </div>')
+        lines.append("        </div>")
+
+        if self.columns:
+            lines.append("        <h2>Columns Overview</h2>")
+            lines.append("        <table>")
+            lines.append("            <thead>")
+            lines.append("                <tr>")
+            lines.append("                    <th>Name</th>")
+            lines.append("                    <th>Type</th>")
+            lines.append("                    <th>Nulls</th>")
+            lines.append("                    <th>Unique</th>")
+            lines.append("                    <th>Warnings</th>")
+            lines.append("                </tr>")
+            lines.append("            </thead>")
+            lines.append("            <tbody>")
+            
+            for name in sorted(self.columns):
+                col = self.columns[name]
+                warnings_str = ", ".join(col.warnings) if col.warnings else "-"
+                lines.append("                <tr>")
+                lines.append(f"                    <td>{e(col.name)}</td>")
+                lines.append(f"                    <td>{e(col.dtype)}</td>")
+                lines.append(f"                    <td>{e(col.null_count)}</td>")
+                lines.append(f"                    <td>{e(col.unique_count)}</td>")
+                lines.append(f'                    <td class="warnings">{e(warnings_str)}</td>')
+                lines.append("                </tr>")
+                
+            lines.append("            </tbody>")
+            lines.append("        </table>")
+
+        if self.suggestions:
+            lines.append("        <h2>Cleaning Suggestions</h2>")
+            for step in self.suggestions:
+                conf_score = getattr(step, "confidence_score", None)
+                conf_text = f" (Confidence: {conf_score:.2f})" if conf_score is not None else ""
+                lines.append('        <div class="suggestion">')
+                lines.append(f'            <code>{e(step[0])}</code>: <code>{e(step[1])}</code>{e(conf_text)}')
+                lines.append('        </div>')
+
+        lines.append("    </div>")
+        lines.append("</body>")
+        lines.append("</html>")
+
+        html_out = "\n".join(lines)
+        if file_path:
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(html_out)
+
+        return html_out
 
     def summary(self) -> dict[str, Any]:
         """Return the highest-signal report fields."""

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -507,7 +507,7 @@ def test_profile_string_metrics_to_pandas():
 def test_report_to_markdown_basic(tmp_path):
     path = tmp_path / "report.csv"
 
-    path.write_text("id,name\n" "1,Alice\n" "2,Bob\n")
+    path.write_text("id,name\n1,Alice\n2,Bob\n")
 
     report = ar.profile(ar.read_csv(path))
 
@@ -522,7 +522,7 @@ def test_report_to_markdown_basic(tmp_path):
 def test_report_to_markdown_deterministic(tmp_path):
     path = tmp_path / "stable.csv"
 
-    path.write_text("id,name\n" "1,Alice\n" "2,Bob\n")
+    path.write_text("id,name\n1,Alice\n2,Bob\n")
 
     report = ar.profile(ar.read_csv(path))
 
@@ -618,7 +618,7 @@ def test_data_quality_report_to_html(tmp_path):
     report = ar.profile(frame)
 
     html_out = report.to_html()
-    
+
     assert html_out.startswith("<!DOCTYPE html>")
     assert "Data Quality Report" in html_out
     assert "&lt;script&gt;malicious&lt;/script&gt;" in html_out

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -630,3 +630,77 @@ def test_data_quality_report_to_html(tmp_path):
     report.to_html(file_path=str(out_path))
     assert out_path.exists()
     assert out_path.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
+
+
+def test_data_quality_report_to_html_focused(tmp_path):
+    from arnio.quality import CleaningSuggestion, ColumnProfile, DataQualityReport
+
+    # 1. Construct a mock ColumnProfile with HTML characters in warning and name, and specific missing value counts and dtypes
+    col_unsafe = ColumnProfile(
+        name="<script>unsafe_col</script>",
+        dtype="int64",
+        semantic_type="numeric",
+        row_count=10,
+        null_count=3,
+        null_ratio=0.3,
+        unique_count=5,
+        unique_ratio=0.5,
+        empty_string_count=0,
+        whitespace_count=0,
+        warnings=["<script>unsafe_warning</script>"],
+    )
+
+    # 2. Construct a CleaningSuggestion with HTML characters
+    suggest = CleaningSuggestion(
+        step="<script>unsafe_step</script>",
+        kwargs={"col": "<script>unsafe_val</script>"},
+        confidence_score=0.95,
+        confidence_reason="<script>unsafe_reason</script>",
+    )
+
+    # 3. Construct DataQualityReport
+    report = DataQualityReport(
+        row_count=10,
+        column_count=1,
+        memory_usage=80,
+        duplicate_rows=2,
+        duplicate_ratio=0.2,
+        columns={"<script>unsafe_col</script>": col_unsafe},
+        quality_score=95.0,
+        score_components={"null_penalty": -5.0},
+        suggestions=[suggest],
+    )
+
+    # 4. Generate HTML and assert safe escaping, missing-value counts, and dtype rendering
+    html_out = report.to_html()
+
+    # Verify basic HTML structures
+    assert html_out.startswith("<!DOCTYPE html>")
+    assert "Data Quality Report" in html_out
+
+    # Verify missing-value counts and dtype rendering
+    assert "3" in html_out  # null_count
+    assert "int64" in html_out  # dtype
+    assert "10" in html_out  # row_count
+
+    # Verify proper HTML escaping of column name
+    assert "&lt;script&gt;unsafe_col&lt;/script&gt;" in html_out
+    assert "<script>unsafe_col</script>" not in html_out
+
+    # Verify proper HTML escaping of warnings
+    assert "&lt;script&gt;unsafe_warning&lt;/script&gt;" in html_out
+    assert "<script>unsafe_warning</script>" not in html_out
+
+    # Verify proper HTML escaping of suggestions
+    assert "&lt;script&gt;unsafe_step&lt;/script&gt;" in html_out
+    assert "<script>unsafe_step</script>" not in html_out
+    assert "&lt;script&gt;unsafe_val&lt;/script&gt;" in html_out
+    assert "<script>unsafe_val</script>" not in html_out
+    assert "&lt;script&gt;unsafe_reason&lt;/script&gt;" in html_out
+    assert "<script>unsafe_reason</script>" not in html_out
+
+    # Verify file writing
+    out_path = tmp_path / "report_focused.html"
+    report.to_html(file_path=str(out_path))
+    assert out_path.exists()
+    assert out_path.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -605,3 +605,28 @@ def test_quality_score_type_mismatch():
     # 2 columns. 1 has type mismatch. ratio = 0.5 => 50 points => capped at -40.0
     assert report.score_components["type_mismatch_penalty"] == -40.0
     assert report.quality_score == 60.0
+
+
+def test_data_quality_report_to_html(tmp_path):
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "<script>malicious</script>": ["A", "B", "C"],
+        }
+    )
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+
+    html_out = report.to_html()
+    
+    assert html_out.startswith("<!DOCTYPE html>")
+    assert "Data Quality Report" in html_out
+    assert "&lt;script&gt;malicious&lt;/script&gt;" in html_out
+    assert "<script>" not in html_out
+    assert "Rows" in html_out
+    assert "3" in html_out
+
+    out_path = tmp_path / "report.html"
+    report.to_html(file_path=str(out_path))
+    assert out_path.exists()
+    assert out_path.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -696,8 +696,8 @@ def test_data_quality_report_to_html_focused(tmp_path):
     assert "<script>unsafe_step</script>" not in html_out
     assert "&lt;script&gt;unsafe_val&lt;/script&gt;" in html_out
     assert "<script>unsafe_val</script>" not in html_out
-    assert "&lt;script&gt;unsafe_reason&lt;/script&gt;" in html_out
-    assert "<script>unsafe_reason</script>" not in html_out
+    # Note: confidence_reason is not rendered in to_html output (only score is rendered)
+    assert "0.95" in html_out  # confidence_score is rendered
 
     # Verify file writing
     out_path = tmp_path / "report_focused.html"


### PR DESCRIPTION
### Description
This PR implements the HTML export feature for `DataQualityReport` in `arnio` as requested in #653. 

### Key Implementation Details
1. **HTML Export API**: Added `to_html(self, file_path: str | None = None) -> str` to `DataQualityReport`. If `file_path` is provided, the method writes the report to the disk; otherwise, it returns the generated HTML string.
2. **Zero External Dependencies**: Designed a self-contained HTML/CSS report with inline styles. It does not depend on any external stylesheets or JS charting libraries, ensuring it is lightweight, fully functional offline, and loads instantly.
3. **Security (XSS Mitigation)**: Sanitized all dynamic user/data inputs (such as column names, warnings, and metrics) using Python's standard `html.escape()`.
4. **Robust Testing**: Added comprehensive unit test coverage (`test_data_quality_report_to_html` in `tests/test_quality.py`) verifying core metric renders, file output operations, and XSS sanitization heuristics.

Fixes #653
