### PR TITLE
Add CSV delimiter sniffing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,23 @@ Useful for exploring datasets before committing memory.
 </details>
 
 <details>
+<summary><b>Detect CSV delimiters before loading</b></summary>
+<br>
+
+`sniff_csv_delimiter` samples a CSV-like file and returns the most likely
+delimiter from comma, semicolon, tab, and pipe by default.
+
+```python
+delimiter = ar.sniff_csv_delimiter("unknown_export.csv")
+frame = ar.read_csv("unknown_export.csv", delimiter=delimiter)
+```
+
+Pass `candidates` for project-specific delimiters. Arnio raises a clear
+`ValueError` when no delimiter is detected or when the sample is ambiguous, so
+ingestion code can ask for an explicit delimiter instead of guessing.
+</details>
+
+<details>
 <summary><b>👀 Preview rows without pandas conversion or full-column Python list materialization</b></summary>
 <br>
 

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -38,7 +38,7 @@ from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame
 from .integrations import ArnioPandasAccessor
-from .io import read_csv, scan_csv, write_csv
+from .io import read_csv, scan_csv, sniff_csv_delimiter, write_csv
 from .pipeline import pipeline, register_step
 from .quality import (
     ColumnProfile,
@@ -74,6 +74,7 @@ __all__ = [
     "read_csv",
     "write_csv",
     "scan_csv",
+    "sniff_csv_delimiter",
     # Cleaning
     "drop_nulls",
     "keep_rows_with_nulls",

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -16,6 +16,8 @@ from ._core import _CsvConfig, _CsvReader, _CsvWriteConfig, _CsvWriter
 from .exceptions import CsvReadError
 from .frame import ArFrame
 
+DEFAULT_DELIMITER_CANDIDATES = (",", ";", "\t", "|")
+
 
 def _is_utf8_encoding(encoding: str) -> bool:
     """Return whether the encoding should be treated as raw UTF-8 input."""
@@ -104,6 +106,139 @@ def _validate_delimiter(delimiter: str) -> str:
         raise ValueError("delimiter must be exactly one character")
 
     return delimiter
+
+
+def _validate_delimiter_candidates(candidates: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(candidates, str):
+        raise TypeError("candidates must be a sequence of delimiter strings")
+    if not isinstance(candidates, Sequence):
+        raise TypeError("candidates must be a sequence of delimiter strings")
+    if not candidates:
+        raise ValueError("candidates must contain at least one delimiter")
+
+    validated = tuple(_validate_delimiter(candidate) for candidate in candidates)
+    if len(set(validated)) != len(validated):
+        raise ValueError("candidates must not contain duplicate delimiters")
+    return validated
+
+
+def _delimiter_score(sample: str, delimiter: str) -> tuple[int, int, int]:
+    try:
+        rows = [
+            row
+            for row in csv.reader(sample.splitlines(), delimiter=delimiter)
+            if row and any(field.strip() for field in row)
+        ]
+    except csv.Error:
+        return (0, 0, 0)
+
+    widths = [len(row) for row in rows]
+    delimited_widths = [width for width in widths if width > 1]
+    if not delimited_widths:
+        return (0, 0, 0)
+
+    width_counts = {
+        width: delimited_widths.count(width) for width in set(delimited_widths)
+    }
+    most_common_width = max(width_counts, key=width_counts.get)
+    consistent_rows = width_counts[most_common_width]
+    delimiter_occurrences = sum(line.count(delimiter) for line in sample.splitlines())
+    return (consistent_rows, most_common_width, delimiter_occurrences)
+
+
+def sniff_csv_delimiter(
+    path: str | os.PathLike[str],
+    *,
+    candidates: Sequence[str] = DEFAULT_DELIMITER_CANDIDATES,
+    encoding: str = "utf-8",
+    sample_size: int = 65536,
+) -> str:
+    """Detect the delimiter used by a CSV-like text file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the CSV-like file.
+    candidates : sequence of str, default (",", ";", "\\t", "|")
+        Single-character delimiters to evaluate.
+    encoding : str, default "utf-8"
+        Text encoding used to read the sample.
+    sample_size : int, default 65536
+        Maximum number of characters to sample from the file.
+
+    Returns
+    -------
+    str
+        Detected delimiter character.
+
+    Raises
+    ------
+    ValueError
+        If candidates are invalid, no delimiter is detected, or the best
+        delimiter is ambiguous.
+
+    TypeError
+        If candidates or sample_size have invalid types.
+
+    CsvReadError
+        If the file is empty, binary/corrupted, missing, or cannot be decoded.
+
+    Examples
+    --------
+    >>> delimiter = ar.sniff_csv_delimiter("data.csv")
+    >>> frame = ar.read_csv("data.csv", delimiter=delimiter)
+    """
+    if isinstance(sample_size, bool) or not isinstance(sample_size, int):
+        raise TypeError("sample_size must be an integer")
+    if sample_size <= 0:
+        raise ValueError("sample_size must be a positive integer greater than 0")
+
+    path = os.fspath(path)
+    validated_candidates = _validate_delimiter_candidates(candidates)
+
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(sample_size)
+    except OSError as e:
+        raise CsvReadError(str(e)) from e
+
+    if not raw:
+        raise CsvReadError(f"CSV file is empty: {path!r}")
+    if b"\0" in raw:
+        raise CsvReadError(
+            "CSV input contains NUL bytes and appears to be binary or corrupted"
+        )
+
+    try:
+        sample = raw.decode(encoding)
+    except LookupError as e:
+        raise ValueError(f"Unknown encoding: {encoding}") from e
+    except UnicodeDecodeError as e:
+        raise CsvReadError(
+            f"Could not decode {path!r} using encoding {encoding!r}"
+        ) from e
+
+    scores = {
+        delimiter: _delimiter_score(sample, delimiter)
+        for delimiter in validated_candidates
+    }
+    usable_scores = {
+        delimiter: score for delimiter, score in scores.items() if score[0] > 0
+    }
+    if not usable_scores:
+        raise ValueError(
+            f"Could not detect a delimiter from candidates {validated_candidates!r}"
+        )
+
+    best_score = max(usable_scores.values())
+    best_delimiters = [
+        delimiter for delimiter, score in usable_scores.items() if score == best_score
+    ]
+    if len(best_delimiters) > 1:
+        formatted = ", ".join(repr(delimiter) for delimiter in best_delimiters)
+        raise ValueError(f"Ambiguous delimiter candidates: {formatted}")
+
+    return best_delimiters[0]
 
 
 def _validate_usecols(usecols: Sequence[str]) -> list[str]:

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -442,6 +442,88 @@ class TestReadCsv:
             ar.read_csv(str(tmp_path / "nonexistent.csv"))
 
 
+class TestSniffCsvDelimiter:
+    @pytest.mark.parametrize(
+        ("delimiter", "content"),
+        [
+            (",", "name,age\nAlice,30\nBob,41\n"),
+            (";", "name;age\nAlice;30\nBob;41\n"),
+            ("\t", "name\tage\nAlice\t30\nBob\t41\n"),
+            ("|", "name|age\nAlice|30\nBob|41\n"),
+        ],
+    )
+    def test_detects_default_delimiters(self, tmp_path, delimiter, content):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text(content)
+
+        assert ar.sniff_csv_delimiter(csv_path) == delimiter
+
+    def test_ignores_quoted_candidate_delimiters(self, tmp_path):
+        csv_path = tmp_path / "quoted.csv"
+        csv_path.write_text('name,comment\nAlice,"hello, world"\nBob,"a,b,c"\n')
+
+        assert ar.sniff_csv_delimiter(csv_path) == ","
+
+    def test_custom_candidates(self, tmp_path):
+        csv_path = tmp_path / "custom.csv"
+        csv_path.write_text("name^age\nAlice^30\n")
+
+        assert ar.sniff_csv_delimiter(csv_path, candidates=["^", "|"]) == "^"
+
+    def test_non_utf8_encoding(self, tmp_path):
+        csv_path = tmp_path / "latin.csv"
+        csv_path.write_bytes("name;city\nAndré;Québec\n".encode("latin-1"))
+
+        assert ar.sniff_csv_delimiter(csv_path, encoding="latin-1") == ";"
+
+    def test_no_delimiter_detected(self, tmp_path):
+        csv_path = tmp_path / "single_column.csv"
+        csv_path.write_text("name\nAlice\nBob\n")
+
+        with pytest.raises(ValueError, match="Could not detect a delimiter"):
+            ar.sniff_csv_delimiter(csv_path)
+
+    def test_ambiguous_delimiter_detected(self, tmp_path):
+        csv_path = tmp_path / "ambiguous.csv"
+        csv_path.write_text("a,b|c\n1,2|3\n")
+
+        with pytest.raises(ValueError, match="Ambiguous delimiter candidates"):
+            ar.sniff_csv_delimiter(csv_path, candidates=[",", "|"])
+
+    def test_invalid_candidates(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+
+        with pytest.raises(TypeError, match="candidates must be a sequence"):
+            ar.sniff_csv_delimiter(csv_path, candidates=",")
+        with pytest.raises(ValueError, match="at least one delimiter"):
+            ar.sniff_csv_delimiter(csv_path, candidates=[])
+        with pytest.raises(ValueError, match="duplicate delimiters"):
+            ar.sniff_csv_delimiter(csv_path, candidates=[",", ","])
+        with pytest.raises(ValueError, match="delimiter must be exactly one character"):
+            ar.sniff_csv_delimiter(csv_path, candidates=["::"])
+
+    def test_invalid_sample_size(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+
+        with pytest.raises(TypeError, match="sample_size must be an integer"):
+            ar.sniff_csv_delimiter(csv_path, sample_size=True)
+        with pytest.raises(ValueError, match="sample_size must be a positive integer"):
+            ar.sniff_csv_delimiter(csv_path, sample_size=0)
+
+    def test_empty_and_binary_files_raise_csv_read_error(self, tmp_path):
+        empty_path = tmp_path / "empty.csv"
+        empty_path.write_text("")
+        with pytest.raises(ar.CsvReadError, match="CSV file is empty"):
+            ar.sniff_csv_delimiter(empty_path)
+
+        binary_path = tmp_path / "binary.csv"
+        binary_path.write_bytes(b"a,b\n1,\0\n")
+        with pytest.raises(ar.CsvReadError, match="NUL bytes"):
+            ar.sniff_csv_delimiter(binary_path)
+
+
 class TestScanCsv:
     def test_scan_schema(self, sample_csv):
         schema = ar.scan_csv(sample_csv)


### PR DESCRIPTION
## Summary
- add `ar.sniff_csv_delimiter()` to detect comma, semicolon, tab, and pipe-delimited CSV-like files before loading
- validate custom candidate lists, sample sizes, empty/binary files, undecodable input, no-delimiter samples, and ambiguous delimiter samples with clear errors
- document the helper and add CSV tests for default delimiters, quoted delimiters, custom candidates, non-UTF-8 input, and invalid cases

Fixes #127

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_csv.py -q` ✅ 113 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_csv.py tests/test_write_csv.py tests/test_gil.py -q` ✅ 134 passed
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest -q` ✅ 650 passed, 6 pre-existing pandas warnings
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check arnio/io.py arnio/__init__.py tests/test_csv.py` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff format --check arnio/io.py arnio/__init__.py tests/test_csv.py` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m black --check arnio/io.py arnio/__init__.py tests/test_csv.py` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile arnio/io.py arnio/__init__.py tests/test_csv.py` ✅
- `git diff --check` ✅