### PR TITLE
feat(io): add safe_for_spreadsheet CSV export mode

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -87,6 +87,11 @@ ar.write_csv(frame, "output.csv")
 | `delimiter` | `str` | `","` | Single character field separator |
 | `write_header` | `bool` | `True` | Whether to write the column header row |
 | `line_terminator` | `str` | `"\n"` | Line terminator between rows |
+| `safe_for_spreadsheet` | `bool` | `False` | Prefix dangerous string cells with `'` to prevent CSV injection in Excel/Sheets |
+
+> **🔒 Security: CSV Injection Prevention**
+>
+> When `safe_for_spreadsheet=True`, any string cell starting with `=`, `+`, `-`, `@`, `\t`, or `\r` is prefixed with a single-quote (`'`). Spreadsheet applications treat the leading quote as a "display as text" signal, neutralising formula-injection attacks. Use this when the CSV is destined for human users opening it in a spreadsheet.
 
 #### Raises
 
@@ -110,6 +115,9 @@ ar.write_csv(frame, "output.csv", write_header=False)
 
 # Windows line endings
 ar.write_csv(frame, "output.csv", line_terminator="\r\n")
+
+# Safe for spreadsheet (prevents CSV injection)
+ar.write_csv(frame, "export.csv", safe_for_spreadsheet=True)
 ```
 
 ---

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -250,6 +250,41 @@ def read_csv(
     return ArFrame(cpp_frame)
 
 
+# Characters that spreadsheet applications (Excel, Sheets, LibreOffice Calc)
+# interpret as formula triggers when they appear at the start of a cell.
+_SPREADSHEET_FORMULA_PREFIXES: frozenset[str] = frozenset(
+    {"=", "+", "-", "@", "\t", "\r"}
+)
+
+
+def _sanitize_for_spreadsheet(frame: ArFrame) -> ArFrame:
+    """Return a copy of *frame* with dangerous string cells prefixed.
+
+    Any string cell whose first character is one of ``= + - @ \\t \\r``
+    is prefixed with a single-quote (``'``).  Spreadsheet applications
+    treat the leading single-quote as a "display as literal text" marker
+    without displaying it, which neutralises CSV-injection attacks.
+
+    Non-string columns and null values are left untouched.
+    """
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    def _prefix_if_dangerous(val: object) -> object:
+        if isinstance(val, str) and val and val[0] in _SPREADSHEET_FORMULA_PREFIXES:
+            return "'" + val
+        return val
+
+    df = to_pandas(frame)
+
+    for col in df.columns:
+        if pd.api.types.is_string_dtype(df[col]):
+            df[col] = df[col].apply(_prefix_if_dangerous)
+
+    return from_pandas(df)
+
+
 def write_csv(
     frame: ArFrame,
     path: str | os.PathLike[str],
@@ -257,6 +292,7 @@ def write_csv(
     delimiter: str = ",",
     write_header: bool = True,
     line_terminator: str = "\n",
+    safe_for_spreadsheet: bool = False,
 ) -> None:
     """Write an ArFrame to a CSV file via C++ backend.
 
@@ -272,6 +308,15 @@ def write_csv(
         Whether to write the column header row.
     line_terminator : str, default "\\n"
         Line terminator to use between rows.
+    safe_for_spreadsheet : bool, default False
+        When ``True``, prefix every string cell that starts with a
+        spreadsheet formula trigger (``= + - @ \\t \\r``) with a
+        single-quote (``'``).  This prevents CSV-injection attacks when
+        the file is opened in Excel, Google Sheets, or LibreOffice Calc.
+
+        The default is ``False`` so that raw data is preserved for
+        programmatic consumers.  Set to ``True`` when the CSV is
+        destined for human users opening it in a spreadsheet.
 
     Raises
     ------
@@ -284,6 +329,7 @@ def write_csv(
     --------
     >>> ar.write_csv(frame, "output.csv")
     >>> ar.write_csv(frame, "output.tsv", delimiter="\\t")
+    >>> ar.write_csv(frame, "export.csv", safe_for_spreadsheet=True)
     """
     path = os.fspath(path)
     path_lower = path.lower()
@@ -298,6 +344,15 @@ def write_csv(
 
     if len(delimiter) != 1:
         raise ValueError(f"delimiter must be a single character, got {delimiter!r}")
+
+    if not isinstance(safe_for_spreadsheet, bool):
+        raise TypeError(
+            f"safe_for_spreadsheet must be True or False, "
+            f"got {type(safe_for_spreadsheet).__name__}"
+        )
+
+    if safe_for_spreadsheet:
+        frame = _sanitize_for_spreadsheet(frame)
 
     config = _CsvWriteConfig()
     config.delimiter = delimiter

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -131,3 +131,114 @@ class TestWriteCsvLineTerminatorBytes:
         df = ar.to_pandas(frame2)
         assert df["note"].iloc[0] == "line1\nline2"
         assert df["note"].iloc[1] == "plain"
+
+
+class TestWriteCsvSafeForSpreadsheet:
+    """Tests for the safe_for_spreadsheet CSV export mode (issue #681)."""
+
+    def test_prefixes_formula_cells(self, tmp_path):
+        """Dangerous formula triggers are prefixed with a single-quote."""
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "data": [
+                        "=SUM(A1:A10)",
+                        "+cmd|'/C calc'!A0",
+                        "-1+1",
+                        "@SUM(A1)",
+                    ]
+                }
+            )
+        )
+        out = tmp_path / "safe.csv"
+        ar.write_csv(frame, out, safe_for_spreadsheet=True)
+        frame2 = ar.read_csv(out)
+        df = ar.to_pandas(frame2)
+        assert df["data"].iloc[0] == "'=SUM(A1:A10)"
+        assert df["data"].iloc[1] == "'+cmd|'/C calc'!A0"
+        assert df["data"].iloc[2] == "'-1+1"
+        assert df["data"].iloc[3] == "'@SUM(A1)"
+
+    def test_leaves_non_dangerous_strings(self, tmp_path):
+        """Normal strings without dangerous prefixes are unchanged."""
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob", "hello world"]}))
+        out = tmp_path / "safe.csv"
+        ar.write_csv(frame, out, safe_for_spreadsheet=True)
+        frame2 = ar.read_csv(out)
+        df = ar.to_pandas(frame2)
+        assert list(df["name"]) == ["Alice", "Bob", "hello world"]
+
+    def test_skips_numeric_and_bool_columns(self, tmp_path):
+        """Non-string columns (int, float, bool) are not modified."""
+        frame = ar.from_pandas(
+            pd.DataFrame({"val": [-1, 0, 1], "flag": [True, False, True]})
+        )
+        out = tmp_path / "safe.csv"
+        ar.write_csv(frame, out, safe_for_spreadsheet=True)
+        frame2 = ar.read_csv(out)
+        df = ar.to_pandas(frame2)
+        assert list(df["val"]) == [-1, 0, 1]
+        assert list(df["flag"]) == [True, False, True]
+
+    def test_handles_nulls(self, tmp_path):
+        """Null values are not corrupted; dangerous cells are still prefixed."""
+        frame = ar.from_pandas(pd.DataFrame({"data": ["=cmd", None, "safe"]}))
+        out = tmp_path / "safe.csv"
+        ar.write_csv(frame, out, safe_for_spreadsheet=True)
+        raw = out.read_text()
+        # The dangerous cell must be prefixed in the raw output
+        assert "'=cmd" in raw
+        # The safe cell must appear unchanged
+        assert "safe" in raw
+
+    def test_round_trip_content(self, tmp_path):
+        """Written content is readable and matches expectations."""
+        frame = ar.from_pandas(pd.DataFrame({"a": ["=1", "normal"], "b": [10, 20]}))
+        out = tmp_path / "rt.csv"
+        ar.write_csv(frame, out, safe_for_spreadsheet=True)
+        raw = out.read_text()
+        # The prefixed cell should appear as '=1 in the raw CSV
+        assert "'=1" in raw
+        assert "normal" in raw
+
+    def test_default_is_false(self, tmp_path):
+        """Default write_csv does NOT prefix dangerous strings."""
+        frame = ar.from_pandas(pd.DataFrame({"data": ["=SUM(A1)"]}))
+        out = tmp_path / "default.csv"
+        ar.write_csv(frame, out)
+        frame2 = ar.read_csv(out)
+        df = ar.to_pandas(frame2)
+        assert df["data"].iloc[0] == "=SUM(A1)"
+
+    def test_tab_and_cr_prefixed(self, tmp_path):
+        """Tab and carriage-return leading characters are prefixed."""
+        frame = ar.from_pandas(pd.DataFrame({"data": ["\tcmd", "\rmalicious"]}))
+        out = tmp_path / "special.csv"
+        ar.write_csv(frame, out, safe_for_spreadsheet=True)
+        frame2 = ar.read_csv(out)
+        df = ar.to_pandas(frame2)
+        assert df["data"].iloc[0].startswith("'")
+        assert df["data"].iloc[1].startswith("'")
+
+    def test_strict_bool_rejects_none(self, tmp_path):
+        """safe_for_spreadsheet=None raises TypeError."""
+        frame = ar.from_pandas(pd.DataFrame({"a": ["hello"]}))
+        out = tmp_path / "out.csv"
+        with pytest.raises(TypeError):
+            ar.write_csv(frame, out, safe_for_spreadsheet=None)
+
+    def test_strict_bool_rejects_int(self, tmp_path):
+        """safe_for_spreadsheet=1 or 0 raises TypeError."""
+        frame = ar.from_pandas(pd.DataFrame({"a": ["hello"]}))
+        out = tmp_path / "out.csv"
+        with pytest.raises(TypeError):
+            ar.write_csv(frame, out, safe_for_spreadsheet=1)
+        with pytest.raises(TypeError):
+            ar.write_csv(frame, out, safe_for_spreadsheet=0)
+
+    def test_strict_bool_rejects_string(self, tmp_path):
+        """safe_for_spreadsheet='true' raises TypeError."""
+        frame = ar.from_pandas(pd.DataFrame({"a": ["hello"]}))
+        out = tmp_path / "out.csv"
+        with pytest.raises(TypeError):
+            ar.write_csv(frame, out, safe_for_spreadsheet="true")


### PR DESCRIPTION
Add `safe_for_spreadsheet` parameter to `write_csv()` that prefixes string cells starting with formula triggers (= + - @ \t \r) with a single-quote to prevent CSV injection when opened in Excel/Sheets.
- Add _sanitize_for_spreadsheet() helper with pandas 3.0 compat
- Add 7 regression tests in TestWriteCsvSafeForSpreadsheet
- Update API_REFERENCE.md with parameter docs and security note Closes #681

## Summary
<!-- What changed and why? Keep this short but specific. -->

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [ ] I read the contributing guide.
- [ ] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
