### PR TITLE
feat(quality): add email and URL validity ratios to column profiles (#176)

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -93,6 +93,8 @@ class ColumnProfile:
     empty_string_count: int = 0
     whitespace_count: int = 0
     suggested_dtype: str | None = None
+    email_validity_ratio: float | None = None
+    url_validity_ratio: float | None = None
     min: Any = None
     max: Any = None
     mean: float | None = None
@@ -127,6 +129,8 @@ class ColumnProfile:
             "empty_string_count": self.empty_string_count,
             "whitespace_count": self.whitespace_count,
             "suggested_dtype": self.suggested_dtype,
+            "email_validity_ratio": self.email_validity_ratio,
+            "url_validity_ratio": self.url_validity_ratio,
             "min": _clean_scalar(self.min),
             "max": _clean_scalar(self.max),
             "mean": self.mean,
@@ -522,6 +526,8 @@ class DataQualityReport:
                     "empty_string_count": column.empty_string_count,
                     "whitespace_count": column.whitespace_count,
                     "suggested_dtype": column.suggested_dtype,
+                    "email_validity_ratio": column.email_validity_ratio,
+                    "url_validity_ratio": column.url_validity_ratio,
                     "min": _clean_scalar(column.min),
                     "max": _clean_scalar(column.max),
                     "mean": column.mean,
@@ -1667,6 +1673,15 @@ def _profile_column(
 
     semantic_type = _detect_semantic_type(name, series, dtype)
     suggested_dtype = _suggest_column_dtype(series, dtype)
+    
+    email_validity_ratio = None
+    url_validity_ratio = None
+    if len(non_null) > 0:
+        if semantic_type == "email":
+            email_validity_ratio = _match_ratio(non_null.astype("string").str.strip(), _EMAIL_PATTERN)
+        elif semantic_type == "url":
+            url_validity_ratio = _match_ratio(non_null.astype("string").str.strip(), _URL_PATTERN)
+
     warnings = _column_warnings(
         null_count=null_count,
         row_count=row_count,
@@ -1687,6 +1702,8 @@ def _profile_column(
         empty_string_count=empty_string_count,
         whitespace_count=whitespace_count,
         suggested_dtype=suggested_dtype,
+        email_validity_ratio=email_validity_ratio,
+        url_validity_ratio=url_validity_ratio,
         min=min_value,
         max=max_value,
         mean=mean,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1673,14 +1673,18 @@ def _profile_column(
 
     semantic_type = _detect_semantic_type(name, series, dtype)
     suggested_dtype = _suggest_column_dtype(series, dtype)
-    
+
     email_validity_ratio = None
     url_validity_ratio = None
     if len(non_null) > 0:
         if semantic_type == "email":
-            email_validity_ratio = _match_ratio(non_null.astype("string").str.strip(), _EMAIL_PATTERN)
+            email_validity_ratio = _match_ratio(
+                non_null.astype("string").str.strip(), _EMAIL_PATTERN
+            )
         elif semantic_type == "url":
-            url_validity_ratio = _match_ratio(non_null.astype("string").str.strip(), _URL_PATTERN)
+            url_validity_ratio = _match_ratio(
+                non_null.astype("string").str.strip(), _URL_PATTERN
+            )
 
     warnings = _column_warnings(
         null_count=null_count,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -76,50 +76,79 @@ def test_profile_non_numeric_no_quantiles():
 
 
 def test_profile_email_and_url_validity_ratios():
-    df = pd.DataFrame({
-        "good_email": ["alice@test.com", "bob@test.com", "cara@test.com", "dave@test.com", "eve@test.com"],
-        "mixed_email": ["alice@test.com", "bob@test.com", "cara@test.com", "dave@test.com", "invalid-email"],
-        "good_url": ["http://test.com", "https://example.com/foo", "https://another.org", "http://a.b", "https://last.com"],
-        "mixed_url": ["http://test.com", "https://example.com/foo", "https://another.org", "http://a.b", "not-a-url"],
-        "generic": ["hello", "world", "foo", "bar", "baz"]
-    })
-    
+    df = pd.DataFrame(
+        {
+            "good_email": [
+                "alice@test.com",
+                "bob@test.com",
+                "cara@test.com",
+                "dave@test.com",
+                "eve@test.com",
+            ],
+            "mixed_email": [
+                "alice@test.com",
+                "bob@test.com",
+                "cara@test.com",
+                "dave@test.com",
+                "invalid-email",
+            ],
+            "good_url": [
+                "http://test.com",
+                "https://example.com/foo",
+                "https://another.org",
+                "http://a.b",
+                "https://last.com",
+            ],
+            "mixed_url": [
+                "http://test.com",
+                "https://example.com/foo",
+                "https://another.org",
+                "http://a.b",
+                "not-a-url",
+            ],
+            "generic": ["hello", "world", "foo", "bar", "baz"],
+        }
+    )
+
     frame = ar.from_pandas(df)
     report = ar.profile(frame)
-    
+
     assert report.columns["good_email"].semantic_type == "email"
     assert report.columns["mixed_email"].semantic_type == "email"
     assert report.columns["good_url"].semantic_type == "url"
     assert report.columns["mixed_url"].semantic_type == "url"
     assert report.columns["generic"].semantic_type == "categorical"
-    
+
     assert report.columns["good_email"].email_validity_ratio == 1.0
     assert report.columns["good_email"].url_validity_ratio is None
-    
+
     assert report.columns["mixed_email"].email_validity_ratio == 0.8
     assert report.columns["mixed_email"].url_validity_ratio is None
-    
+
     assert report.columns["good_url"].url_validity_ratio == 1.0
     assert report.columns["good_url"].email_validity_ratio is None
-    
+
     assert report.columns["mixed_url"].url_validity_ratio == 0.8
     assert report.columns["mixed_url"].email_validity_ratio is None
-    
+
     assert report.columns["generic"].email_validity_ratio is None
     assert report.columns["generic"].url_validity_ratio is None
 
     good_email_dict = report.columns["good_email"].to_dict()
     assert good_email_dict["email_validity_ratio"] == 1.0
     assert good_email_dict["url_validity_ratio"] is None
-    
+
     mixed_url_dict = report.columns["mixed_url"].to_dict()
     assert mixed_url_dict["url_validity_ratio"] == 0.8
     assert mixed_url_dict["email_validity_ratio"] is None
-    
+
     pdf = report.to_pandas()
     good_email_row = pdf[pdf["name"] == "good_email"].iloc[0]
     assert good_email_row["email_validity_ratio"] == 1.0
-    assert pd.isna(good_email_row["url_validity_ratio"]) or good_email_row["url_validity_ratio"] is None
+    assert (
+        pd.isna(good_email_row["url_validity_ratio"])
+        or good_email_row["url_validity_ratio"] is None
+    )
 
 
 def test_compare_profiles_identical_profiles_are_ok():

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -75,6 +75,53 @@ def test_profile_non_numeric_no_quantiles():
     assert "q95" not in profile
 
 
+def test_profile_email_and_url_validity_ratios():
+    df = pd.DataFrame({
+        "good_email": ["alice@test.com", "bob@test.com", "cara@test.com", "dave@test.com", "eve@test.com"],
+        "mixed_email": ["alice@test.com", "bob@test.com", "cara@test.com", "dave@test.com", "invalid-email"],
+        "good_url": ["http://test.com", "https://example.com/foo", "https://another.org", "http://a.b", "https://last.com"],
+        "mixed_url": ["http://test.com", "https://example.com/foo", "https://another.org", "http://a.b", "not-a-url"],
+        "generic": ["hello", "world", "foo", "bar", "baz"]
+    })
+    
+    frame = ar.from_pandas(df)
+    report = ar.profile(frame)
+    
+    assert report.columns["good_email"].semantic_type == "email"
+    assert report.columns["mixed_email"].semantic_type == "email"
+    assert report.columns["good_url"].semantic_type == "url"
+    assert report.columns["mixed_url"].semantic_type == "url"
+    assert report.columns["generic"].semantic_type == "categorical"
+    
+    assert report.columns["good_email"].email_validity_ratio == 1.0
+    assert report.columns["good_email"].url_validity_ratio is None
+    
+    assert report.columns["mixed_email"].email_validity_ratio == 0.8
+    assert report.columns["mixed_email"].url_validity_ratio is None
+    
+    assert report.columns["good_url"].url_validity_ratio == 1.0
+    assert report.columns["good_url"].email_validity_ratio is None
+    
+    assert report.columns["mixed_url"].url_validity_ratio == 0.8
+    assert report.columns["mixed_url"].email_validity_ratio is None
+    
+    assert report.columns["generic"].email_validity_ratio is None
+    assert report.columns["generic"].url_validity_ratio is None
+
+    good_email_dict = report.columns["good_email"].to_dict()
+    assert good_email_dict["email_validity_ratio"] == 1.0
+    assert good_email_dict["url_validity_ratio"] is None
+    
+    mixed_url_dict = report.columns["mixed_url"].to_dict()
+    assert mixed_url_dict["url_validity_ratio"] == 0.8
+    assert mixed_url_dict["email_validity_ratio"] is None
+    
+    pdf = report.to_pandas()
+    good_email_row = pdf[pdf["name"] == "good_email"].iloc[0]
+    assert good_email_row["email_validity_ratio"] == 1.0
+    assert pd.isna(good_email_row["url_validity_ratio"]) or good_email_row["url_validity_ratio"] is None
+
+
 def test_compare_profiles_identical_profiles_are_ok():
     frame = ar.from_pandas(
         pd.DataFrame({"score": [10.0, 11.0, 12.0], "city": ["a", "b", "a"]})


### PR DESCRIPTION
### Description
This Pull Request implements email and URL validity ratios for the data quality profiling module as requested in #176.

### Changes
- Added optional `email_validity_ratio` and `url_validity_ratio` fields to `ColumnProfile`.
- Calculated validity ratios in `_profile_column` when the column's semantic type is identified as `"email"` or `"url"`.
- Updated `to_dict()` and `to_pandas()` to serialize and map these fields.
- Added comprehensive unit tests in `tests/test_quality.py` to ensure exact and mixed validation matches.

Closes #176
