### PR TITLE
tests(convert): cover all-null Float64, boolean, and string extension…

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -481,6 +481,27 @@ class TestFromPandas:
         message = str(exc_info.value)
         assert "True" in message
 
+    def test_from_pandas_all_null_float64_extension(self):
+        df = pd.DataFrame({"score": pd.Series([pd.NA, pd.NA, pd.NA], dtype="Float64")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert len(result) == 3
+        assert result["score"].isna().all()
+        assert str(result["score"].dtype) == "string"
+
+    def test_from_pandas_all_null_boolean_extension(self):
+        df = pd.DataFrame({"active": pd.Series([pd.NA, pd.NA, pd.NA], dtype="boolean")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert len(result) == 3
+        assert result["active"].isna().all()
+        assert str(result["active"].dtype) == "string"
+
+    def test_from_pandas_all_null_string_extension(self):
+        df = pd.DataFrame({"name": pd.Series([pd.NA, pd.NA, pd.NA], dtype="string")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert len(result) == 3
+        assert result["name"].isna().all()
+        assert str(result["name"].dtype) == "string"
+
 
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):


### PR DESCRIPTION
## Summary
Added regression coverage for all-null pandas nullable extension dtype round-trips in from_pandas. Tests cover Float64, boolean, and string extension columns where all values are pd.NA

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #625

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [X] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [X] `make test`
- [X] `make lint`
- [ ] Other:

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Labels requested
`gssoc` `gssoc: level 2` `difficulty: intermediate`

