### PR TITLE
fix: reject newline delimiters in write_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -300,6 +300,8 @@ def write_csv(
         raise TypeError("delimiter must be a string")
     if len(delimiter) != 1:
         raise ValueError(f"delimiter must be a single character, got {delimiter!r}")
+    if delimiter in {"\n", "\r"}:
+        raise ValueError("delimiter must not be a newline character")
     if not isinstance(line_terminator, str):
         raise TypeError("line_terminator must be a string")
     if line_terminator == "":

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -86,7 +86,9 @@ class TestWriteCsv:
     @pytest.mark.parametrize("delimiter", ["\n", "\r"])
     def test_newline_delimiters_rejected(self, tmp_path, delimiter):
         frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
-        with pytest.raises(ValueError, match="delimiter must not be a newline character"):
+        with pytest.raises(
+            ValueError, match="delimiter must not be a newline character"
+        ):
             ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=delimiter)
 
 

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -83,6 +83,12 @@ class TestWriteCsv:
         with pytest.raises(TypeError, match="delimiter must be a string"):
             ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=1)
 
+    @pytest.mark.parametrize("delimiter", ["\n", "\r"])
+    def test_newline_delimiters_rejected(self, tmp_path, delimiter):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with pytest.raises(ValueError, match="delimiter must not be a newline character"):
+            ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=delimiter)
+
 
 class TestWriteCsvLineTerminatorBytes:
     """Raw-byte regression tests for line_terminator.


### PR DESCRIPTION
## Summary
- reject newline characters (`\n` and `\r`) as `write_csv` delimiters before invoking the native writer
- add a focused regression test covering both newline delimiter variants

Fixes #574

## Validation
- `git diff --check`
- `python3 -m py_compile arnio/io.py tests/test_write_csv.py`
- `python3 -m pytest tests/test_write_csv.py -q` could not run locally because `pytest` is not installed in this environment

## GSSoC labels requested
This issue is already marked `gssoc`, `difficulty: intermediate`, and `type:bug`; please add/keep the scoring labels required by the tracker if this is accepted.