### PR TITLE
Fix issue #226

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ frame = ar.from_dict({})
 print(frame.shape)
 # (0, 0)
 ```
+
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 
 <br>

--- a/README.md
+++ b/README.md
@@ -224,6 +224,35 @@ frame = ar.read_csv("data.csv", null_values=["", "MISSING", "UNKNOWN"])
 frame = ar.read_csv("data.csv", null_values=[])
 ```
 
+### Create an ArFrame from a dictionary
+
+Use `from_dict()` to quickly convert a Python dictionary into an ArFrame. Each key becomes a column, and each value must be a list (column data). All columns must have equal length.
+
+```python
+import arnio as ar
+
+frame = ar.from_dict({
+    "name": ["Alice", "Bob"],
+    "age": [25, 30]
+})
+
+print(frame.shape)
+# (2, 2)
+
+print(frame.columns)
+# ['name', 'age']
+```
+
+This is useful for quick testing, prototyping, or building small datasets without reading from a CSV.
+
+Empty dictionaries are supported and return an empty ArFrame.
+
+```python
+frame = ar.from_dict({})
+
+print(frame.shape)
+# (0, 0)
+```
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 
 <br>

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -173,3 +173,4 @@ __all__ = [
     "register_validator",
     "Date",
 ]
+

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -65,7 +65,6 @@ def from_dict(data):
     try:
         df = pd.DataFrame(data)
         return from_pandas(df)
-    
     except ValueError as e:
         raise ValueError(
             "All columns in from_dict() must have equal lengths."

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -54,6 +54,20 @@ def _to_binding_safe(value: Any) -> Any:
 
     return value
 
+def from_dicti(data):
+    """Convert a Python dictionary into an ArFrame."""
+    
+    if not isinstance(data, dict):
+        raise TypeError(
+            f"from_dict() expected a dict, but got {type(data).__name__}"
+        )
+
+    try:
+        df = pd.DataFrame(data)
+    except ValueError as e:
+        raise ValueError(
+            "All columns in from_dict() must have equal lengths."
+        ) from e
 
 def _check_unsupported_dtype(col_name: object, series: pd.Series) -> None:
     """Raise a clear TypeError for dtypes that arnio cannot convert."""

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -54,9 +54,9 @@ def _to_binding_safe(value: Any) -> Any:
 
     return value
 
-def from_dicti(data):
+def from_dict(data):
     """Convert a Python dictionary into an ArFrame."""
-    
+
     if not isinstance(data, dict):
         raise TypeError(
             f"from_dict() expected a dict, but got {type(data).__name__}"
@@ -64,10 +64,14 @@ def from_dicti(data):
 
     try:
         df = pd.DataFrame(data)
+        return from_pandas(df)
+    
     except ValueError as e:
         raise ValueError(
             "All columns in from_dict() must have equal lengths."
         ) from e
+    
+    
 
 def _check_unsupported_dtype(col_name: object, series: pd.Series) -> None:
     """Raise a clear TypeError for dtypes that arnio cannot convert."""

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -23,7 +23,10 @@ class ArFrame:
         self._attrs: dict = attrs if attrs is not None else {}
 
     # --- Properties ---
-
+    @classmethod
+    def from_dict(cls, data:dict) -> "ArFrame":
+        from .convert import from_dicti 
+        return from_dicti(data)
     @property
     def shape(self) -> tuple[int, int]:
         """Row and column count.

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -25,8 +25,9 @@ class ArFrame:
     # --- Properties ---
     @classmethod
     def from_dict(cls, data:dict) -> "ArFrame":
-        from .convert import from_dicti 
-        return from_dicti(data)
+        from .convert import from_dict as _from_dict 
+        return _from_dict(data)
+    
     @property
     def shape(self) -> tuple[int, int]:
         """Row and column count.

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -24,8 +24,8 @@ class ArFrame:
 
     # --- Properties ---
     @classmethod
-    def from_dict(cls, data:dict) -> "ArFrame":
-        from .convert import from_dict as _from_dict 
+    def from_dict(cls, data: dict) -> "ArFrame":
+        from .convert import from_dict as _from_dict
         return _from_dict(data)
     
     @property

--- a/arnio/integrations/__init__.py
+++ b/arnio/integrations/__init__.py
@@ -3,3 +3,7 @@
 from .pandas import ArnioPandasAccessor
 
 __all__ = ["ArnioPandasAccessor"]
+
+from .frame import ArFrame
+from_dict = ArFrame.from_dict
+

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -47,6 +47,8 @@ def test_from_dict_dtype():
     })
 
     assert frame.shape == (2, 1)
+
+    assert frame.shape == (2, 1)
 def test_preview_returns_string(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview()

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -33,6 +33,20 @@ def test_from_dict_bad_length():
             "age": [20]
         })
         
+def test_from_dict_with_none():
+    frame = ar.from_dict({
+        "name": ["A", None]
+    })
+
+    assert frame.shape == (2, 1)
+
+
+def test_from_dict_dtype():
+    frame = ar.from_dict({
+        "age": [1, 2]
+    })
+
+    assert frame.shape == (2, 1)
 def test_preview_returns_string(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview()
@@ -71,6 +85,7 @@ def test_preview_n_equals_one(sample_csv):
     assert "showing 1 of 3" in result
 
 
+
 # ── Edge cases ────────────────────────────────────────────────────────────────
 
 
@@ -98,6 +113,7 @@ def test_preview_large_csv(large_csv):
     frame = ar.read_csv(large_csv)
     result = frame.preview()
     assert "showing 5 of 1000" in result
+
 
 
 # ── Invalid inputs ────────────────────────────────────────────────────────────

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -48,7 +48,6 @@ def test_from_dict_dtype():
 
     assert frame.shape == (2, 1)
 
-    assert frame.shape == (2, 1)
 def test_preview_returns_string(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview()

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -23,12 +23,12 @@ def test_from_dict_empty():
 
 def test_from_dict_invalid():
     with pytest.raises(TypeError):
-        ar.ArFrame.from_dict([1, 2, 3])
+        ar.from_dict([1, 2, 3])
 
 
 def test_from_dict_bad_length():
     with pytest.raises(ValueError):
-        ar.ArFrame.from_dict({
+        ar.from_dict({
             "name": ["A", "B"],
             "age": [20]
         })

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -9,7 +9,30 @@ import arnio as ar
 
 # ── Normal behaviour ──────────────────────────────────────────────────────────
 
+def test_from_dict_basic():
+    frame = ar.from_dict({"name": ["A", "B"], "age": [20, 21]})
 
+    assert frame.shape == (2, 2)
+    assert frame.columns == ["name", "age"]
+
+def test_from_dict_empty():
+    frame = ar.from_dict({})
+
+    assert frame.shape == (0, 0)
+    assert frame.columns == []
+
+def test_from_dict_invalid():
+    with pytest.raises(TypeError):
+        ar.ArFrame.from_dict([1, 2, 3])
+
+
+def test_from_dict_bad_length():
+    with pytest.raises(ValueError):
+        ar.ArFrame.from_dict({
+            "name": ["A", "B"],
+            "age": [20]
+        })
+        
 def test_preview_returns_string(sample_csv):
     frame = ar.read_csv(sample_csv)
     result = frame.preview()


### PR DESCRIPTION
## Summary

Adds support for creating an `ArFrame` directly from a Python dictionary using `from_dict()`.

### Changes

* Added `ArFrame.from_dict()` constructor
* Added top-level `arnio.from_dict()` API
* Added validation for invalid input types
* Added validation for mismatched column lengths
* Added tests for:

  * basic dictionary conversion
  * empty dictionaries
  * null values
  * dtype behavior

Fixes #226
