### PR TITLE
test: add round_numeric_columns regression coverage

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1127,6 +1127,20 @@ class TestRoundNumericColumns:
                 decimals=1,
             )
 
+    def test_round_subset_with_non_numeric(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"name": ["john"], "score": [98.765]})
+        frame = ar.from_pandas(df)
+        result = ar.round_numeric_columns(
+            frame,
+            subset=["name", "score"],
+            decimals=1,
+        )
+        result_df = ar.to_pandas(result)
+        assert list(result_df["name"]) == ["john"]
+        assert list(result_df["score"]) == [98.8]
+    
     def test_round_all_numeric(self):
         import pandas as pd
 
@@ -1206,18 +1220,6 @@ class TestRoundNumericColumns:
         frame = ar.from_pandas(df)
         with pytest.raises(TypeError, match="decimals must be an integer"):
             ar.round_numeric_columns(frame, decimals=True)
-
-    def test_round_subset_with_non_numeric(self):
-        import pandas as pd
-
-        df = pd.DataFrame({"name": ["john"], "score": [98.765]})
-        frame = ar.from_pandas(df)
-        result = ar.round_numeric_columns(frame, subset=["name", "score"], decimals=1)
-        result_df = ar.to_pandas(result)
-
-        assert list(result_df["name"]) == ["john"]
-        assert list(result_df["score"]) == [98.8]
-
 
 class TestCombineColumns:
     def test_combines_columns_with_separator(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1105,6 +1105,29 @@ class TestFilterRows:
 
 
 class TestRoundNumericColumns:
+
+    def test_round_subset_missing_column_raises_clear_error(self):
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "price": [1.234, 5.678],
+                "name": ["Alice", "Bob"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+
+        with pytest.raises(
+            ValueError,
+            match=r"round_numeric_columns: unknown column\(s\) in subset",
+        ):
+            ar.round_numeric_columns(
+                frame,
+                subset=["price", "missing_column"],
+                decimals=1,
+            )
+            
     def test_round_all_numeric(self):
         import pandas as pd
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1221,6 +1221,7 @@ class TestRoundNumericColumns:
         with pytest.raises(TypeError, match="decimals must be an integer"):
             ar.round_numeric_columns(frame, decimals=True)
 
+
 class TestCombineColumns:
     def test_combines_columns_with_separator(self):
         import pandas as pd

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1105,7 +1105,6 @@ class TestFilterRows:
 
 
 class TestRoundNumericColumns:
-
     def test_round_subset_missing_column_raises_clear_error(self):
         import pandas as pd
 
@@ -1127,7 +1126,7 @@ class TestRoundNumericColumns:
                 subset=["price", "missing_column"],
                 decimals=1,
             )
-            
+
     def test_round_all_numeric(self):
         import pandas as pd
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1140,7 +1140,7 @@ class TestRoundNumericColumns:
         result_df = ar.to_pandas(result)
         assert list(result_df["name"]) == ["john"]
         assert list(result_df["score"]) == [98.8]
-    
+
     def test_round_all_numeric(self):
         import pandas as pd
 


### PR DESCRIPTION
## Summary

Adds focused regression coverage for `round_numeric_columns`.

Covers:
- missing subset columns raising clear validation errors
- mixed subset handling where non-numeric selected columns are ignored safely while numeric columns are rounded

Fixes #613