### PR TITLE
Added approximate top-values summaries for high-cardinality strings

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -342,6 +342,10 @@ Key options:
 - `approx_top_values_min_ratio`: minimum unique ratio to trigger approximation.
 - `approx_top_values_sample_size`: sample size for top-value estimation.
 
+When `approx_top_values` is enabled, `top_values` counts/ratios are computed on
+the sample, and `top_values_is_approximate`, `top_values_sample_count`, and
+`top_values_sample_ratio` are included in each `ColumnProfile`.
+
 ### suggest_cleaning
 
 Examine a report or frame and get a list of recommended cleaning steps.

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -335,6 +335,13 @@ ar.register_step("custom_func", custom_func)
 
 Analyze an `ArFrame` and get a structural `DataQualityReport`.
 
+Key options:
+- `sample_size`: number of non-null sample values stored per column.
+- `approx_top_values`: enable approximate top values for high-cardinality string columns.
+- `approx_top_values_min_unique`: minimum unique count to trigger approximation.
+- `approx_top_values_min_ratio`: minimum unique ratio to trigger approximation.
+- `approx_top_values_sample_size`: sample size for top-value estimation.
+
 ### suggest_cleaning
 
 Examine a report or frame and get a list of recommended cleaning steps.

--- a/README.md
+++ b/README.md
@@ -982,6 +982,18 @@ df = ar.from_pandas(pd.DataFrame(data))
 # Bounded profiling for large datasets (controls how many sample values are kept)
 report = ar.profile(df, sample_size=5)
 safe_report = report.to_dict(redact_sample_values=True)
+
+When `approx_top_values=True`, string columns with high cardinality will use a
+deterministic sample to estimate top values. Each column includes
+`top_values_is_approximate` so consumers can distinguish sampled results.
+# Optional: approximate top values for high-cardinality string columns
+report = ar.profile(
+  df,
+  approx_top_values=True,
+  approx_top_values_min_unique=1000,
+  approx_top_values_min_ratio=0.2,
+  approx_top_values_sample_size=2000,
+)
 ```
 
 ### Notebook dashboard (Jupyter / Colab)

--- a/README.md
+++ b/README.md
@@ -982,17 +982,21 @@ df = ar.from_pandas(pd.DataFrame(data))
 # Bounded profiling for large datasets (controls how many sample values are kept)
 report = ar.profile(df, sample_size=5)
 safe_report = report.to_dict(redact_sample_values=True)
+```
 
-When `approx_top_values=True`, string columns with high cardinality will use a
+When `approx_top_values=True`, string columns with high cardinality use a
 deterministic sample to estimate top values. Each column includes
-`top_values_is_approximate` so consumers can distinguish sampled results.
+`top_values_is_approximate`, `top_values_sample_count`, and
+`top_values_sample_ratio`, and the counts/ratios are sample-based.
+
+```python
 # Optional: approximate top values for high-cardinality string columns
 report = ar.profile(
-  df,
-  approx_top_values=True,
-  approx_top_values_min_unique=1000,
-  approx_top_values_min_ratio=0.2,
-  approx_top_values_sample_size=2000,
+    df,
+    approx_top_values=True,
+    approx_top_values_min_unique=1000,
+    approx_top_values_min_ratio=0.2,
+    approx_top_values_sample_size=2000,
 )
 ```
 

--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -56,9 +56,24 @@ class ArnioPandasAccessor:
         )
         return to_pandas(frame)
 
-    def profile(self, *, sample_size: int = 5) -> DataQualityReport:
+    def profile(
+        self,
+        *,
+        sample_size: int = 5,
+        approx_top_values: bool = False,
+        approx_top_values_min_unique: int = 1000,
+        approx_top_values_min_ratio: float = 0.2,
+        approx_top_values_sample_size: int = 2000,
+    ) -> DataQualityReport:
         """Profile DataFrame quality with Arnio."""
-        return profile(self.to_arframe(), sample_size=sample_size)
+        return profile(
+            self.to_arframe(),
+            sample_size=sample_size,
+            approx_top_values=approx_top_values,
+            approx_top_values_min_unique=approx_top_values_min_unique,
+            approx_top_values_min_ratio=approx_top_values_min_ratio,
+            approx_top_values_sample_size=approx_top_values_sample_size,
+        )
 
     def suggest_cleaning(self) -> list[tuple[str, dict[str, Any]]]:
         """Return Arnio pipeline-compatible cleaning suggestions."""

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -77,7 +77,9 @@ class ColumnProfile:
     therefore counted as empty.
 
     ``top_values_is_approximate`` indicates whether ``top_values`` were
-    estimated from a deterministic sample.
+    estimated from a deterministic sample. When ``True``,
+    ``top_values_sample_count`` and ``top_values_sample_ratio`` describe the
+    sample used for the counts/ratios.
     """
 
     name: str
@@ -103,6 +105,8 @@ class ColumnProfile:
     warnings: list[str] = field(default_factory=list)
     top_values: list[tuple[Any, int, float]] | None = None
     top_values_is_approximate: bool = False
+    top_values_sample_count: int | None = None
+    top_values_sample_ratio: float | None = None
 
     def to_dict(self, *, redact_sample_values: bool = False) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
@@ -148,6 +152,8 @@ class ColumnProfile:
                 else None
             ),
             "top_values_is_approximate": self.top_values_is_approximate,
+            "top_values_sample_count": self.top_values_sample_count,
+            "top_values_sample_ratio": self.top_values_sample_ratio,
         }
 
 
@@ -530,6 +536,8 @@ class DataQualityReport:
                     "warnings": column.warnings,
                     "top_values": column.top_values,
                     "top_values_is_approximate": column.top_values_is_approximate,
+                    "top_values_sample_count": column.top_values_sample_count,
+                    "top_values_sample_ratio": column.top_values_sample_ratio,
                 }
                 for column in self.columns.values()
             ]
@@ -1608,6 +1616,8 @@ def _profile_column(
     whitespace_count = 0
     top_values = None
     top_values_is_approximate = False
+    top_values_sample_count = None
+    top_values_sample_ratio = None
     q25 = q50 = q75 = q95 = None
     std = None
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
@@ -1620,11 +1630,13 @@ def _profile_column(
             and unique_count >= approx_top_values_min_unique
             and unique_ratio >= approx_top_values_min_ratio
         ):
-            top_values = _approx_top_values(
+            top_values, sample_count, sample_ratio = _approx_top_values(
                 non_null,
                 sample_size=approx_top_values_sample_size,
             )
             top_values_is_approximate = True
+            top_values_sample_count = sample_count
+            top_values_sample_ratio = sample_ratio
         else:
             top_values = _top_values(non_null)
 
@@ -1684,6 +1696,8 @@ def _profile_column(
         warnings=warnings,
         top_values=top_values,
         top_values_is_approximate=top_values_is_approximate,
+        top_values_sample_count=top_values_sample_count,
+        top_values_sample_ratio=top_values_sample_ratio,
     )
 
 
@@ -1829,20 +1843,20 @@ def _approx_top_values(
     *,
     n: int = 5,
     sample_size: int = 2000,
-) -> list[tuple[Any, int, float]]:
+) -> tuple[list[tuple[Any, int, float]], int, float]:
     """Return approximate top-N value frequencies for a non-null series.
 
     Sampling uses a fixed seed for deterministic output.
     """
     if len(series) == 0:
-        return []
+        return [], 0, 0.0
     sample_n = min(len(series), sample_size)
     sampled = series.sample(n=sample_n, random_state=_APPROX_TOP_VALUES_SEED)
     counts = sampled.value_counts(dropna=True)
     total = int(counts.sum())
     return [
         (val, int(cnt), _ratio(int(cnt), total)) for val, cnt in counts.head(n).items()
-    ]
+    ], sample_n, _ratio(sample_n, len(series))
 
 
 _EMAIL_PATTERN = r"[^@\s]+@[^@\s]+\.[^@\s]+"

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -75,6 +75,9 @@ class ColumnProfile:
     ``empty_string_count`` is the number of non-null values that become empty
     after stripping leading/trailing whitespace — whitespace-only strings are
     therefore counted as empty.
+
+    ``top_values_is_approximate`` indicates whether ``top_values`` were
+    estimated from a deterministic sample.
     """
 
     name: str
@@ -99,6 +102,7 @@ class ColumnProfile:
     sample_values: list[Any] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     top_values: list[tuple[Any, int, float]] | None = None
+    top_values_is_approximate: bool = False
 
     def to_dict(self, *, redact_sample_values: bool = False) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
@@ -143,6 +147,7 @@ class ColumnProfile:
                 if self.top_values is not None
                 else None
             ),
+            "top_values_is_approximate": self.top_values_is_approximate,
         }
 
 
@@ -524,6 +529,7 @@ class DataQualityReport:
                     ),
                     "warnings": column.warnings,
                     "top_values": column.top_values,
+                    "top_values_is_approximate": column.top_values_is_approximate,
                 }
                 for column in self.columns.values()
             ]
@@ -659,7 +665,15 @@ class QualityGateResult:
         )
 
 
-def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
+def profile(
+    frame: ArFrame,
+    *,
+    sample_size: int = 5,
+    approx_top_values: bool = False,
+    approx_top_values_min_unique: int = 1000,
+    approx_top_values_min_ratio: float = 0.2,
+    approx_top_values_sample_size: int = 2000,
+) -> DataQualityReport:
     """Profile data quality for an ArFrame.
 
     Parameters
@@ -668,6 +682,14 @@ def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
         Input frame to inspect.
     sample_size : int, default 5
         Number of non-null sample values to keep per column.
+    approx_top_values : bool, default False
+        When True, approximate top values for high-cardinality string columns.
+    approx_top_values_min_unique : int, default 1000
+        Minimum unique count required to enable approximate top values.
+    approx_top_values_min_ratio : float, default 0.2
+        Minimum unique ratio (unique / non-null) required to enable approximation.
+    approx_top_values_sample_size : int, default 2000
+        Number of non-null values sampled to estimate top values.
 
     Returns
     -------
@@ -685,6 +707,26 @@ def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
         raise TypeError("sample_size must be an integer")
     if sample_size < 0:
         raise ValueError("sample_size must be non-negative")
+    if not isinstance(approx_top_values, bool):
+        raise TypeError("approx_top_values must be a bool")
+    if not isinstance(approx_top_values_min_unique, int) or isinstance(
+        approx_top_values_min_unique, bool
+    ):
+        raise TypeError("approx_top_values_min_unique must be an integer")
+    if approx_top_values_min_unique < 0:
+        raise ValueError("approx_top_values_min_unique must be non-negative")
+    if not isinstance(approx_top_values_min_ratio, (int, float)) or isinstance(
+        approx_top_values_min_ratio, bool
+    ):
+        raise TypeError("approx_top_values_min_ratio must be a float")
+    if approx_top_values_min_ratio < 0 or approx_top_values_min_ratio > 1:
+        raise ValueError("approx_top_values_min_ratio must be between 0 and 1")
+    if not isinstance(approx_top_values_sample_size, int) or isinstance(
+        approx_top_values_sample_size, bool
+    ):
+        raise TypeError("approx_top_values_sample_size must be an integer")
+    if approx_top_values_sample_size <= 0:
+        raise ValueError("approx_top_values_sample_size must be positive")
 
     df = to_pandas(frame)
     row_count, column_count = frame.shape
@@ -698,6 +740,10 @@ def profile(frame: ArFrame, *, sample_size: int = 5) -> DataQualityReport:
             dtype=frame.dtypes.get(name, str(df[name].dtype)),
             row_count=row_count,
             sample_size=sample_size,
+            approx_top_values=approx_top_values,
+            approx_top_values_min_unique=approx_top_values_min_unique,
+            approx_top_values_min_ratio=approx_top_values_min_ratio,
+            approx_top_values_sample_size=approx_top_values_sample_size,
         )
         for name in df.columns
     }
@@ -1547,6 +1593,10 @@ def _profile_column(
     dtype: str,
     row_count: int,
     sample_size: int,
+    approx_top_values: bool,
+    approx_top_values_min_unique: int,
+    approx_top_values_min_ratio: float,
+    approx_top_values_sample_size: int,
 ) -> ColumnProfile:
     null_count = int(series.isna().sum())
     non_null = series.dropna()
@@ -1557,6 +1607,7 @@ def _profile_column(
     empty_string_count = 0
     whitespace_count = 0
     top_values = None
+    top_values_is_approximate = False
     q25 = q50 = q75 = q95 = None
     std = None
     if dtype == "string" or pd.api.types.is_string_dtype(series.dtype):
@@ -1564,7 +1615,18 @@ def _profile_column(
         stripped = as_text.str.strip()
         empty_string_count = int((stripped == "").sum())
         whitespace_count = int((as_text != stripped).sum())
-        top_values = _top_values(non_null)
+        if (
+            approx_top_values
+            and unique_count >= approx_top_values_min_unique
+            and unique_ratio >= approx_top_values_min_ratio
+        ):
+            top_values = _approx_top_values(
+                non_null,
+                sample_size=approx_top_values_sample_size,
+            )
+            top_values_is_approximate = True
+        else:
+            top_values = _top_values(non_null)
 
     min_value = max_value = mean = None
     if len(non_null) and _is_numeric_dtype(dtype):
@@ -1621,6 +1683,7 @@ def _profile_column(
         sample_values=sample_values,
         warnings=warnings,
         top_values=top_values,
+        top_values_is_approximate=top_values_is_approximate,
     )
 
 
@@ -1741,6 +1804,9 @@ def _clean_scalar(value: Any) -> Any:
     return value
 
 
+_APPROX_TOP_VALUES_SEED = 0
+
+
 def _top_values(
     series: pd.Series,
     n: int = 5,
@@ -1752,6 +1818,27 @@ def _top_values(
     if len(series) == 0:
         return []
     counts = series.value_counts(dropna=True)
+    total = int(counts.sum())
+    return [
+        (val, int(cnt), _ratio(int(cnt), total)) for val, cnt in counts.head(n).items()
+    ]
+
+
+def _approx_top_values(
+    series: pd.Series,
+    *,
+    n: int = 5,
+    sample_size: int = 2000,
+) -> list[tuple[Any, int, float]]:
+    """Return approximate top-N value frequencies for a non-null series.
+
+    Sampling uses a fixed seed for deterministic output.
+    """
+    if len(series) == 0:
+        return []
+    sample_n = min(len(series), sample_size)
+    sampled = series.sample(n=sample_n, random_state=_APPROX_TOP_VALUES_SEED)
+    counts = sampled.value_counts(dropna=True)
     total = int(counts.sum())
     return [
         (val, int(cnt), _ratio(int(cnt), total)) for val, cnt in counts.head(n).items()

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1854,9 +1854,14 @@ def _approx_top_values(
     sampled = series.sample(n=sample_n, random_state=_APPROX_TOP_VALUES_SEED)
     counts = sampled.value_counts(dropna=True)
     total = int(counts.sum())
-    return [
-        (val, int(cnt), _ratio(int(cnt), total)) for val, cnt in counts.head(n).items()
-    ], sample_n, _ratio(sample_n, len(series))
+    return (
+        [
+            (val, int(cnt), _ratio(int(cnt), total))
+            for val, cnt in counts.head(n).items()
+        ],
+        sample_n,
+        _ratio(sample_n, len(series)),
+    )
 
 
 _EMAIL_PATTERN = r"[^@\s]+@[^@\s]+\.[^@\s]+"

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -426,6 +426,13 @@ def test_profile_approx_top_values_deterministic_high_cardinality():
     assert column.top_values_is_approximate is True
     assert column.top_values == report_again.columns["user"].top_values
     assert len(column.top_values) <= 5
+    assert column.top_values_sample_count == 200
+    assert column.top_values_sample_ratio == pytest.approx(0.1, rel=1e-3)
+
+    payload = report.to_dict()
+    col_dict = payload["columns"]["user"]
+    assert col_dict["top_values_is_approximate"] is True
+    assert col_dict["top_values_sample_count"] == 200
 
 
 def test_profile_approx_top_values_skips_low_cardinality():
@@ -442,6 +449,26 @@ def test_profile_approx_top_values_skips_low_cardinality():
     assert column.top_values_is_approximate is False
     assert column.top_values[0][0] == "a"
     assert column.top_values[0][1] == 2
+
+
+def test_profile_approx_top_values_avoids_exact_counts(monkeypatch):
+    values = [f"user_{i}" for i in range(1500)]
+    frame = ar.from_pandas(pd.DataFrame({"user": values}))
+
+    def raise_exact(*_args, **_kwargs):
+        raise AssertionError("exact top_values should not be called")
+
+    monkeypatch.setattr("arnio.quality._top_values", raise_exact)
+
+    report = ar.profile(
+        frame,
+        approx_top_values=True,
+        approx_top_values_min_unique=1000,
+        approx_top_values_min_ratio=0.5,
+        approx_top_values_sample_size=200,
+    )
+
+    assert report.columns["user"].top_values_is_approximate is True
 
 
 def test_quality_to_dict_default_preserves_sample_values(tmp_path):
@@ -515,6 +542,33 @@ def test_profile_sample_size_validation(tmp_path):
         assert False, "Expected TypeError"
     except TypeError as exc:
         assert "sample_size must be an integer" in str(exc)
+
+
+def test_profile_approx_top_values_validation(tmp_path):
+    path = tmp_path / "sample.csv"
+    path.write_text("id\n1\n")
+    frame = ar.read_csv(path)
+
+    with pytest.raises(TypeError, match="approx_top_values must be a bool"):
+        ar.profile(frame, approx_top_values="yes")
+
+    with pytest.raises(TypeError, match="approx_top_values_min_unique must be an integer"):
+        ar.profile(frame, approx_top_values_min_unique="5")
+
+    with pytest.raises(ValueError, match="approx_top_values_min_unique must be non-negative"):
+        ar.profile(frame, approx_top_values_min_unique=-1)
+
+    with pytest.raises(TypeError, match="approx_top_values_min_ratio must be a float"):
+        ar.profile(frame, approx_top_values_min_ratio="0.5")
+
+    with pytest.raises(ValueError, match="approx_top_values_min_ratio must be between 0 and 1"):
+        ar.profile(frame, approx_top_values_min_ratio=1.5)
+
+    with pytest.raises(TypeError, match="approx_top_values_sample_size must be an integer"):
+        ar.profile(frame, approx_top_values_sample_size="10")
+
+    with pytest.raises(ValueError, match="approx_top_values_sample_size must be positive"):
+        ar.profile(frame, approx_top_values_sample_size=0)
 
 
 # ── top_values tests ──────────────────────────────────────────────────────────

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -403,6 +403,47 @@ def test_profile_sample_size_small_dataset_and_nulls(tmp_path):
     assert report.columns["id"].sample_values == [1.0, 3.0]
 
 
+def test_profile_approx_top_values_deterministic_high_cardinality():
+    values = [f"user_{i}" for i in range(2000)]
+    frame = ar.from_pandas(pd.DataFrame({"user": values}))
+
+    report = ar.profile(
+        frame,
+        approx_top_values=True,
+        approx_top_values_min_unique=1000,
+        approx_top_values_min_ratio=0.5,
+        approx_top_values_sample_size=200,
+    )
+    report_again = ar.profile(
+        frame,
+        approx_top_values=True,
+        approx_top_values_min_unique=1000,
+        approx_top_values_min_ratio=0.5,
+        approx_top_values_sample_size=200,
+    )
+
+    column = report.columns["user"]
+    assert column.top_values_is_approximate is True
+    assert column.top_values == report_again.columns["user"].top_values
+    assert len(column.top_values) <= 5
+
+
+def test_profile_approx_top_values_skips_low_cardinality():
+    frame = ar.from_pandas(pd.DataFrame({"city": ["a", "b", "a", "c"]}))
+
+    report = ar.profile(
+        frame,
+        approx_top_values=True,
+        approx_top_values_min_unique=10,
+        approx_top_values_min_ratio=0.9,
+    )
+
+    column = report.columns["city"]
+    assert column.top_values_is_approximate is False
+    assert column.top_values[0][0] == "a"
+    assert column.top_values[0][1] == 2
+
+
 def test_quality_to_dict_default_preserves_sample_values(tmp_path):
     path = tmp_path / "dict_default.csv"
     path.write_text("name\nAlice\nBob\n")

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -552,22 +552,32 @@ def test_profile_approx_top_values_validation(tmp_path):
     with pytest.raises(TypeError, match="approx_top_values must be a bool"):
         ar.profile(frame, approx_top_values="yes")
 
-    with pytest.raises(TypeError, match="approx_top_values_min_unique must be an integer"):
+    with pytest.raises(
+        TypeError, match="approx_top_values_min_unique must be an integer"
+    ):
         ar.profile(frame, approx_top_values_min_unique="5")
 
-    with pytest.raises(ValueError, match="approx_top_values_min_unique must be non-negative"):
+    with pytest.raises(
+        ValueError, match="approx_top_values_min_unique must be non-negative"
+    ):
         ar.profile(frame, approx_top_values_min_unique=-1)
 
     with pytest.raises(TypeError, match="approx_top_values_min_ratio must be a float"):
         ar.profile(frame, approx_top_values_min_ratio="0.5")
 
-    with pytest.raises(ValueError, match="approx_top_values_min_ratio must be between 0 and 1"):
+    with pytest.raises(
+        ValueError, match="approx_top_values_min_ratio must be between 0 and 1"
+    ):
         ar.profile(frame, approx_top_values_min_ratio=1.5)
 
-    with pytest.raises(TypeError, match="approx_top_values_sample_size must be an integer"):
+    with pytest.raises(
+        TypeError, match="approx_top_values_sample_size must be an integer"
+    ):
         ar.profile(frame, approx_top_values_sample_size="10")
 
-    with pytest.raises(ValueError, match="approx_top_values_sample_size must be positive"):
+    with pytest.raises(
+        ValueError, match="approx_top_values_sample_size must be positive"
+    ):
         ar.profile(frame, approx_top_values_sample_size=0)
 
 


### PR DESCRIPTION
## Summary

- Adds an opt-in approximate top-values path for high-cardinality string columns to reduce profiling overhead while keeping exact behavior by default.
- Uses deterministic sampling and exposes `top_values_is_approximate`, `top_values_sample_count`, and `top_values_sample_ratio` so users can identify sample-based counts.
- Documents the new profiling options and adds regression coverage for deterministic sampling, low-cardinality exact behavior, validation, and avoiding the exact top-values path when approximation is enabled.

## Linked issue

Closes #663

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area

- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [x] GitHub Actions CI passed for lint, smoke tests, and the full OS/Python test matrix.
- [x] Added focused coverage in `tests/test_quality.py`.

## Performance Impact

Approximate top-values avoids the exact full-column `value_counts()` path for opted-in high-cardinality string columns. Exact behavior remains the default unless `approx_top_values=True` is passed.

## Contributor checklist

- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
