### PR TITLE
feat: add explain=True mode to auto_clean with structured CleanExplanation

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -47,6 +47,8 @@ from .integrations import ArnioPandasAccessor
 from .io import read_csv, scan_csv, write_csv
 from .pipeline import pipeline, register_step
 from .quality import (
+    CleanExplanation,
+    CleanStepRecord,
     ColumnProfile,
     DataQualityReport,
     ProfileComparison,
@@ -125,6 +127,8 @@ __all__ = [
     "auto_clean",
     "ColumnProfile",
     "DataQualityReport",
+    "CleanStepRecord",
+    "CleanExplanation",
     "ProfileComparison",
     "QualityGateIssue",
     "QualityGateResult",

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1345,6 +1345,60 @@ def suggest_cleaning(
     return suggestions
 
 
+@dataclass(frozen=True)
+class CleanStepRecord:
+    """Audit record for a single step applied by auto_clean."""
+
+    step: str
+    """Name of the cleaning step (e.g. ``strip_whitespace``)."""
+    kwargs: dict[str, Any]
+    """Keyword arguments passed to the step."""
+    rows_before: int
+    """Row count before this step was applied."""
+    rows_after: int
+    """Row count after this step was applied."""
+    rows_removed: int
+    """Number of rows removed by this step (0 for non-row-dropping steps)."""
+    reason: str
+    """Human-readable explanation of why this step was selected."""
+
+
+@dataclass(frozen=True)
+class CleanExplanation:
+    """Structured audit trail returned by ``auto_clean`` when ``explain=True``.
+
+    This object captures a before-and-after summary of every cleaning step
+    that was applied, making it easy to audit, log, or display what
+    ``auto_clean`` changed and why.
+    """
+
+    mode: str
+    """The cleaning mode that was used (``'safe'`` or ``'strict'``)."""
+    rows_before: int
+    """Total row count before any cleaning."""
+    rows_after: int
+    """Total row count after all cleaning steps."""
+    rows_removed: int
+    """Total rows removed across all steps."""
+    steps: list[CleanStepRecord]
+    """Ordered list of steps that were actually applied."""
+
+    def __str__(self) -> str:
+        lines: list[str] = [
+            f"CleanExplanation(mode={self.mode!r})",
+            f"  rows : {self.rows_before} -> {self.rows_after} ({self.rows_removed} removed)",
+            f"  steps applied ({len(self.steps)}):",
+        ]
+        for rec in self.steps:
+            lines.append(
+                f"    [{rec.step}] rows {rec.rows_before}->{rec.rows_after} "
+                f"(-{rec.rows_removed}) | reason: {rec.reason}"
+            )
+        if not self.steps:
+            lines.append("    (none)")
+        return "\n".join(lines)
+
+
 def auto_clean(
     frame: ArFrame,
     *,
@@ -1352,7 +1406,14 @@ def auto_clean(
     return_report: bool = False,
     dry_run: bool = False,
     allow_lossy_casts: bool = False,
-) -> ArFrame | DataQualityReport | tuple[ArFrame, DataQualityReport]:
+    explain: bool = False,
+) -> (
+    ArFrame
+    | DataQualityReport
+    | tuple[ArFrame, DataQualityReport]
+    | tuple[ArFrame, CleanExplanation]
+    | tuple[ArFrame, DataQualityReport, CleanExplanation]
+):
     """Apply built-in automatic cleaning.
 
     Parameters
@@ -1368,17 +1429,33 @@ def auto_clean(
         Return the proposed pre-cleaning report without mutating the frame.
     allow_lossy_casts : bool, default False
         Required before strict mode applies suggested type casts.
+    explain : bool, default False
+        When ``True``, return a :class:`CleanExplanation` object that records
+        which steps ran, before/after row counts for each step, and why each
+        step was selected. The cleaned frame is always the first element in the
+        returned tuple.
 
     Returns
     -------
-    ArFrame, DataQualityReport, or tuple[ArFrame, DataQualityReport]
-        Cleaned frame, the dry-run report, or a frame/report tuple.
+    ArFrame
+        Cleaned frame (when *return_report*, *dry_run*, and *explain* are all ``False``).
+    DataQualityReport
+        When *dry_run* is ``True`` and *return_report* is ``False``.
+    tuple[ArFrame, DataQualityReport]
+        When only *return_report* is ``True``.
+    tuple[ArFrame, CleanExplanation]
+        When only *explain* is ``True``.
+    tuple[ArFrame, DataQualityReport, CleanExplanation]
+        When both *return_report* and *explain* are ``True``.
 
     Examples
     --------
     >>> clean = ar.auto_clean(frame)
     >>> report = ar.auto_clean(frame, mode="strict", dry_run=True)
     >>> clean = ar.auto_clean(frame, mode="strict", allow_lossy_casts=True)
+    >>> clean, report = ar.auto_clean(frame, mode="strict", return_report=True)
+    >>> clean, explanation = ar.auto_clean(frame, explain=True)
+    >>> print(explanation)
     """
     if mode not in {"safe", "strict"}:
         raise ValueError("mode must be 'safe' or 'strict'")
@@ -1387,6 +1464,11 @@ def auto_clean(
         raise TypeError("dry_run must be a bool")
     if not isinstance(allow_lossy_casts, bool):
         raise TypeError("allow_lossy_casts must be a bool")
+    if not isinstance(explain, bool):
+        raise TypeError("explain must be a bool")
+
+    if dry_run and explain:
+        raise ValueError("explain=True cannot be used with dry_run=True")
 
     report = profile(frame)
     if dry_run:
@@ -1395,10 +1477,23 @@ def auto_clean(
         return report
 
     result = frame
+    step_records: list[CleanStepRecord] = []
+    rows_before_all = result.shape[0]
 
-    for step, kwargs in report.suggestions:
+    for suggestion in report.suggestions:
+        if isinstance(suggestion, CleaningSuggestion):
+            step = suggestion.step
+            kwargs = suggestion.kwargs
+            reason = suggestion.confidence_reason
+        else:
+            step, kwargs = suggestion
+            reason = step
+
         if mode == "safe" and step != "strip_whitespace":
             continue
+
+        rows_before_step = result.shape[0]
+
         if step == "strip_whitespace":
             result = strip_whitespace(result, **kwargs)
         elif step == "cast_types":
@@ -1411,6 +1506,34 @@ def auto_clean(
             result = cast_types(result, kwargs)
         elif step == "drop_duplicates":
             result = drop_duplicates(result, **kwargs)
+        else:
+            continue
+
+        rows_after_step = result.shape[0]
+        step_records.append(
+            CleanStepRecord(
+                step=step,
+                kwargs=kwargs,
+                rows_before=rows_before_step,
+                rows_after=rows_after_step,
+                rows_removed=rows_before_step - rows_after_step,
+                reason=reason,
+            )
+        )
+
+    rows_after_all = result.shape[0]
+
+    if explain:
+        explanation = CleanExplanation(
+            mode=mode,
+            rows_before=rows_before_all,
+            rows_after=rows_after_all,
+            rows_removed=rows_before_all - rows_after_all,
+            steps=step_records,
+        )
+        if return_report:
+            return result, report, explanation
+        return result, explanation
 
     if return_report:
         return result, report

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -960,3 +960,148 @@ def test_data_quality_report_repr_html_snippet():
     assert "Data Quality Report" in html_out
     assert "&lt;script&gt;unsafe_col&lt;/script&gt;" in html_out
     assert "<script>unsafe_col</script>" not in html_out
+
+
+# ── explain mode tests ────────────────────────────────────────────────────────
+
+
+def test_auto_clean_explain_normal_clean(tmp_path):
+    """Normal auto_clean with explain=False and return_report=False should return ArFrame."""
+    path = tmp_path / "data.csv"
+    path.write_text("id,name\n1, Alice \n2, Bob \n")
+    frame = ar.read_csv(path)
+
+    result = ar.auto_clean(frame, explain=False, return_report=False)
+    assert isinstance(result, ar.ArFrame)
+
+
+def test_auto_clean_explain_return_report_only(tmp_path):
+    """return_report=True and explain=False should return (ArFrame, DataQualityReport)."""
+    path = tmp_path / "data.csv"
+    path.write_text("id,name\n1, Alice \n2, Bob \n")
+    frame = ar.read_csv(path)
+
+    result = ar.auto_clean(frame, explain=False, return_report=True)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    cleaned, report = result
+    assert isinstance(cleaned, ar.ArFrame)
+    assert isinstance(report, ar.DataQualityReport)
+
+
+def test_auto_clean_explain_returns_tuple(tmp_path):
+    """explain=True and return_report=False should return (ArFrame, CleanExplanation)."""
+    path = tmp_path / "data.csv"
+    path.write_text("id,name\n1, Alice \n2, Alice \n")
+    frame = ar.read_csv(path)
+
+    result = ar.auto_clean(frame, mode="strict", explain=True, allow_lossy_casts=True)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    cleaned, explanation = result
+    assert isinstance(cleaned, ar.ArFrame)
+    assert isinstance(explanation, ar.CleanExplanation)
+
+
+def test_auto_clean_explain_row_counts(tmp_path):
+    """CleanExplanation rows_before/after/removed should be accurate."""
+    path = tmp_path / "dups.csv"
+    path.write_text("id,name\n1,Alice\n1,Alice\n2,Bob\n")
+    frame = ar.read_csv(path)
+
+    cleaned, explanation = ar.auto_clean(
+        frame, mode="strict", explain=True, allow_lossy_casts=True
+    )
+
+    assert explanation.rows_before == 3
+    assert explanation.rows_after == 2
+    assert explanation.rows_removed == 1
+    assert explanation.mode == "strict"
+
+
+def test_auto_clean_explain_steps_recorded(tmp_path):
+    """Each applied step should produce a CleanStepRecord."""
+    path = tmp_path / "ws.csv"
+    path.write_text("id,name\n1, Alice \n2, Bob \n")
+    frame = ar.read_csv(path)
+
+    cleaned, explanation = ar.auto_clean(
+        frame, mode="safe", explain=True, allow_lossy_casts=True
+    )
+
+    assert len(explanation.steps) >= 1
+    step = explanation.steps[0]
+    assert isinstance(step, ar.CleanStepRecord)
+    assert step.step == "strip_whitespace"
+    assert step.rows_before == 2
+    assert step.rows_after == 2
+    assert step.rows_removed == 0
+    assert isinstance(step.reason, str)
+    assert len(step.reason) > 0
+
+
+def test_auto_clean_explain_with_return_report(tmp_path):
+    """explain=True and return_report=True should return (ArFrame, DataQualityReport, CleanExplanation)."""
+    path = tmp_path / "data.csv"
+    path.write_text("id,name\n1, Alice \n2, Bob \n")
+    frame = ar.read_csv(path)
+
+    result = ar.auto_clean(
+        frame,
+        mode="safe",
+        return_report=True,
+        explain=True,
+        allow_lossy_casts=True,
+    )
+
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+    cleaned, report, explanation = result
+    assert isinstance(cleaned, ar.ArFrame)
+    assert isinstance(report, ar.DataQualityReport)
+    assert isinstance(explanation, ar.CleanExplanation)
+
+
+def test_auto_clean_explain_no_steps_clean_data(tmp_path):
+    """A perfectly clean dataset should result in zero steps applied."""
+    path = tmp_path / "clean.csv"
+    path.write_text("id,name\n1,Alice\n2,Bob\n")
+    frame = ar.read_csv(path)
+
+    cleaned, explanation = ar.auto_clean(
+        frame, mode="strict", explain=True, allow_lossy_casts=True
+    )
+
+    assert explanation.rows_removed == 0
+    assert explanation.rows_before == explanation.rows_after
+
+
+def test_auto_clean_explain_str_representation(tmp_path):
+    """CleanExplanation __str__ should be human-readable."""
+    path = tmp_path / "ws.csv"
+    path.write_text("id,name\n1, Alice \n2, Bob \n")
+    frame = ar.read_csv(path)
+
+    _, explanation = ar.auto_clean(
+        frame, mode="safe", explain=True, allow_lossy_casts=True
+    )
+    text = str(explanation)
+
+    assert "CleanExplanation" in text
+    assert "rows" in text
+    assert "steps applied" in text
+
+
+def test_auto_clean_explain_dry_run_error(tmp_path):
+    """Using explain=True with dry_run=True should raise a ValueError."""
+    path = tmp_path / "data.csv"
+    path.write_text("id,name\n1,Alice\n2,Bob\n")
+    frame = ar.read_csv(path)
+
+    import pytest
+
+    with pytest.raises(
+        ValueError, match="explain=True cannot be used with dry_run=True"
+    ):
+        ar.auto_clean(frame, explain=True, dry_run=True)


### PR DESCRIPTION
Closes #649

## What this PR does
Adds an opt-in `explain=True` parameter to `auto_clean()` that returns a structured `CleanExplanation` object instead of silently cleaning.

## New public API

```python
# Basic explain mode
clean, explanation = ar.auto_clean(frame, explain=True)
print(explanation)

# With report too
clean, report, explanation = ar.auto_clean(frame, return_report=True, explain=True)
