### PR TITLE
fix: escape markdown pipes in data quality report (#597)

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -231,13 +231,13 @@ class DataQualityReport:
                 warnings = ", ".join(column.warnings) if column.warnings else "-"
 
                 lines.append(
-                    f"| {column.name} "
-                    f"| {column.dtype} "
-                    f"| {column.semantic_type} "
-                    f"| {column.null_count} "
-                    f"| {column.unique_count} "
-                    f"| {column.unique_ratio:.2%} "
-                    f"| {warnings} |"
+                    f"| {_markdown_cell(column.name)} "
+                    f"| {_markdown_cell(column.dtype)} "
+                    f"| {_markdown_cell(column.semantic_type)} "
+                    f"| {_markdown_cell(column.null_count)} "
+                    f"| {_markdown_cell(column.unique_count)} "
+                    f"| {_markdown_cell(f'{column.unique_ratio:.2%}')} "
+                    f"| {_markdown_cell(warnings)} |"
                 )
 
             lines.append("")

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -844,6 +844,36 @@ def test_report_to_markdown_deterministic(tmp_path):
     assert report.to_markdown() == report.to_markdown()
 
 
+def test_report_to_markdown_escapes_pipe_characters_in_column_cells():
+    report = ar.DataQualityReport(
+        row_count=2,
+        column_count=1,
+        memory_usage=128,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={
+            "bad|name": ar.ColumnProfile(
+                name="bad|name",
+                dtype="string",
+                semantic_type="free|text",
+                row_count=2,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=2,
+                unique_ratio=1.0,
+                warnings=["contains | pipe"],
+            )
+        },
+        suggestions=[],
+    )
+
+    md = report.to_markdown()
+
+    assert "bad\\|name" in md
+    assert "free\\|text" in md
+    assert "contains \\| pipe" in md
+
+
 def test_report_to_markdown_empty_sections():
     report = ar.DataQualityReport(
         row_count=0,


### PR DESCRIPTION
Fixes #597

## Summary
- escape pipe characters in `DataQualityReport.to_markdown()` column-table cells
- reuse the existing Markdown cell helper so names, semantic types, counts, ratios, and warnings render safely
- add focused regression coverage for a column name and warning text that contain `|`

## Verification
- `python -m pytest tests/test_quality.py -k "report_to_markdown_basic or report_to_markdown_includes_uniqueness_metrics or report_to_markdown_deterministic or report_to_markdown_escapes_pipe_characters_in_column_cells or report_to_markdown_empty_sections"`
- `python -m ruff check arnio/quality.py tests/test_quality.py`
- `python -m black --check arnio/quality.py tests/test_quality.py`
