### PR TITLE
fix: validate schema fields before row validation

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -68,6 +68,13 @@ class Schema:
     unique: list[str] | tuple[str, ...] | None = None
     rules: list[Callable[[pd.DataFrame], list[ValidationIssue]]] | None = None
 
+    def __post_init__(self) -> None:
+        for name, field_def in self.fields.items():
+            if not isinstance(field_def, Field):
+                raise TypeError(
+                    f"Schema value for column {name!r} must be a Field instance such as ar.Int64(), got {type(field_def).__name__}"
+                )
+
     def validate(self, frame: ArFrame) -> ValidationResult:
         """Validate a frame against this schema."""
         return validate(frame, self)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -24,6 +24,24 @@ def test_schema_validation_passes_for_valid_frame(sample_csv):
     assert result.bad_rows == []
 
 
+def test_schema_rejects_invalid_field_values_string(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(TypeError, match="must be a Field instance"):
+        ar.validate(frame, {"id": "int64"})
+
+
+def test_schema_rejects_invalid_field_values_dict(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(TypeError, match="must be a Field instance"):
+        ar.validate(frame, {"id": {"type": "int64"}})
+
+
+def test_schema_rejects_invalid_field_values_none(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(TypeError, match="must be a Field instance"):
+        ar.validate(frame, {"id": None})
+
+
 def test_schema_validation_collects_row_level_issues(tmp_path):
     path = tmp_path / "bad.csv"
     path.write_text(


### PR DESCRIPTION
## Summary
Currently, `validate()` accepts a `dict[str, Field]` but does not check if the dictionary values are actually `Field` instances. Passing an invalid value like a string or dictionary causes a raw `AttributeError` during row validation. This PR adds a type check to the `Schema` dataclass `__post_init__` to raise a clear `TypeError` early, identifying the offending column before validation begins. Also includes test coverage for string, dict, and None schema values.

## Linked issue
Fixes #722

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Tested locally inside the virtual environment. Both tests and pre-commit checks passed successfully.
- [x] `make test` (685 tests passed)
- [x] `make lint` (Ruff and Black checks passed)
- [ ] Other:

## Screenshots / Media
N/A (Backend validation logic only)

## Performance Impact
N/A (Negligible type check during Schema initialization)

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
N/A
