### PR TITLE
tests(schema): cover DateTime timezone-aware min and max bounds

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1459,3 +1459,62 @@ def test_schema_diff_summary_and_markdown_escape_cells():
     assert "notes\\|raw" in markdown
     assert "left\\|right" in markdown
     assert "left<br>right" in markdown
+
+
+def test_datetime_timezone_aware_within_bounds_passes(tmp_path):
+    path = tmp_path / "tz_datetimes.csv"
+    path.write_text("ts\n2026-06-01T12:00:00+05:30\n")
+    frame = ar.read_csv(path)
+    schema = ar.Schema(
+        {
+            "ts": ar.DateTime(
+                nullable=False,
+                format="%Y-%m-%dT%H:%M:%S%z",
+                min="2026-01-01T00:00:00+05:30",
+                max="2026-12-31T23:59:59+05:30",
+            )
+        }
+    )
+    result = schema.validate(frame)
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_datetime_timezone_aware_below_min_fails(tmp_path):
+    path = tmp_path / "tz_datetimes.csv"
+    path.write_text("ts\n2025-12-31T23:59:59+05:30\n")
+    frame = ar.read_csv(path)
+    schema = ar.Schema(
+        {
+            "ts": ar.DateTime(
+                nullable=False,
+                format="%Y-%m-%dT%H:%M:%S%z",
+                min="2026-01-01T00:00:00+05:30",
+                max="2026-12-31T23:59:59+05:30",
+            )
+        }
+    )
+    result = schema.validate(frame)
+    assert not result.passed
+    assert any(i.rule == "min" for i in result.issues)
+    assert result.issues[0].row_index == 1
+
+
+def test_datetime_timezone_aware_above_max_fails(tmp_path):
+    path = tmp_path / "tz_datetimes.csv"
+    path.write_text("ts\n2027-01-01T00:00:00+05:30\n")
+    frame = ar.read_csv(path)
+    schema = ar.Schema(
+        {
+            "ts": ar.DateTime(
+                nullable=False,
+                format="%Y-%m-%dT%H:%M:%S%z",
+                min="2026-01-01T00:00:00+05:30",
+                max="2026-12-31T23:59:59+05:30",
+            )
+        }
+    )
+    result = schema.validate(frame)
+    assert not result.passed
+    assert any(i.rule == "max" for i in result.issues)
+    assert result.issues[0].row_index == 1


### PR DESCRIPTION
## Summary
Added focused pytest coverage for DateTime timezone-aware min and max bound comparisons. Tests cover values within bounds, below min, and above max, with 1-based row index assertions.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #623

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [X] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [X] `make test`
- [X] `make lint`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
