### PR TITLE
tests(sklearn): cover ArnioCleaner feature-name and order mismatch

### DIFF
--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -84,3 +84,30 @@ def test_arniocleaner_rejects_transform_column_order_mismatch():
 
     with pytest.raises(ValueError, match="columns must match"):
         cleaner.transform(test)
+
+
+def test_arniocleaner_rejects_transform_with_renamed_column():
+    train = pd.DataFrame({"A": [" x "], "B": [1]})
+    test = pd.DataFrame({"A": [" x "], "C": [1]})
+    cleaner = ArnioCleaner(steps=[("strip_whitespace",)])
+    cleaner.fit(train)
+    with pytest.raises(ValueError, match="columns must match"):
+        cleaner.transform(test)
+
+
+def test_arniocleaner_rejects_transform_with_extra_columns():
+    train = pd.DataFrame({"A": [" x "], "B": [1]})
+    test = pd.DataFrame({"A": [" x "], "B": [1], "C": [2]})
+    cleaner = ArnioCleaner(steps=[("strip_whitespace",)])
+    cleaner.fit(train)
+    with pytest.raises(ValueError, match="columns must match"):
+        cleaner.transform(test)
+
+
+def test_arniocleaner_rejects_transform_with_missing_columns():
+    train = pd.DataFrame({"A": [" x "], "B": [1]})
+    test = pd.DataFrame({"A": [" x "]})
+    cleaner = ArnioCleaner(steps=[("strip_whitespace",)])
+    cleaner.fit(train)
+    with pytest.raises(ValueError, match="columns must match"):
+        cleaner.transform(test)


### PR DESCRIPTION
## Summary
Added focused pytest coverage for ArnioCleaner's column validation contract after fit. Tests verify that transform correctly rejects mismatched feature names, extra columns, and missing columns.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #628

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [X] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [X] `make test`
- [X] `make lint`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
