### PR TITLE
fix(cleaning): preserve Unicode bytes in normalize_case

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -554,7 +554,11 @@ def normalize_case(
     subset: list[str] | None = None,
     case_type: str = "lower",
 ) -> ArFrame:
-    """Normalize string columns to lower/upper/title case.
+    """Normalize ASCII letters in string columns to lower/upper/title case.
+
+    Non-ASCII UTF-8 bytes are preserved unchanged. This keeps accented text,
+    CJK characters, emoji, and other multibyte data valid while avoiding a
+    heavyweight Unicode case-folding dependency.
 
     Parameters
     ----------

--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -326,7 +326,8 @@ Frame normalize_case(const Frame& frame, const std::optional<std::vector<std::st
                     next_upper = false;
                 } else {
                     c = ascii_lower(c);
-                    if (is_ascii_alpha(c)) {
+                    if (is_ascii_alpha(c) ||
+                        static_cast<unsigned char>(c) >= 0x80) {
                         next_upper = false;
                     }
                 }

--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -268,22 +268,50 @@ Frame normalize_case(const Frame& frame, const std::optional<std::vector<std::st
                      const std::string& case_type) {
     auto target_indices_set = resolve_subset(frame, subset);
     std::unordered_set<size_t> targets(target_indices_set.begin(), target_indices_set.end());
+    auto ascii_lower = [](char c) -> char {
+        const auto uc = static_cast<unsigned char>(c);
+        if (uc >= 'A' && uc <= 'Z') {
+            return static_cast<char>(uc + ('a' - 'A'));
+        }
+        return c;
+    };
+    auto ascii_upper = [](char c) -> char {
+        const auto uc = static_cast<unsigned char>(c);
+        if (uc >= 'a' && uc <= 'z') {
+            return static_cast<char>(uc - ('a' - 'A'));
+        }
+        return c;
+    };
+    auto is_ascii_alpha = [](char c) -> bool {
+        const auto uc = static_cast<unsigned char>(c);
+        return (uc >= 'A' && uc <= 'Z') || (uc >= 'a' && uc <= 'z');
+    };
 
     std::function<std::string(const std::string&)> transform_fn;
     if (case_type == "lower") {
         transform_fn = [](const std::string& s) {
             std::string result = s;
-            std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+            for (auto& c : result) {
+                const auto uc = static_cast<unsigned char>(c);
+                if (uc >= 'A' && uc <= 'Z') {
+                    c = static_cast<char>(uc + ('a' - 'A'));
+                }
+            }
             return result;
         };
     } else if (case_type == "upper") {
         transform_fn = [](const std::string& s) {
             std::string result = s;
-            std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+            for (auto& c : result) {
+                const auto uc = static_cast<unsigned char>(c);
+                if (uc >= 'a' && uc <= 'z') {
+                    c = static_cast<char>(uc - ('a' - 'A'));
+                }
+            }
             return result;
         };
     } else if (case_type == "title") {
-        transform_fn = [](const std::string& s) {
+        transform_fn = [ascii_lower, ascii_upper, is_ascii_alpha](const std::string& s) {
             std::string result = s;
             bool next_upper = true;
             auto is_word_boundary = [](char c) -> bool {
@@ -293,11 +321,14 @@ Frame normalize_case(const Frame& frame, const std::optional<std::vector<std::st
             for (auto& c : result) {
                 if (is_word_boundary(c)) {
                     next_upper = true;
-                } else if (next_upper) {
-                    c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+                } else if (next_upper && is_ascii_alpha(c)) {
+                    c = ascii_upper(c);
                     next_upper = false;
                 } else {
-                    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+                    c = ascii_lower(c);
+                    if (is_ascii_alpha(c)) {
+                        next_upper = false;
+                    }
                 }
             }
             return result;

--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -326,8 +326,7 @@ Frame normalize_case(const Frame& frame, const std::optional<std::vector<std::st
                     next_upper = false;
                 } else {
                     c = ascii_lower(c);
-                    if (is_ascii_alpha(c) ||
-                        static_cast<unsigned char>(c) >= 0x80) {
+                    if (is_ascii_alpha(c) || static_cast<unsigned char>(c) >= 0x80) {
                         next_upper = false;
                     }
                 }

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -561,8 +561,12 @@ class TestNormalizeCase:
             pd.DataFrame({"city": ["São Paulo", "München", "東京", "Dev 🚀"]})
         )
 
-        lower = ar.to_pandas(ar.normalize_case(frame, subset=["city"], case_type="lower"))
-        upper = ar.to_pandas(ar.normalize_case(frame, subset=["city"], case_type="upper"))
+        lower = ar.to_pandas(
+            ar.normalize_case(frame, subset=["city"], case_type="lower")
+        )
+        upper = ar.to_pandas(
+            ar.normalize_case(frame, subset=["city"], case_type="upper")
+        )
 
         assert lower["city"].tolist() == ["são paulo", "münchen", "東京", "dev 🚀"]
         assert upper["city"].tolist() == ["SãO PAULO", "MüNCHEN", "東京", "DEV 🚀"]
@@ -578,6 +582,16 @@ class TestNormalizeCase:
         df = ar.to_pandas(result)
 
         assert df["city"].tolist() == ["São-Paulo", "München Central", "東京 Station"]
+
+    def test_title_preserves_non_ascii_word_prefixes(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"word": ["éclair", "ñandú", "über-cool"]}))
+
+        result = ar.normalize_case(frame, subset=["word"], case_type="title")
+        df = ar.to_pandas(result)
+
+        assert df["word"].tolist() == ["éclair", "ñandú", "über-Cool"]
 
 
 class TestNormalizeUnicode:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -554,6 +554,31 @@ class TestNormalizeCase:
         assert df["name"].iloc[0] == "Hello/World"
         assert df["name"].iloc[1] == "Foo/Bar"
 
+    def test_unicode_bytes_are_preserved_for_lower_and_upper(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame({"city": ["São Paulo", "München", "東京", "Dev 🚀"]})
+        )
+
+        lower = ar.to_pandas(ar.normalize_case(frame, subset=["city"], case_type="lower"))
+        upper = ar.to_pandas(ar.normalize_case(frame, subset=["city"], case_type="upper"))
+
+        assert lower["city"].tolist() == ["são paulo", "münchen", "東京", "dev 🚀"]
+        assert upper["city"].tolist() == ["SãO PAULO", "MüNCHEN", "東京", "DEV 🚀"]
+
+    def test_unicode_bytes_are_preserved_for_title(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(
+            pd.DataFrame({"city": ["são-paulo", "münchen central", "東京 station"]})
+        )
+
+        result = ar.normalize_case(frame, subset=["city"], case_type="title")
+        df = ar.to_pandas(result)
+
+        assert df["city"].tolist() == ["São-Paulo", "München Central", "東京 Station"]
+
 
 class TestNormalizeUnicode:
     def test_normalize_unicode(self):


### PR DESCRIPTION
## Summary
- make `normalize_case` convert only ASCII letters so UTF-8 multibyte characters are preserved instead of being processed byte-by-byte through `tolower`/`toupper`
- preserve existing ASCII lower/upper/title behavior and existing title word-boundary handling
- document the current ASCII-only case conversion behavior in the Python docstring
- add regression coverage for accented text, CJK text, and emoji across lower/upper/title modes

Fixes #26

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pip install -e .` ✅ rebuilt local C++ extension
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_cleaning.py -q` ✅ 144 passed, 5 pre-existing pandas warnings
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_cleaning.py tests/test_pipeline.py tests/test_pandas_accessor.py -q` ✅ 199 passed, 5 pre-existing pandas warnings
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check arnio/cleaning.py tests/test_cleaning.py` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile arnio/cleaning.py tests/test_cleaning.py` ✅
- `git diff --check` ✅

## Note
I saw the maintainer reopened #26 after the previous PR was closed, so I kept this focused on the requested Unicode-safety fix without adding a Unicode dependency.