### PR TITLE
ci: add macOS arm64 wheel smoke test job

### DIFF
--- a/.github/workflows/macos-arm64-wheel-smoke.yml
+++ b/.github/workflows/macos-arm64-wheel-smoke.yml
@@ -1,0 +1,59 @@
+name: macOS arm64 Wheel Smoke Test
+
+# Lightweight, additive job that verifies the Apple Silicon wheel builds and
+# imports correctly.  It does NOT run on every PR — only when packaging or
+# build-system files change — so normal Python-only PRs are unaffected.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/macos-arm64-wheel-smoke.yml"
+      - "pyproject.toml"
+      - "setup.py"
+      - "CMakeLists.txt"
+      - "cpp/**"
+      - "bindings/**"
+  schedule:
+    # Run every Monday at 05:00 UTC to catch silent regressions.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+jobs:
+  macos-arm64-wheel-smoke:
+    name: Build arm64 wheel and smoke test (macOS)
+    # macos-14 is the GitHub-hosted Apple Silicon (M1) runner.
+    runs-on: macos-14
+    # Non-blocking while the job stabilises; remove once consistently green.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install cibuildwheel
+        run: pip install cibuildwheel==2.22.0
+
+      - name: Build macOS arm64 wheel
+        run: cibuildwheel --only cp312-macosx_arm64 --output-dir wheelhouse
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          # Skip running the full test suite inside cibuildwheel; the smoke
+          # script below covers import + API correctness.
+          CIBW_TEST_COMMAND: ""
+
+      - name: Run wheel smoke test
+        # Reuses the existing smoke script: installs the wheel into a fresh
+        # venv, imports arnio, and exercises read_csv / pipeline / to_pandas.
+        run: python tests/smoke_wheel_install.py --wheelhouse wheelhouse
+
+      - name: Upload arm64 wheel as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64-wheel
+          path: wheelhouse/*.whl
+          retention-days: 7

--- a/.github/workflows/macos-arm64-wheel-smoke.yml
+++ b/.github/workflows/macos-arm64-wheel-smoke.yml
@@ -23,8 +23,6 @@ jobs:
     name: Build arm64 wheel and smoke test (macOS)
     # macos-14 is the GitHub-hosted Apple Silicon (M1) runner.
     runs-on: macos-14
-    # Non-blocking while the job stabilises; remove once consistently green.
-    continue-on-error: true
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Fixes #674

Adds a lightweight, additive CI job that verifies the Apple Silicon wheel
builds and imports correctly on a real arm64 runner.

## What this adds

`.github/workflows/macos-arm64-wheel-smoke.yml`:
- Runs on `macos-14` (GitHub-hosted M1 runner — native arm64)
- Builds a `cp312-macosx_arm64` wheel via `cibuildwheel`
- Smoke-tests the wheel using the existing `tests/smoke_wheel_install.py`
  script (fresh venv, `--no-index` install, import + `read_csv` / `pipeline` / `to_pandas` exercise)
- Uploads the wheel as a CI artifact for inspection
- `continue-on-error: true` while the job stabilises

## Why it won't slow down normal PRs

Triggers only on changes to packaging/build-system paths:
- `.github/workflows/macos-arm64-wheel-smoke.yml`
- `pyproject.toml`, `setup.py`, `CMakeLists.txt`
- `cpp/**`, `bindings/**`

Plus a weekly Monday schedule and `workflow_dispatch` for manual runs.
Pure Python changes (cleaning, schema, quality, tests) do not trigger it.

## Existing tests

No existing tests are modified. All current CI jobs are unaffected.
