### PR TITLE
perf(cleaning): avoid pandas round-trip in trim_column_names

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -701,17 +701,18 @@ def trim_column_names(frame: ArFrame) -> ArFrame:
     >>> frame = ar.read_csv("data.csv")  # columns: [" name ", " age "]
     >>> clean = ar.trim_column_names(frame)  # columns: ["name", "age"]
     """
-    from .convert import from_pandas, to_pandas
-
-    df = to_pandas(frame)
-    trimmed = [col.strip() for col in df.columns]
+    trimmed = [col.strip() for col in frame.columns]
 
     if len(trimmed) != len(set(trimmed)):
         raise ValueError(f"Trimming column names would create duplicates: {trimmed}")
 
-    df = df.copy()
-    df.columns = trimmed
-    return from_pandas(df)
+    mapping = {
+        original: updated
+        for original, updated in zip(frame.columns, trimmed)
+        if original != updated
+    }
+    result = _rename_columns(frame._frame, mapping)
+    return ArFrame(result)
 
 
 def cast_types(

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -916,6 +916,23 @@ class TestTrimColumnNames:
         with pytest.raises(ValueError, match="duplicates"):
             ar.trim_column_names(frame)
 
+    def test_trim_column_names_whitespace_only(self):
+        df = pd.DataFrame({"   ": [1], " b ": [2]})
+        frame = from_pandas(df)
+        result = ar.trim_column_names(frame)
+        assert to_pandas(result).columns.tolist() == ["", "b"]
+
+    def test_trim_column_names_skips_pandas_round_trip(self, monkeypatch):
+        import arnio.convert as convert
+
+        def _boom(*_args, **_kwargs):
+            raise AssertionError("trim_column_names should not call to_pandas")
+
+        monkeypatch.setattr(convert, "to_pandas", _boom)
+        frame = from_pandas(pd.DataFrame({" name ": [1]}))
+        result = ar.trim_column_names(frame)
+        assert result.columns == ["name"]
+
 
 class TestCastTypes:
     def test_cast_int_to_string(self, sample_csv):


### PR DESCRIPTION

## Summary
<!-- What changed and why? Keep this short but specific. -->

- I have removed the pandas conversion in trim_column_names by trimming native column metadata and using the existing native rename path. 
- Also added focused tests for whitespace-only names and a guard that fails if pandas conversion is invoked.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
Closes #656 
## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
python -m pytest test_cleaning.py -k trim_column_names
7 passed, 150 deselected in 0.32s
## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->
<img width="1454" height="498" alt="image" src="https://github.com/user-attachments/assets/d6f99168-bdee-4ac6-9555-0478273c8f04" />

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
