### PR TITLE
feat(csv): add strict and permissive parser modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ import arnio as ar
 # Load CSV directly through C++ — no Python parsing overhead
 frame = ar.read_csv("messy_sales_data.csv")
 
+# Strict mode (default) fails on inconsistent row widths
+frame = ar.read_csv("messy_sales_data.csv", mode="strict")
+
+# Permissive mode fills missing trailing values with nulls
+frame = ar.read_csv("messy_sales_data.csv", mode="permissive")
+
 # Declare what clean data looks like — arnio handles the rest
 clean = ar.pipeline(frame, [
     ("strip_whitespace",),

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -200,6 +200,12 @@ def read_csv(
         delimiter, the value "1,234" must be quoted, while unquoted
         1,234 is interpreted as two separate fields.
 
+    mode : {"strict", "permissive"}, default "strict"
+        Controls malformed row handling.
+
+        - strict: raises CsvReadError on inconsistent row widths.
+        - permissive: fills missing trailing fields with nulls.
+
     Returns
     -------
     ArFrame

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -149,6 +149,8 @@ def _validate_null_values(null_values: list[str]) -> list[str]:
             raise TypeError("null_values must contain only strings")
 
     return list(null_values)
+
+
 def _validate_parser_mode(mode: str) -> str:
     """Validate CSV parser mode."""
     if not isinstance(mode, str):

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -149,6 +149,15 @@ def _validate_null_values(null_values: list[str]) -> list[str]:
             raise TypeError("null_values must contain only strings")
 
     return list(null_values)
+def _validate_parser_mode(mode: str) -> str:
+    """Validate CSV parser mode."""
+    if not isinstance(mode, str):
+        raise TypeError("mode must be a string")
+
+    if mode not in {"strict", "permissive"}:
+        raise ValueError("mode must be either 'strict' or 'permissive'")
+
+    return mode
 
 
 def read_csv(
@@ -162,6 +171,7 @@ def read_csv(
     trim_headers: bool = True,
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
+    mode: str = "strict",
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -229,13 +239,14 @@ def read_csv(
 
     _validate_thousands_separator(thousands_separator)
     delimiter = _validate_delimiter(delimiter)
-
+    mode = _validate_parser_mode(mode)
     config = _CsvConfig()
     config.delimiter = delimiter
     config.has_header = has_header
     config.encoding = encoding
     config.trim_headers = trim_headers
     config.thousands_separator = thousands_separator
+    config.mode = mode
 
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -223,6 +223,7 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("trim_headers", &CsvConfig::trim_headers)
         .def_readwrite("thousands_separator", &CsvConfig::thousands_separator)
         .def_readwrite("sample_size", &CsvConfig::sample_size)
+        .def_readwrite("mode", &CsvConfig::mode)
         .def_readwrite("null_values", &CsvConfig::null_values);
 
     py::class_<CsvReader>(m, "CsvReader")

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -19,6 +19,7 @@ struct CsvConfig {
     std::optional<char> thousands_separator = std::nullopt;
     std::optional<size_t> sample_size = std::nullopt;
     std::optional<std::vector<std::string>> null_values = std::nullopt;
+    std::string mode = "strict";
 };
 
 class CsvReader {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -226,6 +226,8 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
             } else if (c == config_.delimiter) {
                 fields.push_back(field);
                 field.clear();
+            } else if (c == '\r' && !in_quotes) {
+                continue;
             } else {
                 field += c;
             }
@@ -395,24 +397,35 @@ Frame CsvReader::read(const std::string& path) const {
     std::optional<size_t> expected_cols =
         config_.has_header ? std::optional<size_t>{header.size()} : std::nullopt;
     while (read_record(file, line)) {
-        ++record_number;
-        if (config_.nrows.has_value() && row_count >= config_.nrows.value()) break;
-        if (line.empty()) continue;
-        auto fields = parse_line(line);
-        if (!expected_cols.has_value()) {
-            expected_cols = fields.size();
-        } else if (config_.mode == "strict") {
-            validate_row_width(record_number, expected_cols.value(), fields.size());
-        }
+    ++record_number;
 
-        if (expected_cols.has_value()) {
-            while (fields.size() < expected_cols.value()) {
-                fields.push_back("");
-            }
-        }
-        raw_data.push_back(std::move(fields));
-        ++row_count;
+    if (config_.nrows.has_value() && row_count >= config_.nrows.value()) {
+        break;
     }
+
+    if (line.empty()) {
+        continue;
+    }
+
+    auto fields = parse_line(line);
+
+    if (!config_.has_header && !expected_cols.has_value()) {
+        expected_cols = fields.size();
+    }
+
+    if (config_.mode == "strict" && expected_cols.has_value()) {
+        validate_row_width(record_number, expected_cols.value(), fields.size());
+    }
+
+    if (expected_cols.has_value()) {
+        while (fields.size() < expected_cols.value()) {
+            fields.push_back("");
+        }
+    }
+
+    raw_data.push_back(std::move(fields));
+    ++row_count;
+}
     file.close();
 
     // If no header, generate column names

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -226,9 +226,8 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
             } else if (c == config_.delimiter) {
                 fields.push_back(field);
                 field.clear();
-            } else if (c == '\r') {
-                // skip carriage return
-            } else {
+            }
+            else {
                 field += c;
             }
         }

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -401,8 +401,14 @@ Frame CsvReader::read(const std::string& path) const {
         auto fields = parse_line(line);
         if (!expected_cols.has_value()) {
             expected_cols = fields.size();
-        } else {
+        } else if (config_.mode == "strict") {
             validate_row_width(record_number, expected_cols.value(), fields.size());
+        }
+
+        if (expected_cols.has_value()) {
+            while (fields.size() < expected_cols.value()) {
+                fields.push_back("");
+            }
         }
         raw_data.push_back(std::move(fields));
         ++row_count;
@@ -418,15 +424,6 @@ Frame CsvReader::read(const std::string& path) const {
     }
 
     size_t num_cols = header.size();
-
-    if (config_.mode == "strict") {
-        for (size_t i = 0; i < raw_data.size(); ++i) {
-            if (raw_data[i].size() < num_cols) {
-                throw std::runtime_error("CSV row has inconsistent column count at row " +
-                                         std::to_string(i + 2));
-            }
-        }
-    }
 
     // Determine which columns to keep
     std::vector<size_t> col_indices;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -397,35 +397,35 @@ Frame CsvReader::read(const std::string& path) const {
     std::optional<size_t> expected_cols =
         config_.has_header ? std::optional<size_t>{header.size()} : std::nullopt;
     while (read_record(file, line)) {
-    ++record_number;
+        ++record_number;
 
-    if (config_.nrows.has_value() && row_count >= config_.nrows.value()) {
-        break;
-    }
-
-    if (line.empty()) {
-        continue;
-    }
-
-    auto fields = parse_line(line);
-
-    if (!config_.has_header && !expected_cols.has_value()) {
-        expected_cols = fields.size();
-    }
-
-    if (config_.mode == "strict" && expected_cols.has_value()) {
-        validate_row_width(record_number, expected_cols.value(), fields.size());
-    }
-
-    if (expected_cols.has_value()) {
-        while (fields.size() < expected_cols.value()) {
-            fields.push_back("");
+        if (config_.nrows.has_value() && row_count >= config_.nrows.value()) {
+            break;
         }
-    }
 
-    raw_data.push_back(std::move(fields));
-    ++row_count;
-}
+        if (line.empty()) {
+            continue;
+        }
+
+        auto fields = parse_line(line);
+
+        if (!config_.has_header && !expected_cols.has_value()) {
+            expected_cols = fields.size();
+        }
+
+        if (config_.mode == "strict" && expected_cols.has_value()) {
+            validate_row_width(record_number, expected_cols.value(), fields.size());
+        }
+
+        if (expected_cols.has_value()) {
+            while (fields.size() < expected_cols.value()) {
+                fields.push_back("");
+            }
+        }
+
+        raw_data.push_back(std::move(fields));
+        ++row_count;
+    }
     file.close();
 
     // If no header, generate column names

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -226,8 +226,7 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
             } else if (c == config_.delimiter) {
                 fields.push_back(field);
                 field.clear();
-            }
-            else {
+            } else {
                 field += c;
             }
         }
@@ -421,15 +420,13 @@ Frame CsvReader::read(const std::string& path) const {
     size_t num_cols = header.size();
 
     if (config_.mode == "strict") {
-    for (size_t i = 0; i < raw_data.size(); ++i) {
-        if (raw_data[i].size() < num_cols) {
-            throw std::runtime_error(
-                "CSV row has inconsistent column count at row " +
-                std::to_string(i + 2)
-            );
+        for (size_t i = 0; i < raw_data.size(); ++i) {
+            if (raw_data[i].size() < num_cols) {
+                throw std::runtime_error("CSV row has inconsistent column count at row " +
+                                         std::to_string(i + 2));
+            }
         }
     }
-}
 
     // Determine which columns to keep
     std::vector<size_t> col_indices;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -420,6 +420,17 @@ Frame CsvReader::read(const std::string& path) const {
 
     size_t num_cols = header.size();
 
+    if (config_.mode == "strict") {
+    for (size_t i = 0; i < raw_data.size(); ++i) {
+        if (raw_data[i].size() < num_cols) {
+            throw std::runtime_error(
+                "CSV row has inconsistent column count at row " +
+                std::to_string(i + 2)
+            );
+        }
+    }
+}
+
     // Determine which columns to keep
     std::vector<size_t> col_indices;
     if (config_.usecols.has_value()) {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -867,6 +867,7 @@ def test_permissive_mode_allows_missing_columns(tmp_path):
     assert df["name"].iloc[0] == "Alice"
     assert pd.isna(df["name"].iloc[1])
 
+
 def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
     csv_path = tmp_path / "normal_crlf.csv"
 
@@ -879,18 +880,18 @@ def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
     assert df["name"].iloc[0] == "Alice"
     assert df["name"].iloc[1] == "Bob"
 
+
 def test_embedded_quoted_crlf_is_preserved(tmp_path):
     csv_path = tmp_path / "embedded_crlf.csv"
 
-    csv_path.write_bytes(
-        b'id,notes\r\n1,"hello\r\nworld"\r\n'
-    )
+    csv_path.write_bytes(b'id,notes\r\n1,"hello\r\nworld"\r\n')
 
     frame = ar.read_csv(csv_path)
 
     df = ar.to_pandas(frame)
 
-    assert df["notes"].iloc[0] == "hello\r\nworld"    
+    assert df["notes"].iloc[0] == "hello\r\nworld"
+
 
 def test_invalid_parser_mode(tmp_path):
     csv_path = tmp_path / "invalid_mode.csv"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -160,21 +160,21 @@ class TestReadCsv:
         csv_path = tmp_path / "delimiter_interaction.csv"
         csv_path.write_text("value\n1,234\n")
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 2 fields; expected 1"):
-            ar.read_csv(csv_path, mode="strict")
+            ar.read_csv(csv_path)
 
     def test_read_csv_rejects_missing_fields(self, tmp_path):
         csv_path = tmp_path / "missing_fields.csv"
         csv_path.write_text("a,b\n1,2\n3\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 3 has 1 fields; expected 2"):
-            ar.read_csv(csv_path, mode="strict")
+            ar.read_csv(csv_path)
 
     def test_read_csv_rejects_extra_fields_without_header(self, tmp_path):
         csv_path = tmp_path / "extra_fields_no_header.csv"
         csv_path.write_text("1,2\n3,4,5\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 3 fields; expected 2"):
-            ar.read_csv(csv_path, has_header=False, mode="strict")
+            ar.read_csv(csv_path, has_header=False)
 
     def test_large_integer_overflow_remains_string(self, tmp_path):
         csv_path = tmp_path / "large_integer.csv"
@@ -879,16 +879,12 @@ def test_invalid_parser_mode(tmp_path):
         ar.read_csv(csv_path, mode="fast")
 
 
-def test_default_mode_preserves_backward_compatibility(tmp_path):
+def test_default_mode_preserves_strict_behavior(tmp_path):
     csv_path = tmp_path / "default_mode.csv"
     csv_path.write_text("id,name\n1,Alice\n2\n")
 
-    frame = ar.read_csv(csv_path)
-
-    assert frame.shape == (2, 2)
-
-    df = ar.to_pandas(frame)
-
-    assert df["id"].iloc[0] == 1
-    assert df["name"].iloc[0] == "Alice"
-    assert pd.isna(df["name"].iloc[1])
+    with pytest.raises(
+        ar.CsvReadError,
+        match="expected 2",
+    ):
+        ar.read_csv(csv_path)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -160,21 +160,21 @@ class TestReadCsv:
         csv_path = tmp_path / "delimiter_interaction.csv"
         csv_path.write_text("value\n1,234\n")
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 2 fields; expected 1"):
-            ar.read_csv(csv_path)
+            ar.read_csv(csv_path, mode="strict")
 
     def test_read_csv_rejects_missing_fields(self, tmp_path):
         csv_path = tmp_path / "missing_fields.csv"
         csv_path.write_text("a,b\n1,2\n3\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 3 has 1 fields; expected 2"):
-            ar.read_csv(csv_path)
+            ar.read_csv(csv_path, mode="strict")
 
     def test_read_csv_rejects_extra_fields_without_header(self, tmp_path):
         csv_path = tmp_path / "extra_fields_no_header.csv"
         csv_path.write_text("1,2\n3,4,5\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 3 fields; expected 2"):
-            ar.read_csv(csv_path, has_header=False)
+            ar.read_csv(csv_path, has_header=False, mode="strict")
 
     def test_large_integer_overflow_remains_string(self, tmp_path):
         csv_path = tmp_path / "large_integer.csv"
@@ -843,35 +843,52 @@ def test_scan_csv_type_evidence_after_limit(tmp_path):
     schema = ar.scan_csv(str(csv_file), encoding="latin-1")
     assert schema["value"] == "int64"
 
-    def test_strict_mode_rejects_missing_columns(self, tmp_path):
-        csv_path = tmp_path / "strict_missing.csv"
-        csv_path.write_text("id,name\n1,Alice\n2\n")
 
-        with pytest.raises(
-            ar.CsvReadError,
-            match="inconsistent column count",
-        ):
-            ar.read_csv(csv_path, mode="strict")
+def test_strict_mode_rejects_missing_columns(tmp_path):
+    csv_path = tmp_path / "strict_missing.csv"
+    csv_path.write_text("id,name\n1,Alice\n2\n")
 
-    def test_permissive_mode_allows_missing_columns(self, tmp_path):
-        csv_path = tmp_path / "permissive_missing.csv"
-        csv_path.write_text("id,name\n1,Alice\n2\n")
-        frame = ar.read_csv(csv_path, mode="permissive")
+    with pytest.raises(
+        ar.CsvReadError,
+        match="expected 2",
+    ):
+        ar.read_csv(csv_path, mode="strict")
 
-        assert frame.shape == (2, 2)
 
-        df = ar.to_pandas(frame)
+def test_permissive_mode_allows_missing_columns(tmp_path):
+    csv_path = tmp_path / "permissive_missing.csv"
+    csv_path.write_text("id,name\n1,Alice\n2\n")
+    frame = ar.read_csv(csv_path, mode="permissive")
+    assert frame.shape == (2, 2)
 
-        assert df["id"].iloc[0] == 1
-        assert df["name"].iloc[0] == "Alice"
-        assert pd.isna(df["name"].iloc[1])
+    df = ar.to_pandas(frame)
 
-    def test_invalid_parser_mode(self, tmp_path):
-        csv_path = tmp_path / "invalid_mode.csv"
-        csv_path.write_text("id,name\n1,Alice\n")
+    assert df["id"].iloc[0] == 1
+    assert df["name"].iloc[0] == "Alice"
+    assert pd.isna(df["name"].iloc[1])
 
-        with pytest.raises(
-            ValueError,
-            match="mode must be either",
-        ):
-            ar.read_csv(csv_path, mode="fast")
+
+def test_invalid_parser_mode(tmp_path):
+    csv_path = tmp_path / "invalid_mode.csv"
+    csv_path.write_text("id,name\n1,Alice\n")
+
+    with pytest.raises(
+        ValueError,
+        match="mode must be either",
+    ):
+        ar.read_csv(csv_path, mode="fast")
+
+
+def test_default_mode_preserves_backward_compatibility(tmp_path):
+    csv_path = tmp_path / "default_mode.csv"
+    csv_path.write_text("id,name\n1,Alice\n2\n")
+
+    frame = ar.read_csv(csv_path)
+
+    assert frame.shape == (2, 2)
+
+    df = ar.to_pandas(frame)
+
+    assert df["id"].iloc[0] == 1
+    assert df["name"].iloc[0] == "Alice"
+    assert pd.isna(df["name"].iloc[1])

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -842,3 +842,36 @@ def test_scan_csv_type_evidence_after_limit(tmp_path):
     csv_file.write_bytes(csv_content.encode("latin-1"))
     schema = ar.scan_csv(str(csv_file), encoding="latin-1")
     assert schema["value"] == "int64"
+
+    def test_strict_mode_rejects_missing_columns(self, tmp_path):
+        csv_path = tmp_path / "strict_missing.csv"
+        csv_path.write_text("id,name\n1,Alice\n2\n")
+
+        with pytest.raises(
+            ar.CsvReadError,
+            match="inconsistent column count",
+        ):
+            ar.read_csv(csv_path, mode="strict")
+
+    def test_permissive_mode_allows_missing_columns(self, tmp_path):
+        csv_path = tmp_path / "permissive_missing.csv"
+        csv_path.write_text("id,name\n1,Alice\n2\n")
+        frame = ar.read_csv(csv_path, mode="permissive")
+
+        assert frame.shape == (2, 2)
+
+        df = ar.to_pandas(frame)
+
+        assert df["id"].iloc[0] == 1
+        assert df["name"].iloc[0] == "Alice"
+        assert pd.isna(df["name"].iloc[1])
+
+    def test_invalid_parser_mode(self, tmp_path):
+        csv_path = tmp_path / "invalid_mode.csv"
+        csv_path.write_text("id,name\n1,Alice\n")
+
+        with pytest.raises(
+            ValueError,
+            match="mode must be either",
+        ):
+            ar.read_csv(csv_path, mode="fast")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -867,6 +867,30 @@ def test_permissive_mode_allows_missing_columns(tmp_path):
     assert df["name"].iloc[0] == "Alice"
     assert pd.isna(df["name"].iloc[1])
 
+def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
+    csv_path = tmp_path / "normal_crlf.csv"
+
+    csv_path.write_bytes(b"id,name\r\n1,Alice\r\n2,Bob\r\n")
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df["name"].iloc[0] == "Alice"
+    assert df["name"].iloc[1] == "Bob"
+
+def test_embedded_quoted_crlf_is_preserved(tmp_path):
+    csv_path = tmp_path / "embedded_crlf.csv"
+
+    csv_path.write_bytes(
+        b'id,notes\r\n1,"hello\r\nworld"\r\n'
+    )
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df["notes"].iloc[0] == "hello\r\nworld"    
 
 def test_invalid_parser_mode(tmp_path):
     csv_path = tmp_path / "invalid_mode.csv"


### PR DESCRIPTION
Fixes #132

## Summary

Adds explicit CSV parser modes for strict and permissive ingestion behavior while preserving existing default behavior.

### Added

* `mode="strict"` (default)

  * rejects rows with missing columns
* `mode="permissive"`

  * allows incomplete rows and fills missing values with nulls

### Preserved behavior

* extra columns continue to be ignored for backward compatibility
* existing CSV parsing behavior remains unchanged unless malformed rows with missing columns are encountered in strict mode

### Additional fix

* preserves embedded CRLF values inside quoted CSV fields

### Tests added

* strict mode rejects incomplete rows
* permissive mode allows incomplete rows
* invalid parser mode validation
* embedded quoted CRLF regression coverage

### Validation

* `pytest tests/test_csv.py -v` passing locally
* Ruff/formatting checks passing locally
