### PR TITLE
fix: align round_numeric_columns subset error contract (#587)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -891,7 +891,10 @@ def round_numeric_columns(
     if subset is not None:
         missing = [col for col in subset if col not in df.columns]
         if missing:
-            raise IndexError(f"Column not found: {missing[0]}")
+            raise ValueError(
+                f"round_numeric_columns: unknown column(s) in subset: {missing}. "
+                f"Available columns: {list(df.columns)}"
+            )
         cols_to_round = subset
     else:
         cols_to_round = df.select_dtypes(include=["number"]).columns

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1066,7 +1066,10 @@ class TestRoundNumericColumns:
 
         df = pd.DataFrame({"a": [1.123]})
         frame = ar.from_pandas(df)
-        with pytest.raises(IndexError, match="Column not found"):
+        with pytest.raises(
+            ValueError,
+            match=r"round_numeric_columns: unknown column\(s\) in subset: \['missing_col'\]",
+        ):
             ar.round_numeric_columns(frame, subset=["missing_col"])
 
     def test_with_nulls(self):


### PR DESCRIPTION
Fixes #587

## Summary
- align `round_numeric_columns(..., subset=...)` with the project-wide missing-column contract
- raise a clear `ValueError` that includes the unknown subset columns and available columns
- add focused regression coverage for the missing-column case

## Verification
- `python -m pytest tests/test_cleaning.py -k "round_all_numeric or round_subset or round_mixed_types or test_missing_column or test_with_nulls or test_invalid_subset_type or test_invalid_decimals_type or test_decimals_rejects_bool or test_round_subset_with_non_numeric"`
- `python -m ruff check arnio/cleaning.py tests/test_cleaning.py`
- `python -m black --check arnio/cleaning.py tests/test_cleaning.py`
