### PR TITLE
ci: add ASAN workflow for native C++ checks

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/asan-workflow   # temporary for testing (remove before PR)
+      - feat/asan-workflow   # remove before final PR
 
 jobs:
   asan:
@@ -39,7 +39,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install scikit-build-core cmake ninja
+          pip install scikit-build-core cmake ninja pybind11
 
       - name: Install project
         run: |

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -2,6 +2,9 @@ name: ASAN Checks
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - feat/asan-workflow   
 
 jobs:
   asan:

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,10 +1,7 @@
 name: ASAN Checks
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - feat/asan-workflow   
+  workflow_dispatch:  
 
 jobs:
   asan:

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -26,14 +26,14 @@ jobs:
 
       - name: Set ASAN and CMake flags
         run: |
-          echo "CC=clang"                                              >> $GITHUB_ENV
-          echo "CXX=clang++"                                          >> $GITHUB_ENV
-          echo "CMAKE_CXX_FLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
-          echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address"         >> $GITHUB_ENV
-          echo "CMAKE_EXE_LINKER_FLAGS=-fsanitize=address"            >> $GITHUB_ENV
-          echo "ASAN_OPTIONS=detect_leaks=0:abort_on_error=1"         >> $GITHUB_ENV
-          echo "PYTHONMALLOC=malloc"                                  >> $GITHUB_ENV
-          echo "PYTHONFAULTHANDLER=1"                                 >> $GITHUB_ENV
+          echo "CC=clang"                                                        >> $GITHUB_ENV
+          echo "CXX=clang++"                                                     >> $GITHUB_ENV
+          echo "CMAKE_CXX_FLAGS=-fsanitize=address -fno-omit-frame-pointer"      >> $GITHUB_ENV
+          echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address"                    >> $GITHUB_ENV
+          echo "CMAKE_EXE_LINKER_FLAGS=-fsanitize=address"                       >> $GITHUB_ENV
+          echo "ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:log_path=/tmp/asan.log" >> $GITHUB_ENV
+          echo "PYTHONMALLOC=malloc"                                              >> $GITHUB_ENV
+          echo "PYTHONFAULTHANDLER=1"                                             >> $GITHUB_ENV
 
       - name: Install build dependencies
         run: |
@@ -51,9 +51,19 @@ jobs:
             ASAN_LIB=$(find /usr/lib/llvm-*/lib /usr/lib/x86_64-linux-gnu \
               -name "libasan.so*" 2>/dev/null | head -1)
           fi
-          echo "Resolved: $ASAN_LIB"
+          echo "Resolved ASAN lib: $ASAN_LIB"
           echo "LD_PRELOAD=$ASAN_LIB" >> $GITHUB_ENV
 
       - name: Run tests with ASAN
         run: |
           pytest tests/ -v -k "not benchmark"
+
+      - name: Print ASAN report (if any)
+        if: always()
+        run: |
+          if ls /tmp/asan.log.* 2>/dev/null; then
+            echo "===== ASAN REPORT ====="
+            cat /tmp/asan.log.*
+          else
+            echo "No ASAN log files found."
+          fi

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/asan-workflow   # remove before final PR
+      - feat/asan-workflow   # remove later
 
 jobs:
   asan:
@@ -44,6 +44,10 @@ jobs:
       - name: Install project
         run: |
           pip install -e ".[dev]" --no-build-isolation
+
+      - name: Preload ASAN runtime
+        run: |
+          echo "LD_PRELOAD=$(clang -print-file-name=libasan.so)" >> $GITHUB_ENV
 
       - name: Run tests (ASAN enabled)
         run: |

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,7 +1,10 @@
 name: ASAN Checks
 
 on:
-  workflow_dispatch:  
+  workflow_dispatch:
+  push:
+    branches:
+      - feat/asan-workflow
 
 jobs:
   asan:
@@ -23,14 +26,14 @@ jobs:
 
       - name: Set ASAN and CMake flags
         run: |
-          echo "CC=clang"                                                        >> $GITHUB_ENV
-          echo "CXX=clang++"                                                     >> $GITHUB_ENV
-          echo "CMAKE_CXX_FLAGS=-fsanitize=address -fno-omit-frame-pointer"      >> $GITHUB_ENV
-          echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address"                    >> $GITHUB_ENV
-          echo "CMAKE_EXE_LINKER_FLAGS=-fsanitize=address"                       >> $GITHUB_ENV
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CMAKE_CXX_FLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
+          echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address" >> $GITHUB_ENV
+          echo "CMAKE_EXE_LINKER_FLAGS=-fsanitize=address" >> $GITHUB_ENV
           echo "ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:log_path=/tmp/asan.log" >> $GITHUB_ENV
-          echo "PYTHONMALLOC=malloc"                                              >> $GITHUB_ENV
-          echo "PYTHONFAULTHANDLER=1"                                             >> $GITHUB_ENV
+          echo "PYTHONMALLOC=malloc" >> $GITHUB_ENV
+          echo "PYTHONFAULTHANDLER=1" >> $GITHUB_ENV
 
       - name: Install build dependencies
         run: |
@@ -52,6 +55,7 @@ jobs:
           echo "LD_PRELOAD=$ASAN_LIB" >> $GITHUB_ENV
 
       - name: Run tests with ASAN
+        continue-on-error: true
         run: |
           pytest tests/ -v -k "not benchmark"
 

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -2,9 +2,9 @@ name: ASAN Checks
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - feat/asan-workflow
+  pull_request:
+    paths:
+      - '.github/workflows/asan.yml'
 
 jobs:
   asan:
@@ -40,7 +40,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install scikit-build-core cmake ninja pybind11
 
-      - name: Install project with ASAN instrumentation
+      - name: Install project
         run: |
           pip install -e ".[dev]" --no-build-isolation
 
@@ -51,15 +51,13 @@ jobs:
             ASAN_LIB=$(find /usr/lib/llvm-*/lib /usr/lib/x86_64-linux-gnu \
               -name "libasan.so*" 2>/dev/null | head -1)
           fi
-          echo "Resolved ASAN lib: $ASAN_LIB"
           echo "LD_PRELOAD=$ASAN_LIB" >> $GITHUB_ENV
 
       - name: Run tests with ASAN
-        continue-on-error: true
         run: |
           pytest tests/ -v -k "not benchmark"
 
-      - name: Print ASAN report (if any)
+      - name: Print ASAN report
         if: always()
         run: |
           if ls /tmp/asan.log.* 2>/dev/null; then
@@ -68,3 +66,4 @@ jobs:
           else
             echo "No ASAN log files found."
           fi
+

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -2,6 +2,9 @@ name: ASAN Checks
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - feat/asan-workflow
 
 jobs:
   asan:

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/asan-workflow   # temporary for testing (remove later)
+      - feat/asan-workflow   # temporary for testing (remove before PR)
 
 jobs:
   asan:
@@ -36,9 +36,13 @@ jobs:
           echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address" >> $GITHUB_ENV
           echo "ASAN_OPTIONS=detect_leaks=1:abort_on_error=1" >> $GITHUB_ENV
 
-      - name: Install project
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install scikit-build-core cmake ninja
+
+      - name: Install project
+        run: |
           pip install -e ".[dev]" --no-build-isolation
 
       - name: Run tests (ASAN enabled)

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,40 @@
+name: ASAN Checks
+
+on:
+  workflow_dispatch:
+
+jobs:
+  asan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang build-essential
+
+      - name: Set ASAN environment variables
+        run: |
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CFLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
+          echo "CXXFLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
+          echo "LDFLAGS=-fsanitize=address" >> $GITHUB_ENV
+          echo "ASAN_OPTIONS=detect_leaks=1:abort_on_error=1" >> $GITHUB_ENV
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests (ASAN enabled)
+        run: |
+          pytest tests/ -v

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feat/asan-workflow
+      - feat/asan-workflow   # temporary for testing (remove later)
 
 jobs:
   asan:
@@ -24,20 +24,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang build-essential
 
-      - name: Set ASAN environment variables
+      - name: Set ASAN + CMake flags
         run: |
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
           echo "CFLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
           echo "CXXFLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
           echo "LDFLAGS=-fsanitize=address" >> $GITHUB_ENV
+          echo "CMAKE_CXX_FLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
+          echo "CMAKE_EXE_LINKER_FLAGS=-fsanitize=address" >> $GITHUB_ENV
+          echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address" >> $GITHUB_ENV
           echo "ASAN_OPTIONS=detect_leaks=1:abort_on_error=1" >> $GITHUB_ENV
 
       - name: Install project
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev]" --no-build-isolation
 
       - name: Run tests (ASAN enabled)
         run: |
-          pytest tests/ -v
+          pytest tests/ -v -k "not benchmark"

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -2,9 +2,6 @@ name: ASAN Checks
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - feat/asan-workflow   # remove later
 
 jobs:
   asan:
@@ -24,31 +21,36 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang build-essential
 
-      - name: Set ASAN + CMake flags
+      - name: Set ASAN and CMake flags
         run: |
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
-          echo "CFLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
-          echo "CXXFLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
-          echo "LDFLAGS=-fsanitize=address" >> $GITHUB_ENV
+          echo "CC=clang"                                              >> $GITHUB_ENV
+          echo "CXX=clang++"                                          >> $GITHUB_ENV
           echo "CMAKE_CXX_FLAGS=-fsanitize=address -fno-omit-frame-pointer" >> $GITHUB_ENV
-          echo "CMAKE_EXE_LINKER_FLAGS=-fsanitize=address" >> $GITHUB_ENV
-          echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address" >> $GITHUB_ENV
-          echo "ASAN_OPTIONS=detect_leaks=1:abort_on_error=1" >> $GITHUB_ENV
+          echo "CMAKE_SHARED_LINKER_FLAGS=-fsanitize=address"         >> $GITHUB_ENV
+          echo "CMAKE_EXE_LINKER_FLAGS=-fsanitize=address"            >> $GITHUB_ENV
+          echo "ASAN_OPTIONS=detect_leaks=0:abort_on_error=1"         >> $GITHUB_ENV
+          echo "PYTHONMALLOC=malloc"                                  >> $GITHUB_ENV
+          echo "PYTHONFAULTHANDLER=1"                                 >> $GITHUB_ENV
 
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           pip install scikit-build-core cmake ninja pybind11
 
-      - name: Install project
+      - name: Install project with ASAN instrumentation
         run: |
           pip install -e ".[dev]" --no-build-isolation
 
-      - name: Preload ASAN runtime
+      - name: Resolve ASAN runtime path
         run: |
-          echo "LD_PRELOAD=$(clang -print-file-name=libasan.so)" >> $GITHUB_ENV
+          ASAN_LIB=$(clang -print-file-name=libasan.so)
+          if [[ "$ASAN_LIB" == "libasan.so" ]]; then
+            ASAN_LIB=$(find /usr/lib/llvm-*/lib /usr/lib/x86_64-linux-gnu \
+              -name "libasan.so*" 2>/dev/null | head -1)
+          fi
+          echo "Resolved: $ASAN_LIB"
+          echo "LD_PRELOAD=$ASAN_LIB" >> $GITHUB_ENV
 
-      - name: Run tests (ASAN enabled)
+      - name: Run tests with ASAN
         run: |
           pytest tests/ -v -k "not benchmark"


### PR DESCRIPTION
Adds a Linux-only GitHub Actions workflow to run AddressSanitizer (ASAN) checks on native C++ components.

### What changed

* Added a GitHub Actions workflow for ASAN-based testing
* Uses `ubuntu-latest` with `clang`
* Enables ASAN via explicit compiler and CMake flags
* Preloads ASAN runtime using `LD_PRELOAD` for correct linking
* Installs required build dependencies (`scikit-build-core`, `cmake`, `ninja`, `pybind11`)
* Runs `pytest` (excluding benchmarks) to exercise native code paths
* Captures ASAN logs to `/tmp/asan.log` and prints them in CI output
* Configured as manual workflow (`workflow_dispatch`) to avoid slowing regular CI

### Why

* To detect memory-safety issues in the native C++ layer during CI
* Ensures regressions are caught early and are visible to contributors
* Improves reliability of Python ↔ C++ integration

### How to test

1. Go to the **Actions** tab in the repository
2. Select **ASAN Checks**
3. Click **Run workflow**
4. Observe test execution under ASAN
5. If a memory-safety issue is detected, the workflow will abort and print an ASAN report

### Notes

* The workflow successfully builds and runs tests with ASAN enabled
* During execution, ASAN aborts on `test_incompatible_fill_rejected`
* The ASAN report shows a stack trace involving `fill_nulls` and `std::stoll`, indicating unsafe handling of invalid input in the native layer
* This confirms the workflow is correctly detecting issues in C++ code paths

Fixes #260