### PR TITLE
docs: add CLI roadmap and command examples

### DIFF
--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -1,0 +1,71 @@
+# CLI Reference and Roadmap
+
+This document covers the current command-line workflows and
+planned CLI goals for Arnio contributors and users.
+
+## Development Commands
+
+```bash
+# Install in development mode with all dev dependencies
+make install
+
+# Run the full test suite with coverage
+make test
+
+# Run linter and formatter checks
+make lint
+
+# Run benchmarks against pandas
+make benchmark
+```
+
+## Common Python Workflow Examples
+
+```python
+import arnio as ar
+
+# Load a CSV file through C++
+frame = ar.read_csv("data.csv")
+
+# Run a cleaning pipeline
+clean = ar.pipeline(frame, [
+    ("strip_whitespace",),
+    ("normalize_case", {"case_type": "lower"}),
+    ("drop_nulls",),
+    ("drop_duplicates",),
+])
+
+# Profile your dataset
+report = ar.profile(frame)
+print(report.summary())
+
+# Get cleaning suggestions
+suggestions = ar.suggest_cleaning(frame)
+print(suggestions)
+
+# Auto clean safely
+clean = ar.auto_clean(frame, mode="safe")
+
+# Auto clean strictly (includes deduplication)
+clean = ar.auto_clean(frame, mode="strict")
+
+# Convert to pandas
+df = ar.to_pandas(clean)
+```
+
+## CLI Roadmap
+
+| Version | Goal | Status |
+|---------|------|--------|
+| v1.0 | Stable release, PyPI publishing, CI/CD | ✅ Shipped |
+| v1.1 | Release hardening, docs, tooling | ✅ Shipped |
+| v1.2 | C++ pipeline optimization, hash-based deduplication | 🔨 Active |
+| v1.3 | Chunked/streaming processing, Parquet and JSON readers | 📋 Planned |
+| v1.4 | Parallel column processing, SIMD string operations | 💭 Exploring |
+
+## Related Docs
+
+- `ROADMAP.md` — full version roadmap
+- `ARCHITECTURE.md` — system architecture
+- `API_REFERENCE.md` — full API reference
+- `GSSOC_GUIDE.md` — contributor onboarding guide

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -67,5 +67,5 @@ df = ar.to_pandas(clean)
 
 - `ROADMAP.md` — full version roadmap
 - `ARCHITECTURE.md` — system architecture
-- `API_REFERENCE.md` — full API reference
 - `GSSOC_GUIDE.md` — contributor onboarding guide
+- `README.md` — quickstart and examples

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -55,13 +55,17 @@ df = ar.to_pandas(clean)
 
 ## CLI Roadmap
 
-| Version | Goal | Status |
-|---------|------|--------|
-| v1.0 | Stable release, PyPI publishing, CI/CD | ✅ Shipped |
-| v1.1 | Release hardening, docs, tooling | ✅ Shipped |
-| v1.2 | C++ pipeline optimization, hash-based deduplication | 🔨 Active |
-| v1.3 | Chunked/streaming processing, Parquet and JSON readers | 📋 Planned |
-| v1.4 | Parallel column processing, SIMD string operations | 💭 Exploring |
+| Focus Area | Status |
+|-----------|--------|
+| CSV parsing and cleaning | 🔨 Current |
+| Data quality and schema validation | 🔨 Current |
+| Chunked and streaming processing | 📋 Near Term |
+| Native CSV writers | 📋 Near Term |
+| Parallel column processing | 💭 Long Term |
+| SIMD string operations | 💭 Long Term |
+| JSON Lines and Parquet support | 💭 Long Term |
+
+> Full roadmap: [ROADMAP.md](ROADMAP.md)
 
 ## Related Docs
 

--- a/README.md
+++ b/README.md
@@ -1034,13 +1034,14 @@ DataQualityReport(
 ## 🗺️ Roadmap
 
 | Version | Focus | Status |
-|:---:|:---|:---:|
+|:---:|:S---|:---:|
 | **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
 | **v1.1** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
 | **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
 | **v1.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
 | **v1.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
 
+> For CLI command reference and examples, see [CLI_REFERENCE.md](CLI_REFERENCE.md).
 <br>
 
 ---

--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,7 @@ DataQualityReport(
 ## 🗺️ Roadmap
 
 | Version | Focus | Status |
-|:---:|:S---|:---:|
+|:---:|:---|:---:|
 | **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
 | **v1.1** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
 | **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |


### PR DESCRIPTION
## Summary
Added CLI_REFERENCE.md documenting current development commands,
common Python workflow examples, and CLI version roadmap table.

## Linked issue
Fixes #671

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
Documentation only change — no code was added or modified.
Existing tests are unaffected.