### PR TITLE
docs: document ValidationResult row-index convention (1-based, header excluded)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -344,6 +344,20 @@ The primary function used to check an `ArFrame` against a `Schema`. It returns a
 
 The objects returned after calling `validate()`.
 
+**Row index convention:** `ValidationIssue.row_index` is **1-based** and refers to
+data rows only — the CSV header is not counted. So `row_index=1` means the first
+data row, `row_index=2` means the second, and so on.
+
+```python
+# CSV content:
+# name,age        ← header (not counted)
+# Alice,30        ← row 1
+# Bob,-1          ← row 2  ← row_index=2 will appear here for a min violation
+
+result = ar.validate(frame, {"age": ar.Int64(min=0)})
+print(result.issues[0].row_index)  # 2
+```
+
 #### Field Type Helpers
 
 Each helper maps to a specific data type rule.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ schema = ar.Schema(
 result = schema.validate(ar.read_csv("events.csv"))
 print(result.passed)
 ```
+> **Row index convention:** `ValidationIssue.row_index` values are **1-based** and
+> count data rows only. The header row is excluded. `row_index=1` is the first data
+> row in the file.
 
 ### Select specific columns
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1045,6 +1045,21 @@ def test_schema_rules_row_index_for_multiple_failing_rows(tmp_path):
     assert row_indexes == [1, 3]
 
 
+def test_row_index_convention_is_documented_and_correct(tmp_path):
+    """Regression: row_index is 1-based, header excluded, first data row = 1."""
+    path = tmp_path / "rows.csv"
+    path.write_text("name,age\nAlice,30\nBob,-1\nCarol,25\n")
+    frame = ar.read_csv(path)
+    result = ar.validate(frame, {"age": ar.Int64(min=0)})
+
+    assert not result.passed
+    assert len(result.issues) == 1
+    # Bob is the second data row → row_index must be 2, not 0 or 1
+    assert result.issues[0].row_index == 2
+    assert result.issues[0].column == "age"
+    assert result.issues[0].rule == "min"
+
+
 def test_schema_rules_missing_column_returns_validation_issue(tmp_path):
     path = tmp_path / "dates.csv"
     path.write_text("start_date,end_date\n2024-01-01,2024-06-01\n")


### PR DESCRIPTION

## Summary
Documents the `ValidationIssue.row_index` convention, values are 1-based and count data rows only, with the CSV header excluded. Added a concise note in the README under the cross-field validation section and an explicit entry in the API reference under `ValidationResult / ValidationIssue`. Also adds a focused regression test that pins the contract.

## Linked issue
Fixes #667 

## Type of change

- [x] Documentation
- [x] Tests

## Area

- [x] Schema validation
- [x] Docs / website

## Testing
* `pytest tests/test_schema.py -v` - 81 passed
* `pytest tests/ -v` - 592 passed, 1 skipped
* `black tests/test_schema.py` - reformatted cleanly
* `ruff check tests/test_schema.py` - no issues

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
None.
