### PR TITLE
Add uniqueness metrics to quality markdown report

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -139,9 +139,11 @@ class DataQualityReport:
             lines.append("## Columns")
             lines.append("")
 
-            lines.append("| Name | Dtype | Semantic Type | Nulls | Unique | Warnings |")
+            lines.append(
+                "| Name | Dtype | Semantic Type | Nulls | Unique Count | Unique Ratio | Warnings |"
+            )
 
-            lines.append("|---|---|---|---|---|---|")
+            lines.append("|---|---|---|---|---|---|---|")
 
             for name in sorted(self.columns):
                 column = self.columns[name]
@@ -154,6 +156,7 @@ class DataQualityReport:
                     f"| {column.semantic_type} "
                     f"| {column.null_count} "
                     f"| {column.unique_count} "
+                    f"| {column.unique_ratio:.2%} "
                     f"| {warnings} |"
                 )
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -400,6 +400,35 @@ def test_report_to_markdown_basic(tmp_path):
     assert "| id | int64 | identifier |" in md
 
 
+def test_report_to_markdown_includes_uniqueness_metrics(tmp_path):
+    path = tmp_path / "unique_metrics.csv"
+
+    path.write_text("id,name\n" "1,Alice\n" "2,Bob\n" "2,Bob\n")
+
+    report = ar.profile(ar.read_csv(path))
+
+    md = report.to_markdown()
+
+    assert "Unique Count" in md
+    assert "Unique Ratio" in md
+
+    # id column: 2 unique non-null values across 3 rows
+    assert "66.67%" in md
+
+
+def test_unique_ratio_empty_column(tmp_path):
+    path = tmp_path / "empty_unique.csv"
+
+    path.write_text("name\n\n\n")
+
+    report = ar.profile(ar.read_csv(path))
+
+    column = report.columns["name"]
+
+    assert column.unique_count >= 0
+    assert column.unique_ratio >= 0.0
+
+
 def test_report_to_markdown_deterministic(tmp_path):
     path = tmp_path / "stable.csv"
 


### PR DESCRIPTION
## Summary
* Add unique count and unique ratio columns to DataQualityReport.to_markdown()
* Add focused markdown tests for uniqueness metrics
* Preserve existing report structure and behavior

## Linked issue
Fixes #171 

## Type of change
- [x] Feature
- [x] Tests

## Area
- [x] Data quality / profiling

## Testing
- [x] Other:

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
None.
