### PR TITLE
fix(pandas): reject stringified column label collisions

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -219,6 +219,39 @@ def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
     return None
 
 
+def _validate_unique_column_labels(labels: pd.Index) -> None:
+    seen: set[object] = set()
+    dupes: list[object] = []
+    for label in labels:
+        if label in seen and label not in dupes:
+            dupes.append(label)
+        seen.add(label)
+    if dupes:
+        raise ValueError(
+            "from_pandas() does not support duplicate column labels: "
+            f"{[repr(label) for label in dupes]}"
+        )
+
+    normalized: dict[str, object] = {}
+    collisions: dict[str, list[object]] = {}
+    for label in labels:
+        name = str(label)
+        if name in normalized:
+            collisions.setdefault(name, [normalized[name]]).append(label)
+        else:
+            normalized[name] = label
+
+    if collisions:
+        details = ", ".join(
+            f"{name!r}: {[repr(label) for label in labels]}"
+            for name, labels in collisions.items()
+        )
+        raise ValueError(
+            "from_pandas() column labels must remain unique after string "
+            f"conversion: {details}"
+        )
+
+
 def from_pandas(df: pd.DataFrame) -> ArFrame:
     """Convert pandas.DataFrame to ArFrame.
 
@@ -243,16 +276,7 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
     >>> df = pd.DataFrame({"name": ["Alice"], "age": [25]})
     >>> frame = ar.from_pandas(df)
     """
-    seen: set[object] = set()
-    dupes: list[object] = []
-    for label in df.columns:
-        if label in seen and label not in dupes:
-            dupes.append(label)
-        seen.add(label)
-    if dupes:
-        raise ValueError(
-            f"from_pandas() does not support duplicate column labels: {[repr(label) for label in dupes]}"
-        )
+    _validate_unique_column_labels(df.columns)
 
     columns = {}
     dtype_hints = {}

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -453,11 +453,33 @@ class TestFromPandas:
         frame = ar.from_pandas(df)
         assert frame.columns == ["x", "y"]
 
+    def test_unique_non_string_labels_convert_cleanly(self):
+        df = pd.DataFrame([[1, 2]], columns=[0, 1])
+        frame = ar.from_pandas(df)
+        assert frame.columns == ["0", "1"]
+
     def test_duplicate_non_string_labels_raises(self):
         df = pd.DataFrame([[1, 2, 3]], columns=[0, 1, 0])
         with pytest.raises(ValueError, match="duplicate column labels") as exc_info:
             ar.from_pandas(df)
         assert "0" in str(exc_info.value)
+
+    def test_stringified_integer_label_collision_raises(self):
+        df = pd.DataFrame([[1, 2]], columns=[1, "1"])
+        with pytest.raises(ValueError, match="string conversion") as exc_info:
+            ar.from_pandas(df)
+
+        message = str(exc_info.value)
+        assert "'1'" in message
+        assert "1" in message
+
+    def test_stringified_bool_label_collision_raises(self):
+        df = pd.DataFrame([[1, 2]], columns=[True, "True"])
+        with pytest.raises(ValueError, match="string conversion") as exc_info:
+            ar.from_pandas(df)
+
+        message = str(exc_info.value)
+        assert "True" in message
 
 
 class TestAttrsPreservation:


### PR DESCRIPTION
## Summary
- reject pandas column labels that collide after Arnio stringifies them
- keep existing duplicate-label rejection intact
- add regression coverage for integer/string and bool/string label collisions

## Verification
- `python -m pytest tests/test_convert.py -v --tb=short`
- `python -m pytest tests/ -v --tb=short` (`634 passed, 1 skipped`)
- `ruff check .`
- `black --check .`
- CMake native build + `test_column_consistency.exe`

Closes #711