### PR TITLE
feat(io): add read_jsonl() for JSON Lines support

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,32 @@ Useful for exploring datasets before committing memory.
 </details>
 
 <details>
+<summary><b>📄 Read JSON Lines (JSONL / NDJSON) files</b></summary>
+<br>
+
+`read_jsonl` parses one JSON object per line into an ArFrame. Blank lines are skipped, missing keys become nulls, and mixed-type columns are coerced to string — the same rules as `from_pandas`.
+
+```python
+# events.jsonl
+# {"user": "alice", "score": 9.5, "active": true}
+# {"user": "bob",   "score": 8.1, "active": false}
+
+frame = ar.read_jsonl("events.jsonl")
+
+# Limit rows
+frame = ar.read_jsonl("large.jsonl", nrows=1000)
+
+# Non-UTF-8 encoding
+frame = ar.read_jsonl("data.ndjson", encoding="latin-1")
+
+# Plug straight into the cleaning pipeline
+clean = ar.pipeline(frame, [("strip_whitespace",), ("drop_nulls",)])
+```
+
+Raises `ar.JsonlReadError` with the 1-based line number if a line contains invalid JSON.
+</details>
+
+<details>
 <summary><b>👀 Preview rows without pandas conversion or full-column Python list materialization</b></summary>
 <br>
 
@@ -1382,7 +1408,7 @@ arnio/
 │   └── bind_arnio.cpp       # pybind11 module — the Python↔C++ bridge
 ├── arnio/
 │   ├── __init__.py          # Public API surface
-│   ├── io.py                # read_csv, scan_csv
+│   ├── io.py                # read_csv, read_jsonl, scan_csv, write_csv
 │   ├── cleaning.py          # Python wrappers for C++ cleaning functions
 │   ├── pipeline.py          # Step registry + pipeline executor
 │   ├── convert.py           # to_pandas (zero-copy), from_pandas

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -40,13 +40,14 @@ from .convert import from_pandas, to_pandas
 from .exceptions import (
     ArnioError,
     CsvReadError,
+    JsonlReadError,
     PipelineStepError,
     TypeCastError,
     UnknownStepError,
 )
 from .frame import ArFrame
 from .integrations import ArnioPandasAccessor
-from .io import read_csv, scan_csv, write_csv
+from .io import read_csv, read_jsonl, scan_csv, write_csv
 from .pipeline import pipeline, register_step
 from .quality import (
     CleanExplanation,
@@ -91,6 +92,7 @@ __all__ = [
     "ArFrame",
     # I/O
     "read_csv",
+    "read_jsonl",
     "write_csv",
     "scan_csv",
     # Cleaning
@@ -159,6 +161,7 @@ __all__ = [
     "UnknownStepError",
     "ArnioError",
     "CsvReadError",
+    "JsonlReadError",
     "TypeCastError",
     "PipelineStepError",
     "normalize_unicode",

--- a/arnio/exceptions.py
+++ b/arnio/exceptions.py
@@ -27,6 +27,12 @@ class CsvReadError(ArnioError):
     pass
 
 
+class JsonlReadError(ArnioError):
+    """Raised when a JSON Lines file cannot be read or contains malformed data."""
+
+    pass
+
+
 class TypeCastError(ArnioError):
     """Raised when cast_types encounters an incompatible type."""
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 
 from ._core import _CsvConfig, _CsvReader, _CsvWriteConfig, _CsvWriter
-from .exceptions import CsvReadError
+from .exceptions import CsvReadError, JsonlReadError
 from .frame import ArFrame
 
 
@@ -437,3 +437,107 @@ def scan_csv(
             return reader.scan_schema(native_path)
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e
+
+
+def read_jsonl(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+    nrows: int | None = None,
+) -> ArFrame:
+    """Read a JSON Lines file into an ArFrame.
+
+    Each non-blank line must be a complete JSON object (``{...}``).  Column
+    names are taken from the union of all keys found in the file.  Missing
+    keys in a row become null values.  Type inference follows the same rules
+    as :func:`from_pandas`: the first non-null value in a column determines
+    its dtype; mixed-type columns are coerced to string.
+
+    Parameters
+    ----------
+    path : str or path-like
+        Path to the ``.jsonl`` or ``.ndjson`` file.
+    encoding : str, default ``"utf-8"``
+        File encoding.
+    nrows : int, optional
+        Maximum number of data rows to read.  If ``None``, all rows are read.
+
+    Returns
+    -------
+    ArFrame
+        Data frame containing the parsed records.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not ``.jsonl`` or ``.ndjson``, or if
+        ``nrows`` is not a non-negative integer.
+    JsonlReadError
+        If the file is empty (no data rows), or if a line contains invalid
+        JSON.  The error message includes the 1-based line number.
+
+    Examples
+    --------
+    >>> frame = ar.read_jsonl("events.jsonl")
+    >>> frame = ar.read_jsonl("data.ndjson", nrows=1000)
+    """
+    import json
+
+    from .convert import from_pandas
+
+    path = os.fspath(path)
+    path_lower = path.lower()
+    if not (path_lower.endswith(".jsonl") or path_lower.endswith(".ndjson")):
+        raise ValueError(
+            f"Unsupported file format: {path}. "
+            "read_jsonl only supports .jsonl and .ndjson files."
+        )
+
+    if nrows is not None:
+        if isinstance(nrows, bool) or not isinstance(nrows, int):
+            raise TypeError("nrows must be an integer")
+        if nrows < 0:
+            raise ValueError("nrows must be non-negative")
+
+    records: list[dict] = []
+    try:
+        with open(path, encoding=encoding) as fh:
+            for lineno, raw_line in enumerate(fh, start=1):
+                line = raw_line.rstrip("\r\n")
+                if not line.strip():
+                    continue  # skip blank / whitespace-only lines
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise JsonlReadError(
+                        f"Invalid JSON on line {lineno} of {path!r}: {exc}"
+                    ) from exc
+                if not isinstance(obj, dict):
+                    raise JsonlReadError(
+                        f"Expected a JSON object on line {lineno} of {path!r}, "
+                        f"got {type(obj).__name__}"
+                    )
+                if nrows is not None and len(records) >= nrows:
+                    break
+                records.append(obj)
+    except OSError as exc:
+        raise JsonlReadError(str(exc)) from exc
+    except UnicodeDecodeError as exc:
+        raise JsonlReadError(
+            f"Could not decode {path!r} using encoding {encoding!r}: {exc}"
+        ) from exc
+
+    if not records:
+        if nrows == 0:
+            # nrows=0 is a valid request for zero rows — return empty frame
+            import pandas as pd
+
+            from .convert import from_pandas
+
+            return from_pandas(pd.DataFrame())
+        raise JsonlReadError(f"JSON Lines file is empty (no data rows): {path!r}")
+
+    import pandas as pd
+
+    df = pd.DataFrame(records)
+    return from_pandas(df)

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -498,6 +498,15 @@ def read_jsonl(
             raise TypeError("nrows must be an integer")
         if nrows < 0:
             raise ValueError("nrows must be non-negative")
+        if nrows == 0:
+            # Short-circuit: caller explicitly requested zero rows.
+            # Do not open or inspect the file at all — even malformed content
+            # must not raise when nrows=0.
+            import pandas as pd
+
+            from .convert import from_pandas
+
+            return from_pandas(pd.DataFrame())
 
     records: list[dict] = []
     try:
@@ -528,13 +537,6 @@ def read_jsonl(
         ) from exc
 
     if not records:
-        if nrows == 0:
-            # nrows=0 is a valid request for zero rows — return empty frame
-            import pandas as pd
-
-            from .convert import from_pandas
-
-            return from_pandas(pd.DataFrame())
         raise JsonlReadError(f"JSON Lines file is empty (no data rows): {path!r}")
 
     import pandas as pd

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -1,0 +1,263 @@
+"""Tests for read_jsonl functionality."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+def _write(tmp_path: Path, name: str, lines: list) -> Path:
+    """Write a list of objects/strings as a .jsonl file."""
+    p = tmp_path / name
+    p.write_text(
+        "\n".join(json.dumps(obj) if not isinstance(obj, str) else obj for obj in lines)
+        + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+class TestReadJsonlBasic:
+    def test_simple_round_trip(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}],
+        )
+        frame = ar.read_jsonl(path)
+        df = ar.to_pandas(frame)
+
+        assert list(df.columns) == ["name", "age"]
+        assert df["name"].tolist() == ["Alice", "Bob"]
+        assert df["age"].tolist() == [30, 25]
+
+    def test_returns_arframe(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"x": 1}])
+        assert isinstance(ar.read_jsonl(path), ar.ArFrame)
+
+    def test_ndjson_extension_accepted(self, tmp_path):
+        path = tmp_path / "data.ndjson"
+        path.write_text('{"a": 1}\n', encoding="utf-8")
+        frame = ar.read_jsonl(path)
+        assert frame.shape == (1, 1)
+
+    def test_pathlike_input(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"v": 42}])
+        frame = ar.read_jsonl(Path(path))
+        assert ar.to_pandas(frame)["v"].tolist() == [42]
+
+    def test_string_path_input(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"v": 42}])
+        frame = ar.read_jsonl(str(path))
+        assert ar.to_pandas(frame)["v"].tolist() == [42]
+
+
+class TestReadJsonlNullsAndTypes:
+    def test_null_values_preserved(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"a": 1, "b": None}, {"a": 2, "b": "hello"}],
+        )
+        frame = ar.read_jsonl(path)
+        df = ar.to_pandas(frame)
+
+        assert pd.isna(df["b"].iloc[0])
+        assert df["b"].iloc[1] == "hello"
+
+    def test_missing_key_becomes_null(self, tmp_path):
+        # Row 2 is missing key "b" — should become null
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"a": 1, "b": "x"}, {"a": 2}],
+        )
+        frame = ar.read_jsonl(path)
+        df = ar.to_pandas(frame)
+
+        assert df.shape == (2, 2)
+        assert pd.isna(df["b"].iloc[1])
+
+    def test_mixed_type_column_coerced_to_string(self, tmp_path):
+        # int and string in same column → coerced to string by from_pandas
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"v": 1}, {"v": "two"}],
+        )
+        frame = ar.read_jsonl(path)
+        assert frame.dtypes["v"] == "string"
+
+    def test_integer_column_inferred(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"n": 10}, {"n": 20}])
+        frame = ar.read_jsonl(path)
+        assert frame.dtypes["n"] == "int64"
+
+    def test_float_column_inferred(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"f": 1.5}, {"f": 2.5}])
+        frame = ar.read_jsonl(path)
+        assert frame.dtypes["f"] == "float64"
+
+    def test_bool_column_inferred(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"b": True}, {"b": False}])
+        frame = ar.read_jsonl(path)
+        assert frame.dtypes["b"] == "bool"
+
+    def test_all_null_column(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"a": 1, "b": None}, {"a": 2, "b": None}],
+        )
+        frame = ar.read_jsonl(path)
+        assert ar.to_pandas(frame)["b"].isna().all()
+
+
+class TestReadJsonlNrows:
+    def test_nrows_limits_rows(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"i": i} for i in range(10)],
+        )
+        frame = ar.read_jsonl(path, nrows=3)
+        assert frame.shape[0] == 3
+
+    def test_nrows_zero_returns_empty_frame(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"x": 1}, {"x": 2}])
+        # nrows=0 is valid — reads 0 rows, returns empty frame
+        frame = ar.read_jsonl(path, nrows=0)
+        assert frame.shape[0] == 0
+
+    def test_nrows_larger_than_file_reads_all(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"x": i} for i in range(5)])
+        frame = ar.read_jsonl(path, nrows=100)
+        assert frame.shape[0] == 5
+
+    def test_nrows_negative_raises(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"x": 1}])
+        with pytest.raises(ValueError, match="nrows must be non-negative"):
+            ar.read_jsonl(path, nrows=-1)
+
+    def test_nrows_non_integer_raises(self, tmp_path):
+        path = _write(tmp_path, "data.jsonl", [{"x": 1}])
+        with pytest.raises(TypeError, match="nrows must be an integer"):
+            ar.read_jsonl(path, nrows=1.5)
+
+
+class TestReadJsonlBlankLines:
+    def test_blank_lines_skipped(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        path.write_text('{"a": 1}\n\n{"a": 2}\n\n{"a": 3}\n', encoding="utf-8")
+        frame = ar.read_jsonl(path)
+        assert frame.shape[0] == 3
+
+    def test_whitespace_only_lines_skipped(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        path.write_text('{"a": 1}\n   \n{"a": 2}\n', encoding="utf-8")
+        frame = ar.read_jsonl(path)
+        assert frame.shape[0] == 2
+
+
+class TestReadJsonlErrors:
+    def test_unsupported_extension_raises(self, tmp_path):
+        path = tmp_path / "data.json"
+        path.write_text('{"a": 1}\n', encoding="utf-8")
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            ar.read_jsonl(path)
+
+    def test_csv_extension_raises(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("a,b\n1,2\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            ar.read_jsonl(path)
+
+    def test_empty_file_raises(self, tmp_path):
+        path = tmp_path / "empty.jsonl"
+        path.write_text("", encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="empty"):
+            ar.read_jsonl(path)
+
+    def test_blank_lines_only_raises(self, tmp_path):
+        path = tmp_path / "blank.jsonl"
+        path.write_text("\n\n\n", encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="empty"):
+            ar.read_jsonl(path)
+
+    def test_malformed_json_raises_with_line_number(self, tmp_path):
+        path = tmp_path / "bad.jsonl"
+        path.write_text('{"a": 1}\n{bad json}\n{"a": 3}\n', encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="line 2"):
+            ar.read_jsonl(path)
+
+    def test_malformed_first_line_raises(self, tmp_path):
+        path = tmp_path / "bad.jsonl"
+        path.write_text("not json\n", encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="line 1"):
+            ar.read_jsonl(path)
+
+    def test_non_object_line_raises(self, tmp_path):
+        # A JSON array is not a valid JSONL record
+        path = tmp_path / "bad.jsonl"
+        path.write_text("[1, 2, 3]\n", encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="JSON object"):
+            ar.read_jsonl(path)
+
+    def test_jsonl_read_error_is_arnio_error(self, tmp_path):
+        path = tmp_path / "empty.jsonl"
+        path.write_text("", encoding="utf-8")
+        with pytest.raises(ar.ArnioError):
+            ar.read_jsonl(path)
+
+
+class TestReadJsonlEncoding:
+    def test_utf8_default(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        path.write_text('{"city": "São Paulo"}\n', encoding="utf-8")
+        frame = ar.read_jsonl(path)
+        df = ar.to_pandas(frame)
+        assert df["city"].iloc[0] == "São Paulo"
+
+    def test_latin1_encoding(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        path.write_bytes('{"city": "M\xfcnchen"}\n'.encode("latin-1"))
+        frame = ar.read_jsonl(path, encoding="latin-1")
+        df = ar.to_pandas(frame)
+        assert df["city"].iloc[0] == "München"
+
+    def test_wrong_encoding_raises(self, tmp_path):
+        path = tmp_path / "data.jsonl"
+        path.write_bytes('{"city": "M\xfcnchen"}\n'.encode("latin-1"))
+        with pytest.raises(ar.JsonlReadError, match="decode"):
+            ar.read_jsonl(path, encoding="utf-8")
+
+
+class TestReadJsonlPipelineCompat:
+    def test_result_is_pipeline_compatible(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"name": " Alice ", "score": 95}, {"name": " Bob ", "score": 80}],
+        )
+        frame = ar.read_jsonl(path)
+        result = ar.pipeline(frame, [("strip_whitespace",)])
+        df = ar.to_pandas(result)
+
+        assert df["name"].tolist() == ["Alice", "Bob"]
+
+    def test_result_works_with_profile(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "data.jsonl",
+            [{"a": 1, "b": "x"}, {"a": 1, "b": "x"}, {"a": 2, "b": "y"}],
+        )
+        frame = ar.read_jsonl(path)
+        report = ar.profile(frame)
+
+        assert report.row_count == 3
+        assert report.duplicate_rows == 1

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -134,6 +134,14 @@ class TestReadJsonlNrows:
         frame = ar.read_jsonl(path, nrows=0)
         assert frame.shape[0] == 0
 
+    def test_nrows_zero_does_not_inspect_file_contents(self, tmp_path):
+        # nrows=0 must short-circuit before opening the file, so malformed
+        # content must never raise even when the first line is invalid JSON.
+        path = tmp_path / "bad.jsonl"
+        path.write_text("not valid json at all\n{also bad}\n", encoding="utf-8")
+        frame = ar.read_jsonl(path, nrows=0)
+        assert frame.shape[0] == 0
+
     def test_nrows_larger_than_file_reads_all(self, tmp_path):
         path = _write(tmp_path, "data.jsonl", [{"x": i} for i in range(5)])
         frame = ar.read_jsonl(path, nrows=100)


### PR DESCRIPTION
## Summary

Fixes #634

Adds `ar.read_jsonl()` — a lightweight JSON Lines (`.jsonl` / `.ndjson`) reader implemented entirely in the Python layer using the existing `from_pandas()` conversion path.

No C++ or CSV behavior is modified.

## API

```python
ar.read_jsonl(path, *, encoding="utf-8", nrows=None) -> ArFrame
```

## Behavior

* Supports `.jsonl` and `.ndjson` files
* Reads one JSON object per line
* Skips blank lines automatically
* Missing keys become null values
* `nrows` limits the number of records read
* Mixed-type columns follow existing `from_pandas()` coercion behavior

Raises `ar.JsonlReadError` with clear line-number information for:

* malformed JSON
* non-object lines
* empty files
* encoding issues

## Tests

Added 32 focused test cases covering:

* round-trip reading
* nulls and missing keys
* mixed types
* type inference
* blank lines
* malformed input
* unsupported extensions
* encoding handling
* `nrows`
* pipeline/profile compatibility

## Docs

Updated README with a small `read_jsonl()` usage example alongside existing IO examples.
