### PR TITLE
fix(quality): correct metric status defaults and numeric drift thresholds in compare_profiles

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1172,7 +1172,7 @@ def _compare_column_profiles(
             "delta": _clean_scalar(delta),
         }
 
-        metric_status = "warning"
+        metric_status = "ok"
         if (
             changed_threshold is not None
             and delta is not None
@@ -1236,8 +1236,8 @@ def _compare_column_profiles(
                 metric,
                 value_a,
                 value_b,
-                warning_threshold=scale,
-                changed_threshold=scale * 2.0,
+                warning_threshold=scale * 0.1,
+                changed_threshold=scale * 0.25,
                 reason=f"numeric {metric} changed",
             )
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1105,3 +1105,37 @@ def test_auto_clean_explain_dry_run_error(tmp_path):
         ValueError, match="explain=True cannot be used with dry_run=True"
     ):
         ar.auto_clean(frame, explain=True, dry_run=True)
+
+
+def test_compare_profiles_under_threshold_is_ok():
+    """Changes below warning thresholds should result in 'ok' status."""
+    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 10.0, 10.0]})))
+    # A tiny change (mean changes from 10.0 to 10.1, delta = 0.1, scale = 10.1, warning = 1.01)
+    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.3, 10.0, 10.0]})))
+
+    comparison = ar.compare_profiles(baseline, current)
+    assert comparison.drift_report["score"]["status"] == "ok"
+    assert comparison.status_counts == {"ok": 1, "warning": 0, "changed": 0}
+
+
+def test_compare_profiles_above_warning_threshold_is_warning():
+    """Changes above warning but below changed threshold should result in 'warning' status."""
+    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 10.0, 10.0]})))
+    # Change mean by ~15% (mean from 10.0 to 11.5, delta = 1.5, scale = 11.5, warning = 1.15, changed = 2.875)
+    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [14.5, 10.0, 10.0]})))
+
+    comparison = ar.compare_profiles(baseline, current)
+    assert comparison.drift_report["score"]["status"] == "warning"
+    assert comparison.status_counts == {"ok": 0, "warning": 1, "changed": 0}
+
+
+def test_compare_profiles_above_changed_threshold_is_changed():
+    """Changes above changed threshold should result in 'changed' status."""
+    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 10.0, 10.0]})))
+    # Change mean by ~50% (mean from 10.0 to 15.0, delta = 5.0, scale = 15.0, warning = 1.5, changed = 3.75)
+    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [25.0, 10.0, 10.0]})))
+
+    comparison = ar.compare_profiles(baseline, current)
+    assert comparison.drift_report["score"]["status"] == "changed"
+    assert comparison.status_counts == {"ok": 0, "warning": 0, "changed": 1}
+

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1150,6 +1150,3 @@ def test_compare_profiles_above_changed_threshold_is_changed():
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "changed"
     assert comparison.status_counts == {"ok": 0, "warning": 0, "changed": 1}
-
-
-

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1109,9 +1109,13 @@ def test_auto_clean_explain_dry_run_error(tmp_path):
 
 def test_compare_profiles_under_threshold_is_ok():
     """Changes below warning thresholds should result in 'ok' status."""
-    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 10.0, 10.0]})))
-    # A tiny change (mean changes from 10.0 to 10.1, delta = 0.1, scale = 10.1, warning = 1.01)
-    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.3, 10.0, 10.0]})))
+    baseline = ar.profile(
+        ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]}))
+    )
+    # Shift values by 0.1 to keep std constant but shift mean slightly
+    current = ar.profile(
+        ar.from_pandas(pd.DataFrame({"score": [10.1, 11.1, 12.1]}))
+    )
 
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "ok"
@@ -1120,9 +1124,13 @@ def test_compare_profiles_under_threshold_is_ok():
 
 def test_compare_profiles_above_warning_threshold_is_warning():
     """Changes above warning but below changed threshold should result in 'warning' status."""
-    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 10.0, 10.0]})))
-    # Change mean by ~15% (mean from 10.0 to 11.5, delta = 1.5, scale = 11.5, warning = 1.15, changed = 2.875)
-    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [14.5, 10.0, 10.0]})))
+    baseline = ar.profile(
+        ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]}))
+    )
+    # Shift values by 1.8 to trigger warning status (approx 15% shift)
+    current = ar.profile(
+        ar.from_pandas(pd.DataFrame({"score": [11.8, 12.8, 13.8]}))
+    )
 
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "warning"
@@ -1131,11 +1139,17 @@ def test_compare_profiles_above_warning_threshold_is_warning():
 
 def test_compare_profiles_above_changed_threshold_is_changed():
     """Changes above changed threshold should result in 'changed' status."""
-    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 10.0, 10.0]})))
-    # Change mean by ~50% (mean from 10.0 to 15.0, delta = 5.0, scale = 15.0, warning = 1.5, changed = 3.75)
-    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [25.0, 10.0, 10.0]})))
+    baseline = ar.profile(
+        ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]}))
+    )
+    # Shift values by 5.0 to trigger changed status (approx 45% shift)
+    current = ar.profile(
+        ar.from_pandas(pd.DataFrame({"score": [15.0, 16.0, 17.0]}))
+    )
 
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "changed"
     assert comparison.status_counts == {"ok": 0, "warning": 0, "changed": 1}
+
+
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1109,13 +1109,9 @@ def test_auto_clean_explain_dry_run_error(tmp_path):
 
 def test_compare_profiles_under_threshold_is_ok():
     """Changes below warning thresholds should result in 'ok' status."""
-    baseline = ar.profile(
-        ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]}))
-    )
+    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]})))
     # Shift values by 0.1 to keep std constant but shift mean slightly
-    current = ar.profile(
-        ar.from_pandas(pd.DataFrame({"score": [10.1, 11.1, 12.1]}))
-    )
+    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.1, 11.1, 12.1]})))
 
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "ok"
@@ -1124,13 +1120,9 @@ def test_compare_profiles_under_threshold_is_ok():
 
 def test_compare_profiles_above_warning_threshold_is_warning():
     """Changes above warning but below changed threshold should result in 'warning' status."""
-    baseline = ar.profile(
-        ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]}))
-    )
+    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]})))
     # Shift values by 1.8 to trigger warning status (approx 15% shift)
-    current = ar.profile(
-        ar.from_pandas(pd.DataFrame({"score": [11.8, 12.8, 13.8]}))
-    )
+    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [11.8, 12.8, 13.8]})))
 
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "warning"
@@ -1139,13 +1131,9 @@ def test_compare_profiles_above_warning_threshold_is_warning():
 
 def test_compare_profiles_above_changed_threshold_is_changed():
     """Changes above changed threshold should result in 'changed' status."""
-    baseline = ar.profile(
-        ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]}))
-    )
+    baseline = ar.profile(ar.from_pandas(pd.DataFrame({"score": [10.0, 11.0, 12.0]})))
     # Shift values by 5.0 to trigger changed status (approx 45% shift)
-    current = ar.profile(
-        ar.from_pandas(pd.DataFrame({"score": [15.0, 16.0, 17.0]}))
-    )
+    current = ar.profile(ar.from_pandas(pd.DataFrame({"score": [15.0, 16.0, 17.0]})))
 
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "changed"


### PR DESCRIPTION
### Summary
This PR fixes a bug in `compare_profiles()` where minor profile variations below the warning threshold were incorrectly flagged as `"warning"`. It also corrects the threshold scaling calculations for numeric distribution metrics, which previously made the `"changed"` status mathematically unreachable due to the triangle inequality.

### Details of Changes
1. **Status Logic Correction**:
   - Initialized `metric_status` in the internal `add_change` helper in `arnio/quality.py` to `"ok"` instead of defaulting to `"warning"`. This ensures columns with variations below the `warning_threshold` retain an `"ok"` status.
   - Retained the `"changed"` fallback for metrics without specified warning/changed thresholds (like `dtype`).

2. **Numeric Threshold Recalibration**:
   - Replaced mathematically unreachable static thresholds (`warning_threshold=scale` and `changed_threshold=scale * 2.0`) with relative thresholds:
     - `warning_threshold=scale * 0.1` (10% drift)
     - `changed_threshold=scale * 0.25` (25% drift)
   - These parameters ensure robust handling under the triangle inequality constraint ($|X - Y| \le 2 \times \text{scale}$).

3. **Unit Tests Added**:
   - Added `test_compare_profiles_under_threshold_is_ok`
   - Added `test_compare_profiles_above_warning_threshold_is_warning`
   - Added `test_compare_profiles_above_changed_threshold_is_changed`

### Verification
Verified status transitions locally with custom baseline and comparison profiles to ensure appropriate status transitions to `"ok"`, `"warning"`, and `"changed"`.

Closes #747 
