### PR TITLE
test: expand drop_duplicates keep parameter coverage

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -200,28 +200,28 @@ class TestDropDuplicates:
         with pytest.raises(ValueError, match="keep must be one of"):
             ar.drop_duplicates(frame, keep=True)
 
-        @pytest.mark.parametrize(
-            ("keep", "expected_names"),
-            [
-                ("first", ["Alice", "Bob", "Charlie"]),
-                ("last", ["Alice", "Bob", "Charlie"]),
-                ("none", ["Charlie"]),
-                (False, ["Charlie"]),
-            ],
-        )
-        def test_drop_duplicates_keep_matrix_deterministic(
-            self,
-            csv_with_duplicates,
-            keep,
-            expected_names,
-        ):
-            frame = ar.read_csv(csv_with_duplicates)
+    @pytest.mark.parametrize(
+        ("keep", "expected_names"),
+        [
+            ("first", ["Alice", "Bob", "Charlie"]),
+            ("last", ["Alice", "Charlie", "Bob"]),
+            ("none", ["Charlie"]),
+            (False, ["Charlie"]),
+        ],
+    )
+    def test_drop_duplicates_keep_matrix_deterministic(
+        self,
+        csv_with_duplicates,
+        keep,
+        expected_names,
+    ):
+        frame = ar.read_csv(csv_with_duplicates)
 
-            result = ar.drop_duplicates(frame, keep=keep)
+        result = ar.drop_duplicates(frame, keep=keep)
 
-            names = result.to_pandas()["name"].tolist()
+        names = ar.to_pandas(result)["name"].tolist()
 
-            assert names == expected_names
+        assert names == expected_names
 
 
 class TestDropColumns:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -180,7 +180,10 @@ class TestDropDuplicates:
         # Only Charlie is unique
         assert result.shape[0] == 1
 
-    @pytest.mark.parametrize("keep", ["invalid", True, None])
+    @pytest.mark.parametrize(
+        "keep",
+        ["invalid", "FIRST", "all", "", True, None],
+    )
     def test_drop_dupes_rejects_invalid_keep_values(self, csv_with_duplicates, keep):
         frame = ar.read_csv(csv_with_duplicates)
         with pytest.raises(ValueError, match="keep must be one of"):
@@ -196,6 +199,29 @@ class TestDropDuplicates:
 
         with pytest.raises(ValueError, match="keep must be one of"):
             ar.drop_duplicates(frame, keep=True)
+
+        @pytest.mark.parametrize(
+            ("keep", "expected_names"),
+            [
+                ("first", ["Alice", "Bob", "Charlie"]),
+                ("last", ["Alice", "Bob", "Charlie"]),
+                ("none", ["Charlie"]),
+                (False, ["Charlie"]),
+            ],
+        )
+        def test_drop_duplicates_keep_matrix_deterministic(
+            self,
+            csv_with_duplicates,
+            keep,
+            expected_names,
+        ):
+            frame = ar.read_csv(csv_with_duplicates)
+
+            result = ar.drop_duplicates(frame, keep=keep)
+
+            names = result.to_pandas()["name"].tolist()
+
+            assert names == expected_names
 
 
 class TestDropColumns:


### PR DESCRIPTION
Fixes #611 

## Summary

Adds focused regression coverage for the `drop_duplicates` keep parameter matrix.

## Changes

* added deterministic tests for:

  * `"first"`
  * `"last"`
  * `"none"`
  * `False`
* expanded invalid keep value coverage with additional invalid string cases
* verified `keep=True` rejection behavior remains consistent
* strengthened assertions by validating retained rows instead of only row counts

## Validation

* `python -m pytest tests/test_cleaning.py`
* `python -m pytest tests/test_cleaning.py tests/test_pipeline.py`
