### PR TITLE
docs: add backend execution map for pipeline steps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,7 +103,7 @@ When a step is invoked, the system follows a priority-based dispatch model:
 
 The system first queries `_STEP_REGISTRY`.
 
-This built-in registry routes operations to highly optimized C++-backed steps (executing directly within the `Frame` / C++ core), while also housing Python-backed built-ins.
+This built-in registry routes operations to highly optimized native C++ backed steps executing directly within the `Frame` / C++ core.
 
 ### Custom Pipeline Steps
 
@@ -131,25 +131,37 @@ Core cleaning primitives should ideally be implemented as C++ built-ins to bypas
 
 ### Step Backend Execution Map
 
+This map reflects the current pipeline registry defined in `arnio/pipeline.py`.
+
+The current pipeline registry is split into native C++ backed steps and Python/pandas backed steps.
+
 | Step | Backend |
 |---|---|
 | drop_nulls | Native C++ |
+| fill_nulls | Native C++ |
+| validate_columns_exist | Native C++ |
+| drop_duplicates | Native C++ |
+| drop_constant_columns | Native C++ |
+| clip_numeric | Native C++ |
 | strip_whitespace | Native C++ |
 | normalize_case | Native C++ |
-| drop_duplicates | Native C++ |
-| fill_nulls | Native C++ |
-| filter_rows | Python-backed |
-| custom registered steps | Python-backed |
+| rename_columns | Native C++ |
+| cast_types | Native C++ |
+| round_numeric_columns | Native C++ |
+| filter_rows | Python/pandas |
+| safe_divide_columns | Python/pandas |
+| custom registered steps | Python/pandas |
 
 ### Why backend selection matters
 
-C++-backed steps execute directly inside the Arnio runtime and avoid unnecessary pandas conversion overhead.
+Native C++ backed steps execute directly inside the Arnio runtime and avoid pandas conversion overhead.
 
-Python-backed steps may require:
+Python/pandas backed steps use the slower conversion path:
 
 ```text
 Frame → to_pandas() → from_pandas() → Frame
 ```
+
 These roundtrips can introduce additional memory allocation and type re-inference overhead.
 
 ---

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -129,6 +129,31 @@ Core cleaning primitives should ideally be implemented as C++ built-ins to bypas
 
 ---
 
+### Step Backend Execution Map
+
+| Step | Backend |
+|---|---|
+| drop_nulls | Native C++ |
+| strip_whitespace | Native C++ |
+| normalize_case | Native C++ |
+| drop_duplicates | Native C++ |
+| fill_nulls | Native C++ |
+| filter_rows | Python-backed |
+| custom registered steps | Python-backed |
+
+### Why backend selection matters
+
+C++-backed steps execute directly inside the Arnio runtime and avoid unnecessary pandas conversion overhead.
+
+Python-backed steps may require:
+
+```text
+Frame → to_pandas() → from_pandas() → Frame
+```
+These roundtrips can introduce additional memory allocation and type re-inference overhead.
+
+---
+
 ## 6. Converting to Pandas
 
 The `to_pandas()` function is a critical boundary.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,7 +107,7 @@ This built-in registry routes operations to highly optimized native C++ backed s
 
 ### Custom Pipeline Steps
 
-If the name is absent from the built-in registries, it searches `_PYTHON_STEP_REGISTRY` for custom, user-defined Python fallbacks.
+If the name is absent from `_STEP_REGISTRY`, the system then checks `_PYTHON_STEP_REGISTRY` for Python-backed built-ins and custom user-defined fallback steps.
 
 ### The Conversion Penalty
 
@@ -138,18 +138,26 @@ The current pipeline registry is split into native C++ backed steps and Python/p
 | Step | Backend |
 |---|---|
 | drop_nulls | Native C++ |
+| keep_rows_with_nulls | Native C++ |
 | fill_nulls | Native C++ |
 | validate_columns_exist | Native C++ |
 | drop_duplicates | Native C++ |
 | drop_constant_columns | Native C++ |
 | clip_numeric | Native C++ |
 | strip_whitespace | Native C++ |
+| parse_bool_strings | Native C++ |
 | normalize_case | Native C++ |
+| normalize_unicode | Native C++ |
 | rename_columns | Native C++ |
 | cast_types | Native C++ |
 | round_numeric_columns | Native C++ |
+| combine_columns | Native C++ |
+| trim_column_names | Native C++ |
+| standardize_missing_tokens | Python/pandas |
 | filter_rows | Python/pandas |
+| drop_columns_matching | Python/pandas |
 | safe_divide_columns | Python/pandas |
+| replace_values | Python/pandas |
 | custom registered steps | Python/pandas |
 
 ### Why backend selection matters
@@ -161,8 +169,6 @@ Python/pandas backed steps use the slower conversion path:
 ```text
 Frame → to_pandas() → from_pandas() → Frame
 ```
-
-These roundtrips can introduce additional memory allocation and type re-inference overhead.
 
 ---
 


### PR DESCRIPTION
## Summary

Added a concise documentation section explaining which pipeline steps are native C++ backed versus Python/pandas backed, along with a short explanation of conversion overhead involved in Python-backed execution.

Fixes #672
