### PR TITLE
feat: add PhoneNumber schema validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ ar.register_validator("positive", lambda v: v > 0)
 schema = ar.Schema({
     "id": ar.Int64(nullable=False, unique=True),
     "email": ar.Email(nullable=False),
+    "phone": ar.PhoneNumber(nullable=False),
 
     "user_type": ar.String(nullable=False),
 

--- a/README.md
+++ b/README.md
@@ -883,7 +883,6 @@ print(result.passed)
 
 Accepted examples include:
 - `+1-555-123-4567`
-- `(555) 123-4567`
 - `+91 9876543210`
 - `5551234567`
 

--- a/README.md
+++ b/README.md
@@ -868,6 +868,25 @@ In this example, `country` becomes required only when
 
 Date validates strict YYYY-MM-DD calendar dates.
 
+### Phone number validation
+
+`PhoneNumber()` validates common international and formatted phone number strings.
+
+```python
+schema = ar.Schema({
+    "phone": ar.PhoneNumber(nullable=False),
+})
+
+result = ar.validate(frame, schema)
+print(result.passed)
+```
+
+Accepted examples include:
+- `+1-555-123-4567`
+- `(555) 123-4567`
+- `+91 9876543210`
+- `5551234567`
+
 ### Warning-only validation
 
 ```python

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -73,6 +73,7 @@ from .schema import (
     Field,
     Float64,
     Int64,
+    PhoneNumber,
     Regex,
     Schema,
     SchemaDiff,
@@ -152,6 +153,7 @@ __all__ = [
     "Bool",
     "Email",
     "URL",
+    "PhoneNumber",
     "DateTime",
     # Exceptions
     "UnknownStepError",

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -737,6 +737,7 @@ def PhoneNumber(
     *,
     nullable: bool = True,
     unique: bool = False,
+    severity: str = "error",
     required_if: tuple[str, Any] | None = None,
 ) -> Field:
     """Create a phone-number schema field."""
@@ -746,6 +747,7 @@ def PhoneNumber(
         semantic="phone",
         unique=unique,
         required_if=required_if,
+        severity=severity,
     )
 
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -733,6 +733,22 @@ def URL(
     )
 
 
+def PhoneNumber(
+    *,
+    nullable: bool = True,
+    unique: bool = False,
+    required_if: tuple[str, Any] | None = None,
+) -> Field:
+    """Create a phone-number schema field."""
+    return Field(
+        dtype="string",
+        nullable=nullable,
+        semantic="phone",
+        unique=unique,
+        required_if=required_if,
+    )
+
+
 def CountryCode(
     *,
     nullable: bool = True,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -713,6 +713,32 @@ def test_phone_number_mixed_object_column_behavior():
     assert "invalid" in invalid_values
 
 
+def test_phone_number_warning_severity_does_not_fail_validation():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(severity="warning"),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": ["invalid-phone"],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.validate(frame, schema)
+
+    assert result.passed
+
+    assert result.issue_count == 1
+
+    assert result.issues[0].severity == "warning"
+
+
 def test_country_code_validation_accepts_iso_alpha_2_codes(tmp_path):
     path = tmp_path / "countries.csv"
     path.write_text("country\nIN\nUS\nGB\nFR\n")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -566,6 +566,7 @@ def test_phone_number_validation_fails():
 
     assert not result.passed
 
+
 def test_phone_number_nullable_true_accepts_nulls():
     import pandas as pd
 
@@ -590,6 +591,7 @@ def test_phone_number_nullable_true_accepts_nulls():
     result = ar.validate(frame, schema)
 
     assert result.passed
+
 
 def test_phone_number_nullable_false_rejects_nulls():
     import pandas as pd
@@ -617,6 +619,7 @@ def test_phone_number_nullable_false_rejects_nulls():
 
     assert any(issue.rule == "nullable" for issue in result.issues)
 
+
 def test_phone_number_unique_constraint():
     import pandas as pd
 
@@ -642,6 +645,7 @@ def test_phone_number_unique_constraint():
     assert not result.passed
 
     assert any(issue.rule == "unique" for issue in result.issues)
+
 
 def test_phone_number_formatted_and_invalid_edge_cases():
     import pandas as pd
@@ -673,6 +677,7 @@ def test_phone_number_formatted_and_invalid_edge_cases():
 
     assert "++1-555-123-4567" in invalid_values
     assert "123" in invalid_values
+
 
 def test_phone_number_mixed_object_column_behavior():
     import pandas as pd

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -566,6 +566,147 @@ def test_phone_number_validation_fails():
 
     assert not result.passed
 
+def test_phone_number_nullable_true_accepts_nulls():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(nullable=True),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "+1-555-123-4567",
+                None,
+                pd.NA,
+            ]
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.validate(frame, schema)
+
+    assert result.passed
+
+def test_phone_number_nullable_false_rejects_nulls():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(nullable=False),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "+1-555-123-4567",
+                None,
+            ]
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+
+    assert any(issue.rule == "nullable" for issue in result.issues)
+
+def test_phone_number_unique_constraint():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(unique=True),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "555-123-4567",
+                "555-123-4567",
+            ]
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+
+    assert any(issue.rule == "unique" for issue in result.issues)
+
+def test_phone_number_formatted_and_invalid_edge_cases():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "+1 (555) 123-4567",
+                "555-123-4567",
+                "++1-555-123-4567",
+                "123",
+            ]
+        }
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+
+    invalid_values = {issue.value for issue in result.issues}
+
+    assert "++1-555-123-4567" in invalid_values
+    assert "123" in invalid_values
+
+def test_phone_number_mixed_object_column_behavior():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(nullable=True),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "+1-555-123-4567",
+                1234567890,
+                True,
+                None,
+                "invalid",
+            ]
+        },
+        dtype=object,
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+
+    invalid_values = {str(issue.value) for issue in result.issues}
+
+    assert "True" in invalid_values
+    assert "invalid" in invalid_values
+
 
 def test_country_code_validation_accepts_iso_alpha_2_codes(tmp_path):
     path = tmp_path / "countries.csv"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -515,6 +515,58 @@ def test_email_strict_validation_accepts_valid_emails(tmp_path):
     assert result.passed
 
 
+def test_phone_number_validation_passes():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "+1-555-123-4567",
+                "+1 (555) 123-4567",
+                "+91 9876543210",
+                "5551234567",
+            ]
+        }
+    )
+
+    frame = ar.from_pandas(df)
+    result = ar.validate(frame, schema)
+
+    assert result.passed
+
+
+def test_phone_number_validation_fails():
+    import pandas as pd
+
+    schema = ar.Schema(
+        {
+            "phone": ar.PhoneNumber(),
+        }
+    )
+
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "abc123",
+                "12",
+                "++123456",
+                "phone-number",
+            ]
+        }
+    )
+
+    frame = ar.from_pandas(df)
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+
+
 def test_country_code_validation_accepts_iso_alpha_2_codes(tmp_path):
     path = tmp_path / "countries.csv"
     path.write_text("country\nIN\nUS\nGB\nFR\n")


### PR DESCRIPTION
## Summary
Adds a new PhoneNumber semantic schema validator for validating common phone-number formats through the Arnio schema API.

## Linked issue
Fixes #654 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
        `pytest` → passed
        `ruff check .` → passed
        `black .` → passed

## Screenshots / Media
NA

## Performance Impact
NA

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Implemented `PhoneNumber()` following the existing semantic schema validator patterns used by `Email()` and `URL()`.
Added focused validation tests covering:
1. valid phone-number formats
2. invalid values
3. nullable handling
4. mixed object-column behavior
Updated the README schema example to include PhoneNumber.
