### PR TITLE
fix: use one-based composite unique row indexes (#603)

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -558,7 +558,7 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
                                     "Duplicate rows found for columns"
                                     f" {list(schema.unique)}"
                                 ),
-                                row_index=int(index),
+                                row_index=int(index) + 1,
                             )
                         )
     if schema.rules:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -667,8 +667,8 @@ def test_schema_composite_unique_fails(tmp_path):
     assert not result.passed
     issues = [i for i in result.issues if i.rule == "composite_unique"]
     assert len(issues) == 2
-    assert issues[0].row_index == 0
-    assert issues[1].row_index == 2
+    assert issues[0].row_index == 1
+    assert issues[1].row_index == 3
     assert "['user_id', 'course_id']" in issues[0].message
 
 


### PR DESCRIPTION
Fixes #603

## Summary
- align composite unique validation row indexes with the one-based row numbering used by field-level schema issues
- keep the fix limited to the composite unique reporting path
- add regression coverage for the reported row-index contract

## Verification
- `python -m pytest tests/test_schema.py -k "composite_unique"`
- `python -m ruff check arnio/schema.py tests/test_schema.py`
- `python -m black --check arnio/schema.py tests/test_schema.py`
