### PR TITLE
fix: reject quote delimiter in write_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -302,6 +302,8 @@ def write_csv(
         raise ValueError(f"delimiter must be a single character, got {delimiter!r}")
     if delimiter in {"\n", "\r"}:
         raise ValueError("delimiter must not be a newline character")
+    if delimiter == '"':
+        raise ValueError("delimiter must not be the CSV quote character")
     if not isinstance(line_terminator, str):
         raise TypeError("line_terminator must be a string")
     if line_terminator == "":

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -91,6 +91,13 @@ class TestWriteCsv:
         ):
             ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=delimiter)
 
+    def test_quote_character_delimiter_rejected(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with pytest.raises(
+            ValueError, match="delimiter must not be the CSV quote character"
+        ):
+            ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter='"')
+
 
 class TestWriteCsvLineTerminatorBytes:
     """Raw-byte regression tests for line_terminator.


### PR DESCRIPTION
## Summary
- reject the CSV quote character (`"`) as a `write_csv` delimiter before calling the native writer
- add a regression test for the public API validation contract

Fixes #575

## Validation
- `git diff --check`
- `python3 -m py_compile arnio/io.py tests/test_write_csv.py`
- `python3 -m pytest tests/test_write_csv.py -q` could not run locally because `pytest` is not installed in this environment

## GSSoC labels requested
This issue is already marked `gssoc`, `difficulty: intermediate`, and `type:bug`; please add/keep the tracker-required scoring labels if this is accepted.