### PR TITLE
feat(io): support text file-like inputs in read_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -149,6 +149,8 @@ def _validate_null_values(null_values: list[str]) -> list[str]:
             raise TypeError("null_values must contain only strings")
 
     return list(null_values)
+
+
 def _validate_parser_mode(mode: str) -> str:
     """Validate CSV parser mode."""
     if not isinstance(mode, str):

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -156,17 +156,6 @@ def _validate_parser_mode(mode: str) -> str:
     """Validate CSV parser mode."""
     if not isinstance(mode, str):
         raise TypeError("mode must be a string")
-
-    if mode not in {"strict", "permissive"}:
-        raise ValueError("mode must be either 'strict' or 'permissive'")
-
-    return mode
-
-
-def _validate_parser_mode(mode: str) -> str:
-    """Validate CSV parser mode."""
-    if not isinstance(mode, str):
-        raise TypeError("mode must be a string")
     if mode not in {"strict", "permissive"}:
         raise ValueError("mode must be either 'strict' or 'permissive'")
     return mode

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -149,6 +149,15 @@ def _validate_null_values(null_values: list[str]) -> list[str]:
             raise TypeError("null_values must contain only strings")
 
     return list(null_values)
+def _validate_parser_mode(mode: str) -> str:
+    """Validate CSV parser mode."""
+    if not isinstance(mode, str):
+        raise TypeError("mode must be a string")
+
+    if mode not in {"strict", "permissive"}:
+        raise ValueError("mode must be either 'strict' or 'permissive'")
+
+    return mode
 
 
 def _validate_parser_mode(mode: str) -> str:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -6,6 +6,7 @@ CSV reading and writing functions.
 from __future__ import annotations
 
 import csv
+import io
 import os
 import shutil
 import tempfile
@@ -166,11 +167,41 @@ def _validate_parser_mode(mode: str) -> str:
     """Validate CSV parser mode."""
     if not isinstance(mode, str):
         raise TypeError("mode must be a string")
-
     if mode not in {"strict", "permissive"}:
         raise ValueError("mode must be either 'strict' or 'permissive'")
-
     return mode
+
+
+def _materialize_csv_input(
+    source: str | os.PathLike[str] | io.TextIOBase,
+) -> tuple[str, bool]:
+    """Convert supported CSV inputs into a filesystem path."""
+    if isinstance(source, (str, os.PathLike)):
+        return os.fspath(source), False
+    if isinstance(source, io.StringIO) or (
+        hasattr(source, "read") and callable(source.read)
+    ):
+        content = source.read()
+
+        if not isinstance(content, str):
+            raise TypeError("read_csv file-like objects must return text, not bytes")
+
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            suffix=".csv",
+            delete=False,
+        )
+
+        try:
+            tmp.write(content)
+            tmp.close()
+            return tmp.name, True
+        except Exception:
+            os.unlink(tmp.name)
+            raise
+
+    raise TypeError("read_csv expected a filesystem path or text file-like object")
 
 
 def read_csv(
@@ -190,8 +221,9 @@ def read_csv(
 
     Parameters
     ----------
-    path : str
-        Path to the CSV file. Supports .csv, .txt, and .tsv extensions.
+    path : str or file-like object
+        Filesystem path or text file-like object containing CSV data.
+        Supports .csv, .txt, and .tsv extensions for path inputs.
     delimiter : str, default ","
         Field delimiter character.
     has_header : bool, default True
@@ -239,7 +271,7 @@ def read_csv(
     --------
     >>> frame = ar.read_csv("data.csv", delimiter=",", has_header=True)
     """
-    path = os.fspath(path)
+    path, should_cleanup = _materialize_csv_input(path)
     path_lower = path.lower()
     if not (
         path_lower.endswith(".csv")
@@ -277,9 +309,13 @@ def read_csv(
         config.nrows = _validate_nrows(nrows)
 
     reader = _CsvReader(config)
+
     try:
         with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
             cpp_frame = reader.read(native_path)
+
+        return ArFrame(cpp_frame)
+
     except ValueError:
         raise
     except CsvReadError:
@@ -287,7 +323,9 @@ def read_csv(
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e
 
-    return ArFrame(cpp_frame)
+    finally:
+        if should_cleanup and os.path.exists(path):
+            os.unlink(path)
 
 
 def write_csv(

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -438,15 +438,6 @@ Frame CsvReader::read(const std::string& path) const {
 
     size_t num_cols = header.size();
 
-    if (config_.mode == "strict") {
-        for (size_t i = 0; i < raw_data.size(); ++i) {
-            if (raw_data[i].size() < num_cols) {
-                throw std::runtime_error("CSV row has inconsistent column count at row " +
-                                         std::to_string(i + 2));
-            }
-        }
-    }
-
     // Determine which columns to keep
     std::vector<size_t> col_indices;
     if (config_.usecols.has_value()) {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -439,15 +439,13 @@ Frame CsvReader::read(const std::string& path) const {
     size_t num_cols = header.size();
 
     if (config_.mode == "strict") {
-    for (size_t i = 0; i < raw_data.size(); ++i) {
-        if (raw_data[i].size() < num_cols) {
-            throw std::runtime_error(
-                "CSV row has inconsistent column count at row " +
-                std::to_string(i + 2)
-            );
+        for (size_t i = 0; i < raw_data.size(); ++i) {
+            if (raw_data[i].size() < num_cols) {
+                throw std::runtime_error("CSV row has inconsistent column count at row " +
+                                         std::to_string(i + 2));
+            }
         }
     }
-}
 
     // Determine which columns to keep
     std::vector<size_t> col_indices;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -438,6 +438,17 @@ Frame CsvReader::read(const std::string& path) const {
 
     size_t num_cols = header.size();
 
+    if (config_.mode == "strict") {
+    for (size_t i = 0; i < raw_data.size(); ++i) {
+        if (raw_data[i].size() < num_cols) {
+            throw std::runtime_error(
+                "CSV row has inconsistent column count at row " +
+                std::to_string(i + 2)
+            );
+        }
+    }
+}
+
     // Determine which columns to keep
     std::vector<size_t> col_indices;
     if (config_.usecols.has_value()) {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -867,6 +867,30 @@ def test_permissive_mode_allows_missing_columns(tmp_path):
     assert df["name"].iloc[0] == "Alice"
     assert pd.isna(df["name"].iloc[1])
 
+def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
+    csv_path = tmp_path / "normal_crlf.csv"
+
+    csv_path.write_bytes(b"id,name\r\n1,Alice\r\n2,Bob\r\n")
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df["name"].iloc[0] == "Alice"
+    assert df["name"].iloc[1] == "Bob"
+
+def test_embedded_quoted_crlf_is_preserved(tmp_path):
+    csv_path = tmp_path / "embedded_crlf.csv"
+
+    csv_path.write_bytes(
+        b'id,notes\r\n1,"hello\r\nworld"\r\n'
+    )
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df["notes"].iloc[0] == "hello\r\nworld"    
 
 def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
     csv_path = tmp_path / "normal_crlf.csv"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -160,21 +160,21 @@ class TestReadCsv:
         csv_path = tmp_path / "delimiter_interaction.csv"
         csv_path.write_text("value\n1,234\n")
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 2 fields; expected 1"):
-            ar.read_csv(csv_path, mode="strict")
+            ar.read_csv(csv_path)
 
     def test_read_csv_rejects_missing_fields(self, tmp_path):
         csv_path = tmp_path / "missing_fields.csv"
         csv_path.write_text("a,b\n1,2\n3\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 3 has 1 fields; expected 2"):
-            ar.read_csv(csv_path, mode="strict")
+            ar.read_csv(csv_path)
 
     def test_read_csv_rejects_extra_fields_without_header(self, tmp_path):
         csv_path = tmp_path / "extra_fields_no_header.csv"
         csv_path.write_text("1,2\n3,4,5\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 3 fields; expected 2"):
-            ar.read_csv(csv_path, has_header=False, mode="strict")
+            ar.read_csv(csv_path, has_header=False)
 
     def test_large_integer_overflow_remains_string(self, tmp_path):
         csv_path = tmp_path / "large_integer.csv"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -856,6 +856,37 @@ def test_strict_mode_rejects_missing_columns(tmp_path):
         ar.read_csv(csv_path, mode="strict")
 
 
+def test_read_csv_supports_stringio():
+    buffer = io.StringIO("id,name\n1,Alice\n2,Bob\n")
+
+    frame = ar.read_csv(buffer)
+
+    df = ar.to_pandas(frame)
+
+    assert list(df["name"]) == ["Alice", "Bob"]
+
+
+def test_read_csv_rejects_binary_buffer():
+    buffer = io.BytesIO(b"id,name\n1,Alice\n")
+
+    with pytest.raises(
+        TypeError,
+        match="must return text",
+    ):
+        ar.read_csv(buffer)
+
+
+def test_read_csv_path_behavior_unchanged(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("id,name\n1,Alice\n")
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert list(df["name"]) == ["Alice"]
+
+
 def test_permissive_mode_allows_missing_columns(tmp_path):
     csv_path = tmp_path / "permissive_missing.csv"
     csv_path.write_text("id,name\n1,Alice\n2\n")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -160,21 +160,21 @@ class TestReadCsv:
         csv_path = tmp_path / "delimiter_interaction.csv"
         csv_path.write_text("value\n1,234\n")
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 2 fields; expected 1"):
-            ar.read_csv(csv_path)
+            ar.read_csv(csv_path, mode="strict")
 
     def test_read_csv_rejects_missing_fields(self, tmp_path):
         csv_path = tmp_path / "missing_fields.csv"
         csv_path.write_text("a,b\n1,2\n3\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 3 has 1 fields; expected 2"):
-            ar.read_csv(csv_path)
+            ar.read_csv(csv_path, mode="strict")
 
     def test_read_csv_rejects_extra_fields_without_header(self, tmp_path):
         csv_path = tmp_path / "extra_fields_no_header.csv"
         csv_path.write_text("1,2\n3,4,5\n")
 
         with pytest.raises(ar.CsvReadError, match="CSV row 2 has 3 fields; expected 2"):
-            ar.read_csv(csv_path, has_header=False)
+            ar.read_csv(csv_path, has_header=False, mode="strict")
 
     def test_large_integer_overflow_remains_string(self, tmp_path):
         csv_path = tmp_path / "large_integer.csv"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,5 +1,6 @@
 """Tests for CSV reading functionality."""
 
+import io
 from pathlib import Path
 
 import pandas as pd

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -722,6 +722,31 @@ def test_quoted_field_with_embedded_crlf(tmp_path):
     assert df["note"][0] == "line1\r\nline2"
 
 
+def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
+    csv_path = tmp_path / "normal_crlf.csv"
+
+    csv_path.write_bytes(b"id,name\r\n1,Alice\r\n2,Bob\r\n")
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df["name"].iloc[0] == "Alice"
+    assert df["name"].iloc[1] == "Bob"
+
+
+def test_embedded_quoted_crlf_is_preserved(tmp_path):
+    csv_path = tmp_path / "embedded_crlf.csv"
+
+    csv_path.write_bytes(b'id,notes\r\n1,"hello\r\nworld"\r\n')
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df["notes"].iloc[0] == "hello\r\nworld"
+
+
 def test_quoted_field_with_embedded_cr(tmp_path):
     """CR-only inside quotes must be preserved as field content."""
     csv_file = tmp_path / "test.csv"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -869,56 +869,6 @@ def test_permissive_mode_allows_missing_columns(tmp_path):
     assert pd.isna(df["name"].iloc[1])
 
 
-def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
-    csv_path = tmp_path / "normal_crlf.csv"
-
-    csv_path.write_bytes(b"id,name\r\n1,Alice\r\n2,Bob\r\n")
-
-    frame = ar.read_csv(csv_path)
-
-    df = ar.to_pandas(frame)
-
-    assert df["name"].iloc[0] == "Alice"
-    assert df["name"].iloc[1] == "Bob"
-
-
-def test_embedded_quoted_crlf_is_preserved(tmp_path):
-    csv_path = tmp_path / "embedded_crlf.csv"
-
-    csv_path.write_bytes(b'id,notes\r\n1,"hello\r\nworld"\r\n')
-
-    frame = ar.read_csv(csv_path)
-
-    df = ar.to_pandas(frame)
-
-    assert df["notes"].iloc[0] == "hello\r\nworld"
-
-
-def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
-    csv_path = tmp_path / "normal_crlf.csv"
-
-    csv_path.write_bytes(b"id,name\r\n1,Alice\r\n2,Bob\r\n")
-
-    frame = ar.read_csv(csv_path)
-
-    df = ar.to_pandas(frame)
-
-    assert df["name"].iloc[0] == "Alice"
-    assert df["name"].iloc[1] == "Bob"
-
-
-def test_embedded_quoted_crlf_is_preserved(tmp_path):
-    csv_path = tmp_path / "embedded_crlf.csv"
-
-    csv_path.write_bytes(b'id,notes\r\n1,"hello\r\nworld"\r\n')
-
-    frame = ar.read_csv(csv_path)
-
-    df = ar.to_pandas(frame)
-
-    assert df["notes"].iloc[0] == "hello\r\nworld"
-
-
 def test_invalid_parser_mode(tmp_path):
     csv_path = tmp_path / "invalid_mode.csv"
     csv_path.write_text("id,name\n1,Alice\n")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -867,6 +867,7 @@ def test_permissive_mode_allows_missing_columns(tmp_path):
     assert df["name"].iloc[0] == "Alice"
     assert pd.isna(df["name"].iloc[1])
 
+
 def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
     csv_path = tmp_path / "normal_crlf.csv"
 
@@ -879,18 +880,18 @@ def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
     assert df["name"].iloc[0] == "Alice"
     assert df["name"].iloc[1] == "Bob"
 
+
 def test_embedded_quoted_crlf_is_preserved(tmp_path):
     csv_path = tmp_path / "embedded_crlf.csv"
 
-    csv_path.write_bytes(
-        b'id,notes\r\n1,"hello\r\nworld"\r\n'
-    )
+    csv_path.write_bytes(b'id,notes\r\n1,"hello\r\nworld"\r\n')
 
     frame = ar.read_csv(csv_path)
 
     df = ar.to_pandas(frame)
 
-    assert df["notes"].iloc[0] == "hello\r\nworld"    
+    assert df["notes"].iloc[0] == "hello\r\nworld"
+
 
 def test_crlf_line_endings_do_not_preserve_trailing_carriage_return(tmp_path):
     csv_path = tmp_path / "normal_crlf.csv"


### PR DESCRIPTION
Fixes #128

## Summary
- add support for text file-like inputs in read_csv
- preserve existing filesystem path behavior
- reject unsupported binary buffers with clear errors
- add regression coverage for StringIO and invalid buffers
- document updated read_csv API behavior

## Tests
- py -3.12 -m black arnio/io.py tests/test_csv.py
- py -3.12 -m ruff check . --fix
- py -3.12 -m pytest tests/test_csv.py -v