### PR TITLE
test: cover quality markdown newline escaping

### DIFF
--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -889,6 +889,37 @@ def test_report_to_markdown_escapes_pipe_characters_in_column_cells():
     assert "contains \\| pipe" in md
 
 
+def test_report_to_markdown_escapes_newlines_in_column_cells():
+    report = ar.DataQualityReport(
+        row_count=2,
+        column_count=1,
+        memory_usage=128,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={
+            "multi\nline": ar.ColumnProfile(
+                name="multi\nline",
+                dtype="string",
+                semantic_type="free\ntext",
+                row_count=2,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=2,
+                unique_ratio=1.0,
+                warnings=["contains\nnewline"],
+            )
+        },
+        suggestions=[],
+    )
+
+    md = report.to_markdown()
+
+    assert "multi<br>line" in md
+    assert "free<br>text" in md
+    assert "contains<br>newline" in md
+    assert "| multi\nline |" not in md
+
+
 def test_report_to_markdown_empty_sections():
     report = ar.DataQualityReport(
         row_count=0,


### PR DESCRIPTION
## Summary
- add focused regression coverage for `DataQualityReport.to_markdown()` newline escaping in column table cells
- verify newlines in column names, semantic types, and warnings render as `<br>` instead of splitting Markdown rows

Fixes #619

## Validation
- `git diff --check`
- `python3 -m py_compile tests/test_quality.py arnio/quality.py`
- `python3 -m pytest tests/test_quality.py::test_report_to_markdown_escapes_newlines_in_column_cells -q`

## Note
`python3 -m pytest tests/test_quality.py -q` currently has unrelated local failures before/around CSV profiling because the installed native extension reports `AttributeError: 'arnio._arnio_cpp.CsvConfig' object has no attribute 'mode'`. The new markdown-only regression test passes in isolation.

## GSSoC labels requested
This issue is marked `gssoc`, `gssoc: good first issue`, `gssoc: level 1`, and `type: tests`; please add/keep the tracker-required scoring labels if this is accepted.