### PR TITLE
ci: add notebook execution smoke test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,33 @@ jobs:
       - name: Run smoke test
         run: |
           python -c "import arnio; print('arnio import OK')"
+
+  notebook_smoke:
+    name: Notebook Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -e .[dev]
+          pip install jupyter nbconvert ipykernel
+
+      - name: Execute notebook
+        run: |
+          jupyter nbconvert \
+            --to notebook \
+            --execute \
+            --ExecutePreprocessor.timeout=300 \
+            examples/financial_csv_example.ipynb \
+            --output executed_notebook.ipynb
+            


### PR DESCRIPTION
## Summary

Adds a lightweight Linux-only notebook execution smoke CI job for example notebooks.

The new job installs notebook execution dependencies only inside the notebook smoke job and executes `examples/financial_csv_example.ipynb` headlessly in CI without modifying notebook contents or metadata.

## Linked issue

Fixes #678

## Type of change

* [x] CI / packaging

## Area

* [x] Developer tooling

## Testing

* [x] Other:

```bash
python -m pytest tests/test_schema.py
```

Result:

* existing local tests passed
* notebook execution validated through CI workflow

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

* Adds a separate Linux-only notebook smoke test job
* Keeps the existing CI test matrix unchanged
* Installs notebook execution dependencies only inside the notebook job
* Executes the example notebook without overwriting notebook contents/metadata
