### PR TITLE
feat: add warning severity support to schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,8 +754,8 @@ schema = ar.Schema({
     "revenue": ar.Custom("positive", nullable=True),
     "signup_date": ar.Date(nullable=False),
     "created_at": ar.DateTime(nullable=False, format="%Y-%m-%d"),
-})
 
+})
 
 result = ar.validate(frame, schema)
 
@@ -773,6 +773,26 @@ In this example, `country` becomes required only when
 
 Date validates strict YYYY-MM-DD calendar dates.
 
+### Warning-only validation
+
+```python
+schema = ar.Schema(
+    {
+        "age": ar.Int64(
+            min=18,
+            severity="warning",
+        )
+    }
+)
+
+result = ar.validate(frame, schema)
+
+print(result.passed)  # True
+print(result.issue_count)  # Warning issues are still reported
+```
+
+Warning-level issues remain visible in validation results without failing the overall validation status.
+
 `ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
 
 For multi-column uniqueness (composite keys):
@@ -785,7 +805,7 @@ schema = ar.Schema({
 
 result = ar.validate(frame, schema)
 ```
-Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
+
 
 For low-risk automatic cleanup:
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -124,8 +124,10 @@ class ValidationResult:
         by_rule: dict[str, int] = {}
         by_column: dict[str, int] = {}
         by_column_and_rule: dict[str, dict[str, int]] = {}
+        severity_counts: dict[str, int] = {}
         for issue in self.issues:
             by_rule[issue.rule] = by_rule.get(issue.rule, 0) + 1
+            severity_counts[issue.severity] = severity_counts.get(issue.severity, 0) + 1
             if issue.column is not None:
                 by_column[issue.column] = by_column.get(issue.column, 0) + 1
                 column_rules = by_column_and_rule.setdefault(issue.column, {})
@@ -135,6 +137,7 @@ class ValidationResult:
             "issue_count": self.issue_count,
             "bad_row_count": len(self.bad_rows),
             "issues_by_rule": by_rule,
+            "severity_counts": severity_counts,
             "issues_by_column": by_column,
             "issues_by_column_and_rule": by_column_and_rule,
         }
@@ -183,8 +186,8 @@ class ValidationResult:
         lines.extend(
             [
                 "",
-                "| Column | Rule | Row | Value | Message |",
-                "| --- | --- | ---: | --- | --- |",
+                "| Column | Rule | Severity | Row | Value | Message |",
+                "|---|---|---|---|---|---|",
             ]
         )
         for issue in visible_issues:
@@ -192,6 +195,7 @@ class ValidationResult:
                 "| "
                 f"{_markdown_cell(issue.column)} | "
                 f"{_markdown_cell(issue.rule)} | "
+                f"{_markdown_cell(issue.severity)} | "
                 f"{_markdown_cell(issue.row_index)} | "
                 f"{_markdown_cell(_clean_scalar(issue.value))} | "
                 f"{_markdown_cell(issue.message)} |"
@@ -586,6 +590,7 @@ def _validate_column(
                         f"Column {name!r} has dtype {actual_dtype!r}; "
                         f"expected {field_def.dtype!r}"
                     ),
+                    severity=field_def.severity,
                 )
             )
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -27,6 +27,13 @@ ISSUE_COLUMNS = [
 
 DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
+_VALID_SEVERITIES = {"error", "warning"}
+
+
+def _validate_severity(severity: str) -> None:
+    if severity not in _VALID_SEVERITIES:
+        raise ValueError("severity must be 'error' or 'warning'")
+
 
 @dataclass(frozen=True)
 class Field:
@@ -47,6 +54,9 @@ class Field:
     _datetime_max: pd.Timestamp | None = None
     required_if: tuple[str, Any] | None = None
     severity: str = "error"
+
+    def __post_init__(self) -> None:
+        _validate_severity(self.severity)
 
 
 @dataclass(frozen=True)
@@ -249,6 +259,7 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
                     column=name,
                     rule="required_column",
                     message=f"Missing required column: {name}",
+                    severity=field_def.severity,
                 )
             )
             continue
@@ -319,6 +330,7 @@ def Int64(
     min: int | None = None,
     max: int | None = None,
     unique: bool = False,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create an int64 schema field."""
@@ -333,6 +345,7 @@ def Int64(
         max=max,
         unique=unique,
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -342,6 +355,7 @@ def Float64(
     min: float | None = None,
     max: float | None = None,
     unique: bool = False,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create a float64 schema field."""
@@ -356,6 +370,7 @@ def Float64(
         max=max,
         unique=unique,
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -365,6 +380,7 @@ def String(
     pattern: str | None = None,
     allowed: set[Any] | list[Any] | tuple[Any, ...] | None = None,
     unique: bool = False,
+    severity: str = "error",
     min_length: int | None = None,
     max_length: int | None = None,
     required_if: tuple[str, Any] | None = None,
@@ -385,22 +401,30 @@ def String(
         min_length=min_length,
         max_length=max_length,
         required_if=required_if,
+        severity=severity,
     )
 
 
 def Bool(
     *,
     nullable: bool = True,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create a bool schema field."""
-    return Field(dtype="bool", nullable=nullable, required_if=required_if)
+    return Field(
+        dtype="bool",
+        nullable=nullable,
+        required_if=required_if,
+        severity=severity,
+    )
 
 
 def Email(
     *,
     nullable: bool = True,
     unique: bool = False,
+    severity: str = "error",
     validation: str = "light",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
@@ -413,6 +437,7 @@ def Email(
         semantic="email" if validation == "light" else "email:strict",
         unique=unique,
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -420,6 +445,7 @@ def URL(
     *,
     nullable: bool = True,
     unique: bool = False,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create a URL schema field."""
@@ -429,6 +455,7 @@ def URL(
         semantic="url",
         unique=unique,
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -436,6 +463,7 @@ def CountryCode(
     *,
     nullable: bool = True,
     unique: bool = False,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create an uppercase ISO alpha-2 country-code schema field."""
@@ -444,6 +472,7 @@ def CountryCode(
         nullable=nullable,
         semantic="country_code",
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -451,6 +480,7 @@ def Date(
     *,
     nullable: bool = True,
     unique: bool = False,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create a date schema field."""
@@ -460,6 +490,7 @@ def Date(
         semantic="date",
         unique=unique,
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -468,6 +499,7 @@ def Regex(
     *,
     nullable: bool = True,
     unique: bool = False,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create a regex-validated string schema field.
@@ -500,6 +532,7 @@ def Regex(
         pattern=pattern,
         unique=unique,
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -509,6 +542,7 @@ def DateTime(
     min: Any = None,
     max: Any = None,
     unique: bool = False,
+    severity: str = "error",
     format: str | None = None,
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
@@ -529,6 +563,7 @@ def DateTime(
         _datetime_min=min_val,
         _datetime_max=max_val,
         required_if=required_if,
+        severity=severity,
     )
 
 
@@ -904,6 +939,7 @@ def Custom(
     *,
     nullable: bool = True,
     unique: bool = False,
+    severity: str = "error",
 ) -> Field:
     """Create a field validated by a registered custom validator.
 
@@ -927,5 +963,9 @@ def Custom(
             "Call ar.register_validator() first."
         )
     return Field(
-        dtype=None, nullable=nullable, unique=unique, semantic=f"custom:{name}"
+        dtype=None,
+        nullable=nullable,
+        unique=unique,
+        semantic=f"custom:{name}",
+        severity=severity,
     )

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -22,6 +22,7 @@ ISSUE_COLUMNS = [
     "message",
     "row_index",
     "value",
+    "severity",
 ]
 
 DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -45,6 +46,7 @@ class Field:
     _datetime_min: pd.Timestamp | None = None
     _datetime_max: pd.Timestamp | None = None
     required_if: tuple[str, Any] | None = None
+    severity: str = "error"
 
 
 @dataclass(frozen=True)
@@ -69,6 +71,7 @@ class ValidationIssue:
     message: str
     row_index: int | None = None
     value: Any = None
+    severity: str = "error"
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
@@ -78,6 +81,7 @@ class ValidationIssue:
             "message": self.message,
             "row_index": self.row_index,
             "value": _clean_scalar(self.value),
+            "severity": self.severity,
         }
 
 
@@ -92,8 +96,8 @@ class ValidationResult:
 
     @property
     def passed(self) -> bool:
-        """Whether validation passed with zero issues."""
-        return self.issue_count == 0
+        """Whether validation passed with zero error-level issues."""
+        return not any(issue.severity == "error" for issue in self.issues)
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
@@ -106,11 +110,7 @@ class ValidationResult:
         }
 
     def summary(self) -> dict[str, Any]:
-        """Return a compact validation summary.
-
-        Severity counts are not included because ``ValidationIssue`` does not
-        currently carry severity information.
-        """
+        """Return a compact validation summary."""
         by_rule: dict[str, int] = {}
         by_column: dict[str, int] = {}
         by_column_and_rule: dict[str, dict[str, int]] = {}
@@ -162,7 +162,7 @@ class ValidationResult:
             f"- Bad rows: {len(self.bad_rows)}",
         ]
 
-        if self.passed:
+        if self.passed and self.issue_count == 0:
             return "\n".join(lines)
 
         visible_issues = self.issues if max_issues is None else self.issues[:max_issues]
@@ -561,6 +561,7 @@ def _validate_column(
                 column=name,
                 rule="nullable",
                 message=f"Column {name!r} contains null values",
+                severity=field_def.severity,
             )
         )
 
@@ -590,6 +591,7 @@ def _validate_column(
                         f"Column {name!r} is required when "
                         f"{condition_column!r} == {expected_value!r}"
                     ),
+                    severity=field_def.severity,
                 )
             )
 
@@ -601,6 +603,7 @@ def _validate_column(
                 column=name,
                 rule="unique",
                 message=f"Column {name!r} contains duplicate values",
+                severity=field_def.severity,
             )
         )
 
@@ -612,6 +615,7 @@ def _validate_column(
                 column=name,
                 rule="allowed",
                 message=f"Column {name!r} contains values outside the allowed set",
+                severity=field_def.severity,
             )
         )
 
@@ -627,6 +631,7 @@ def _validate_column(
                 column=name,
                 rule="numeric",
                 message=f"Column {name!r} contains non-numeric values",
+                severity=field_def.severity,
             )
         )
         if field_def.min is not None:
@@ -636,6 +641,7 @@ def _validate_column(
                     column=name,
                     rule="min",
                     message=f"Column {name!r} has values below {field_def.min}",
+                    severity=field_def.severity,
                 )
             )
         if field_def.max is not None:
@@ -645,6 +651,7 @@ def _validate_column(
                     column=name,
                     rule="max",
                     message=f"Column {name!r} has values above {field_def.max}",
+                    severity=field_def.severity,
                 )
             )
 
@@ -658,6 +665,7 @@ def _validate_column(
                 column=name,
                 rule="pattern",
                 message=f"Column {name!r} has values that do not match the pattern",
+                severity=field_def.severity,
             )
         )
 
@@ -684,6 +692,7 @@ def _validate_column(
                             f"Column {name!r} contains values that failed "
                             f"the {validator_name!r} validator"
                         ),
+                        severity=field_def.severity,
                     )
                 )
         else:
@@ -720,6 +729,7 @@ def _validate_column(
                         column=name,
                         rule=field_def.semantic,
                         message=f"Column {name!r} contains invalid {field_def.semantic} values",
+                        severity=field_def.severity,
                     )
                 )
     if field_def.min_length is not None:
@@ -730,6 +740,7 @@ def _validate_column(
                 column=name,
                 rule="min_length",
                 message=f"Column {name!r} has values shorter than {field_def.min_length}",
+                severity=field_def.severity,
             )
         )
 
@@ -741,6 +752,7 @@ def _validate_column(
                 column=name,
                 rule="max_length",
                 message=f"Column {name!r} has values longer than {field_def.max_length}",
+                severity=field_def.severity,
             )
         )
 
@@ -762,6 +774,7 @@ def _validate_datetime(
             column=name,
             rule="format",
             message=f"Column {name!r} does not match the required datetime format",
+            severity=field_def.severity,
         )
     )
 
@@ -776,6 +789,7 @@ def _validate_datetime(
                 column=name,
                 rule="min",
                 message=f"Column {name!r} has values below {field_def._datetime_min}",
+                severity=field_def.severity,
             )
         )
     if field_def._datetime_max is not None:
@@ -785,6 +799,7 @@ def _validate_datetime(
                 column=name,
                 rule="max",
                 message=f"Column {name!r} has values above {field_def._datetime_max}",
+                severity=field_def.severity,
             )
         )
 
@@ -812,6 +827,7 @@ def _row_issues(
     column: str,
     rule: str,
     message: str,
+    severity: str = "error",
 ) -> list[ValidationIssue]:
     return [
         ValidationIssue(
@@ -820,6 +836,7 @@ def _row_issues(
             message=message,
             row_index=int(index) + 1,
             value=value,
+            severity=severity,
         )
         for index, value in invalid.items()
     ]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -79,6 +79,7 @@ def test_validation_result_to_pandas_empty_has_stable_columns():
         "message",
         "row_index",
         "value",
+        "severity",
     ]
 
 
@@ -203,6 +204,26 @@ def test_validation_result_to_markdown_for_success(sample_csv):
     assert "- Status: **passed**" in markdown
     assert "- Issues found: 0" in markdown
     assert "| Column | Rule | Row | Value | Message |" not in markdown
+
+
+def test_warning_severity_does_not_fail_validation(tmp_path):
+    path = tmp_path / "warnings.csv"
+    path.write_text("age\n15\n")
+
+    schema = {
+        "age": ar.Field(
+            dtype="int64",
+            min=18,
+            severity="warning",
+        )
+    }
+
+    result = ar.validate(ar.read_csv(path), schema)
+
+    assert result.passed
+    assert result.issue_count == 1
+    assert result.issues[0].severity == "warning"
+    assert result.issues[0].rule == "min"
 
 
 def test_validation_result_to_markdown_includes_issue_table(sample_csv):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -512,6 +512,11 @@ def test_int64_rejects_impossible_bounds():
         raise AssertionError("Expected invalid Int64 bounds to raise")
 
 
+def test_invalid_severity_raises():
+    with pytest.raises(ValueError, match="severity must be"):
+        ar.Int64(severity="warn")
+
+
 def test_float64_rejects_impossible_bounds():
     try:
         ar.Float64(min=10.0, max=1.0)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -226,6 +226,21 @@ def test_warning_severity_does_not_fail_validation(tmp_path):
     assert result.issues[0].rule == "min"
 
 
+def test_warning_severity_does_not_fail_dtype_mismatch(tmp_path):
+    path = tmp_path / "dtype_warning.csv"
+    path.write_text("age\nhello\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"age": ar.Int64(severity="warning")},
+    )
+
+    assert result.passed
+    assert result.issue_count == 1
+    assert result.issues[0].rule == "dtype"
+    assert result.issues[0].severity == "warning"
+
+
 def test_validation_result_to_markdown_includes_issue_table(sample_csv):
     result = ar.validate(
         ar.read_csv(sample_csv),
@@ -236,10 +251,10 @@ def test_validation_result_to_markdown_includes_issue_table(sample_csv):
 
     assert "- Status: **failed**" in markdown
     assert "- Issues found: 3" in markdown
-    assert "| Column | Rule | Row | Value | Message |" in markdown
-    assert "| age | min | 1 |" in markdown
+    assert "| Column | Rule | Severity | Row | Value | Message |" in markdown
+    assert "| age | min | error | 1 |" in markdown
     assert (
-        "| missing | required_column |  |  | Missing required column: missing |"
+        "| missing | required_column | error |  |  | Missing required column: missing |"
         in markdown
     )
 
@@ -249,7 +264,7 @@ def test_validation_result_to_markdown_limits_visible_issues(sample_csv):
 
     markdown = result.to_markdown(max_issues=1)
 
-    assert "| age | min | 1 |" in markdown
+    assert "| age | min | error | 1 |" in markdown
     assert "| age | min | 2 |" not in markdown
     assert "_Showing 1 of 2 issues._" in markdown
 


### PR DESCRIPTION
Fixes #192

## Description
This PR adds support for warning-level schema validation issues without failing the overall validation result.

### Changes made
- Added `severity` support to `ValidationIssue`
- Added severity propagation across schema validation checks
- Updated validation result handling so warning-only issues do not fail validation
- Preserved existing error-level validation behavior
- Added tests for warning severity validation flow
- Updated validation issue serialization and dataframe output to include severity metadata

### Testing
- Ran `python -m black arnio/schema.py tests/test_schema.py`
- Ran `python -m pytest tests/test_schema.py`

### Screenshots
- Added screenshots showing:
  - all schema tests passing successfully
 
<img width="1462" height="848" alt="Screenshot 2026-05-19 011656" src="https://github.com/user-attachments/assets/1b1bfd64-b2cd-4db0-8535-0d6e655004dd" />
