### PR TITLE
fix: validate write_csv delimiter type

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -296,6 +296,8 @@ def write_csv(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
 
+    if not isinstance(delimiter, str):
+        raise TypeError("delimiter must be a string")
     if len(delimiter) != 1:
         raise ValueError(f"delimiter must be a single character, got {delimiter!r}")
 

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -78,6 +78,11 @@ class TestWriteCsv:
         with pytest.raises(ValueError, match="delimiter must be a single character"):
             ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=",,")
 
+    def test_non_string_delimiter_rejected(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with pytest.raises(TypeError, match="delimiter must be a string"):
+            ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=1)
+
 
 class TestWriteCsvLineTerminatorBytes:
     """Raw-byte regression tests for line_terminator.


### PR DESCRIPTION
## Summary
- validate that `write_csv(delimiter=...)` receives a string before checking its length
- add a regression test so non-string delimiters raise a clear `TypeError` instead of an incidental length error

Fixes #573

## Validation
- `git diff --check`
- `python3 -m py_compile arnio/io.py tests/test_write_csv.py`
- `python3 -m pytest tests/test_write_csv.py -q` could not run locally because `pytest` is not installed in this environment

## GSSoC labels requested
This issue is already marked `gssoc`, `gssoc: level 1`, and `type:bug`; please add/keep the tracker-required scoring labels if this is accepted.