### PR TITLE
feat(csv): add configurable null_values tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ print(selected.columns)
 ```
 
 
+### Handling missing values
+
+Arnio supports configuring which strings are treated as null during CSV parsing using the `null_values` parameter in `read_csv` and `scan_csv`. By default, Arnio preserves its existing behavior and treats only empty cells as null. Custom matching is case-insensitive and applies to cell values only (not headers).
+
+```python
+# Default behavior: empty cells are null
+frame = ar.read_csv("data.csv")
+
+# Provide a custom list of sentinels (overrides the empty-cell default)
+frame = ar.read_csv("data.csv", null_values=["", "MISSING", "UNKNOWN"])
+
+# Disable null sentinel handling completely
+frame = ar.read_csv("data.csv", null_values=[])
+```
+
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 
 <br>

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -135,6 +135,21 @@ def _validate_nrows(nrows: int) -> int:
     return nrows
 
 
+def _validate_null_values(null_values: list[str]) -> list[str]:
+    """Validate null_values parameter."""
+    if isinstance(null_values, str):
+        raise TypeError("null_values must be a list of strings, not a bare string")
+
+    if not isinstance(null_values, list):
+        raise TypeError("null_values must be a list of strings")
+
+    for val in null_values:
+        if not isinstance(val, str):
+            raise TypeError("null_values must contain only strings")
+
+    return list(null_values)
+
+
 def read_csv(
     path: str | os.PathLike[str],
     *,
@@ -145,6 +160,7 @@ def read_csv(
     encoding: str = "utf-8",
     trim_headers: bool = True,
     thousands_separator: str | None = None,
+    null_values: list[str] | None = None,
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -229,6 +245,9 @@ def read_csv(
     config.encoding = encoding
     config.trim_headers = trim_headers
     config.thousands_separator = thousands_separator
+
+    if null_values is not None:
+        config.null_values = _validate_null_values(null_values)
 
     if usecols is not None:
         config.usecols = _validate_usecols(usecols)
@@ -327,6 +346,7 @@ def scan_csv(
     trim_headers: bool = True,
     thousands_separator: str | None = None,
     sample_size: int | None = None,
+    null_values: list[str] | None = None,
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
 
@@ -409,6 +429,9 @@ def scan_csv(
     config.encoding = encoding
     config.trim_headers = trim_headers
     config.thousands_separator = thousands_separator
+
+    if null_values is not None:
+        config.null_values = _validate_null_values(null_values)
 
     if sample_size is not None:
         if not isinstance(sample_size, int) or isinstance(sample_size, bool):

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -222,7 +222,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("encoding", &CsvConfig::encoding)
         .def_readwrite("trim_headers", &CsvConfig::trim_headers)
         .def_readwrite("thousands_separator", &CsvConfig::thousands_separator)
-        .def_readwrite("sample_size", &CsvConfig::sample_size);
+        .def_readwrite("sample_size", &CsvConfig::sample_size)
+        .def_readwrite("null_values", &CsvConfig::null_values);
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -18,6 +18,7 @@ struct CsvConfig {
     bool trim_headers = true;        // for implementing the trim_headers option
     std::optional<char> thousands_separator = std::nullopt;
     std::optional<size_t> sample_size = std::nullopt;
+    std::optional<std::vector<std::string>> null_values = std::nullopt;
 };
 
 class CsvReader {
@@ -35,6 +36,9 @@ class CsvReader {
 
     // Parse a single CSV line respecting quotes
     std::vector<std::string> parse_line(const std::string& line) const;
+
+    // Check if a string is a null sentinel
+    bool is_null_sentinel(const std::string& value) const;
 
     // Infer DType from a string value
     DType infer_type(const std::string& value) const;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -233,8 +233,29 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
     return fields;
 }
 
+bool CsvReader::is_null_sentinel(const std::string& value) const {
+    if (config_.null_values.has_value()) {
+        const auto& sentinels = config_.null_values.value();
+        for (const auto& sentinel : sentinels) {
+            if (value.size() != sentinel.size()) continue;
+            bool match = true;
+            for (size_t i = 0; i < value.size(); ++i) {
+                if (std::tolower(static_cast<unsigned char>(value[i])) !=
+                    std::tolower(static_cast<unsigned char>(sentinel[i]))) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return true;
+        }
+        return false;
+    }
+
+    return value.empty();
+}
+
 DType CsvReader::infer_type(const std::string& value) const {
-    if (value.empty()) return DType::NULL_TYPE;
+    if (is_null_sentinel(value)) return DType::NULL_TYPE;
 
     // Try bool
     std::string lower = value;
@@ -303,7 +324,7 @@ DType CsvReader::promote_type(DType current, DType incoming) {
 }
 
 CellValue CsvReader::parse_value(const std::string& raw, DType dtype) const {
-    if (raw.empty()) return std::monostate{};
+    if (is_null_sentinel(raw)) return std::monostate{};
 
     switch (dtype) {
         case DType::BOOL: {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -442,6 +442,68 @@ class TestReadCsv:
         with pytest.raises(ar.CsvReadError):
             ar.read_csv(str(tmp_path / "nonexistent.csv"))
 
+    def test_null_values_default_preserves_empty_only_behavior(self, tmp_path):
+        csv_path = tmp_path / "default_nulls.csv"
+        csv_path.write_text("a,b\n,1\nNA,2\n")
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+        assert pd.isna(df.loc[0, "a"])
+        assert df.loc[1, "a"] == "NA"
+        assert frame.dtypes["a"] == "string"
+
+    def test_null_values_custom_is_case_insensitive(self, tmp_path):
+        csv_path = tmp_path / "case_nulls.csv"
+        csv_path.write_text("a\nNa\nnA\nna\n")
+        frame = ar.read_csv(csv_path, null_values=["NA"])
+        df = ar.to_pandas(frame)
+        assert df["a"].isna().sum() == 3
+
+    def test_null_values_custom_preserves_type_inference(self, tmp_path):
+        csv_path = tmp_path / "type_infer.csv"
+        csv_path.write_text("a\n1\nNA\n3\n")
+        frame = ar.read_csv(csv_path, null_values=["NA"])
+        assert frame.dtypes["a"] == "int64"
+
+    def test_null_values_empty_disables_default_empty_null(self, tmp_path):
+        csv_path = tmp_path / "empty_nulls.csv"
+        csv_path.write_text("a,b\n,1\nNA,2\n")
+        frame = ar.read_csv(csv_path, null_values=[])
+        df = ar.to_pandas(frame)
+        assert df.loc[0, "a"] == ""
+        assert df.loc[1, "a"] == "NA"
+
+    def test_null_values_custom_overrides_defaults(self, tmp_path):
+        csv_path = tmp_path / "custom_nulls.csv"
+        csv_path.write_text("a,b\n,1\nMISSING,2\n")
+        frame = ar.read_csv(csv_path, null_values=["MISSING"])
+        df = ar.to_pandas(frame)
+        assert df.loc[0, "a"] == ""
+        assert pd.isna(df.loc[1, "a"])
+
+    def test_null_values_read_and_scan_csv_parity(self, tmp_path):
+        csv_path = tmp_path / "parity.csv"
+        csv_path.write_text("a\n1\nNA\n3\n")
+
+        default_frame = ar.read_csv(csv_path)
+        default_schema = ar.scan_csv(csv_path)
+        assert default_frame.dtypes["a"] == "string"
+        assert default_schema["a"] == "string"
+
+        custom_frame = ar.read_csv(csv_path, null_values=["NA"])
+        custom_schema = ar.scan_csv(csv_path, null_values=["NA"])
+        assert custom_frame.dtypes["a"] == "int64"
+        assert custom_schema["a"] == "int64"
+
+    def test_null_values_invalid_type(self):
+        with pytest.raises(
+            TypeError, match="must be a list of strings, not a bare string"
+        ):
+            ar.read_csv("dummy.csv", null_values="NA")
+        with pytest.raises(TypeError, match="must be a list of strings"):
+            ar.read_csv("dummy.csv", null_values=("NA",))
+        with pytest.raises(TypeError, match="must contain only strings"):
+            ar.read_csv("dummy.csv", null_values=[1])
+
 
 class TestScanCsv:
     def test_scan_schema(self, sample_csv):
@@ -559,6 +621,16 @@ class TestScanCsv:
     def test_scan_missing_file_passthrough(self, tmp_path):
         with pytest.raises(ar.CsvReadError):
             ar.scan_csv(str(tmp_path / "nonexistent.csv"))
+
+    def test_scan_null_values_invalid_type(self):
+        with pytest.raises(
+            TypeError, match="must be a list of strings, not a bare string"
+        ):
+            ar.scan_csv("dummy.csv", null_values="NA")
+        with pytest.raises(TypeError, match="must be a list of strings"):
+            ar.scan_csv("dummy.csv", null_values=("NA",))
+        with pytest.raises(TypeError, match="must contain only strings"):
+            ar.scan_csv("dummy.csv", null_values=[1])
 
     def test_scan_schema_preserves_column_order(self, tmp_path):
         csv_path = tmp_path / "order_test.csv"


### PR DESCRIPTION
## Description

This PR introduces configurable handling for missing data values (nulls) when parsing CSV files, addressing issue #126. 

By default, Arnio preserves its legacy behavior, meaning only entirely empty CSV fields (`""`) are treated as null. However, users can now explicitly define a list of custom sentinel strings that should be parsed as nulls by passing the new `null_values` argument to `read_csv` and `scan_csv`.

## Changes Made

- **`CsvConfig` & Pybind11 Integration:** Added a new `null_values` property (a list of strings) to the `CsvConfig` struct in the C++ layer and exposed it to Python via Pybind11.
- **Python API (`arnio/io.py`):** Added the `null_values` parameter to both `read_csv` and `scan_csv`. Implemented strict type validation to ensure the parameter is explicitly passed as a `list[str]`.
- **C++ Engine (`csv_reader.cpp`):** 
  - Added a private `is_null_sentinel` helper function.
  - Implemented case-insensitive matching for custom sentinels (e.g., `NA` matches `na`, `Na`, etc.).
  - Preserved the default behavior of checking `value.empty()` when the user hasn't overridden `null_values`.
- **Testing:** Added extensive unit tests ensuring parity between `read_csv` and `scan_csv`, verifying case-insensitivity, verifying invalid type rejections, and confirming that dtype inference remains consistent.
- **Documentation:** Updated `README.md` to clearly explain the default behavior and demonstrate how users can opt-in to custom null handling.

## Examples

**Default Behavior:**
```python
# Empty strings are null
frame = ar.read_csv("data.csv")
```

**Custom Sentinels:**
```python
# Treats "", "MISSING", and "UNKNOWN" as null
frame = ar.read_csv("data.csv", null_values=["", "MISSING", "UNKNOWN"])
```

**Disabling Null Handling:**
```python
# Treat every string exactly as it appears (no null interpolation)
frame = ar.read_csv("data.csv", null_values=[])
```

## Related Issues
Fixes #126
