### PR TITLE
docs: document sklearn row-dropping pipeline behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,28 @@ not to replace it.
 | **DuckDB / Arrow** | Validate and prepare data before analytics and columnar exchange. |
 | **notebooks** | Inspect quality issues and cleaning suggestions before analysis. |
 
+### Row-dropping pipeline behavior
+
+Some pipeline steps such as `drop_nulls` or `drop_duplicates`
+can change the number of rows returned during `transform`.
+
+By default, `ArnioCleaner` raises a `ValueError` if a pipeline
+changes row count during transform because many scikit-learn
+workflows expect input and output sample counts to remain aligned.
+
+If row-dropping behavior is intentional, pass
+`allow_row_count_change=True` when constructing `ArnioCleaner`.
+
+```python
+cleaner = ArnioCleaner(
+    steps=[
+        ("drop_nulls",),
+        ("strip_whitespace",),
+    ],
+    allow_row_count_change=True,
+)
+```
+
 ### Pandas accessor
 
 ```python


### PR DESCRIPTION
## Summary

Document sklearn integration behavior for row-dropping pipeline steps in `ArnioCleaner`.

Adds a concise note explaining:

- default row-count preservation expectations
- why row-dropping transforms raise errors by default
- how to intentionally allow row-dropping behavior using `allow_row_count_change=True`

Fixes #665