### PR TITLE
fix: accept sequence subsets in parse_bool_strings (#595)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -409,7 +409,7 @@ def strip_whitespace(
 def parse_bool_strings(
     frame: ArFrame,
     *,
-    subset: list[str] | None = None,
+    subset: Sequence[str] | None = None,
     true_values: set[str] | None = None,
     false_values: set[str] | None = None,
 ) -> ArFrame:
@@ -419,7 +419,7 @@ def parse_bool_strings(
     ----------
     frame : ArFrame
         Input Arnio frame.
-    subset : list[str], optional
+    subset : sequence of str, optional
         Columns to apply conversion on. If None, applies to all object/string columns.
     true_values : set[str], optional
         String values treated as True.
@@ -460,18 +460,15 @@ def parse_bool_strings(
         )
 
     if subset is not None:
-        if not isinstance(subset, list):
-            raise TypeError("subset must be a list of column names or None")
+        columns = _validate_column_sequence(subset, argument_name="subset")
 
-        if len(subset) == 0:
+        if len(columns) == 0:
             raise ValueError("subset cannot be empty")
 
-        missing = [col for col in subset if col not in df.columns]
+        missing = [col for col in columns if col not in df.columns]
 
         if missing:
             raise ValueError(f"Columns not found in frame: {missing}")
-
-        columns = subset
     else:
         columns = df.select_dtypes(include=["object", "string"]).columns.tolist()
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -666,6 +666,23 @@ class TestParseBoolStrings:
         with pytest.raises(ValueError):
             ar.parse_bool_strings(frame, subset=[])
 
+    def test_parse_bool_strings_accepts_tuple_subset(self):
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "active": ["YES", "no"],
+                "name": ["Alice", "Bob"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.parse_bool_strings(frame, subset=("active",))
+        out = ar.to_pandas(result)
+
+        assert out["active"].tolist() == [True, False]
+        assert out["name"].tolist() == ["Alice", "Bob"]
+
     def test_parse_bool_strings_missing_subset_column(self):
         import pandas as pd
 


### PR DESCRIPTION
## Summary
- align parse_bool_strings with the rest of the cleaning API by accepting generic column-name sequences for subset
- keep the existing empty-subset and missing-column validation behavior intact
- add a regression test covering tuple input so this sequence contract stays locked down

## Verification
- python -m pytest tests/test_cleaning.py -k parse_bool_strings
- python -m ruff check arnio/cleaning.py tests/test_cleaning.py
- python -m black --check arnio/cleaning.py tests/test_cleaning.py

## Notes
- behavior for string subset input remains rejected as before