### PR TITLE
test(quality): add duplicate_rows correctness tests and candidate benchmark (Refs #662)

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -738,22 +738,7 @@ def profile(
 
     df = to_pandas(frame)
     row_count, column_count = frame.shape
-    # Use pd.util.hash_pandas_object to compute a 64-bit MurmurHash3 per row,
-    # then call duplicated() on the resulting 1-D integer Series.  This is
-    # ~1.5× faster than df.duplicated() on large frames because the multi-column
-    # object hashing is done in a single vectorized C pass rather than row-by-row.
-    #
-    # Collision risk: MurmurHash3 produces 64-bit digests, giving a collision
-    # probability of ~n²/2⁶⁴ per frame.  At 10 million rows that is ≈5×10⁻⁹ —
-    # negligible for a profiling metric where an occasional off-by-one in
-    # duplicate_rows has no downstream data-correctness impact.  The semantics
-    # (NaN == NaN treated as duplicate, same as pandas default) are identical to
-    # df.duplicated().sum() as verified by the test suite.
-    if row_count:
-        _row_hashes = pd.util.hash_pandas_object(df, index=False)
-        duplicate_rows = int(_row_hashes.duplicated().sum())
-    else:
-        duplicate_rows = 0
+    duplicate_rows = int(df.duplicated().sum()) if row_count else 0
     duplicate_ratio = _ratio(duplicate_rows, row_count)
 
     columns = {

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -738,7 +738,22 @@ def profile(
 
     df = to_pandas(frame)
     row_count, column_count = frame.shape
-    duplicate_rows = int(df.duplicated().sum()) if row_count else 0
+    # Use pd.util.hash_pandas_object to compute a 64-bit MurmurHash3 per row,
+    # then call duplicated() on the resulting 1-D integer Series.  This is
+    # ~1.5× faster than df.duplicated() on large frames because the multi-column
+    # object hashing is done in a single vectorized C pass rather than row-by-row.
+    #
+    # Collision risk: MurmurHash3 produces 64-bit digests, giving a collision
+    # probability of ~n²/2⁶⁴ per frame.  At 10 million rows that is ≈5×10⁻⁹ —
+    # negligible for a profiling metric where an occasional off-by-one in
+    # duplicate_rows has no downstream data-correctness impact.  The semantics
+    # (NaN == NaN treated as duplicate, same as pandas default) are identical to
+    # df.duplicated().sum() as verified by the test suite.
+    if row_count:
+        _row_hashes = pd.util.hash_pandas_object(df, index=False)
+        duplicate_rows = int(_row_hashes.duplicated().sum())
+    else:
+        duplicate_rows = 0
     duplicate_ratio = _ratio(duplicate_rows, row_count)
 
     columns = {

--- a/benchmarks/benchmark_profile_duplicate_count.py
+++ b/benchmarks/benchmark_profile_duplicate_count.py
@@ -1,15 +1,19 @@
 """
 Benchmark: hash_pandas_object vs df.duplicated() for duplicate counting
 ========================================================================
-Measures the wall-clock time for counting duplicate rows inside profile()
-using two approaches:
+Compares two approaches for counting duplicate rows inside profile():
 
-  * **current (baseline)** — df.duplicated().sum()
-  * **proposed (new)**     — pd.util.hash_pandas_object + Series.duplicated()
+  * **baseline** — df.duplicated().sum()  (current default in profile())
+  * **candidate** — pd.util.hash_pandas_object + Series.duplicated()
 
-This script documents the performance win from perf/#662.  It is NOT run
-as part of the test suite because wall-clock comparisons are too noisy on
-shared CI runners.
+Context (perf/#662):
+  The candidate path was proposed as a faster alternative.  Local benchmarks
+  showed ~1.5x speedup at 500k rows, but CI results were inconsistent
+  (0.72x–1.58x across Python versions and OS configurations).  The hot-path
+  change was therefore reverted; profile() continues to use df.duplicated().
+
+  Run this script manually to measure both approaches on your hardware before
+  re-enabling the candidate path.
 
 Run::
 
@@ -49,12 +53,12 @@ def _make_frame(n_rows: int) -> ar.ArFrame:
 def run(n_rows: int = 500_000, runs: int = 5) -> None:
     print(f"Building frame: {n_rows:,} rows × 3 columns (~10% duplicates) …")
     frame = _make_frame(n_rows)
-    # Pre-convert once — profile() already has df in hand at this point
+    # Pre-convert once — profile() already has df in hand at this point.
     df = to_pandas(frame)
     print(f"Frame memory: {frame.memory_usage() / 1024 / 1024:.1f} MB\n")
 
     times_baseline: list[float] = []
-    times_new: list[float] = []
+    times_candidate: list[float] = []
 
     for i in range(runs):
         t0 = time.perf_counter()
@@ -64,38 +68,40 @@ def run(n_rows: int = 500_000, runs: int = 5) -> None:
         t0 = time.perf_counter()
         hashes = pd.util.hash_pandas_object(df, index=False)
         _ = int(hashes.duplicated().sum())
-        times_new.append(time.perf_counter() - t0)
+        times_candidate.append(time.perf_counter() - t0)
 
         print(
             f"  run {i + 1}/{runs}  "
             f"baseline={times_baseline[-1] * 1000:.1f} ms  "
-            f"new={times_new[-1] * 1000:.1f} ms"
+            f"candidate={times_candidate[-1] * 1000:.1f} ms"
         )
 
     avg_b = sum(times_baseline) / runs
-    avg_n = sum(times_new) / runs
-    speedup = avg_b / avg_n if avg_n > 0 else float("inf")
+    avg_c = sum(times_candidate) / runs
+    speedup = avg_b / avg_c if avg_c > 0 else float("inf")
 
     print()
-    print(f"{'':=<60}")
+    print(f"{'':=<65}")
     print(f"  Rows:  {n_rows:>12,}")
     print(f"  Runs:  {runs:>12}")
-    print(f"{'':=<60}")
-    print(f"  {'Approach':<30} {'Avg time':>12}")
-    print(f"  {'-'*30} {'-'*12}")
-    print(f"  {'df.duplicated().sum()':<30} {avg_b * 1000:>10.1f} ms")
-    print(f"  {'hash_pandas_object path':<30} {avg_n * 1000:>10.1f} ms")
-    print(f"{'':=<60}")
-    print(f"  Speedup: {speedup:.2f}x")
-    print(f"{'':=<60}")
+    print(f"{'':=<65}")
+    print(f"  {'Approach':<35} {'Avg time':>12}")
+    print(f"  {'-'*35} {'-'*12}")
+    print(f"  {'df.duplicated().sum()  [current]':<35} {avg_b * 1000:>10.1f} ms")
+    print(f"  {'hash_pandas_object     [candidate]':<35} {avg_c * 1000:>10.1f} ms")
+    print(f"{'':=<65}")
+    print(
+        f"  Speedup: {speedup:.2f}x  {'✓ candidate faster' if speedup > 1 else '✗ baseline faster'}"
+    )
+    print(f"{'':=<65}")
 
     # Verify correctness
     baseline_count = int(df.duplicated().sum())
-    new_count = int(pd.util.hash_pandas_object(df, index=False).duplicated().sum())
-    assert (
-        baseline_count == new_count
-    ), f"Mismatch: baseline={baseline_count}, new={new_count}"
-    print(f"\n  duplicate_rows = {new_count}  ✓ matches pandas baseline")
+    candidate_count = int(
+        pd.util.hash_pandas_object(df, index=False).duplicated().sum()
+    )
+    match = "✓" if baseline_count == candidate_count else "✗ MISMATCH"
+    print(f"\n  duplicate_rows = {baseline_count}  {match}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/benchmark_profile_duplicate_count.py
+++ b/benchmarks/benchmark_profile_duplicate_count.py
@@ -1,0 +1,108 @@
+"""
+Benchmark: hash_pandas_object vs df.duplicated() for duplicate counting
+========================================================================
+Measures the wall-clock time for counting duplicate rows inside profile()
+using two approaches:
+
+  * **current (baseline)** — df.duplicated().sum()
+  * **proposed (new)**     — pd.util.hash_pandas_object + Series.duplicated()
+
+This script documents the performance win from perf/#662.  It is NOT run
+as part of the test suite because wall-clock comparisons are too noisy on
+shared CI runners.
+
+Run::
+
+    python benchmarks/benchmark_profile_duplicate_count.py
+
+Optional flags::
+
+    --rows   N   Number of rows (default: 500_000)
+    --runs   N   Repetitions per approach (default: 5)
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+import pandas as pd
+
+import arnio as ar
+from arnio.convert import to_pandas
+
+
+def _make_frame(n_rows: int) -> ar.ArFrame:
+    """Return an ArFrame with ~10% duplicate rows and mixed dtypes."""
+    rng = np.random.default_rng(42)
+    df = pd.DataFrame(
+        {
+            "int_col": rng.integers(0, int(n_rows * 0.9), size=n_rows).tolist(),
+            "float_col": rng.uniform(0, 1000, size=n_rows).tolist(),
+            "str_col": [f"s{i % int(n_rows * 0.1)}" for i in range(n_rows)],
+        }
+    )
+    return ar.from_pandas(df)
+
+
+def run(n_rows: int = 500_000, runs: int = 5) -> None:
+    print(f"Building frame: {n_rows:,} rows × 3 columns (~10% duplicates) …")
+    frame = _make_frame(n_rows)
+    # Pre-convert once — profile() already has df in hand at this point
+    df = to_pandas(frame)
+    print(f"Frame memory: {frame.memory_usage() / 1024 / 1024:.1f} MB\n")
+
+    times_baseline: list[float] = []
+    times_new: list[float] = []
+
+    for i in range(runs):
+        t0 = time.perf_counter()
+        _ = int(df.duplicated().sum())
+        times_baseline.append(time.perf_counter() - t0)
+
+        t0 = time.perf_counter()
+        hashes = pd.util.hash_pandas_object(df, index=False)
+        _ = int(hashes.duplicated().sum())
+        times_new.append(time.perf_counter() - t0)
+
+        print(
+            f"  run {i + 1}/{runs}  "
+            f"baseline={times_baseline[-1] * 1000:.1f} ms  "
+            f"new={times_new[-1] * 1000:.1f} ms"
+        )
+
+    avg_b = sum(times_baseline) / runs
+    avg_n = sum(times_new) / runs
+    speedup = avg_b / avg_n if avg_n > 0 else float("inf")
+
+    print()
+    print(f"{'':=<60}")
+    print(f"  Rows:  {n_rows:>12,}")
+    print(f"  Runs:  {runs:>12}")
+    print(f"{'':=<60}")
+    print(f"  {'Approach':<30} {'Avg time':>12}")
+    print(f"  {'-'*30} {'-'*12}")
+    print(f"  {'df.duplicated().sum()':<30} {avg_b * 1000:>10.1f} ms")
+    print(f"  {'hash_pandas_object path':<30} {avg_n * 1000:>10.1f} ms")
+    print(f"{'':=<60}")
+    print(f"  Speedup: {speedup:.2f}x")
+    print(f"{'':=<60}")
+
+    # Verify correctness
+    baseline_count = int(df.duplicated().sum())
+    new_count = int(pd.util.hash_pandas_object(df, index=False).duplicated().sum())
+    assert (
+        baseline_count == new_count
+    ), f"Mismatch: baseline={baseline_count}, new={new_count}"
+    print(f"\n  duplicate_rows = {new_count}  ✓ matches pandas baseline")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Benchmark hash_pandas_object vs df.duplicated() for duplicate counting"
+    )
+    parser.add_argument("--rows", type=int, default=500_000, help="Number of rows")
+    parser.add_argument("--runs", type=int, default=5, help="Repetitions per approach")
+    args = parser.parse_args()
+    run(n_rows=args.rows, runs=args.runs)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1335,54 +1335,35 @@ class TestProfileDuplicateRowsCorrectness:
 # ── duplicate_rows timing guard (perf/#662) ───────────────────────────────────
 
 
-def test_profile_duplicate_count_faster_than_pandas_baseline():
-    """Hash-based duplicate counting must be faster than df.duplicated().sum().
+def test_profile_duplicate_count_hash_path_matches_pandas_baseline_at_scale():
+    """Hash-based duplicate counting must match df.duplicated().sum() at scale.
 
-    This is a timing guard, not a strict benchmark.  It uses a modest frame
-    size (100k rows) so it runs quickly in CI while still being large enough
-    to show the algorithmic difference.  The assertion requires the new path
-    to be at least 1.2× faster — a conservative threshold well below the
-    ~1.5× measured during development.
+    This test uses a larger frame (50k rows with ~10% duplicates) to exercise
+    the hash path under realistic conditions and confirm the result is identical
+    to the pandas baseline.  Timing is intentionally not asserted here — wall-
+    clock comparisons are too noisy on shared CI runners.  The benchmark script
+    benchmarks/benchmark_profile_duplicate_count.py documents the measured
+    speedup (~1.5x at 500k rows).
     """
-    import time
-
     import numpy as np
 
     rng = np.random.default_rng(0)
-    n = 100_000
+    n = 50_000
     df = pd.DataFrame(
         {
             "a": rng.integers(0, int(n * 0.9), size=n).tolist(),
             "b": rng.uniform(0, 1000, size=n).tolist(),
-            "c": [f"s{i % 10000}" for i in range(n)],
+            "c": [f"s{i % 5000}" for i in range(n)],
         }
     )
     frame = ar.from_pandas(df)
 
-    RUNS = 3
+    # New path (what profile() uses)
+    hashes = pd.util.hash_pandas_object(ar.to_pandas(frame), index=False)
+    new_count = int(hashes.duplicated().sum())
 
-    # Baseline: pandas df.duplicated().sum() on already-converted df
-    df_converted = ar.to_pandas(frame)
-    times_baseline = []
-    for _ in range(RUNS):
-        t0 = time.perf_counter()
-        _ = int(df_converted.duplicated().sum())
-        times_baseline.append(time.perf_counter() - t0)
+    # Pandas baseline
+    baseline_count = int(ar.to_pandas(frame).duplicated().sum())
 
-    # Proposed: hash_pandas_object path (what profile() now uses)
-    times_new = []
-    for _ in range(RUNS):
-        t0 = time.perf_counter()
-        hashes = pd.util.hash_pandas_object(df_converted, index=False)
-        _ = int(hashes.duplicated().sum())
-        times_new.append(time.perf_counter() - t0)
-
-    avg_baseline = sum(times_baseline) / RUNS
-    avg_new = sum(times_new) / RUNS
-    speedup = avg_baseline / avg_new if avg_new > 0 else float("inf")
-
-    assert speedup >= 1.2, (
-        f"Expected hash-based path to be ≥1.2× faster than df.duplicated(), "
-        f"got {speedup:.2f}× (baseline={avg_baseline*1000:.1f}ms, "
-        f"new={avg_new*1000:.1f}ms)"
-    )
+    assert new_count == baseline_count
+    assert ar.profile(frame).duplicate_rows == baseline_count

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1243,3 +1243,146 @@ def test_compare_profiles_above_changed_threshold_is_changed():
     comparison = ar.compare_profiles(baseline, current)
     assert comparison.drift_report["score"]["status"] == "changed"
     assert comparison.status_counts == {"ok": 0, "warning": 0, "changed": 1}
+
+
+# ── duplicate_rows correctness tests (perf/#662) ─────────────────────────────
+# These tests verify that the hash-based duplicate counting introduced in
+# perf/#662 produces the same result as the previous df.duplicated().sum()
+# baseline across all edge cases that matter for the profiling metric.
+
+
+class TestProfileDuplicateRowsCorrectness:
+    """Focused correctness tests for duplicate_rows in DataQualityReport.
+
+    Each test asserts both the new hash-based path (via ar.profile) and the
+    pandas baseline (df.duplicated().sum()) to make regressions immediately
+    visible.
+    """
+
+    def _baseline(self, frame: ar.ArFrame) -> int:
+        """Reference implementation: pandas df.duplicated().sum()."""
+        return int(ar.to_pandas(frame).duplicated().sum())
+
+    def test_no_duplicates(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+        assert ar.profile(frame).duplicate_rows == 0
+        assert ar.profile(frame).duplicate_rows == self._baseline(frame)
+
+    def test_all_duplicate_rows(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [7, 7, 7], "b": ["q", "q", "q"]}))
+        # 3 rows, 1 unique → 2 duplicates
+        assert ar.profile(frame).duplicate_rows == 2
+        assert ar.profile(frame).duplicate_rows == self._baseline(frame)
+
+    def test_partial_duplicates(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, 1, 2, 3, 3], "b": ["x", "x", "y", "z", "z"]})
+        )
+        # rows 0==1 and 3==4 → 2 duplicates
+        assert ar.profile(frame).duplicate_rows == 2
+        assert ar.profile(frame).duplicate_rows == self._baseline(frame)
+
+    def test_null_rows_treated_as_duplicates(self):
+        # Two rows where every cell is null should count as one duplicate,
+        # matching pandas default (NaN == NaN for deduplication purposes).
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [None, None, 1.0], "b": [None, None, 2.0]})
+        )
+        assert ar.profile(frame).duplicate_rows == 1
+        assert ar.profile(frame).duplicate_rows == self._baseline(frame)
+
+    def test_partial_null_rows(self):
+        # Only the null-containing column matches; the other differs.
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [None, None, 1.0], "b": [1.0, 2.0, 3.0]})
+        )
+        # All rows are distinct → 0 duplicates
+        assert ar.profile(frame).duplicate_rows == 0
+        assert ar.profile(frame).duplicate_rows == self._baseline(frame)
+
+    def test_mixed_dtypes_int_float_string_bool(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "i": [1, 1, 2],
+                    "f": [1.0, 1.0, 2.0],
+                    "s": ["a", "a", "b"],
+                    "b": [True, True, False],
+                }
+            )
+        )
+        assert ar.profile(frame).duplicate_rows == 1
+        assert ar.profile(frame).duplicate_rows == self._baseline(frame)
+
+    def test_single_row_frame(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [42]}))
+        assert ar.profile(frame).duplicate_rows == 0
+        assert ar.profile(frame).duplicate_rows == self._baseline(frame)
+
+    def test_empty_frame_returns_zero(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": pd.Series(dtype="float64")}))
+        assert ar.profile(frame).duplicate_rows == 0
+
+    def test_duplicate_ratio_consistent_with_duplicate_rows(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, 1, 2, 3], "b": ["x", "x", "y", "z"]})
+        )
+        report = ar.profile(frame)
+        assert report.duplicate_rows == 1
+        assert abs(report.duplicate_ratio - 1 / 4) < 1e-9
+
+
+# ── duplicate_rows timing guard (perf/#662) ───────────────────────────────────
+
+
+def test_profile_duplicate_count_faster_than_pandas_baseline():
+    """Hash-based duplicate counting must be faster than df.duplicated().sum().
+
+    This is a timing guard, not a strict benchmark.  It uses a modest frame
+    size (100k rows) so it runs quickly in CI while still being large enough
+    to show the algorithmic difference.  The assertion requires the new path
+    to be at least 1.2× faster — a conservative threshold well below the
+    ~1.5× measured during development.
+    """
+    import time
+
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    n = 100_000
+    df = pd.DataFrame(
+        {
+            "a": rng.integers(0, int(n * 0.9), size=n).tolist(),
+            "b": rng.uniform(0, 1000, size=n).tolist(),
+            "c": [f"s{i % 10000}" for i in range(n)],
+        }
+    )
+    frame = ar.from_pandas(df)
+
+    RUNS = 3
+
+    # Baseline: pandas df.duplicated().sum() on already-converted df
+    df_converted = ar.to_pandas(frame)
+    times_baseline = []
+    for _ in range(RUNS):
+        t0 = time.perf_counter()
+        _ = int(df_converted.duplicated().sum())
+        times_baseline.append(time.perf_counter() - t0)
+
+    # Proposed: hash_pandas_object path (what profile() now uses)
+    times_new = []
+    for _ in range(RUNS):
+        t0 = time.perf_counter()
+        hashes = pd.util.hash_pandas_object(df_converted, index=False)
+        _ = int(hashes.duplicated().sum())
+        times_new.append(time.perf_counter() - t0)
+
+    avg_baseline = sum(times_baseline) / RUNS
+    avg_new = sum(times_new) / RUNS
+    speedup = avg_baseline / avg_new if avg_new > 0 else float("inf")
+
+    assert speedup >= 1.2, (
+        f"Expected hash-based path to be ≥1.2× faster than df.duplicated(), "
+        f"got {speedup:.2f}× (baseline={avg_baseline*1000:.1f}ms, "
+        f"new={avg_new*1000:.1f}ms)"
+    )

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1336,14 +1336,17 @@ class TestProfileDuplicateRowsCorrectness:
 
 
 def test_profile_duplicate_count_hash_path_matches_pandas_baseline_at_scale():
-    """Hash-based duplicate counting must match df.duplicated().sum() at scale.
+    """Verify hash_pandas_object produces the same duplicate count as df.duplicated().
 
-    This test uses a larger frame (50k rows with ~10% duplicates) to exercise
-    the hash path under realistic conditions and confirm the result is identical
-    to the pandas baseline.  Timing is intentionally not asserted here — wall-
-    clock comparisons are too noisy on shared CI runners.  The benchmark script
-    benchmarks/benchmark_profile_duplicate_count.py documents the measured
-    speedup (~1.5x at 500k rows).
+    This test documents the candidate faster implementation explored in #662.
+    The hash path is NOT currently used as the default in profile() — benchmark
+    results were inconsistent across CI configurations (0.72x–1.58x depending
+    on Python version and OS).  The correctness equivalence is preserved here so
+    the implementation can be re-enabled once stable benchmark evidence is
+    available across the full CI matrix.
+
+    See benchmarks/benchmark_profile_duplicate_count.py for the manual timing
+    comparison.
     """
     import numpy as np
 
@@ -1357,13 +1360,14 @@ def test_profile_duplicate_count_hash_path_matches_pandas_baseline_at_scale():
         }
     )
     frame = ar.from_pandas(df)
+    df_converted = ar.to_pandas(frame)
 
-    # New path (what profile() uses)
-    hashes = pd.util.hash_pandas_object(ar.to_pandas(frame), index=False)
-    new_count = int(hashes.duplicated().sum())
+    # Candidate path (not yet the default)
+    hashes = pd.util.hash_pandas_object(df_converted, index=False)
+    hash_count = int(hashes.duplicated().sum())
 
-    # Pandas baseline
-    baseline_count = int(ar.to_pandas(frame).duplicated().sum())
+    # Current baseline — what profile() uses
+    baseline_count = int(df_converted.duplicated().sum())
 
-    assert new_count == baseline_count
+    assert hash_count == baseline_count
     assert ar.profile(frame).duplicate_rows == baseline_count

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1245,18 +1245,19 @@ def test_compare_profiles_above_changed_threshold_is_changed():
     assert comparison.status_counts == {"ok": 0, "warning": 0, "changed": 1}
 
 
-# ── duplicate_rows correctness tests (perf/#662) ─────────────────────────────
-# These tests verify that the hash-based duplicate counting introduced in
-# perf/#662 produces the same result as the previous df.duplicated().sum()
-# baseline across all edge cases that matter for the profiling metric.
+# ── duplicate_rows correctness tests (Refs #662) ─────────────────────────────
+# These tests verify the duplicate_rows field in DataQualityReport against
+# the pandas df.duplicated().sum() baseline.  profile() continues to use
+# df.duplicated().sum() as its default; the hash_pandas_object candidate
+# is covered separately below for future comparison only.
 
 
 class TestProfileDuplicateRowsCorrectness:
     """Focused correctness tests for duplicate_rows in DataQualityReport.
 
-    Each test asserts both the new hash-based path (via ar.profile) and the
-    pandas baseline (df.duplicated().sum()) to make regressions immediately
-    visible.
+    profile() uses df.duplicated().sum() as its default implementation.
+    Each test asserts ar.profile() against the pandas baseline directly so
+    any future change to the counting path is immediately caught.
     """
 
     def _baseline(self, frame: ar.ArFrame) -> int:


### PR DESCRIPTION
## Summary

Refs #662 — the performance optimization is deferred; this PR adds correctness
coverage and a manual benchmark to support a future implementation.

## What this PR does NOT change

`profile()` behavior is unchanged — `df.duplicated().sum()` remains the default.
The `hash_pandas_object` candidate was benchmarked but showed inconsistent
results across CI configurations (0.72x–1.58x), so the hot-path change is
deferred until stable evidence is available across the full matrix.

## What this PR adds

**`TestProfileDuplicateRowsCorrectness` (9 tests)** — focused correctness tests for
`duplicate_rows` in `DataQualityReport` covering: no duplicates, all-duplicate rows,
partial duplicates, null rows (NaN==NaN semantics), partial-null rows, mixed dtypes
(int64/float64/string/bool), single row, empty frame, and `duplicate_ratio` consistency.
Each test asserts both `ar.profile()` and the pandas baseline directly.

**`test_profile_duplicate_count_hash_path_matches_pandas_baseline_at_scale`** —
verifies `hash_pandas_object` produces the same count as `df.duplicated()` at 50k rows,
without any timing assertion.

**`benchmarks/benchmark_profile_duplicate_count.py`** — standalone manual benchmark
(not run in CI) comparing both approaches. Notes that pandas `duplicated()` is already
internally optimized and the hash path is not guaranteed to be faster across all
configurations.
