### PR TITLE
fix: respect non-utf8 scan sample count

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -53,9 +53,9 @@ def _utf8_csv_path(
                     reader = csv.reader(src, delimiter=delimiter)
                     writer = csv.writer(tmp, delimiter=delimiter)
                     for row_count, row in enumerate(reader):
-                        writer.writerow(row)
                         if row_count >= sample_rows:
                             break
+                        writer.writerow(row)
                 else:
                     shutil.copyfileobj(src, tmp)
                 tmp_name = tmp.name

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 import arnio as ar
+from arnio.io import _utf8_csv_path
 
 MESSY_CSV = str(Path(__file__).parent / "fixtures" / "messy_sales_data.csv")
 
@@ -528,6 +529,13 @@ class TestScanCsv:
 
         with pytest.raises(TypeError):
             ar.scan_csv(sample_csv, sample_size="100")
+
+    def test_non_utf8_sampling_respects_requested_record_count(self, tmp_path):
+        csv_path = tmp_path / "latin1.csv"
+        csv_path.write_text("name\nAndré\nBeyoncé\n", encoding="latin-1")
+
+        with _utf8_csv_path(str(csv_path), "latin-1", sample_rows=2) as native_path:
+            assert Path(native_path).read_text(encoding="utf-8") == "name\nAndré\n"
 
     def test_scan_invalid_delimiter(self, tmp_path):
         csv_path = tmp_path / "test.csv"


### PR DESCRIPTION
## Summary
- fix the non-UTF-8 CSV sampling loop so it writes exactly the requested number of records
- add a Latin-1 regression test that verifies the temporary UTF-8 sample does not include an extra row

Fixes #578

## Validation
- `git diff --check`
- `python3 -m py_compile arnio/io.py tests/test_csv.py`
- `python3 -m pytest tests/test_csv.py -q` could not run locally because `pytest` is not installed in this environment

## GSSoC labels requested
This issue is already marked `gssoc`, `difficulty: intermediate`, and `type:bug`; please add/keep the tracker-required scoring labels if this is accepted.