### PR TITLE
ci: add Python 3.14 smoke test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,29 @@ jobs:
           file: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  python314_smoke:
+    name: Python 3.14 Smoke Test
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: 'pip'
+
+      - name: Upgrade pip and setuptools
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install dependencies and arnio
+        run: |
+          pip install -e .[dev]
+
+      - name: Run smoke test
+        run: |
+          python -c "import arnio; print('arnio import OK')"


### PR DESCRIPTION
## Summary

Adds a lightweight Ubuntu-only Python 3.14 compatibility/smoke CI job.

This avoids expanding the existing full OS/Python test matrix while still providing early visibility into Python 3.14 compatibility.

## Linked issue

Fixes #677

## Type of change

* [x] CI / packaging

## Area

* [x] Developer tooling

## Testing

* [x] Other:

```bash
python -m pytest tests/test_schema.py
```

Result:

* 55 tests passed locally

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

* Adds a separate Linux-only Python 3.14 smoke test job
* Keeps the existing test matrix unchanged
* Uses `continue-on-error: true` for initial compatibility validation
