### PR TITLE
test: cover invalid cast_types mapping objects (#610)

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -956,11 +956,20 @@ class TestCastTypes:
         with pytest.raises(ValueError, match="errors must be either"):
             ar.cast_types(frame, {"age": "int64"}, errors="ignore")
 
-    def test_cast_rejects_non_mapping_with_clear_error(self, sample_csv):
+    @pytest.mark.parametrize(
+        "mapping",
+        [
+            None,
+            [("age", "int64")],
+            (("age", "int64"),),
+            "age=int64",
+        ],
+    )
+    def test_cast_rejects_non_mapping_with_clear_error(self, sample_csv, mapping):
         frame = ar.read_csv(sample_csv)
 
         with pytest.raises(TypeError, match="mapping must be a mapping"):
-            ar.cast_types(frame, [("age", "int64")])
+            ar.cast_types(frame, mapping)
 
     def test_cast_bool_rejects_unknown_strings(self):
         frame = ar.from_pandas(pd.DataFrame({"active": ["true", "maybe"]}))


### PR DESCRIPTION
Fixes #610

## Summary
- expand `cast_types` mapping validation coverage across several invalid non-mapping inputs
- keep the change test-only and lock in the existing public `TypeError` contract
- cover `None`, list/tuple-shaped inputs, and plain strings

## Verification
- `python -m pytest tests/test_cleaning.py -k "test_cast_rejects_non_mapping_with_clear_error or test_cast_rejects_invalid_errors_policy or test_cast_bool_rejects_unknown_strings"`
- `python -m ruff check tests/test_cleaning.py`
- `python -m black --check tests/test_cleaning.py`
