### PR TITLE
fix: register standalone CMake native test with CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(arnio LANGUAGES CXX)
 
+enable_testing()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,4 +15,10 @@ target_compile_features(arnio_core PUBLIC cxx_std_17)
 add_executable(test_column_consistency
     tests/test_column_consistency.cpp
 )
+
 target_link_libraries(test_column_consistency PRIVATE arnio_core)
+
+add_test(
+    NAME test_column_consistency
+    COMMAND $<TARGET_FILE:test_column_consistency>
+)


### PR DESCRIPTION
## Summary

Adds standalone CMake test discovery for the native C++ test target.

### Changes

* Added `enable_testing()` at the top-level CMake configuration
* Registered `test_column_consistency` with `add_test()` so it is discoverable via CTest

This keeps the change focused on native standalone CMake test discovery without affecting the Python wheel build path.

Closes #724

## Verification

Tested locally using:

```cmd
cmake -S . -B build -G Ninja -Dpybind11_DIR="%LOCALAPPDATA%\Programs\Python\Python313\Lib\site-packages\pybind11\share\cmake\pybind11"
cmake --build build --config Release
ctest --test-dir build --output-on-failure
```

Result:

```text
Start 1: test_column_consistency
1/1 Test #1: test_column_consistency .......... Passed
100% tests passed, 0 tests failed out of 1
```
