### PR TITLE
fix(csv_writer): open output file in binary mode

### DIFF
--- a/cpp/src/csv_writer.cpp
+++ b/cpp/src/csv_writer.cpp
@@ -56,7 +56,11 @@ std::string CsvWriter::cell_to_string(const Frame& frame, size_t row, size_t col
 }
 
 void CsvWriter::write(const Frame& frame, const std::string& path) const {
-    std::ofstream out(path);
+    // Open in binary mode so the configured line_terminator is written
+    // byte-for-byte without platform newline translation.  On Windows, text
+    // mode would silently expand every '\n' to '\r\n', corrupting any
+    // line_terminator that already contains '\r' (e.g. "\r\n" → "\r\r\n").
+    std::ofstream out(path, std::ios::binary);
     if (!out.is_open()) {
         throw std::runtime_error("Could not open file for writing: " + path);
     }

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -77,3 +77,57 @@ class TestWriteCsv:
         frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
         with pytest.raises(ValueError, match="delimiter must be a single character"):
             ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=",,")
+
+
+class TestWriteCsvLineTerminatorBytes:
+    """Raw-byte regression tests for line_terminator.
+
+    These tests read the output file in binary mode and assert the exact bytes
+    written.  They guard against platform newline translation (e.g. Windows
+    text-mode expanding \\n to \\r\\n) and ensure the configured terminator is
+    emitted verbatim on every OS.
+    """
+
+    def test_default_lf_writes_exact_lf_bytes(self, tmp_path):
+        # Default line_terminator="\n" must produce LF bytes, not CRLF.
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        out = tmp_path / "out.csv"
+        ar.write_csv(frame, out)
+        raw = out.read_bytes()
+        # Header + 2 data rows, each terminated by a single LF.
+        assert raw == b"a\n1\n2\n"
+        assert b"\r" not in raw
+
+    def test_crlf_terminator_writes_exact_crlf_bytes(self, tmp_path):
+        # line_terminator="\r\n" must produce exactly CRLF, not CRCRLF.
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        out = tmp_path / "out.csv"
+        ar.write_csv(frame, out, line_terminator="\r\n")
+        raw = out.read_bytes()
+        assert raw == b"a\r\n1\r\n2\r\n"
+        # No double-CR corruption.
+        assert b"\r\r" not in raw
+
+    def test_custom_terminator_writes_exact_bytes(self, tmp_path):
+        # An arbitrary terminator (e.g. "|") must be written verbatim.
+        frame = ar.from_pandas(pd.DataFrame({"x": [7]}))
+        out = tmp_path / "out.csv"
+        ar.write_csv(frame, out, line_terminator="|")
+        raw = out.read_bytes()
+        assert raw == b"x|7|"
+
+    def test_quoted_multiline_field_round_trips(self, tmp_path):
+        # A field containing an embedded newline must be quoted and survive a
+        # write → read round-trip with the default LF terminator.
+        frame = ar.from_pandas(pd.DataFrame({"note": ["line1\nline2", "plain"]}))
+        out = tmp_path / "out.csv"
+        ar.write_csv(frame, out)
+        raw = out.read_bytes()
+        # The embedded newline lives inside quotes; the row terminator is the
+        # bare LF that follows the closing quote.
+        assert b'"line1\nline2"' in raw
+        # Round-trip: values survive a read back.
+        frame2 = ar.read_csv(out)
+        df = ar.to_pandas(frame2)
+        assert df["note"].iloc[0] == "line1\nline2"
+        assert df["note"].iloc[1] == "plain"


### PR DESCRIPTION
## Summary

Fixes #717

I found that `CsvWriter::write()` was opening files in text mode using the default `std::ofstream` behavior. On Windows, text mode automatically converts every `\n` into `\r\n`.

Because of this, when a user explicitly set:

```cpp id="8mq8z8"
line_terminator = "\r\n"
```

the writer ended up producing:

```text id="ry6wgn"
\r\r\n
```

instead of the expected `\r\n`, causing the double-CR issue mentioned in the audit.

## Fix

The fix is intentionally small and focused.

Updated:

```cpp id="2s19u6"
std::ofstream out(path);
```

to:

```cpp id="3djmva"
std::ofstream out(path, std::ios::binary);
```

Opening the file in binary mode disables automatic newline translation, so the configured `line_terminator` is now written exactly as provided on all platforms.

No API changes were made.

## Tests Added

Added regression tests to verify exact raw-byte behavior for:

* default `\n` line endings
* explicit `\r\n` line endings
* custom terminators
* quoted multiline fields surviving write → read round-trip

The newline tests reproduce the issue on Windows before the fix and pass correctly after the change.
