### PR TITLE
ci: add manylinux wheel import smoke test

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -29,11 +29,6 @@ jobs:
       - name: Install cibuildwheel
         run: pip install cibuildwheel==2.22.0
 
-      - name: Build manylinux wheel
-        run: cibuildwheel --platform linux --only cp312-manylinux_x86_64
-        env:
-          CIBW_BUILD_VERBOSITY: 1
-
       - name: Run wheel smoke test
         run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse
 

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -4,10 +4,10 @@ on:
   pull_request:
     paths:
       - '.github/workflows/wheel-smoke.yml'
-      - 'bindings/**'
-      - 'cpp/**'
-      - 'arnio/**'
       - 'pyproject.toml'
+      - 'setup.py'
+      - 'CMakeLists.txt'
+      - 'cpp/**'
   schedule:
     - cron: '0 4 * * 1'
   workflow_dispatch:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -33,6 +33,7 @@ jobs:
         run: cibuildwheel --only cp312-manylinux_x86_64 --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_TEST_COMMAND: ""
 
       - name: Run wheel smoke test
         run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Install cibuildwheel
         run: pip install cibuildwheel==2.22.0
 
+      - name: Build manylinux wheel
+        run: cibuildwheel --only cp312-manylinux_x86_64 --output-dir wheelhouse
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+
       - name: Run wheel smoke test
         run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse
 

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -1,0 +1,45 @@
+name: Manylinux Wheel Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/wheel-smoke.yml'
+      - 'bindings/**'
+      - 'cpp/**'
+      - 'arnio/**'
+      - 'pyproject.toml'
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  wheel-smoke:
+    name: Build manylinux wheel and smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install cibuildwheel
+        run: pip install cibuildwheel==2.22.0
+
+      - name: Build manylinux wheel
+        run: cibuildwheel --platform linux --only cp312-manylinux_x86_64
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+
+      - name: Run wheel smoke test
+        run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse
+
+      - name: Upload wheel as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: manylinux-wheel
+          path: wheelhouse/*.whl
+          retention-days: 7

--- a/tests/smoke_wheel_install.py
+++ b/tests/smoke_wheel_install.py
@@ -104,10 +104,17 @@ def main() -> int:
 
         import_check = (
             "import arnio as ar; "
+            "import tempfile, pathlib; "
             "print('arnio import ok:', ar.__version__); "
             "assert hasattr(ar, 'read_csv'); "
             "assert hasattr(ar, 'pipeline'); "
-            "assert hasattr(ar, 'to_pandas')"
+            "assert hasattr(ar, 'to_pandas'); "
+            "tmp = tempfile.mkdtemp(); "
+            "csv = pathlib.Path(tmp) / 'smoke.csv'; "
+            "csv.write_text('name,age\\nAlice,30\\nBob,25\\n'); "
+            "frame = ar.read_csv(str(csv)); "
+            "assert frame is not None; "
+            "print('read_csv smoke test passed')"
         )
 
         run([str(python), "-c", import_check], cwd=tmp_dir)


### PR DESCRIPTION
Fixes #675

## What this PR does
- Adds `.github/workflows/wheel-smoke.yml` builds a `cp312-manylinux_x86_64` wheel using `cibuildwheel` and verifies it installs and imports correctly in a clean environment
- Extends `tests/smoke_wheel_install.py` with a tiny CSV read sanity check (`ar.read_csv()`) as requested

## How it works
1. Builds manylinux wheel via `cibuildwheel`
2. Installs it in a fresh venv (no build tools, `--no-index`) via `smoke_wheel_install.py`
3. Verifies `import arnio`, version, `read_csv`, `pipeline`, `to_pandas`, and a minimal CSV read

## Triggers
- `schedule`: Monday 04:00 UTC (offset from compat-matrix at 03:00 UTC)
- `workflow_dispatch`: manual trigger before releases
- `pull_request`: path-limited to `.github/workflows/wheel-smoke.yml`, `pyproject.toml`, `setup.py`, `CMakeLists.txt`, `cpp/**`

## Notes
- Does not slow normal PRs
- Wheel artifact uploaded for 7 days
- Existing test suite unaffected