### PR TITLE
fix: reject empty write_csv line terminators

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -298,6 +298,10 @@ def write_csv(
 
     if len(delimiter) != 1:
         raise ValueError(f"delimiter must be a single character, got {delimiter!r}")
+    if not isinstance(line_terminator, str):
+        raise TypeError("line_terminator must be a string")
+    if line_terminator == "":
+        raise ValueError("line_terminator must not be empty")
 
     config = _CsvWriteConfig()
     config.delimiter = delimiter

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -116,6 +116,16 @@ class TestWriteCsvLineTerminatorBytes:
         raw = out.read_bytes()
         assert raw == b"x|7|"
 
+    def test_empty_line_terminator_rejected(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        with pytest.raises(ValueError, match="line_terminator must not be empty"):
+            ar.write_csv(frame, tmp_path / "out.csv", line_terminator="")
+
+    def test_non_string_line_terminator_rejected(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        with pytest.raises(TypeError, match="line_terminator must be a string"):
+            ar.write_csv(frame, tmp_path / "out.csv", line_terminator=None)
+
     def test_quoted_multiline_field_round_trips(self, tmp_path):
         # A field containing an embedded newline must be quoted and survive a
         # write → read round-trip with the default LF terminator.


### PR DESCRIPTION
## Summary
- reject empty `line_terminator` values in `write_csv` so records cannot be concatenated into unreadable output
- add explicit type validation for `line_terminator` at the Python API boundary
- add focused regression tests for empty and non-string terminators

Fixes #576

## Validation
- `git diff --check`
- `python3 -m py_compile arnio/io.py tests/test_write_csv.py`
- `python3 -m pytest tests/test_write_csv.py -q` could not run locally because `pytest` is not installed in this environment

## GSSoC labels requested
This issue is already marked `gssoc`, `difficulty: intermediate`, and `type:bug`; please add/keep the tracker-required scoring labels if this is accepted.