### PR TITLE
fix(cleaning): reject lossy and non-finite fill_nulls values

### DIFF
--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -79,7 +79,13 @@ static CellValue coerce_value(const CellValue& value, DType target) {
             return std::get<bool>(value) ? int64_t{1} : int64_t{0};
         }
         if (std::holds_alternative<double>(value)) {
-            return static_cast<int64_t>(std::get<double>(value));
+            double d = std::get<double>(value);
+            if (std::isnan(d) || std::isinf(d) || d != std::floor(d)) {
+                throw std::invalid_argument(
+                    "Lossy or non-finite numeric fill values are not permitted for integer "
+                    "columns.");
+            }
+            return static_cast<int64_t>(d);
         }
         if (std::holds_alternative<std::string>(value)) {
             const auto& s = std::get<std::string>(value);
@@ -93,7 +99,14 @@ static CellValue coerce_value(const CellValue& value, DType target) {
     }
 
     if (target == DType::FLOAT64) {
-        if (std::holds_alternative<double>(value)) return std::get<double>(value);
+        if (std::holds_alternative<double>(value)) {
+            double d = std::get<double>(value);
+            if (std::isnan(d) || std::isinf(d)) {
+                throw std::invalid_argument(
+                    "Non-finite numeric fill values are not permitted for float columns.");
+            }
+            return d;
+        }
         if (std::holds_alternative<int64_t>(value)) {
             return static_cast<double>(std::get<int64_t>(value));
         }
@@ -103,6 +116,10 @@ static CellValue coerce_value(const CellValue& value, DType target) {
             try {
                 size_t pos = 0;
                 double parsed = std::stod(s, &pos);
+                if (std::isnan(parsed) || std::isinf(parsed)) {
+                    throw std::invalid_argument(
+                        "Non-finite numeric fill values are not permitted for float columns.");
+                }
                 if (pos == s.size()) return parsed;
             } catch (...) {
             }
@@ -123,7 +140,6 @@ static CellValue coerce_value(const CellValue& value, DType target) {
 
     throw std::invalid_argument("Fill value is incompatible with target column type");
 }
-
 static std::invalid_argument cast_error(const std::string& column, const std::string& value,
                                         const std::string& target, size_t row) {
     return std::invalid_argument("Cannot cast column '" + column + "' value '" + value +

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1531,3 +1531,84 @@ def test_drop_columns_matching_all_columns():
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     with pytest.raises(ValueError, match="Pattern matches all columns"):
         ar.drop_columns_matching(df, ".*")
+
+
+def test_fill_nulls_validation_lossy_and_non_finite():
+    """
+    Ensure that fill_nulls rejects non-finite values and lossy float-to-int conversions
+    with strict user-facing error contracts, while allowing compatible type-safe or
+    int-to-float conversions to work.
+    """
+    import pandas as pd
+    import pytest
+
+    import arnio as ar
+
+    # --- 1. VALID FILL COVERAGE (Happy Paths & New Compatible Paths) ---
+    # Valid Int-to-Int fill
+    valid_int = ar.from_pandas(pd.DataFrame({"x": pd.Series([1, None], dtype="Int64")}))
+    res_int = ar.fill_nulls(valid_int, 5, subset=["x"])
+    assert ar.to_pandas(res_int)["x"].iloc[1] == 5
+
+    # Valid Float-to-Float finite fill
+    valid_float = ar.from_pandas(pd.DataFrame({"x": [1.0, None]}))
+    res_float = ar.fill_nulls(valid_float, 3.5, subset=["x"])
+    assert ar.to_pandas(res_float)["x"].iloc[1] == 3.5
+
+    # Compatible Int-to-Float fill (Filling a float column with an integer value)
+    res_compatible = ar.fill_nulls(valid_float, 5, subset=["x"])
+    assert ar.to_pandas(res_compatible)["x"].iloc[1] == 5.0
+
+    # --- 2. INVALID DIRECT USAGE TESTS (Strict Error Message Contracts) ---
+    int_frame = ar.from_pandas(pd.DataFrame({"x": pd.Series([1, None], dtype="Int64")}))
+
+    # Reject lossy float values for integer target columns
+    with pytest.raises(
+        ValueError,
+        match="Lossy or non-finite numeric fill values are not permitted for integer columns.",
+    ):
+        ar.fill_nulls(int_frame, 1.9, subset=["x"])
+
+    # Reject Infinity for integer target columns
+    with pytest.raises(
+        ValueError,
+        match="Lossy or non-finite numeric fill values are not permitted for integer columns.",
+    ):
+        ar.fill_nulls(int_frame, float("inf"), subset=["x"])
+
+    # New Coverage Reject NaN for integer target columns
+    with pytest.raises(
+        ValueError,
+        match="Lossy or non-finite numeric fill values are not permitted for integer columns.",
+    ):
+        ar.fill_nulls(int_frame, float("nan"), subset=["x"])
+
+    float_frame = ar.from_pandas(pd.DataFrame({"x": [1.0, None]}))
+
+    # Reject Infinity and NaN for float target columns
+    with pytest.raises(
+        ValueError,
+        match="Non-finite numeric fill values are not permitted for float columns.",
+    ):
+        ar.fill_nulls(float_frame, float("inf"), subset=["x"])
+
+    with pytest.raises(
+        ValueError,
+        match="Non-finite numeric fill values are not permitted for float columns.",
+    ):
+        ar.fill_nulls(float_frame, float("nan"), subset=["x"])
+
+    # --- 3. PIPELINE USAGE TESTS ---
+    with pytest.raises(
+        ValueError,
+        match="Lossy or non-finite numeric fill values are not permitted for integer columns.",
+    ):
+        ar.pipeline(int_frame, [("fill_nulls", {"value": 1.9, "subset": ["x"]})])
+
+    with pytest.raises(
+        ValueError,
+        match="Non-finite numeric fill values are not permitted for float columns.",
+    ):
+        ar.pipeline(
+            float_frame, [("fill_nulls", {"value": float("inf"), "subset": ["x"]})]
+        )


### PR DESCRIPTION
## Summary
Fixed the native C++ cleaning engine validation path to strictly reject non-finite float values (`NaN`, `Inf`) and lossy float-to-int conversions before data is written. It now triggers a clear Python-facing `ValueError`. Added comprehensive regression tests verifying both invalid edge cases (with string contract match assertions) and ensuring valid safe fills continue to work correctly across direct and pipeline execution workflows.

## Linked issue
Fixes #713

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [x] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps

## Testing
Verified locally via pytest. Explicitly checked valid casting paths and error string contract matches.
- [x] Other: `pytest tests/ -v`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] My PR title uses Conventional Commits (`fix(cleaning):`).