### PR TITLE
fix: validate drop_duplicates keep option

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -281,6 +281,8 @@ def drop_duplicates(
             operation="drop_duplicates",
         )
     keep_arg = "none" if keep is False else keep
+    if keep_arg not in {"first", "last", "none"}:
+        raise ValueError("keep must be one of 'first', 'last', 'none', or False")
     result = _drop_duplicates(frame._frame, subset=subset, keep=keep_arg)
     return ArFrame(result)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -180,6 +180,12 @@ class TestDropDuplicates:
         # Only Charlie is unique
         assert result.shape[0] == 1
 
+    @pytest.mark.parametrize("keep", ["invalid", True, None])
+    def test_drop_dupes_rejects_invalid_keep_values(self, csv_with_duplicates, keep):
+        frame = ar.read_csv(csv_with_duplicates)
+        with pytest.raises(ValueError, match="keep must be one of"):
+            ar.drop_duplicates(frame, keep=keep)
+
     def test_drop_dupes_subset(self, csv_with_duplicates):
         frame = ar.read_csv(csv_with_duplicates)
         result = ar.drop_duplicates(frame, subset=["name"])


### PR DESCRIPTION
## Summary
- validate `drop_duplicates(keep=...)` at the Python API boundary before calling the C++ backend
- keep the existing `False` alias for `none` while rejecting invalid strings, `True`, and `None` with a clear error
- add a focused regression test for invalid keep values

Fixes #585

## Validation
- `git diff --check`
- `python3 -m py_compile arnio/cleaning.py tests/test_cleaning.py`
- `python3 -m pytest tests/test_cleaning.py -q` could not run locally because `pytest` is not installed in this environment

## GSSoC labels requested
This issue is already marked `gssoc`, `difficulty: intermediate`, and `type:bug`; please add/keep the tracker-required scoring labels if this is accepted.