### PR TITLE
test: cover cast_types mapping validation

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -933,6 +933,12 @@ class TestCastTypes:
         with pytest.raises(ValueError, match="errors must be either"):
             ar.cast_types(frame, {"age": "int64"}, errors="ignore")
 
+    def test_cast_rejects_non_mapping_with_clear_error(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="mapping must be a mapping"):
+            ar.cast_types(frame, [("age", "int64")])
+
     def test_cast_bool_rejects_unknown_strings(self):
         frame = ar.from_pandas(pd.DataFrame({"active": ["true", "maybe"]}))
 


### PR DESCRIPTION
## Summary
- add a regression test for `cast_types` rejecting non-mapping inputs with the existing clear `TypeError` contract
- documents the public API boundary behavior that protects the native cast path

Fixes #583

## Validation
- `git diff --check`
- `python3 -m py_compile tests/test_cleaning.py arnio/cleaning.py`
- `python3 -m pytest tests/test_cleaning.py -q` could not run locally because `pytest` is not installed in this environment

## Note
The implementation already validates mappings on `main`; this PR adds the focused regression coverage for the issue.

## GSSoC labels requested
This issue is already marked `gssoc`, `gssoc: level 1`, and `type:bug`; please add/keep the tracker-required scoring labels if this is accepted.