### PR TITLE
fix: explicitly reject keep=True in drop_duplicates (#584)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -327,6 +327,8 @@ def drop_duplicates(
             _validate_column_sequence(subset, argument_name="subset"),
             operation="drop_duplicates",
         )
+    if keep is True:
+        raise ValueError("keep must be one of 'first', 'last', 'none', or False")
     keep_arg = "none" if keep is False else keep
     if keep_arg not in {"first", "last", "none"}:
         raise ValueError("keep must be one of 'first', 'last', 'none', or False")

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -191,6 +191,12 @@ class TestDropDuplicates:
         result = ar.drop_duplicates(frame, subset=["name"])
         assert result.shape[0] == 3
 
+    def test_drop_dupes_regression_keep_true(self, csv_with_duplicates):
+        frame = ar.read_csv(csv_with_duplicates)
+
+        with pytest.raises(ValueError, match="keep must be one of"):
+            ar.drop_duplicates(frame, keep=True)
+
 
 class TestDropColumns:
     def test_drop_columns_removes_requested_columns_and_preserves_order(self):


### PR DESCRIPTION
## Summary
Explicitly rejects `keep=True` with a `ValueError` at the public boundary of `drop_duplicates` to prevent invalid boolean forwarding. Added a dedicated regression test case within `TestDropDuplicates` to guarantee the documented error contract.

## Linked issue
Fixes #584

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [x] `make lint`
- [ ] Other:

## Screenshots / Media
N/A (Backend logic change)

## Performance Impact
None.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The fix introduces an explicit identity check `if keep is True:` before processing the (`keep_arg = "none" if keep is False else keep`). This guarantees that the documented error contract is always thrown immediately at the front gate.