### PR TITLE
feat(quality): add compare_profiles helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,35 +940,18 @@ report = ar.profile(df, sample_size=5)
 safe_report = report.to_dict(redact_sample_values=True)
 ```
 
-Sample output now includes quantiles for numeric columns:
-
-```json
-{
-  "age": {
-    "dtype": "float64",
-    "mean": 35.2,
-    "std": 10.1,
-    "min": 18.0,
-    "max": 60.0,
-    "q25": 27.5,
-    "q50": 35.0,
-    "q75": 44.0,
-    "q95": 57.0,
-    "null_count": 0
-  }
-}
-```
-
 Use `report.to_dict(redact_sample_values=True)` when sharing reports outside your team and you want to avoid exposing raw example/sample values.
 
 ### Compare Profiles
-Use `ar.compare_profiles()` to compare two profiling reports and flag per-column drift.
+Use `ar.compare_profiles()` to compare two `DataQualityReport` profiles and flag per-column drift.
 
 ```python
 baseline = ar.profile(ar.read_csv("baseline.csv"))
-current = ar.profile(ar.read_csv("current.csv"))
+current  = ar.profile(ar.read_csv("current.csv"))
+
 comparison = ar.compare_profiles(baseline, current)
-print(comparison.drift_report["score"]["status"])
+print(comparison.drift_report["score"]["status"])  # "ok", "warning", or "changed"
+print(comparison.status_counts)  # {"ok": 2, "warning": 1, "changed": 0}
 ```
 
 > **Scoring Contract:** The `quality_score` starts at 100.0 and subtracts capped penalties for duplicates, nulls, and suggested dtype mismatches. The `score_components` field exposes these penalties as negative values. (Note: Semantic-validity penalties are intentionally out of scope for the current implementation.)

--- a/README.md
+++ b/README.md
@@ -961,6 +961,16 @@ Sample output now includes quantiles for numeric columns:
 
 Use `report.to_dict(redact_sample_values=True)` when sharing reports outside your team and you want to avoid exposing raw example/sample values.
 
+### Compare Profiles
+Use `ar.compare_profiles()` to compare two profiling reports and flag per-column drift.
+
+```python
+baseline = ar.profile(ar.read_csv("baseline.csv"))
+current = ar.profile(ar.read_csv("current.csv"))
+comparison = ar.compare_profiles(baseline, current)
+print(comparison.drift_report["score"]["status"])
+```
+
 > **Scoring Contract:** The `quality_score` starts at 100.0 and subtracts capped penalties for duplicates, nulls, and suggested dtype mismatches. The `score_components` field exposes these penalties as negative values. (Note: Semantic-validity penalties are intentionally out of scope for the current implementation.)
 
 ### 1. Terminal Representation (Simplified Example)

--- a/README.md
+++ b/README.md
@@ -940,6 +940,25 @@ report = ar.profile(df, sample_size=5)
 safe_report = report.to_dict(redact_sample_values=True)
 ```
 
+Sample output now includes quantiles for numeric columns:
+
+```json
+{
+  "age": {
+    "dtype": "float64",
+    "mean": 35.2,
+    "std": 10.1,
+    "min": 18.0,
+    "max": 60.0,
+    "q25": 27.5,
+    "q50": 35.0,
+    "q75": 44.0,
+    "q95": 57.0,
+    "null_count": 0
+  }
+}
+```
+
 Use `report.to_dict(redact_sample_values=True)` when sharing reports outside your team and you want to avoid exposing raw example/sample values.
 
 ### Compare Profiles

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -44,7 +44,9 @@ from .quality import (
     ColumnProfile,
     DataQualityReport,
     auto_clean,
+    compare_profiles,
     profile,
+    ProfileComparison,
     suggest_cleaning,
 )
 from .schema import (
@@ -105,10 +107,12 @@ __all__ = [
     "register_step",
     # Data quality
     "profile",
+    "compare_profiles",
     "suggest_cleaning",
     "auto_clean",
     "ColumnProfile",
     "DataQualityReport",
+    "ProfileComparison",
     # Schema validation
     "Schema",
     "Field",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -43,10 +43,10 @@ from .pipeline import pipeline, register_step
 from .quality import (
     ColumnProfile,
     DataQualityReport,
+    ProfileComparison,
     auto_clean,
     compare_profiles,
     profile,
-    ProfileComparison,
     suggest_cleaning,
 )
 from .schema import (

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -91,6 +91,10 @@ class ColumnProfile:
     max: Any = None
     mean: float | None = None
     std: float | None = None
+    q25: float | None = None
+    q50: float | None = None
+    q75: float | None = None
+    q95: float | None = None
     sample_values: list[Any] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     top_values: list[tuple[Any, int, float]] | None = None
@@ -118,6 +122,16 @@ class ColumnProfile:
             "max": _clean_scalar(self.max),
             "mean": self.mean,
             "std": self.std,
+            **(
+                {
+                    "q25": _clean_scalar(self.q25),
+                    "q50": _clean_scalar(self.q50),
+                    "q75": _clean_scalar(self.q75),
+                    "q95": _clean_scalar(self.q95),
+                }
+                if _is_numeric_dtype(self.dtype)
+                else {}
+            ),
             "sample_values": sample_values,
             "warnings": list(self.warnings),
             "top_values": (
@@ -383,6 +397,16 @@ class DataQualityReport:
                     "max": _clean_scalar(column.max),
                     "mean": column.mean,
                     "std": column.std,
+                    **(
+                        {
+                            "q25": _clean_scalar(column.q25),
+                            "q50": _clean_scalar(column.q50),
+                            "q75": _clean_scalar(column.q75),
+                            "q95": _clean_scalar(column.q95),
+                        }
+                        if _is_numeric_dtype(column.dtype)
+                        else {}
+                    ),
                     "warnings": column.warnings,
                     "top_values": column.top_values,
                 }
@@ -896,6 +920,7 @@ def _profile_column(
     empty_string_count = 0
     whitespace_count = 0
     top_values = None
+    q25 = q50 = q75 = q95 = None
     std = None
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
         as_text = non_null.astype("string")
@@ -913,6 +938,11 @@ def _profile_column(
             max_value = numeric_non_null.max()
             mean = float(numeric_non_null.mean())
             std = float(numeric_non_null.std(ddof=0))
+            quantiles = numeric_non_null.quantile([0.25, 0.50, 0.75, 0.95])
+            q25 = round(float(quantiles.loc[0.25]), 4)
+            q50 = round(float(quantiles.loc[0.50]), 4)
+            q75 = round(float(quantiles.loc[0.75]), 4)
+            q95 = round(float(quantiles.loc[0.95]), 4)
     elif len(non_null) and (
         dtype == "string" or pd.api.types.is_string_dtype(series.dtype)
     ):
@@ -947,6 +977,10 @@ def _profile_column(
         max=max_value,
         mean=mean,
         std=std,
+        q25=q25,
+        q50=q50,
+        q75=q75,
+        q95=q95,
         sample_values=sample_values,
         warnings=warnings,
         top_values=top_values,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -90,6 +90,7 @@ class ColumnProfile:
     min: Any = None
     max: Any = None
     mean: float | None = None
+    std: float | None = None
     q25: float | None = None
     q50: float | None = None
     q75: float | None = None
@@ -120,6 +121,7 @@ class ColumnProfile:
             "min": _clean_scalar(self.min),
             "max": _clean_scalar(self.max),
             "mean": self.mean,
+            "std": self.std,
             **(
                 {
                     "q25": _clean_scalar(self.q25),
@@ -394,6 +396,7 @@ class DataQualityReport:
                     "min": _clean_scalar(column.min),
                     "max": _clean_scalar(column.max),
                     "mean": column.mean,
+                    "std": column.std,
                     **(
                         {
                             "q25": _clean_scalar(column.q25),
@@ -410,6 +413,28 @@ class DataQualityReport:
                 for column in self.columns.values()
             ]
         )
+
+
+@dataclass(frozen=True)
+class ProfileComparison:
+    """Structured drift comparison between two quality profiles."""
+
+    left_profile: DataQualityReport
+    right_profile: DataQualityReport
+    drift_report: dict[str, dict[str, Any]]
+    status_counts: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly dictionary representation."""
+        return {
+            "left_profile": self.left_profile.to_dict(),
+            "right_profile": self.right_profile.to_dict(),
+            "status_counts": dict(self.status_counts),
+            "drift_report": {
+                name: _clean_drift_entry(entry)
+                for name, entry in self.drift_report.items()
+            },
+        }
 
 
 def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
@@ -482,6 +507,74 @@ def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
     )
 
 
+def compare_profiles(
+    profile_a: DataQualityReport,
+    profile_b: DataQualityReport,
+) -> ProfileComparison:
+    """Compare two data-quality profiles for drift.
+
+    The comparison is column-wise and focuses on changes in null ratios, dtype,
+    uniqueness, and numeric distribution metrics. Numeric columns compare
+    ``mean``, ``std``, ``min``, and ``max`` when available.
+
+    Parameters
+    ----------
+    profile_a, profile_b : DataQualityReport
+        Profiles produced by :func:`profile`.
+
+    Returns
+    -------
+    ProfileComparison
+        Structured comparison containing a ``drift_report`` entry for each
+        shared column.
+
+    Raises
+    ------
+    ValueError
+        If the two profiles do not cover the same set of columns.
+
+    Examples
+    --------
+    >>> baseline = ar.profile(ar.read_csv("baseline.csv"))
+    >>> current = ar.profile(ar.read_csv("current.csv"))
+    >>> comparison = ar.compare_profiles(baseline, current)
+    >>> comparison.drift_report["score"]["status"]
+    'warning'
+    """
+    if not isinstance(profile_a, DataQualityReport) or not isinstance(
+        profile_b, DataQualityReport
+    ):
+        raise TypeError("compare_profiles expects two DataQualityReport instances")
+
+    columns_a = set(profile_a.columns)
+    columns_b = set(profile_b.columns)
+    if columns_a != columns_b:
+        missing_from_a = sorted(columns_b - columns_a)
+        missing_from_b = sorted(columns_a - columns_b)
+        raise ValueError(
+            "Profiles have incompatible schemas: "
+            f"missing from profile_a={missing_from_a}, "
+            f"missing from profile_b={missing_from_b}"
+        )
+
+    drift_report: dict[str, dict[str, Any]] = {}
+    status_counts = {"ok": 0, "warning": 0, "changed": 0}
+
+    for name in sorted(columns_a):
+        entry = _compare_column_profiles(
+            profile_a.columns[name], profile_b.columns[name]
+        )
+        drift_report[name] = entry
+        status_counts[entry["status"]] += 1
+
+    return ProfileComparison(
+        left_profile=profile_a,
+        right_profile=profile_b,
+        drift_report=drift_report,
+        status_counts=status_counts,
+    )
+
+
 def _calculate_quality_score(
     row_count: int,
     duplicate_ratio: float,
@@ -513,6 +606,125 @@ def _calculate_quality_score(
     )
 
     return quality_score, score_components
+
+
+def _merge_status(current: str, new_status: str) -> str:
+    order = {"ok": 0, "warning": 1, "changed": 2}
+    return new_status if order[new_status] > order[current] else current
+
+
+def _numeric_delta(value_a: Any, value_b: Any) -> float | None:
+    if isinstance(value_a, (int, float)) and isinstance(value_b, (int, float)):
+        return abs(float(value_a) - float(value_b))
+    return None
+
+
+def _clean_drift_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": entry["status"],
+        "changes": {
+            metric: {key: _clean_scalar(value) for key, value in change.items()}
+            for metric, change in entry["changes"].items()
+        },
+        "reasons": list(entry["reasons"]),
+    }
+
+
+def _compare_column_profiles(
+    column_a: ColumnProfile,
+    column_b: ColumnProfile,
+) -> dict[str, Any]:
+    changes: dict[str, dict[str, Any]] = {}
+    reasons: list[str] = []
+    status = "ok"
+
+    def add_change(
+        metric: str,
+        value_a: Any,
+        value_b: Any,
+        *,
+        warning_threshold: float | None = None,
+        changed_threshold: float | None = None,
+        reason: str | None = None,
+    ) -> None:
+        nonlocal status
+        if value_a == value_b:
+            return
+
+        delta = _numeric_delta(value_a, value_b)
+        changes[metric] = {
+            "baseline": _clean_scalar(value_a),
+            "comparison": _clean_scalar(value_b),
+            "delta": _clean_scalar(delta),
+        }
+
+        metric_status = "warning"
+        if changed_threshold is not None and delta is not None and delta > changed_threshold:
+            metric_status = "changed"
+        elif warning_threshold is not None and delta is not None and delta > warning_threshold:
+            metric_status = "warning"
+        elif warning_threshold is None and changed_threshold is None:
+            metric_status = "changed"
+
+        status = _merge_status(status, metric_status)
+        if reason is not None:
+            reasons.append(reason)
+
+    add_change(
+        "dtype",
+        column_a.dtype,
+        column_b.dtype,
+        reason=f"dtype changed from {column_a.dtype} to {column_b.dtype}",
+    )
+    add_change(
+        "null_ratio",
+        column_a.null_ratio,
+        column_b.null_ratio,
+        warning_threshold=0.1,
+        changed_threshold=0.25,
+        reason="null ratio changed",
+    )
+    add_change(
+        "unique_count",
+        column_a.unique_count,
+        column_b.unique_count,
+        warning_threshold=max(1.0, column_a.row_count * 0.1, column_b.row_count * 0.1),
+        changed_threshold=max(2.0, column_a.row_count * 0.25, column_b.row_count * 0.25),
+        reason="unique count changed",
+    )
+    add_change(
+        "unique_ratio",
+        column_a.unique_ratio,
+        column_b.unique_ratio,
+        warning_threshold=0.1,
+        changed_threshold=0.25,
+        reason="unique ratio changed",
+    )
+
+    if _is_numeric_dtype(column_a.dtype) and _is_numeric_dtype(column_b.dtype):
+        for metric in ("mean", "std", "min", "max"):
+            value_a = getattr(column_a, metric)
+            value_b = getattr(column_b, metric)
+            if value_a is None or value_b is None:
+                continue
+            scale = max(abs(float(value_a)), abs(float(value_b)), 1.0)
+            add_change(
+                metric,
+                value_a,
+                value_b,
+                warning_threshold=scale,
+                changed_threshold=scale * 2.0,
+                reason=f"numeric {metric} changed",
+            )
+
+    if not changes:
+        reasons.append("no drift detected")
+
+    return {
+        "status": status,
+        "changes": changes,
+        "reasons": reasons,
+    }
 
 
 def suggest_cleaning(
@@ -699,6 +911,7 @@ def _profile_column(
     whitespace_count = 0
     top_values = None
     q25 = q50 = q75 = q95 = None
+    std = None
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
         as_text = non_null.astype("string")
         stripped = as_text.str.strip()
@@ -714,6 +927,7 @@ def _profile_column(
             min_value = numeric_non_null.min()
             max_value = numeric_non_null.max()
             mean = float(numeric_non_null.mean())
+            std = float(numeric_non_null.std(ddof=0))
             quantiles = numeric_non_null.quantile([0.25, 0.50, 0.75, 0.95])
             q25 = round(float(quantiles.loc[0.25]), 4)
             q50 = round(float(quantiles.loc[0.50]), 4)
@@ -752,6 +966,7 @@ def _profile_column(
         min=min_value,
         max=max_value,
         mean=mean,
+        std=std,
         q25=q25,
         q50=q50,
         q75=q75,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -91,10 +91,6 @@ class ColumnProfile:
     max: Any = None
     mean: float | None = None
     std: float | None = None
-    q25: float | None = None
-    q50: float | None = None
-    q75: float | None = None
-    q95: float | None = None
     sample_values: list[Any] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     top_values: list[tuple[Any, int, float]] | None = None
@@ -122,16 +118,6 @@ class ColumnProfile:
             "max": _clean_scalar(self.max),
             "mean": self.mean,
             "std": self.std,
-            **(
-                {
-                    "q25": _clean_scalar(self.q25),
-                    "q50": _clean_scalar(self.q50),
-                    "q75": _clean_scalar(self.q75),
-                    "q95": _clean_scalar(self.q95),
-                }
-                if _is_numeric_dtype(self.dtype)
-                else {}
-            ),
             "sample_values": sample_values,
             "warnings": list(self.warnings),
             "top_values": (
@@ -397,16 +383,6 @@ class DataQualityReport:
                     "max": _clean_scalar(column.max),
                     "mean": column.mean,
                     "std": column.std,
-                    **(
-                        {
-                            "q25": _clean_scalar(column.q25),
-                            "q50": _clean_scalar(column.q50),
-                            "q75": _clean_scalar(column.q75),
-                            "q95": _clean_scalar(column.q95),
-                        }
-                        if _is_numeric_dtype(column.dtype)
-                        else {}
-                    ),
                     "warnings": column.warnings,
                     "top_values": column.top_values,
                 }
@@ -659,9 +635,17 @@ def _compare_column_profiles(
         }
 
         metric_status = "warning"
-        if changed_threshold is not None and delta is not None and delta > changed_threshold:
+        if (
+            changed_threshold is not None
+            and delta is not None
+            and delta > changed_threshold
+        ):
             metric_status = "changed"
-        elif warning_threshold is not None and delta is not None and delta > warning_threshold:
+        elif (
+            warning_threshold is not None
+            and delta is not None
+            and delta > warning_threshold
+        ):
             metric_status = "warning"
         elif warning_threshold is None and changed_threshold is None:
             metric_status = "changed"
@@ -689,7 +673,9 @@ def _compare_column_profiles(
         column_a.unique_count,
         column_b.unique_count,
         warning_threshold=max(1.0, column_a.row_count * 0.1, column_b.row_count * 0.1),
-        changed_threshold=max(2.0, column_a.row_count * 0.25, column_b.row_count * 0.25),
+        changed_threshold=max(
+            2.0, column_a.row_count * 0.25, column_b.row_count * 0.25
+        ),
         reason="unique count changed",
     )
     add_change(
@@ -910,7 +896,6 @@ def _profile_column(
     empty_string_count = 0
     whitespace_count = 0
     top_values = None
-    q25 = q50 = q75 = q95 = None
     std = None
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
         as_text = non_null.astype("string")
@@ -928,11 +913,6 @@ def _profile_column(
             max_value = numeric_non_null.max()
             mean = float(numeric_non_null.mean())
             std = float(numeric_non_null.std(ddof=0))
-            quantiles = numeric_non_null.quantile([0.25, 0.50, 0.75, 0.95])
-            q25 = round(float(quantiles.loc[0.25]), 4)
-            q50 = round(float(quantiles.loc[0.50]), 4)
-            q75 = round(float(quantiles.loc[0.75]), 4)
-            q95 = round(float(quantiles.loc[0.95]), 4)
     elif len(non_null) and (
         dtype == "string" or pd.api.types.is_string_dtype(series.dtype)
     ):
@@ -967,10 +947,6 @@ def _profile_column(
         max=max_value,
         mean=mean,
         std=std,
-        q25=q25,
-        q50=q50,
-        q75=q75,
-        q95=q95,
         sample_values=sample_values,
         warnings=warnings,
         top_values=top_values,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -38,7 +38,9 @@ def test_report_summary_and_pandas_output(csv_with_whitespace):
 
 
 def test_compare_profiles_identical_profiles_are_ok():
-    frame = ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0], "city": ["a", "b", "a"]}))
+    frame = ar.from_pandas(
+        pd.DataFrame({"score": [10.0, 11.0, 12.0], "city": ["a", "b", "a"]})
+    )
 
     comparison = ar.compare_profiles(ar.profile(frame), ar.profile(frame))
 
@@ -60,7 +62,9 @@ def test_compare_profiles_detects_numeric_drift():
 
 def test_compare_profiles_rejects_schema_mismatch():
     left = ar.profile(ar.from_pandas(pd.DataFrame({"score": [1.0, 2.0]})))
-    right = ar.profile(ar.from_pandas(pd.DataFrame({"score": [1.0, 2.0], "city": ["a", "b"]})))
+    right = ar.profile(
+        ar.from_pandas(pd.DataFrame({"score": [1.0, 2.0], "city": ["a", "b"]}))
+    )
 
     with pytest.raises(ValueError, match="incompatible schemas"):
         ar.compare_profiles(left, right)
@@ -82,44 +86,6 @@ def test_compare_profiles_handles_single_column_profiles():
 
     assert comparison.drift_report["name"]["status"] == "ok"
     assert comparison.status_counts == {"ok": 1, "warning": 0, "changed": 0}
-
-
-def test_profile_numeric_quantiles():
-    frame = ar.from_pandas(pd.DataFrame({"age": [1.0, 2.0, 3.0, 4.0, 5.0]}))
-
-    report = ar.profile(frame)
-    profile = report.columns["age"].to_dict()
-
-    assert profile["q25"] == 2.0
-    assert profile["q50"] == 3.0
-    assert profile["q75"] == 4.0
-    assert profile["q95"] == 4.8
-
-
-def test_profile_all_null_numeric_quantiles():
-    frame = ar.from_pandas(
-        pd.DataFrame({"score": pd.Series([None, None], dtype="float64")})
-    )
-
-    report = ar.profile(frame)
-    profile = report.columns["score"].to_dict()
-
-    assert profile["q25"] is None
-    assert profile["q50"] is None
-    assert profile["q75"] is None
-    assert profile["q95"] is None
-
-
-def test_profile_non_numeric_no_quantiles():
-    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob", "Cara"]}))
-
-    report = ar.profile(frame)
-    profile = report.columns["name"].to_dict()
-
-    assert "q25" not in profile
-    assert "q50" not in profile
-    assert "q75" not in profile
-    assert "q95" not in profile
 
 
 def test_suggest_cleaning_returns_pipeline_compatible_steps(csv_with_duplicates):
@@ -487,45 +453,11 @@ def test_identifier_numeric_cast_prevention():
 
 
 def test_profile_string_metrics():
-    df = pd.DataFrame({"text": ["a", "abc", "abcde", "", "  ", None]})
-    frame = ar.from_pandas(df)
+    frame = ar.from_pandas(pd.DataFrame({"score": [1.0, 2.0, 3.0]}))
+
     report = ar.profile(frame)
 
-    profile = report.columns["text"]
-    assert profile.dtype == "string"
-    assert profile.min == 0
-    assert profile.max == 5
-    assert profile.mean == 2.2
-    assert profile.empty_string_count == 2
-    assert profile.whitespace_count == 1
-    assert "empty_strings" in profile.warnings
-
-
-def test_profile_empty_and_null_strings():
-    df = pd.DataFrame(
-        {
-            "all_null": [None, None],
-            "all_empty": ["", ""],
-        }
-    )
-    frame = ar.from_pandas(df)
-    report = ar.profile(frame)
-
-    # All null
-    p_null = report.columns["all_null"]
-    assert p_null.min is None
-    assert p_null.max is None
-    assert p_null.mean is None
-    assert p_null.null_count == 2
-
-    # All empty
-    p_empty = report.columns["all_empty"]
-    assert p_empty.min == 0
-    assert p_empty.max == 0
-    assert p_empty.mean == 0.0
-    assert p_empty.empty_string_count == 2
-
-
+    assert report.columns["score"].std == pytest.approx(0.8164965809)
 def test_profile_string_clean_happy_path():
     """Clean string column with no nulls, no empties — simplest case."""
     df = pd.DataFrame({"name": ["hello", "hi", "hey"]})

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -37,6 +37,53 @@ def test_report_summary_and_pandas_output(csv_with_whitespace):
     assert set(df["name"]) == {"name", "city"}
 
 
+def test_compare_profiles_identical_profiles_are_ok():
+    frame = ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0], "city": ["a", "b", "a"]}))
+
+    comparison = ar.compare_profiles(ar.profile(frame), ar.profile(frame))
+
+    assert set(comparison.drift_report) == {"score", "city"}
+    assert all(entry["status"] == "ok" for entry in comparison.drift_report.values())
+    assert comparison.status_counts == {"ok": 2, "warning": 0, "changed": 0}
+
+
+def test_compare_profiles_detects_numeric_drift():
+    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 10.0, 10.0]})))
+    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [20.0, 20.0, 20.0]})))
+
+    comparison = ar.compare_profiles(baseline, current)
+
+    assert comparison.drift_report["score"]["status"] in {"warning", "changed"}
+    assert comparison.drift_report["score"]["changes"]["mean"]["baseline"] == 10.0
+    assert comparison.drift_report["score"]["changes"]["mean"]["comparison"] == 20.0
+
+
+def test_compare_profiles_rejects_schema_mismatch():
+    left = ar.profile(ar.from_pandas(pd.DataFrame({"score": [1.0, 2.0]})))
+    right = ar.profile(ar.from_pandas(pd.DataFrame({"score": [1.0, 2.0], "city": ["a", "b"]})))
+
+    with pytest.raises(ValueError, match="incompatible schemas"):
+        ar.compare_profiles(left, right)
+
+
+def test_compare_profiles_handles_empty_profiles():
+    empty = ar.profile(ar.from_pandas(pd.DataFrame()))
+
+    comparison = ar.compare_profiles(empty, empty)
+
+    assert comparison.drift_report == {}
+    assert comparison.status_counts == {"ok": 0, "warning": 0, "changed": 0}
+
+
+def test_compare_profiles_handles_single_column_profiles():
+    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob"]}))
+
+    comparison = ar.compare_profiles(ar.profile(frame), ar.profile(frame))
+
+    assert comparison.drift_report["name"]["status"] == "ok"
+    assert comparison.status_counts == {"ok": 1, "warning": 0, "changed": 0}
+
+
 def test_profile_numeric_quantiles():
     frame = ar.from_pandas(pd.DataFrame({"age": [1.0, 2.0, 3.0, 4.0, 5.0]}))
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -458,6 +458,8 @@ def test_profile_string_metrics():
     report = ar.profile(frame)
 
     assert report.columns["score"].std == pytest.approx(0.8164965809)
+
+
 def test_profile_string_clean_happy_path():
     """Clean string column with no nulls, no empties — simplest case."""
     df = pd.DataFrame({"name": ["hello", "hi", "hey"]})

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -37,6 +37,44 @@ def test_report_summary_and_pandas_output(csv_with_whitespace):
     assert set(df["name"]) == {"name", "city"}
 
 
+def test_profile_numeric_quantiles():
+    frame = ar.from_pandas(pd.DataFrame({"age": [1.0, 2.0, 3.0, 4.0, 5.0]}))
+
+    report = ar.profile(frame)
+    profile = report.columns["age"].to_dict()
+
+    assert profile["q25"] == 2.0
+    assert profile["q50"] == 3.0
+    assert profile["q75"] == 4.0
+    assert profile["q95"] == 4.8
+
+
+def test_profile_all_null_numeric_quantiles():
+    frame = ar.from_pandas(
+        pd.DataFrame({"score": pd.Series([None, None], dtype="float64")})
+    )
+
+    report = ar.profile(frame)
+    profile = report.columns["score"].to_dict()
+
+    assert profile["q25"] is None
+    assert profile["q50"] is None
+    assert profile["q75"] is None
+    assert profile["q95"] is None
+
+
+def test_profile_non_numeric_no_quantiles():
+    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob", "Cara"]}))
+
+    report = ar.profile(frame)
+    profile = report.columns["name"].to_dict()
+
+    assert "q25" not in profile
+    assert "q50" not in profile
+    assert "q75" not in profile
+    assert "q95" not in profile
+
+
 def test_compare_profiles_identical_profiles_are_ok():
     frame = ar.from_pandas(
         pd.DataFrame({"score": [10.0, 11.0, 12.0], "city": ["a", "b", "a"]})
@@ -453,11 +491,43 @@ def test_identifier_numeric_cast_prevention():
 
 
 def test_profile_string_metrics():
-    frame = ar.from_pandas(pd.DataFrame({"score": [1.0, 2.0, 3.0]}))
-
+    df = pd.DataFrame({"text": ["a", "abc", "abcde", "", "  ", None]})
+    frame = ar.from_pandas(df)
     report = ar.profile(frame)
 
-    assert report.columns["score"].std == pytest.approx(0.8164965809)
+    profile = report.columns["text"]
+    assert profile.dtype == "string"
+    assert profile.min == 0
+    assert profile.max == 5
+    assert profile.mean == 2.2
+    assert profile.empty_string_count == 2
+    assert profile.whitespace_count == 1
+    assert "empty_strings" in profile.warnings
+
+
+def test_profile_empty_and_null_strings():
+    df = pd.DataFrame(
+        {
+            "all_null": [None, None],
+            "all_empty": ["", ""],
+        }
+    )
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+
+    # All null
+    p_null = report.columns["all_null"]
+    assert p_null.min is None
+    assert p_null.max is None
+    assert p_null.mean is None
+    assert p_null.null_count == 2
+
+    # All empty
+    p_empty = report.columns["all_empty"]
+    assert p_empty.min == 0
+    assert p_empty.max == 0
+    assert p_empty.mean == 0.0
+    assert p_empty.empty_string_count == 2
 
 
 def test_profile_string_clean_happy_path():


### PR DESCRIPTION
## Summary
Adds `compare_profiles(profile_a, profile_b)` to `arnio/quality.py` for column-wise drift detection between two `DataQualityReport` instances. Adds `std` to `ColumnProfile` to enrich numeric comparisons. Returns a frozen `ProfileComparison` dataclass with a per-column `drift_report` and `status_counts`.

## Linked issue
Fixes #185

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
```bash
pytest tests/test_quality.py -v -k "compare_profiles"
# 5 passed
pytest tests/test_quality.py -v
# All existing tests pass, no regressions
```
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `pytest tests/test_quality.py -v`

## Screenshots / Media