### PR TITLE
fix: keep decimal-looking strings on float path (#600)

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1759,7 +1759,9 @@ def _suggest_column_dtype(series: pd.Series, dtype: str) -> str | None:
 
     numeric = pd.to_numeric(values, errors="coerce")
     if numeric.notna().all():
-        return "int64" if (numeric % 1 == 0).all() else "float64"
+        if values.str.fullmatch(r"[+-]?\d+").all():
+            return "int64"
+        return "float64"
     return None
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -708,6 +708,21 @@ def test_identifier_numeric_cast_prevention():
 # ── string length statistics tests ───────────────────────────────────────────
 
 
+def test_decimal_looking_strings_suggest_float64_not_int64():
+    frame = ar.from_pandas(pd.DataFrame({"price": ["1.0", "2.50", "3.00"]}))
+
+    report = ar.profile(frame)
+
+    assert report.columns["price"].suggested_dtype == "float64"
+
+    suggestions = {}
+    for step, kwargs in ar.suggest_cleaning(report):
+        if step == "cast_types":
+            suggestions.update(kwargs)
+
+    assert suggestions["price"] == "float64"
+
+
 def test_profile_string_metrics():
     df = pd.DataFrame({"text": ["a", "abc", "abcde", "", "  ", None]})
     frame = ar.from_pandas(df)


### PR DESCRIPTION
Fixes #600

## Summary
- keep decimal-looking strings like `1.0` and `2.50` on the `float64` suggestion path
- only suggest `int64` when the original trimmed string values are truly integer-shaped text
- add focused regression coverage for the public `suggested_dtype` and `suggest_cleaning` behavior

## Verification
- `python -m pytest tests/test_quality.py -k "identifier_numeric_cast_prevention or decimal_looking_strings_suggest_float64_not_int64"`
- `python -m ruff check arnio/quality.py tests/test_quality.py`
- `python -m black --check arnio/quality.py tests/test_quality.py`
