### PR TITLE
typing(io): add type hints to arnio/io.py + scoped mypy config

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -10,8 +10,8 @@ import os
 import shutil
 import tempfile
 from collections.abc import Iterator, Sequence
-from typing import cast
 from contextlib import contextmanager
+from typing import cast
 
 from ._core import _CsvConfig, _CsvReader, _CsvWriteConfig, _CsvWriter
 from .exceptions import CsvReadError

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import tempfile
 from collections.abc import Iterator, Sequence
+from typing import cast
 from contextlib import contextmanager
 
 from ._core import _CsvConfig, _CsvReader, _CsvWriteConfig, _CsvWriter
@@ -421,6 +422,6 @@ def scan_csv(
             delimiter=delimiter,
             sample_rows=100 if sample_size is None else sample_size,
         ) as native_path:
-            return reader.scan_schema(native_path)
+            return cast(dict[str, str], reader.scan_schema(native_path))
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+files = arnio/io.py
+strict = True
+python_version = 3.9
+follow_imports = skip

--- a/tests/test_io_smoke.py
+++ b/tests/test_io_smoke.py
@@ -3,7 +3,10 @@ import pytest
 try:
     import arnio as ar
 except Exception:
-    pytest.skip("arnio C++ extension not available; skipping IO smoke tests", allow_module_level=True)
+    pytest.skip(
+        "arnio C++ extension not available; skipping IO smoke tests",
+        allow_module_level=True,
+    )
 
 
 def test_read_csv_smoke(tmp_path):

--- a/tests/test_io_smoke.py
+++ b/tests/test_io_smoke.py
@@ -1,8 +1,16 @@
 import pytest
 
+# Only skip the module when the package or its native extension is missing.
 try:
     import arnio as ar
-except Exception:
+except ImportError:
+    pytest.skip("arnio not installed; skipping IO smoke tests", allow_module_level=True)
+
+# If the Python package imports but the native C++ extension isn't built, skip those
+# IO smoke tests specifically. This avoids hiding import/runtime errors that
+# should surface during CI while still allowing CI to skip these tests when the
+# native extension isn't available in the runner.
+if getattr(ar, "_arnio_cpp", None) is None:
     pytest.skip(
         "arnio C++ extension not available; skipping IO smoke tests",
         allow_module_level=True,

--- a/tests/test_io_smoke.py
+++ b/tests/test_io_smoke.py
@@ -1,0 +1,30 @@
+import pytest
+
+try:
+    import arnio as ar
+except Exception:
+    pytest.skip("arnio C++ extension not available; skipping IO smoke tests", allow_module_level=True)
+
+
+def test_read_csv_smoke(tmp_path):
+    csv_path = tmp_path / "smoke.csv"
+    csv_path.write_text("name,age\nAlice,30\nBob,25\n")
+
+    frame = ar.read_csv(str(csv_path))
+    assert isinstance(frame, ar.ArFrame)
+    assert frame.shape == (2, 2)
+    assert list(frame.columns) == ["name", "age"]
+
+
+def test_from_pandas_smoke():
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame({"x": [1, 2], "y": ["a", "b"]})
+
+    frame = ar.from_pandas(df)
+    assert isinstance(frame, ar.ArFrame)
+
+    # round-trip to pandas and compare basic contents
+    out = ar.to_pandas(frame)
+    assert list(out.columns) == ["x", "y"]
+    assert out["x"].tolist() == [1, 2]
+    assert out["y"].tolist() == ["a", "b"]


### PR DESCRIPTION
Refs #751

This draft PR implements the first scoped step for Issue #751: add Python 3.9+ type hints to the public I/O surface.

Changes (scoped):
- `arnio/io.py`: added typing adjustments and a cast for `scan_csv()` to satisfy mypy.
- `mypy.ini`: minimal config scoped to `arnio/io.py` with `follow_imports = skip`.
- `tests/test_io_smoke.py`: small smoke tests for `read_csv` and `from_pandas` (they skip if the C++ extension is not built).
- `arnio/py.typed`: present (PEP 561 marker).

Local verification:
- `python -m mypy --config-file mypy.ini arnio/io.py` succeeded locally.
- Formatting/lint fixes applied per CI feedback.

Notes:
- This PR intentionally limits scope to `arnio/io.py` to keep the change reviewable. I will not expand scope in this PR.
- Keep as draft until maintainers request it be marked ready for review.

Please let me know if you'd like additional small edits before review.
