### PR TITLE
fix: preserve null-valued replace_values results (#616)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1229,18 +1229,22 @@ def replace_values(frame, mapping, column=None):
 
     if column:
         s = df[column]
+        original_null_mask = s.isna() if null_key_present else None
         if normalized_mapping:
             s = s.replace(normalized_mapping)
         if null_key_present:
-            # replace existing nulls (NaN/None/pd.NA) in the series
-            s = s.fillna(null_replacement)
+            # Replace only values that were already null before replacement so
+            # null-valued mapping results remain real nulls.
+            s = s.where(~original_null_mask, null_replacement)
         df[column] = s
     else:
+        original_null_mask = df.isna() if null_key_present else None
         if normalized_mapping:
             df = df.replace(normalized_mapping)
         if null_key_present:
-            # replace existing nulls anywhere in the dataframe
-            df = df.fillna(null_replacement)
+            # Replace only values that were already null before replacement so
+            # null-valued mapping results remain real nulls.
+            df = df.where(~original_null_mask, null_replacement)
 
     return from_pandas(df) if is_arframe else df
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1113,6 +1113,52 @@ class TestFilterRows:
         assert list(df["age"]) == [30, 40]
 
 
+class TestReplaceValues:
+    def test_replace_values_null_key_replaces_existing_nulls_in_target_column(self):
+        import numpy as np
+
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", None, pd.NA],
+                    "city": [None, "Paris", None],
+                }
+            )
+        )
+
+        result = ar.replace_values(frame, {np.nan: "Unknown"}, column="name")
+        df = ar.to_pandas(result)
+
+        assert list(df["name"]) == ["Alice", "Unknown", "Unknown"]
+        assert pd.isna(df.loc[0, "city"])
+        assert df.loc[1, "city"] == "Paris"
+        assert pd.isna(df.loc[2, "city"])
+
+    def test_replace_values_null_replacement_creates_real_nulls(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"status": ["active", "inactive", "active"]})
+        )
+
+        result = ar.replace_values(frame, {"inactive": None})
+        df = ar.to_pandas(result)
+
+        assert list(df["status"].iloc[[0, 2]]) == ["active", "active"]
+        assert pd.isna(df.loc[1, "status"])
+
+    def test_replace_values_supports_pd_na_key_and_value(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"score": [1, None, 3], "flag": ["ok", "missing", "ok"]})
+        )
+
+        result = ar.replace_values(frame, {pd.NA: 0, "missing": pd.NA})
+        df = ar.to_pandas(result)
+
+        assert list(df["score"]) == [1, 0, 3]
+        assert df.loc[0, "flag"] == "ok"
+        assert pd.isna(df.loc[1, "flag"])
+        assert df.loc[2, "flag"] == "ok"
+
+
 class TestRoundNumericColumns:
     def test_round_all_numeric(self):
         import pandas as pd


### PR DESCRIPTION
Fixes #616

## Summary
- add focused coverage for `replace_values` with null-like keys and null-like replacement values
- verify column-scoped null replacement only touches the requested column
- preserve null-valued replacement results instead of filling them back in when a null-like key is also present

## Testing
- `python -m pytest tests/test_cleaning.py -k "replace_values"`
- `python -m ruff check arnio/cleaning.py tests/test_cleaning.py`
- `python -m black --check arnio/cleaning.py tests/test_cleaning.py`