### PR TITLE
fix: validate Schema.unique string and invalid unique members (#621)

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -90,6 +90,23 @@ class Schema:
                     f"Schema value for column {name!r} must be a Field instance such as ar.Int64(), got {type(field_def).__name__}"
                 )
 
+        if self.unique is not None:
+            if isinstance(self.unique, str):
+                raise TypeError(
+                    "Schema 'unique' must be a list or tuple of strings (e.g., ['column_name']), "
+                    f"not a bare string: {self.unique!r}."
+                )
+            if not isinstance(self.unique, (list, tuple)):
+                raise TypeError(
+                    "Schema 'unique' must be a list or tuple of strings (e.g., ['column_name']), "
+                    f"got {type(self.unique).__name__}."
+                )
+            for item in self.unique:
+                if not isinstance(item, str):
+                    raise TypeError(
+                        f"Schema 'unique' members must be strings, got {type(item).__name__} for element {item!r}."
+                    )
+
     def validate(self, frame: ArFrame) -> ValidationResult:
         """Validate a frame against this schema."""
         return validate(frame, self)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -708,6 +708,70 @@ def test_schema_composite_unique_empty_columns(tmp_path):
     assert "cannot be empty" in issues[0].message
 
 
+def test_schema_unique_rejects_string():
+    with pytest.raises(TypeError) as exc:
+        ar.Schema(
+            {
+                "user_id": ar.Int64(),
+            },
+            unique="user_id",
+        )
+    assert "bare string" in str(exc.value)
+
+
+def test_schema_unique_rejects_invalid_type():
+    with pytest.raises(TypeError) as exc:
+        ar.Schema(
+            {
+                "user_id": ar.Int64(),
+            },
+            unique=123,  # type: ignore[arg-type]
+        )
+    assert "must be a list or tuple" in str(exc.value)
+
+
+def test_schema_unique_rejects_non_string_members():
+    with pytest.raises(TypeError) as exc:
+        ar.Schema(
+            {
+                "user_id": ar.Int64(),
+            },
+            unique=["col1", None],  # type: ignore[list-item]
+        )
+    assert "members must be strings" in str(exc.value)
+
+    with pytest.raises(TypeError) as exc:
+        ar.Schema(
+            {
+                "user_id": ar.Int64(),
+            },
+            unique=["col1", 123],  # type: ignore[list-item]
+        )
+    assert "members must be strings" in str(exc.value)
+
+
+def test_schema_unique_accepts_valid_types():
+    # Verify list of strings initializes successfully
+    schema_list = ar.Schema(
+        {
+            "user_id": ar.Int64(),
+            "course_id": ar.Int64(),
+        },
+        unique=["user_id", "course_id"],
+    )
+    assert schema_list.unique == ["user_id", "course_id"]
+
+    # Verify tuple of strings initializes successfully
+    schema_tuple = ar.Schema(
+        {
+            "user_id": ar.Int64(),
+            "course_id": ar.Int64(),
+        },
+        unique=("user_id", "course_id"),
+    )
+    assert schema_tuple.unique == ("user_id", "course_id")
+
+
 def test_email_default_keeps_backward_compatibility(sample_csv):
     frame = ar.read_csv(sample_csv)
 


### PR DESCRIPTION
### Description
Closes #621. This PR introduces robust validation for the `Schema.unique` attribute during instantiation (`__post_init__`) and provides comprehensive test coverage for invalid member types, bare strings, invalid collection types, and valid inputs.

### What Was Done

1. **Added validation inside `Schema.__post_init__`**:
   - Explicitly rejects bare strings passed to `unique` (e.g. `unique="user_id"`), prompting the user with a helpful instruction and expected shape.
   - Rejects non-sequence collection types (e.g., `int`, `dict`, `bool`) and provides a clear `TypeError` containing the received type.
   - Iterates through lists/tuples to ensure all elements are strings, raising a clear `TypeError` pointing out the invalid elements (e.g. `None` or `int`).
   
2. **Added comprehensive pytest coverage**:
   - `test_schema_unique_rejects_string`: Asserts bare string input raises `TypeError`.
   - `test_schema_unique_rejects_invalid_type`: Asserts invalid sequence container types raise `TypeError`.
   - `test_schema_unique_rejects_non_string_members`: Asserts non-string items within sequences raise `TypeError`.
   - `test_schema_unique_accepts_valid_types`: Verifies lists and tuples of strings successfully initialize.

### Verification & Testing

- Successfully installed `hypothesis` to run the full test suite locally.
- All **679 tests passed successfully** (including new regression tests and full fuzzing tests) with 0 errors.
- Verified and passed all linting and style checks (`ruff check` and `ruff format`).

---

### Contributor & AI Disclosure (GSSoC Compliant)

* **AI Assistance**: The base implementation of the validation and the corresponding unit tests were drafted with the assistance of the AI coding assistant **Antigravity (Gemini)**.

* **Contributor Review**: As the GSSoC contributor, I have verified the logic design, and successfully run the full local test suite (all 679 tests passed successfully with 0 errors). Based on my review, execution, and local verification, the implementation matches the issue specifications, runs correctly, and is ready for integration.
