### PR TITLE
fix: reject late NUL bytes in UTF-8 CSV input (#608)

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -215,6 +215,19 @@ def _materialize_csv_input(
     raise TypeError("read_csv expected a filesystem path or text file-like object")
 
 
+def _reject_utf8_nul_bytes(path: str) -> None:
+    """Reject UTF-8 CSV inputs that contain NUL bytes anywhere in the file."""
+    try:
+        with open(path, "rb") as f:
+            while chunk := f.read(8192):
+                if b"\0" in chunk:
+                    raise CsvReadError(
+                        "CSV input contains NUL bytes and appears to be binary or corrupted"
+                    )
+    except FileNotFoundError:
+        pass  # Let C++ backend handle or raise standard error
+
+
 def read_csv(
     path: str | os.PathLike[str],
     *,
@@ -293,6 +306,8 @@ def read_csv(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
 
+    if _is_utf8_encoding(encoding):
+        _reject_utf8_nul_bytes(path)
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")
@@ -597,6 +612,8 @@ def scan_csv(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
 
+    if _is_utf8_encoding(encoding):
+        _reject_utf8_nul_bytes(path)
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -577,8 +577,11 @@ class TestScanCsv:
             f.write(b"a,b\n" * 400)
             f.write(b"\0binary,data\n")
 
-        schema = ar.scan_csv(file_path)
-        assert schema == {"col1": "string", "col2": "string"}
+        with pytest.raises(
+            ar.CsvReadError,
+            match="CSV input contains NUL bytes and appears to be binary or corrupted",
+        ):
+            ar.scan_csv(file_path)
 
     def test_scan_late_binary_file_rejection_with_larger_sample(self, tmp_path):
         file_path = str(tmp_path / "data.csv")
@@ -587,6 +590,12 @@ class TestScanCsv:
             f.write(b"col1,col2\n")
             f.write(b"a,b\n" * 400)
             f.write(b"\0binary,data\n")
+
+        with pytest.raises(
+            ar.CsvReadError,
+            match="CSV input contains NUL bytes and appears to be binary or corrupted",
+        ):
+            ar.scan_csv(file_path)
 
         with pytest.raises(
             ar.CsvReadError,


### PR DESCRIPTION
Fixes #608

## Summary
- reject UTF-8 CSV files that contain NUL bytes anywhere in the file, not just in the first read buffer
- share the UTF-8 NUL-byte guard between `read_csv` and `scan_csv`
- update the late-binary CSV regression coverage to assert rejection even when the NUL appears beyond the first read buffer or outside the default scan sample window

## Testing
- `python -m pytest tests/test_csv.py -k "late_binary or binary_file_rejection"`
- `python -m ruff check arnio/io.py tests/test_csv.py`
- `python -m black --check arnio/io.py tests/test_csv.py`