### PR TITLE
ci: add Windows MSVC wheel smoke test.

### DIFF
--- a/.github/workflows/windows-msvc-wheel-smoke.yml
+++ b/.github/workflows/windows-msvc-wheel-smoke.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Install wheel in fresh environment
         run: |
           python -m venv smoke_env
+          smoke_env\Scripts\pip install --upgrade pip
+          smoke_env\Scripts\pip install pandas numpy
           smoke_env\Scripts\pip install --find-links dist/ arnio --no-index
 
       - name: Run smoke test from temp directory

--- a/.github/workflows/windows-msvc-wheel-smoke.yml
+++ b/.github/workflows/windows-msvc-wheel-smoke.yml
@@ -1,0 +1,47 @@
+name: Windows MSVC Wheel Smoke Test
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "pyproject.toml"
+      - "setup.py"
+      - "CMakeLists.txt"
+      - "bindings/**"
+      - "cpp/**"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "pyproject.toml"
+      - "setup.py"
+      - "CMakeLists.txt"
+      - "bindings/**"
+      - "cpp/**"
+
+jobs:
+  windows_msvc_wheel_smoke:
+    name: Windows MSVC Wheel Smoke Test
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Upgrade pip and setuptools
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Build wheel
+        run: pip wheel . --no-deps -w dist/
+
+      - name: Install wheel in clean environment
+        run: pip install --find-links dist/ arnio --no-index
+
+      - name: Run smoke test
+        run: |
+          python -c "import arnio; print('arnio import OK on Windows MSVC')"
+          python -c "import arnio as ar; print(ar.__version__)"

--- a/.github/workflows/windows-msvc-wheel-smoke.yml
+++ b/.github/workflows/windows-msvc-wheel-smoke.yml
@@ -9,6 +9,7 @@ on:
       - "CMakeLists.txt"
       - "bindings/**"
       - "cpp/**"
+      - ".github/workflows/windows-msvc-wheel-smoke.yml"
   pull_request:
     branches: [ "main" ]
     paths:
@@ -17,6 +18,7 @@ on:
       - "CMakeLists.txt"
       - "bindings/**"
       - "cpp/**"
+      - ".github/workflows/windows-msvc-wheel-smoke.yml"
 
 jobs:
   windows_msvc_wheel_smoke:
@@ -38,10 +40,14 @@ jobs:
       - name: Build wheel
         run: pip wheel . --no-deps -w dist/
 
-      - name: Install wheel in clean environment
-        run: pip install --find-links dist/ arnio --no-index
-
-      - name: Run smoke test
+      - name: Install wheel in fresh environment
         run: |
-          python -c "import arnio; print('arnio import OK on Windows MSVC')"
-          python -c "import arnio as ar; print(ar.__version__)"
+          python -m venv smoke_env
+          smoke_env\Scripts\pip install --find-links dist/ arnio --no-index
+
+      - name: Run smoke test from temp directory
+        run: |
+          cd $env:TEMP
+          smoke_env\Scripts\python -c "import arnio; print('arnio import OK:', arnio.__version__)"
+          smoke_env\Scripts\python -c "from arnio import ArFrame; print('ArFrame import OK')"
+        working-directory: ${{ github.workspace }}

--- a/.github/workflows/windows-msvc-wheel-smoke.yml
+++ b/.github/workflows/windows-msvc-wheel-smoke.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run smoke test from temp directory
         run: |
+          $smokePython = "${{ github.workspace }}\smoke_env\Scripts\python"
           cd $env:TEMP
-          smoke_env\Scripts\python -c "import arnio; print('arnio import OK:', arnio.__version__)"
-          smoke_env\Scripts\python -c "from arnio import ArFrame; print('ArFrame import OK')"
-        working-directory: ${{ github.workspace }}
+          & $smokePython -c "import arnio; print('arnio import OK:', arnio.__version__)"
+          & $smokePython -c "from arnio import ArFrame; print('ArFrame import OK')"


### PR DESCRIPTION
## Summary
Added dedicated Windows MSVC wheel smoke test workflow that
builds the wheel on windows-latest, installs it in a clean
environment, and verifies the native extension loads correctly.
Path filters ensure the job only runs when packaging-relevant
files change.

## Linked issue
Fixes #673

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [x] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
CI workflow only — verified YAML syntax is correct.
No code changes made.

## Screenshots / Media
N/A

## Performance Impact
N/A

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
CI only PR. No code or docs were changed.
Path filters on pyproject.toml, setup.py, CMakeLists.txt,
bindings/ and cpp/ keep the job focused and fast.