### PR TITLE
fix: schema unique string is silently ignored

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -774,6 +774,11 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
     ValidationResult
         Validation result containing all issues and bad row indexes.
 
+    Raises
+    ------
+    TypeError
+        If schema.unique is provided but is not a list or tuple of strings.
+
     Examples
     --------
     >>> schema = ar.Schema({"email": ar.Email(nullable=False)})
@@ -811,7 +816,13 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
                 )
 
     if schema.unique is not None:
-        if isinstance(schema.unique, (list, tuple)) and len(schema.unique) == 0:
+        if not isinstance(schema.unique, (list, tuple)):
+            raise TypeError(
+                "Schema 'unique' must be a list or tuple of strings (e.g., ['column_name']), "
+                f"got {type(schema.unique).__name__}."
+            )
+
+        if len(schema.unique) == 0:
             issues.append(
                 ValidationIssue(
                     column=None,
@@ -819,7 +830,7 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
                     message="Composite unique columns cannot be empty",
                 )
             )
-        elif isinstance(schema.unique, (list, tuple)):
+        else:
             missing_cols = [c for c in schema.unique if c not in df.columns]
             if missing_cols:
                 for col in missing_cols:

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -822,6 +822,12 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
                 f"got {type(schema.unique).__name__}."
             )
 
+        for item in schema.unique:
+            if not isinstance(item, str):
+                raise TypeError(
+                    f"Schema 'unique' members must be strings, got {type(item).__name__} for element {item!r}."
+                )
+
         if len(schema.unique) == 0:
             issues.append(
                 ValidationIssue(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1996,3 +1996,18 @@ def test_datetime_timezone_aware_above_max_fails(tmp_path):
     assert not result.passed
     assert any(i.rule == "max" for i in result.issues)
     assert result.issues[0].row_index == 1
+
+
+def test_validate_unique_string_raises_type_error(tmp_path):
+    schema = ar.Schema(fields={"id": ar.String()}, unique=["id"])
+
+    object.__setattr__(schema, "unique", "id")
+
+    path = tmp_path / "unique_test.csv"
+    path.write_text("id\nA\nB\nA\n")
+    frame = ar.read_csv(path)
+
+    with pytest.raises(
+        TypeError, match="Schema 'unique' must be a list or tuple of strings"
+    ):
+        ar.validate(frame, schema)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2011,3 +2011,16 @@ def test_validate_unique_string_raises_type_error(tmp_path):
         TypeError, match="Schema 'unique' must be a list or tuple of strings"
     ):
         ar.validate(frame, schema)
+
+
+def test_validate_unique_invalid_member_type_raises_type_error(tmp_path):
+    schema = ar.Schema(fields={"id": ar.String()}, unique=["id"])
+
+    object.__setattr__(schema, "unique", ["id", 123])
+
+    path = tmp_path / "unique_member_test.csv"
+    path.write_text("id\nA\nB\n")
+    frame = ar.read_csv(path)
+
+    with pytest.raises(TypeError, match="Schema 'unique' members must be strings"):
+        ar.validate(frame, schema)


### PR DESCRIPTION
## Summary
Tightened validation inside the `validate()` function to ensure that `schema.unique` strictly enforces its sequence contract. Previously, if an invalid type like a bare string (`unique="id"`) bypassed or mutated outside `Schema.__post_init__`, the validation engine fell through its conditional blocks and silently ignored the uniqueness constraint entirely. Added a fail-fast upfront `isinstance` guard to raise a descriptive `TypeError` on invalid configurations, and added a focused regression test case.

## Linked issue
Fixes #602

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (Verified locally that all 837 tests pass, including the new regression test)
- [x] `make lint` (Verified locally that code passes all checks)

## Screenshots / Media
N/A

## Performance Impact
None.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
N/A