### PR TITLE
feat(csv): add chunked streaming CSV reader

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -47,7 +47,14 @@ from .exceptions import (
 )
 from .frame import ArFrame
 from .integrations import ArnioPandasAccessor
-from .io import read_csv, read_csv_chunked, read_jsonl, scan_csv, sniff_delimiter, write_csv
+from .io import (
+    read_csv,
+    read_csv_chunked,
+    read_jsonl,
+    scan_csv,
+    sniff_delimiter,
+    write_csv,
+)
 from .pipeline import pipeline, register_step
 from .quality import (
     CleanExplanation,

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -47,7 +47,7 @@ from .exceptions import (
 )
 from .frame import ArFrame
 from .integrations import ArnioPandasAccessor
-from .io import read_csv, read_jsonl, scan_csv, sniff_delimiter, write_csv
+from .io import read_csv, read_csv_chunked, read_jsonl, scan_csv, sniff_delimiter, write_csv
 from .pipeline import pipeline, register_step
 from .quality import (
     CleanExplanation,
@@ -93,6 +93,7 @@ __all__ = [
     "ArFrame",
     # I/O
     "read_csv",
+    "read_csv_chunked",
     "read_jsonl",
     "write_csv",
     "scan_csv",

--- a/arnio/_core.py
+++ b/arnio/_core.py
@@ -7,6 +7,7 @@ try:
     from ._arnio_cpp import (  # type: ignore[import-not-found]  # noqa: I001
         Column as _Column,  # noqa: F401
         CsvConfig as _CsvConfig,  # noqa: F401
+        CsvChunkReader as _CsvChunkReader,  # noqa: F401
         CsvReader as _CsvReader,  # noqa: F401
         CsvWriteConfig as _CsvWriteConfig,  # noqa: F401
         CsvWriter as _CsvWriter,  # noqa: F401

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from typing import cast
 
-from ._core import _CsvConfig, _CsvReader, _CsvWriteConfig, _CsvWriter
+from ._core import _CsvChunkReader, _CsvConfig, _CsvReader, _CsvWriteConfig, _CsvWriter
 from .exceptions import CsvReadError, JsonlReadError
 from .frame import ArFrame
 
@@ -134,6 +134,28 @@ def _validate_nrows(nrows: int) -> int:
         raise ValueError("nrows must be non-negative")
 
     return nrows
+
+
+def _validate_skip_rows(skip_rows: int) -> int:
+    """Validate skip_rows parameter."""
+    if isinstance(skip_rows, bool) or not isinstance(skip_rows, int):
+        raise TypeError("skip_rows must be an integer")
+
+    if skip_rows < 0:
+        raise ValueError("skip_rows must be non-negative")
+
+    return skip_rows
+
+
+def _validate_chunksize(chunksize: int) -> int:
+    """Validate chunksize parameter."""
+    if isinstance(chunksize, bool) or not isinstance(chunksize, int):
+        raise TypeError("chunksize must be an integer")
+
+    if chunksize <= 0:
+        raise ValueError("chunksize must be a positive integer")
+
+    return chunksize
 
 
 def _validate_null_values(null_values: list[str]) -> list[str]:
@@ -277,6 +299,126 @@ def read_csv(
         raise CsvReadError(str(e)) from e
 
     return ArFrame(cpp_frame)
+
+
+def read_csv_chunked(
+    path: str | os.PathLike[str],
+    *,
+    chunksize: int = 10_000,
+    delimiter: str = ",",
+    has_header: bool = True,
+    usecols: list[str] | None = None,
+    nrows: int | None = None,
+    skip_rows: int = 0,
+    encoding: str = "utf-8",
+    trim_headers: bool = True,
+    thousands_separator: str | None = None,
+    null_values: list[str] | None = None,
+    mode: str = "strict",
+) -> Iterator[ArFrame]:
+    """Read a CSV file in chunks, yielding ArFrame objects.
+
+    Column types are inferred from the first chunk and applied consistently
+    to all subsequent chunks. Memory use is bounded by the chunk size.
+
+    Parameters
+    ----------
+    path : str
+        Path to the CSV file. Supports .csv, .txt, and .tsv extensions.
+    chunksize : int, default 10_000
+        Maximum number of data rows per yielded chunk.
+    delimiter : str, default ","
+        Field delimiter character.
+    has_header : bool, default True
+        Whether the file has a header row.
+    usecols : list[str], optional
+        Columns to read. If None, reads all columns.
+    nrows : int, optional
+        Maximum total number of data rows to read across all chunks.
+    skip_rows : int, default 0
+        Number of data rows to skip after the header row.
+    encoding : str, default "utf-8"
+        File encoding.
+    trim_headers : bool, default True
+        Strip leading/trailing whitespace from column names.
+    thousands_separator : str, optional
+        Single non-alphanumeric character used as a thousands separator
+        during numeric parsing.
+    null_values : list[str], optional
+        Strings treated as null values.
+    mode : {"strict", "permissive"}, default "strict"
+        Controls malformed row handling.
+
+    Yields
+    ------
+    ArFrame
+        Successive chunks of the CSV data.
+
+    Examples
+    --------
+    >>> for chunk in ar.read_csv_chunked("huge.csv", chunksize=100_000):
+    ...     clean = ar.pipeline(chunk, [("drop_nulls",)])
+    ...     df = ar.to_pandas(clean)
+    ...     process(df)
+    """
+    path = os.fspath(path)
+    path_lower = path.lower()
+    if not (
+        path_lower.endswith(".csv")
+        or path_lower.endswith(".txt")
+        or path_lower.endswith(".tsv")
+    ):
+        raise ValueError(
+            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
+        )
+
+    try:
+        if os.path.getsize(path) == 0:
+            raise CsvReadError(f"CSV file is empty: {path!r}")
+    except FileNotFoundError:
+        pass
+
+    _validate_thousands_separator(thousands_separator)
+    delimiter = _validate_delimiter(delimiter)
+    mode = _validate_parser_mode(mode)
+    chunksize = _validate_chunksize(chunksize)
+    skip_rows = _validate_skip_rows(skip_rows)
+
+    config = _CsvConfig()
+    config.delimiter = delimiter
+    config.has_header = has_header
+    config.encoding = encoding
+    config.trim_headers = trim_headers
+    config.thousands_separator = thousands_separator
+    config.mode = mode
+    config.skip_rows = skip_rows
+
+    if null_values is not None:
+        config.null_values = _validate_null_values(null_values)
+
+    if usecols is not None:
+        config.usecols = _validate_usecols(usecols)
+
+    if nrows is not None:
+        config.nrows = _validate_nrows(nrows)
+
+    reader = _CsvChunkReader(config)
+    try:
+        with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
+            reader.open(native_path)
+            while True:
+                cpp_frame = reader.next_chunk(chunksize)
+                if cpp_frame is None:
+                    break
+                yield ArFrame(cpp_frame)
+    except ValueError:
+        raise
+    except CsvReadError:
+        raise
+    except RuntimeError as e:
+        raise CsvReadError(str(e)) from e
+    finally:
+        reader.close()
 
 
 def write_csv(

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -219,6 +219,7 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("has_header", &CsvConfig::has_header)
         .def_readwrite("usecols", &CsvConfig::usecols)
         .def_readwrite("nrows", &CsvConfig::nrows)
+        .def_readwrite("skip_rows", &CsvConfig::skip_rows)
         .def_readwrite("encoding", &CsvConfig::encoding)
         .def_readwrite("trim_headers", &CsvConfig::trim_headers)
         .def_readwrite("thousands_separator", &CsvConfig::thousands_separator)
@@ -245,6 +246,27 @@ PYBIND11_MODULE(_arnio_cpp, m) {
             }
             return schema;
         });
+
+    py::class_<CsvChunkReader>(m, "CsvChunkReader")
+        .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})
+        .def("open",
+             [](CsvChunkReader& reader, const std::string& path) {
+                 py::gil_scoped_release release;
+                 reader.open(path);
+             })
+        .def("next_chunk",
+             [](CsvChunkReader& reader, size_t chunksize) -> py::object {
+                 std::optional<Frame> result;
+                 {
+                     py::gil_scoped_release release;
+                     result = reader.next_chunk(chunksize);
+                 }
+                 if (!result.has_value()) {
+                     return py::none();
+                 }
+                 return py::cast(std::move(*result));
+             })
+        .def("close", &CsvChunkReader::close);
 
     // --- CsvWriter ---
     py::class_<CsvWriteConfig>(m, "CsvWriteConfig")

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <fstream>
 #include <optional>
 #include <string>
 #include <utility>
@@ -14,6 +15,7 @@ struct CsvConfig {
     bool has_header = true;
     std::optional<std::vector<std::string>> usecols = std::nullopt;
     std::optional<size_t> nrows = std::nullopt;
+    std::optional<size_t> skip_rows = std::nullopt;
     std::string encoding = "utf-8";  // Currently only utf-8 supported
     bool trim_headers = true;        // for implementing the trim_headers option
     std::optional<char> thousands_separator = std::nullopt;
@@ -49,6 +51,39 @@ class CsvReader {
 
     // Parse a string value into a CellValue given a target dtype
     CellValue parse_value(const std::string& raw, DType dtype) const;
+};
+
+// Stateful CSV reader for chunked/streaming reads.
+class CsvChunkReader {
+   public:
+    explicit CsvChunkReader(const CsvConfig& config = CsvConfig{});
+
+    void open(const std::string& path);
+    std::optional<Frame> next_chunk(size_t chunksize);
+    void close();
+
+   private:
+    CsvConfig config_;
+    std::ifstream file_;
+    std::vector<std::string> header_;
+    std::vector<size_t> col_indices_;
+    std::vector<DType> col_types_;
+    std::optional<size_t> expected_cols_;
+    size_t record_number_ = 0;
+    size_t rows_read_total_ = 0;
+    bool schema_locked_ = false;
+    bool header_finalized_ = false;
+    bool opened_ = false;
+
+    std::vector<std::string> parse_line(const std::string& line) const;
+    bool is_null_sentinel(const std::string& value) const;
+    DType infer_type(const std::string& value) const;
+    static DType promote_type(DType current, DType incoming);
+    CellValue parse_value(const std::string& raw, DType dtype) const;
+
+    void resolve_col_indices();
+    bool read_one_data_row(std::vector<std::string>& fields_out);
+    Frame build_frame(const std::vector<std::vector<std::string>>& raw_data) const;
 };
 
 }  // namespace arnio

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -24,6 +24,23 @@ struct CsvConfig {
     std::string mode = "strict";
 };
 
+// Shared CSV field parsing and type inference used by CsvReader and CsvChunkReader.
+class CsvParser {
+   public:
+    explicit CsvParser(const CsvConfig& config = CsvConfig{});
+
+    const CsvConfig& config() const { return config_; }
+
+    std::vector<std::string> parse_line(const std::string& line) const;
+    bool is_null_sentinel(const std::string& value) const;
+    DType infer_type(const std::string& value) const;
+    static DType promote_type(DType current, DType incoming);
+    CellValue parse_value(const std::string& raw, DType dtype) const;
+
+   private:
+    CsvConfig config_;
+};
+
 class CsvReader {
    public:
     explicit CsvReader(const CsvConfig& config = CsvConfig{});
@@ -35,22 +52,7 @@ class CsvReader {
     std::vector<std::pair<std::string, std::string>> scan_schema(const std::string& path) const;
 
    private:
-    CsvConfig config_;
-
-    // Parse a single CSV line respecting quotes
-    std::vector<std::string> parse_line(const std::string& line) const;
-
-    // Check if a string is a null sentinel
-    bool is_null_sentinel(const std::string& value) const;
-
-    // Infer DType from a string value
-    DType infer_type(const std::string& value) const;
-
-    // Promote dtype when merging inferences
-    static DType promote_type(DType current, DType incoming);
-
-    // Parse a string value into a CellValue given a target dtype
-    CellValue parse_value(const std::string& raw, DType dtype) const;
+    CsvParser parser_;
 };
 
 // Stateful CSV reader for chunked/streaming reads.
@@ -63,7 +65,7 @@ class CsvChunkReader {
     void close();
 
    private:
-    CsvConfig config_;
+    CsvParser parser_;
     std::ifstream file_;
     std::vector<std::string> header_;
     std::vector<size_t> col_indices_;
@@ -74,12 +76,6 @@ class CsvChunkReader {
     bool schema_locked_ = false;
     bool header_finalized_ = false;
     bool opened_ = false;
-
-    std::vector<std::string> parse_line(const std::string& line) const;
-    bool is_null_sentinel(const std::string& value) const;
-    DType infer_type(const std::string& value) const;
-    static DType promote_type(DType current, DType incoming);
-    CellValue parse_value(const std::string& raw, DType dtype) const;
 
     void resolve_col_indices();
     bool read_one_data_row(std::vector<std::string>& fields_out);

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -539,4 +539,344 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     return schema;
 }
 
+// --- CsvChunkReader (streaming) ---
+
+CsvChunkReader::CsvChunkReader(const CsvConfig& config) : config_(config) {}
+
+std::vector<std::string> CsvChunkReader::parse_line(const std::string& line) const {
+    std::vector<std::string> fields;
+    std::string field;
+    bool in_quotes = false;
+
+    for (size_t i = 0; i < line.size(); ++i) {
+        char c = line[i];
+        if (in_quotes) {
+            if (c == '"') {
+                if (i + 1 < line.size() && line[i + 1] == '"') {
+                    field += '"';
+                    ++i;
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                field += c;
+            }
+        } else {
+            if (c == '"') {
+                in_quotes = true;
+            } else if (c == config_.delimiter) {
+                fields.push_back(field);
+                field.clear();
+            } else if (c == '\r' && !in_quotes) {
+                continue;
+            } else {
+                field += c;
+            }
+        }
+    }
+    fields.push_back(field);
+    return fields;
+}
+
+bool CsvChunkReader::is_null_sentinel(const std::string& value) const {
+    if (config_.null_values.has_value()) {
+        const auto& sentinels = config_.null_values.value();
+        for (const auto& sentinel : sentinels) {
+            if (value.size() != sentinel.size()) continue;
+            bool match = true;
+            for (size_t i = 0; i < value.size(); ++i) {
+                if (std::tolower(static_cast<unsigned char>(value[i])) !=
+                    std::tolower(static_cast<unsigned char>(sentinel[i]))) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return true;
+        }
+        return false;
+    }
+    return value.empty();
+}
+
+DType CsvChunkReader::infer_type(const std::string& value) const {
+    if (is_null_sentinel(value)) return DType::NULL_TYPE;
+
+    std::string lower = value;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    if (lower == "true" || lower == "false") return DType::BOOL;
+
+    std::string cleaned = normalize_numeric(value, config_);
+
+    {
+        const char* start = cleaned.c_str();
+        char* end = nullptr;
+        errno = 0;
+        long long val = std::strtoll(start, &end, 10);
+        (void)val;
+        if (end != start && *end == '\0') {
+            if (errno == ERANGE) return DType::STRING;
+            return DType::INT64;
+        }
+    }
+
+    if (looks_like_integer_literal(cleaned)) return DType::STRING;
+
+    {
+        const char* start = cleaned.c_str();
+        char* end = nullptr;
+        double val = std::strtod(start, &end);
+        (void)val;
+        if (end != start && *end == '\0') return DType::FLOAT64;
+    }
+
+    if (config_.thousands_separator.has_value()) {
+        char sep = config_.thousands_separator.value();
+        if (value.find(sep) != std::string::npos && !has_valid_thousands_grouping(value, sep)) {
+            std::string check = value;
+            trim_in_place(check);
+            if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
+            bool looks_numeric =
+                !check.empty() && std::all_of(check.begin(), check.end(), [sep](char c) {
+                    return std::isdigit((unsigned char)c) || c == sep || c == '.';
+                });
+            if (looks_numeric) return DType::NULL_TYPE;
+        }
+    }
+
+    return DType::STRING;
+}
+
+DType CsvChunkReader::promote_type(DType current, DType incoming) {
+    if (current == incoming) return current;
+    if (current == DType::NULL_TYPE) return incoming;
+    if (incoming == DType::NULL_TYPE) return current;
+
+    if ((current == DType::INT64 && incoming == DType::FLOAT64) ||
+        (current == DType::FLOAT64 && incoming == DType::INT64)) {
+        return DType::FLOAT64;
+    }
+
+    return DType::STRING;
+}
+
+CellValue CsvChunkReader::parse_value(const std::string& raw, DType dtype) const {
+    if (is_null_sentinel(raw)) return std::monostate{};
+
+    switch (dtype) {
+        case DType::BOOL: {
+            std::string lower = raw;
+            std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+            return (lower == "true");
+        }
+        case DType::INT64: {
+            try {
+                std::string cleaned = normalize_numeric(raw, config_);
+                size_t pos = 0;
+                long long value = std::stoll(cleaned, &pos);
+                if (pos != cleaned.size()) {
+                    return std::monostate{};
+                }
+                return static_cast<int64_t>(value);
+            } catch (...) {
+                return std::monostate{};
+            }
+        }
+        case DType::FLOAT64: {
+            try {
+                std::string cleaned = normalize_numeric(raw, config_);
+                size_t pos = 0;
+                double value = std::stod(cleaned, &pos);
+                if (pos != cleaned.size()) {
+                    return std::monostate{};
+                }
+                return value;
+            } catch (...) {
+                return std::monostate{};
+            }
+        }
+        case DType::STRING:
+            return raw;
+        default:
+            return std::monostate{};
+    }
+}
+
+void CsvChunkReader::resolve_col_indices() {
+    col_indices_.clear();
+    const size_t num_cols = header_.size();
+    if (config_.usecols.has_value()) {
+        for (const auto& name : config_.usecols.value()) {
+            auto it = std::find(header_.begin(), header_.end(), name);
+            if (it == header_.end()) {
+                throw std::runtime_error("Column not found: " + name);
+            }
+            col_indices_.push_back(static_cast<size_t>(std::distance(header_.begin(), it)));
+        }
+    } else {
+        for (size_t i = 0; i < num_cols; ++i) {
+            col_indices_.push_back(i);
+        }
+    }
+}
+
+bool CsvChunkReader::read_one_data_row(std::vector<std::string>& fields_out) {
+    std::string line;
+    while (read_record(file_, line)) {
+        ++record_number_;
+
+        if (line.empty()) {
+            continue;
+        }
+
+        fields_out = parse_line(line);
+
+        if (!config_.has_header && !expected_cols_.has_value()) {
+            expected_cols_ = fields_out.size();
+        }
+
+        if (config_.mode == "strict" && expected_cols_.has_value()) {
+            validate_row_width(record_number_, expected_cols_.value(), fields_out.size());
+        }
+
+        if (expected_cols_.has_value()) {
+            while (fields_out.size() < expected_cols_.value()) {
+                fields_out.push_back("");
+            }
+        }
+
+        return true;
+    }
+    return false;
+}
+
+Frame CsvChunkReader::build_frame(const std::vector<std::vector<std::string>>& raw_data) const {
+    std::vector<Column> columns;
+    columns.reserve(col_indices_.size());
+    for (size_t ci : col_indices_) {
+        Column col(header_[ci], col_types_[ci]);
+        for (const auto& row : raw_data) {
+            if (ci < row.size()) {
+                col.push_back(parse_value(row[ci], col_types_[ci]));
+            } else {
+                col.push_null();
+            }
+        }
+        columns.push_back(std::move(col));
+    }
+    return Frame(std::move(columns));
+}
+
+void CsvChunkReader::open(const std::string& path) {
+    close();
+
+    file_.open(path, std::ios::binary);
+    if (!file_.is_open()) {
+        throw std::runtime_error("Cannot open file: " + path);
+    }
+
+    opened_ = true;
+    record_number_ = 0;
+    rows_read_total_ = 0;
+    schema_locked_ = false;
+    header_finalized_ = config_.has_header;
+    header_.clear();
+    col_indices_.clear();
+    col_types_.clear();
+    expected_cols_ = std::nullopt;
+
+    std::string line;
+    if (config_.has_header && read_record(file_, line)) {
+        ++record_number_;
+        strip_utf8_bom(line);
+        header_ = parse_line(line);
+        for (auto& h : header_) {
+            if (config_.trim_headers) trim_in_place(h);
+        }
+        validate_header(header_);
+        expected_cols_ = header_.size();
+        resolve_col_indices();
+        col_types_.assign(header_.size(), DType::NULL_TYPE);
+    }
+
+    const size_t skip_target = config_.skip_rows.value_or(0);
+    size_t skipped = 0;
+    while (skipped < skip_target) {
+        std::vector<std::string> fields;
+        if (!read_one_data_row(fields)) {
+            break;
+        }
+        ++skipped;
+    }
+}
+
+std::optional<Frame> CsvChunkReader::next_chunk(size_t chunksize) {
+    if (!opened_) {
+        throw std::runtime_error("CsvChunkReader is not open");
+    }
+
+    if (chunksize == 0) {
+        throw std::runtime_error("chunksize must be greater than 0");
+    }
+
+    size_t limit = chunksize;
+    if (config_.nrows.has_value()) {
+        const size_t nrows = config_.nrows.value();
+        if (rows_read_total_ >= nrows) {
+            return std::nullopt;
+        }
+        limit = std::min(limit, nrows - rows_read_total_);
+    }
+
+    std::vector<std::vector<std::string>> raw_data;
+    raw_data.reserve(limit);
+
+    while (raw_data.size() < limit) {
+        std::vector<std::string> fields;
+        if (!read_one_data_row(fields)) {
+            break;
+        }
+        raw_data.push_back(std::move(fields));
+    }
+
+    if (raw_data.empty()) {
+        return std::nullopt;
+    }
+
+    if (!header_finalized_) {
+        for (size_t i = 0; i < raw_data[0].size(); ++i) {
+            header_.push_back("col_" + std::to_string(i));
+        }
+        validate_header(header_);
+        header_finalized_ = true;
+        expected_cols_ = header_.size();
+        resolve_col_indices();
+        col_types_.assign(header_.size(), DType::NULL_TYPE);
+    }
+
+    if (!schema_locked_) {
+        for (const auto& row : raw_data) {
+            for (size_t ci : col_indices_) {
+                if (ci < row.size()) {
+                    DType inferred = infer_type(row[ci]);
+                    col_types_[ci] = promote_type(col_types_[ci], inferred);
+                }
+            }
+        }
+        for (auto& dt : col_types_) {
+            if (dt == DType::NULL_TYPE) dt = DType::STRING;
+        }
+        schema_locked_ = true;
+    }
+
+    rows_read_total_ += raw_data.size();
+    return build_frame(raw_data);
+}
+
+void CsvChunkReader::close() {
+    if (file_.is_open()) {
+        file_.close();
+    }
+    opened_ = false;
+}
+
 }  // namespace arnio

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -200,9 +200,11 @@ void validate_row_width(size_t row_number, size_t expected, size_t actual) {
 
 }  // namespace
 
-CsvReader::CsvReader(const CsvConfig& config) : config_(config) {}
+CsvParser::CsvParser(const CsvConfig& config) : config_(config) {}
 
-std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
+CsvReader::CsvReader(const CsvConfig& config) : parser_(config) {}
+
+std::vector<std::string> CsvParser::parse_line(const std::string& line) const {
     std::vector<std::string> fields;
     std::string field;
     bool in_quotes = false;
@@ -237,7 +239,7 @@ std::vector<std::string> CsvReader::parse_line(const std::string& line) const {
     return fields;
 }
 
-bool CsvReader::is_null_sentinel(const std::string& value) const {
+bool CsvParser::is_null_sentinel(const std::string& value) const {
     if (config_.null_values.has_value()) {
         const auto& sentinels = config_.null_values.value();
         for (const auto& sentinel : sentinels) {
@@ -258,7 +260,7 @@ bool CsvReader::is_null_sentinel(const std::string& value) const {
     return value.empty();
 }
 
-DType CsvReader::infer_type(const std::string& value) const {
+DType CsvParser::infer_type(const std::string& value) const {
     if (is_null_sentinel(value)) return DType::NULL_TYPE;
 
     // Try bool
@@ -312,7 +314,7 @@ DType CsvReader::infer_type(const std::string& value) const {
     return DType::STRING;
 }
 
-DType CsvReader::promote_type(DType current, DType incoming) {
+DType CsvParser::promote_type(DType current, DType incoming) {
     if (current == incoming) return current;
     if (current == DType::NULL_TYPE) return incoming;
     if (incoming == DType::NULL_TYPE) return current;
@@ -327,7 +329,7 @@ DType CsvReader::promote_type(DType current, DType incoming) {
     return DType::STRING;
 }
 
-CellValue CsvReader::parse_value(const std::string& raw, DType dtype) const {
+CellValue CsvParser::parse_value(const std::string& raw, DType dtype) const {
     if (is_null_sentinel(raw)) return std::monostate{};
 
     switch (dtype) {
@@ -370,6 +372,7 @@ CellValue CsvReader::parse_value(const std::string& raw, DType dtype) const {
 }
 
 Frame CsvReader::read(const std::string& path) const {
+    const CsvConfig& config = parser_.config();
     std::ifstream file(path, std::ios::binary);
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
@@ -382,12 +385,12 @@ Frame CsvReader::read(const std::string& path) const {
     size_t record_number = 0;
 
     // Read header
-    if (config_.has_header && read_record(file, line)) {
+    if (config.has_header && read_record(file, line)) {
         ++record_number;
         strip_utf8_bom(line);
-        header = parse_line(line);
+        header = parser_.parse_line(line);
         for (auto& h : header) {
-            if (config_.trim_headers) trim_in_place(h);
+            if (config.trim_headers) trim_in_place(h);
         }
         validate_header(header);
     }
@@ -395,11 +398,11 @@ Frame CsvReader::read(const std::string& path) const {
     // Read all rows
     size_t row_count = 0;
     std::optional<size_t> expected_cols =
-        config_.has_header ? std::optional<size_t>{header.size()} : std::nullopt;
+        config.has_header ? std::optional<size_t>{header.size()} : std::nullopt;
     while (read_record(file, line)) {
         ++record_number;
 
-        if (config_.nrows.has_value() && row_count >= config_.nrows.value()) {
+        if (config.nrows.has_value() && row_count >= config.nrows.value()) {
             break;
         }
 
@@ -407,13 +410,13 @@ Frame CsvReader::read(const std::string& path) const {
             continue;
         }
 
-        auto fields = parse_line(line);
+        auto fields = parser_.parse_line(line);
 
-        if (!config_.has_header && !expected_cols.has_value()) {
+        if (!config.has_header && !expected_cols.has_value()) {
             expected_cols = fields.size();
         }
 
-        if (config_.mode == "strict" && expected_cols.has_value()) {
+        if (config.mode == "strict" && expected_cols.has_value()) {
             validate_row_width(record_number, expected_cols.value(), fields.size());
         }
 
@@ -429,7 +432,7 @@ Frame CsvReader::read(const std::string& path) const {
     file.close();
 
     // If no header, generate column names
-    if (!config_.has_header && !raw_data.empty()) {
+    if (!config.has_header && !raw_data.empty()) {
         for (size_t i = 0; i < raw_data[0].size(); ++i) {
             header.push_back("col_" + std::to_string(i));
         }
@@ -440,8 +443,8 @@ Frame CsvReader::read(const std::string& path) const {
 
     // Determine which columns to keep
     std::vector<size_t> col_indices;
-    if (config_.usecols.has_value()) {
-        for (const auto& name : config_.usecols.value()) {
+    if (config.usecols.has_value()) {
+        for (const auto& name : config.usecols.value()) {
             auto it = std::find(header.begin(), header.end(), name);
             if (it == header.end()) {
                 throw std::runtime_error("Column not found: " + name);
@@ -459,8 +462,8 @@ Frame CsvReader::read(const std::string& path) const {
     for (const auto& row : raw_data) {
         for (size_t ci : col_indices) {
             if (ci < row.size()) {
-                DType inferred = infer_type(row[ci]);
-                col_types[ci] = promote_type(col_types[ci], inferred);
+                DType inferred = parser_.infer_type(row[ci]);
+                col_types[ci] = CsvParser::promote_type(col_types[ci], inferred);
             }
         }
     }
@@ -477,7 +480,7 @@ Frame CsvReader::read(const std::string& path) const {
         Column col(header[ci], col_types[ci]);
         for (const auto& row : raw_data) {
             if (ci < row.size()) {
-                col.push_back(parse_value(row[ci], col_types[ci]));
+                col.push_back(parser_.parse_value(row[ci], col_types[ci]));
             } else {
                 col.push_null();
             }
@@ -490,6 +493,7 @@ Frame CsvReader::read(const std::string& path) const {
 
 std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     const std::string& path) const {
+    const CsvConfig& config = parser_.config();
     std::ifstream file(path, std::ios::binary);
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
@@ -500,9 +504,9 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
 
     if (read_record(file, line)) {
         strip_utf8_bom(line);
-        header = parse_line(line);
+        header = parser_.parse_line(line);
         for (auto& h : header) {
-            if (config_.trim_headers) trim_in_place(h);
+            if (config.trim_headers) trim_in_place(h);
         }
         validate_header(header);
     }
@@ -511,7 +515,7 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     std::vector<DType> col_types(num_cols, DType::NULL_TYPE);
     size_t sample_count = 0;
 
-    size_t max_samples = config_.sample_size.value_or(100);
+    size_t max_samples = config.sample_size.value_or(100);
 
     while (read_record(file, line)) {
         if (sample_count >= max_samples) {
@@ -519,10 +523,10 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
         }
 
         if (line.empty()) continue;
-        auto fields = parse_line(line);
+        auto fields = parser_.parse_line(line);
         validate_row_width(sample_count + 2, num_cols, fields.size());
         for (size_t i = 0; i < num_cols && i < fields.size(); ++i) {
-            col_types[i] = promote_type(col_types[i], infer_type(fields[i]));
+            col_types[i] = CsvParser::promote_type(col_types[i], parser_.infer_type(fields[i]));
         }
         ++sample_count;
     }
@@ -541,171 +545,14 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
 
 // --- CsvChunkReader (streaming) ---
 
-CsvChunkReader::CsvChunkReader(const CsvConfig& config) : config_(config) {}
-
-std::vector<std::string> CsvChunkReader::parse_line(const std::string& line) const {
-    std::vector<std::string> fields;
-    std::string field;
-    bool in_quotes = false;
-
-    for (size_t i = 0; i < line.size(); ++i) {
-        char c = line[i];
-        if (in_quotes) {
-            if (c == '"') {
-                if (i + 1 < line.size() && line[i + 1] == '"') {
-                    field += '"';
-                    ++i;
-                } else {
-                    in_quotes = false;
-                }
-            } else {
-                field += c;
-            }
-        } else {
-            if (c == '"') {
-                in_quotes = true;
-            } else if (c == config_.delimiter) {
-                fields.push_back(field);
-                field.clear();
-            } else if (c == '\r' && !in_quotes) {
-                continue;
-            } else {
-                field += c;
-            }
-        }
-    }
-    fields.push_back(field);
-    return fields;
-}
-
-bool CsvChunkReader::is_null_sentinel(const std::string& value) const {
-    if (config_.null_values.has_value()) {
-        const auto& sentinels = config_.null_values.value();
-        for (const auto& sentinel : sentinels) {
-            if (value.size() != sentinel.size()) continue;
-            bool match = true;
-            for (size_t i = 0; i < value.size(); ++i) {
-                if (std::tolower(static_cast<unsigned char>(value[i])) !=
-                    std::tolower(static_cast<unsigned char>(sentinel[i]))) {
-                    match = false;
-                    break;
-                }
-            }
-            if (match) return true;
-        }
-        return false;
-    }
-    return value.empty();
-}
-
-DType CsvChunkReader::infer_type(const std::string& value) const {
-    if (is_null_sentinel(value)) return DType::NULL_TYPE;
-
-    std::string lower = value;
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-    if (lower == "true" || lower == "false") return DType::BOOL;
-
-    std::string cleaned = normalize_numeric(value, config_);
-
-    {
-        const char* start = cleaned.c_str();
-        char* end = nullptr;
-        errno = 0;
-        long long val = std::strtoll(start, &end, 10);
-        (void)val;
-        if (end != start && *end == '\0') {
-            if (errno == ERANGE) return DType::STRING;
-            return DType::INT64;
-        }
-    }
-
-    if (looks_like_integer_literal(cleaned)) return DType::STRING;
-
-    {
-        const char* start = cleaned.c_str();
-        char* end = nullptr;
-        double val = std::strtod(start, &end);
-        (void)val;
-        if (end != start && *end == '\0') return DType::FLOAT64;
-    }
-
-    if (config_.thousands_separator.has_value()) {
-        char sep = config_.thousands_separator.value();
-        if (value.find(sep) != std::string::npos && !has_valid_thousands_grouping(value, sep)) {
-            std::string check = value;
-            trim_in_place(check);
-            if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
-            bool looks_numeric =
-                !check.empty() && std::all_of(check.begin(), check.end(), [sep](char c) {
-                    return std::isdigit((unsigned char)c) || c == sep || c == '.';
-                });
-            if (looks_numeric) return DType::NULL_TYPE;
-        }
-    }
-
-    return DType::STRING;
-}
-
-DType CsvChunkReader::promote_type(DType current, DType incoming) {
-    if (current == incoming) return current;
-    if (current == DType::NULL_TYPE) return incoming;
-    if (incoming == DType::NULL_TYPE) return current;
-
-    if ((current == DType::INT64 && incoming == DType::FLOAT64) ||
-        (current == DType::FLOAT64 && incoming == DType::INT64)) {
-        return DType::FLOAT64;
-    }
-
-    return DType::STRING;
-}
-
-CellValue CsvChunkReader::parse_value(const std::string& raw, DType dtype) const {
-    if (is_null_sentinel(raw)) return std::monostate{};
-
-    switch (dtype) {
-        case DType::BOOL: {
-            std::string lower = raw;
-            std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-            return (lower == "true");
-        }
-        case DType::INT64: {
-            try {
-                std::string cleaned = normalize_numeric(raw, config_);
-                size_t pos = 0;
-                long long value = std::stoll(cleaned, &pos);
-                if (pos != cleaned.size()) {
-                    return std::monostate{};
-                }
-                return static_cast<int64_t>(value);
-            } catch (...) {
-                return std::monostate{};
-            }
-        }
-        case DType::FLOAT64: {
-            try {
-                std::string cleaned = normalize_numeric(raw, config_);
-                size_t pos = 0;
-                double value = std::stod(cleaned, &pos);
-                if (pos != cleaned.size()) {
-                    return std::monostate{};
-                }
-                return value;
-            } catch (...) {
-                return std::monostate{};
-            }
-        }
-        case DType::STRING:
-            return raw;
-        default:
-            return std::monostate{};
-    }
-}
+CsvChunkReader::CsvChunkReader(const CsvConfig& config) : parser_(config) {}
 
 void CsvChunkReader::resolve_col_indices() {
+    const CsvConfig& config = parser_.config();
     col_indices_.clear();
     const size_t num_cols = header_.size();
-    if (config_.usecols.has_value()) {
-        for (const auto& name : config_.usecols.value()) {
+    if (config.usecols.has_value()) {
+        for (const auto& name : config.usecols.value()) {
             auto it = std::find(header_.begin(), header_.end(), name);
             if (it == header_.end()) {
                 throw std::runtime_error("Column not found: " + name);
@@ -720,6 +567,7 @@ void CsvChunkReader::resolve_col_indices() {
 }
 
 bool CsvChunkReader::read_one_data_row(std::vector<std::string>& fields_out) {
+    const CsvConfig& config = parser_.config();
     std::string line;
     while (read_record(file_, line)) {
         ++record_number_;
@@ -728,13 +576,13 @@ bool CsvChunkReader::read_one_data_row(std::vector<std::string>& fields_out) {
             continue;
         }
 
-        fields_out = parse_line(line);
+        fields_out = parser_.parse_line(line);
 
-        if (!config_.has_header && !expected_cols_.has_value()) {
+        if (!config.has_header && !expected_cols_.has_value()) {
             expected_cols_ = fields_out.size();
         }
 
-        if (config_.mode == "strict" && expected_cols_.has_value()) {
+        if (config.mode == "strict" && expected_cols_.has_value()) {
             validate_row_width(record_number_, expected_cols_.value(), fields_out.size());
         }
 
@@ -756,7 +604,7 @@ Frame CsvChunkReader::build_frame(const std::vector<std::vector<std::string>>& r
         Column col(header_[ci], col_types_[ci]);
         for (const auto& row : raw_data) {
             if (ci < row.size()) {
-                col.push_back(parse_value(row[ci], col_types_[ci]));
+                col.push_back(parser_.parse_value(row[ci], col_types_[ci]));
             } else {
                 col.push_null();
             }
@@ -767,6 +615,7 @@ Frame CsvChunkReader::build_frame(const std::vector<std::vector<std::string>>& r
 }
 
 void CsvChunkReader::open(const std::string& path) {
+    const CsvConfig& config = parser_.config();
     close();
 
     file_.open(path, std::ios::binary);
@@ -778,19 +627,19 @@ void CsvChunkReader::open(const std::string& path) {
     record_number_ = 0;
     rows_read_total_ = 0;
     schema_locked_ = false;
-    header_finalized_ = config_.has_header;
+    header_finalized_ = config.has_header;
     header_.clear();
     col_indices_.clear();
     col_types_.clear();
     expected_cols_ = std::nullopt;
 
     std::string line;
-    if (config_.has_header && read_record(file_, line)) {
+    if (config.has_header && read_record(file_, line)) {
         ++record_number_;
         strip_utf8_bom(line);
-        header_ = parse_line(line);
+        header_ = parser_.parse_line(line);
         for (auto& h : header_) {
-            if (config_.trim_headers) trim_in_place(h);
+            if (config.trim_headers) trim_in_place(h);
         }
         validate_header(header_);
         expected_cols_ = header_.size();
@@ -798,7 +647,7 @@ void CsvChunkReader::open(const std::string& path) {
         col_types_.assign(header_.size(), DType::NULL_TYPE);
     }
 
-    const size_t skip_target = config_.skip_rows.value_or(0);
+    const size_t skip_target = config.skip_rows.value_or(0);
     size_t skipped = 0;
     while (skipped < skip_target) {
         std::vector<std::string> fields;
@@ -818,9 +667,10 @@ std::optional<Frame> CsvChunkReader::next_chunk(size_t chunksize) {
         throw std::runtime_error("chunksize must be greater than 0");
     }
 
+    const CsvConfig& config = parser_.config();
     size_t limit = chunksize;
-    if (config_.nrows.has_value()) {
-        const size_t nrows = config_.nrows.value();
+    if (config.nrows.has_value()) {
+        const size_t nrows = config.nrows.value();
         if (rows_read_total_ >= nrows) {
             return std::nullopt;
         }
@@ -857,8 +707,8 @@ std::optional<Frame> CsvChunkReader::next_chunk(size_t chunksize) {
         for (const auto& row : raw_data) {
             for (size_t ci : col_indices_) {
                 if (ci < row.size()) {
-                    DType inferred = infer_type(row[ci]);
-                    col_types_[ci] = promote_type(col_types_[ci], inferred);
+                    DType inferred = parser_.infer_type(row[ci]);
+                    col_types_[ci] = CsvParser::promote_type(col_types_[ci], inferred);
                 }
             }
         }

--- a/tests/test_csv_chunked.py
+++ b/tests/test_csv_chunked.py
@@ -1,0 +1,98 @@
+"""Tests for chunked CSV reading."""
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+def _chunked_rows(path: str, **kwargs) -> list[ar.ArFrame]:
+    return list(ar.read_csv_chunked(path, **kwargs))
+
+
+class TestReadCsvChunked:
+    def test_multi_chunk_row_counts(self, tmp_path):
+        lines = ["id,value,label"]
+        for i in range(250):
+            lines.append(f"{i},{i * 1.5},item_{i}")
+        path = tmp_path / "chunked.csv"
+        path.write_text("\n".join(lines))
+
+        chunks = _chunked_rows(str(path), chunksize=100)
+        assert len(chunks) == 3
+        assert [c.shape[0] for c in chunks] == [100, 100, 50]
+
+    def test_stable_dtypes_across_chunks(self, tmp_path):
+        lines = ["name,age,score"]
+        for i in range(150):
+            lines.append(f"user_{i},{20 + i % 10},{90.5 + i}")
+        path = tmp_path / "dtypes.csv"
+        path.write_text("\n".join(lines))
+
+        chunks = _chunked_rows(str(path), chunksize=50)
+        first_dtypes = chunks[0].dtypes
+        for chunk in chunks[1:]:
+            assert chunk.dtypes == first_dtypes
+
+    def test_concat_matches_read_csv(self, large_csv):
+        chunks = _chunked_rows(large_csv, chunksize=200)
+        chunked_df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        full_df = ar.to_pandas(ar.read_csv(large_csv))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_concat_matches_read_csv_sample(self, sample_csv):
+        chunks = _chunked_rows(sample_csv, chunksize=2)
+        chunked_df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        full_df = ar.to_pandas(ar.read_csv(sample_csv))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_nrows_limits_total_rows(self, large_csv):
+        chunks = _chunked_rows(large_csv, chunksize=200, nrows=350)
+        total = sum(c.shape[0] for c in chunks)
+        assert total == 350
+        full_df = ar.to_pandas(ar.read_csv(large_csv, nrows=350))
+        chunked_df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_skip_rows(self, tmp_path):
+        lines = ["id,value"]
+        for i in range(20):
+            lines.append(f"{i},{i}")
+        path = tmp_path / "skip.csv"
+        path.write_text("\n".join(lines))
+
+        chunks = _chunked_rows(str(path), chunksize=5, skip_rows=10)
+        chunked_df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert chunked_df.shape[0] == 10
+        assert chunked_df["id"].tolist() == list(range(10, 20))
+
+    def test_quoted_multiline_field(self, tmp_path):
+        path = tmp_path / "multiline.csv"
+        path.write_text(
+            'id,text\n'
+            '1,"line one\nline two"\n'
+            '2,simple\n'
+            '3,"another\nquoted"\n'
+            '4,plain\n'
+        )
+        chunks = _chunked_rows(str(path), chunksize=2)
+        chunked_df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        full_df = ar.to_pandas(ar.read_csv(str(path)))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_usecols(self, sample_csv):
+        chunks = _chunked_rows(sample_csv, chunksize=2, usecols=["name", "age"])
+        assert all(c.columns == ["name", "age"] for c in chunks)
+        chunked_df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        full_df = ar.to_pandas(ar.read_csv(sample_csv, usecols=["name", "age"]))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_invalid_chunksize(self, sample_csv):
+        with pytest.raises(ValueError, match="chunksize must be a positive integer"):
+            list(ar.read_csv_chunked(sample_csv, chunksize=0))
+
+    def test_empty_data_rows_header_only(self, tmp_path):
+        path = tmp_path / "header_only.csv"
+        path.write_text("a,b\n")
+        chunks = _chunked_rows(str(path), chunksize=10)
+        assert chunks == []

--- a/tests/test_csv_chunked.py
+++ b/tests/test_csv_chunked.py
@@ -4,10 +4,18 @@ import pandas as pd
 import pytest
 
 import arnio as ar
+from arnio.exceptions import CsvReadError
 
 
 def _chunked_rows(path: str, **kwargs) -> list[ar.ArFrame]:
     return list(ar.read_csv_chunked(path, **kwargs))
+
+
+def _chunked_concat(path: str, chunksize: int = 2, **kwargs) -> pd.DataFrame:
+    chunks = _chunked_rows(path, chunksize=chunksize, **kwargs)
+    if not chunks:
+        return pd.DataFrame()
+    return pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
 
 
 class TestReadCsvChunked:
@@ -69,11 +77,11 @@ class TestReadCsvChunked:
     def test_quoted_multiline_field(self, tmp_path):
         path = tmp_path / "multiline.csv"
         path.write_text(
-            'id,text\n'
+            "id,text\n"
             '1,"line one\nline two"\n'
-            '2,simple\n'
+            "2,simple\n"
             '3,"another\nquoted"\n'
-            '4,plain\n'
+            "4,plain\n"
         )
         chunks = _chunked_rows(str(path), chunksize=2)
         chunked_df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
@@ -96,3 +104,41 @@ class TestReadCsvChunked:
         path.write_text("a,b\n")
         chunks = _chunked_rows(str(path), chunksize=10)
         assert chunks == []
+
+
+class TestReadCsvChunkedParity:
+    """Chunked reads must match read_csv for parser options."""
+
+    def test_parity_has_header_false(self, csv_no_header):
+        chunked_df = _chunked_concat(csv_no_header, chunksize=1, has_header=False)
+        full_df = ar.to_pandas(ar.read_csv(csv_no_header, has_header=False))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_parity_null_values(self, tmp_path):
+        path = tmp_path / "nulls.csv"
+        path.write_text("a\n1\nNA\n3\n")
+        chunked_df = _chunked_concat(str(path), chunksize=1, null_values=["NA"])
+        full_df = ar.to_pandas(ar.read_csv(str(path), null_values=["NA"]))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_parity_thousands_separator(self, tmp_path):
+        path = tmp_path / "thousands.csv"
+        path.write_text('amount\n"1,234"\n500\n')
+        chunked_df = _chunked_concat(str(path), chunksize=1, thousands_separator=",")
+        full_df = ar.to_pandas(ar.read_csv(str(path), thousands_separator=","))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_parity_permissive_mode(self, tmp_path):
+        path = tmp_path / "permissive.csv"
+        path.write_text("id,name\n1,Alice\n2\n")
+        chunked_df = _chunked_concat(str(path), chunksize=1, mode="permissive")
+        full_df = ar.to_pandas(ar.read_csv(str(path), mode="permissive"))
+        pd.testing.assert_frame_equal(chunked_df, full_df)
+
+    def test_parity_strict_mode_raises(self, tmp_path):
+        path = tmp_path / "strict.csv"
+        path.write_text("id,name\n1,Alice\n2\n")
+        with pytest.raises(CsvReadError, match="expected 2"):
+            _chunked_concat(str(path), chunksize=1, mode="strict")
+        with pytest.raises(CsvReadError, match="expected 2"):
+            ar.read_csv(str(path), mode="strict")


### PR DESCRIPTION
## Description

Closes #53  

## This PR adds chunked/streaming CSV reading for large files via a stateful C++ reader and a Python generator API (`read_csv_chunked`), with dtype inference locked after the first chunk and regression tests covering multi-chunk reads, stable dtypes, and parity with `read_csv`.

## What Was Done

**C++ (`CsvChunkReader`)**
- Added a stateful `CsvChunkReader` that keeps a single file handle open between yields.
- Implemented `open()`, `next_chunk(chunksize)`, and `close()` with the same parsing rules as `read_csv` (headers, quoted fields, embedded newlines, strict/permissive mode).
- Added `skip_rows` on `CsvConfig` for skipping data rows after the header.
- Infers column types from the **first chunk only**, then applies that schema consistently to all later chunks.
- Honors `nrows` as a total row cap across all chunks.

**Python (`read_csv_chunked`)**
- Added `arnio.read_csv_chunked()` as a generator yielding `ArFrame` chunks.
- Supports the same parser options as `read_csv` where applicable (`delimiter`, `has_header`, `usecols`, `encoding`, `trim_headers`, `thousands_separator`, `null_values`, `mode`) plus `chunksize`, `skip_rows`, and `nrows`.
- Exported from the public API; existing `read_csv` behavior is unchanged.

**Bindings**
- Exposed `CsvChunkReader` and `skip_rows` via pybind11 with GIL release on I/O.

**Tests (`tests/test_csv_chunked.py`)**
- `test_multi_chunk_row_counts`: Asserts correct chunk sizes for multi-chunk reads.
- `test_stable_dtypes_across_chunks`: Asserts dtypes match across all chunks.
- `test_concat_matches_read_csv` / `test_concat_matches_read_csv_sample`: Asserts concatenated chunks equal a normal `read_csv` result.
- `test_nrows_limits_total_rows`: Asserts total row cap and parity with `read_csv(nrows=...)`.
- `test_skip_rows`: Asserts rows are skipped correctly after the header.
- `test_quoted_multiline_field`: Asserts quoted fields with embedded newlines parse correctly across chunks.
- `test_usecols`: Asserts column selection works in chunked mode.
- `test_invalid_chunksize` / `test_empty_data_rows_header_only`: Edge-case validation.

## Memory / Streaming

`read_csv_chunked` reads at most `chunksize` rows per yield, so peak memory scales with chunk size × column count—not total file size. Dtype inference runs once on the first chunk. This PR uses sequential `ifstream` I/O (no mmap/async); it is intended for processing files larger than available RAM without loading the full file into memory.

## Verification & Testing

- Built and installed the package locally with the C++ extension.
- All CSV and chunked tests passed (`tests/test_csv_chunked.py`, `tests/test_csv.py`).
- IO smoke and GIL-related tests passed.

## Contributor & AI Disclosure (GSSoC Compliant)

**AI Assistance:** The implementation (C++ chunk reader, pybind bindings, Python API, and unit tests) was drafted with the assistance of the Cursor AI coding assistant.

**Contributor Review:** As the GSSoC contributor, I have reviewed the design against the maintainer’s expectations (chunked reader only, preserved `read_csv` behavior, stable cross-chunk dtypes, and required test coverage), run the local test suite, and confirmed the implementation matches issue #53 and is ready for review.

