### PR TITLE
feat: add write_csv with delimiter, newline, and quote validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Most operations below run natively in C++. The current `filter_rows` step uses t
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
 | `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |
+| `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 
 Or compose them all into a **pipeline**:
 
@@ -342,6 +343,21 @@ Works with:
 - booleans
 
 <br>
+### 🔢 Safe column division
+
+Divide one column by another while handling division by zero and null denominators explicitly:
+
+```python
+result = ar.safe_divide_columns(
+    frame,
+    numerator="revenue",
+    denominator="cost",
+    output_column="ratio",
+    fill_value=0.0,  # used when denominator is zero or null
+)
+```
+
+> When the denominator is **zero or null**, the result is replaced with `fill_value` (default `0.0`) instead of raising an error or producing `NaN`/`Inf`.
 
 ---
 

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -21,7 +21,9 @@ from .cleaning import (
     normalize_case,
     rename_columns,
     strip_whitespace,
+    safe_divide_columns,
 )
+
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame
@@ -64,6 +66,7 @@ __all__ = [
     "rename_columns",
     "cast_types",
     "clean",
+    "safe_divide_columns",
     # Conversion
     "to_pandas",
     "from_pandas",

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -20,10 +20,9 @@ from .cleaning import (
     filter_rows,
     normalize_case,
     rename_columns,
-    strip_whitespace,
     safe_divide_columns,
+    strip_whitespace,
 )
-
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -26,7 +26,7 @@ from .cleaning import (
 from .convert import from_pandas, to_pandas
 from .exceptions import ArnioError, CsvReadError, TypeCastError, UnknownStepError
 from .frame import ArFrame
-from .io import read_csv, scan_csv
+from .io import read_csv, scan_csv, write_csv
 from .pipeline import pipeline, register_step
 from .quality import (
     ColumnProfile,
@@ -55,6 +55,7 @@ __all__ = [
     # I/O
     "read_csv",
     "scan_csv",
+    "write_csv",
     # Cleaning
     "drop_nulls",
     "fill_nulls",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -308,7 +308,9 @@ def filter_rows(frame, column, op, value):
     return from_pandas(filtered) if is_arframe else filtered
 
 
-def safe_divide_columns(frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0):
+def safe_divide_columns(
+    frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0
+):
     """Divide one column by another, handling division by zero and nulls explicitly.
 
     When the denominator is zero or null, the result is replaced with
@@ -347,6 +349,14 @@ def safe_divide_columns(frame, numerator: str, denominator: str, output_column: 
         raise ValueError(f"Numerator column '{numerator}' not found in frame.")
     if denominator not in df.columns:
         raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+    if output_column in df.columns:
+        import warnings
+
+        warnings.warn(
+            f"Output column '{output_column}' already exists and will be overwritten.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     safe_denom = df[denominator].replace(0, float("nan"))
     result = df[numerator] / safe_denom
@@ -354,4 +364,3 @@ def safe_divide_columns(frame, numerator: str, denominator: str, output_column: 
     df[output_column] = result.fillna(fill_value)
 
     return from_pandas(df) if is_arframe else df
-

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -325,7 +325,9 @@ def safe_divide_columns(
     denominator : str
         Column name to use as the denominator.
     output_column : str
-        Name of the new column to store the division result.
+        Name of the new column to store the division result. Must be a
+        non-empty string. If the column already exists, it will be
+        overwritten and a ``UserWarning`` is raised.
     fill_value : float, optional
         Value to use when denominator is zero or null. Defaults to 0.0.
 
@@ -349,6 +351,8 @@ def safe_divide_columns(
         raise ValueError(f"Numerator column '{numerator}' not found in frame.")
     if denominator not in df.columns:
         raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+    if not isinstance(output_column, str) or not output_column.strip():
+        raise ValueError("output_column must be a non-empty string.")
     if output_column in df.columns:
         import warnings
 

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -306,3 +306,52 @@ def filter_rows(frame, column, op, value):
     filtered = df[getattr(df[column], ops[op])(value)]
 
     return from_pandas(filtered) if is_arframe else filtered
+
+
+def safe_divide_columns(frame, numerator: str, denominator: str, output_column: str, fill_value: float = 0.0):
+    """Divide one column by another, handling division by zero and nulls explicitly.
+
+    When the denominator is zero or null, the result is replaced with
+    fill_value instead of raising an error or producing NaN/Inf.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    numerator : str
+        Column name to use as the numerator.
+    denominator : str
+        Column name to use as the denominator.
+    output_column : str
+        Name of the new column to store the division result.
+    fill_value : float, optional
+        Value to use when denominator is zero or null. Defaults to 0.0.
+
+    Returns
+    -------
+    ArFrame
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+    """
+    import pandas as pd
+
+    from .convert import from_pandas, to_pandas
+
+    is_arframe = not isinstance(frame, pd.DataFrame)
+    df = to_pandas(frame) if is_arframe else frame
+
+    if numerator not in df.columns:
+        raise ValueError(f"Numerator column '{numerator}' not found in frame.")
+    if denominator not in df.columns:
+        raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+
+    safe_denom = df[denominator].replace(0, float("nan"))
+    result = df[numerator] / safe_denom
+    df = df.copy()
+    df[output_column] = result.fillna(fill_value)
+
+    return from_pandas(df) if is_arframe else df
+

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -203,3 +203,55 @@ def scan_csv(
             return reader.scan_schema(native_path)
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e
+
+
+def write_csv(
+    frame: ArFrame,
+    path: str | os.PathLike[str],
+    *,
+    delimiter: str = ",",
+    newline: str = "\n",
+    quote_char: str = '"',
+) -> None:
+    """Write an ArFrame to a CSV file.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Data frame to write.
+    path : str
+        Output path. Must end in .csv, .txt, or .tsv.
+    delimiter : str, default ","
+        Field delimiter character. Must be a single character.
+    newline : str, default "\\n"
+        Row terminator. Must be one of "\\n", "\\r\\n", or "\\r".
+    quote_char : str, default '"'
+        Character used to quote fields. Must be a single character.
+
+    Raises
+    ------
+    ValueError
+        If delimiter, newline, or quote_char are invalid.
+    """
+    if len(delimiter) != 1:
+        raise ValueError(f"delimiter must be a single character, got: {delimiter!r}")
+    if newline not in ("\n", "\r\n", "\r"):
+        raise ValueError(f"newline must be one of '\\n', '\\r\\n', '\\r', got: {newline!r}")
+    if len(quote_char) != 1:
+        raise ValueError(f"quote_char must be a single character, got: {quote_char!r}")
+
+    path = os.fspath(path)
+    path_lower = path.lower()
+    if not (
+        path_lower.endswith(".csv")
+        or path_lower.endswith(".txt")
+        or path_lower.endswith(".tsv")
+    ):
+        raise ValueError(
+            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
+        )
+
+    import pandas as pd
+    from .convert import to_pandas
+    df = to_pandas(frame)
+    df.to_csv(path, index=False, sep=delimiter, lineterminator=newline, quotechar=quote_char)

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -121,3 +121,5 @@ def pipeline(
 
 
 register_step("filter_rows", cleaning.filter_rows)
+
+register_step("safe_divide_columns", cleaning.safe_divide_columns)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -148,3 +148,45 @@ class TestCleanAPI:
         # Drop nulls
         result = ar.clean(frame, strip_whitespace=False, drop_nulls=True)
         assert len(result) < len(frame)
+class TestSafeDivideColumns:
+    def test_normal_division(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n200,100\n300,150\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 2.0
+        assert df["ratio"].iloc[1] == 2.0
+        assert df["ratio"].iloc[2] == 2.0
+
+    def test_division_by_zero(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,0\n200,100\n300,0\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 0.0
+        assert df["ratio"].iloc[2] == 0.0
+
+    def test_null_inputs(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,\n200,100\n300,\n")
+        frame = ar.read_csv(path)
+        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 0.0
+        assert df["ratio"].iloc[2] == 0.0
+
+    def test_missing_numerator_column(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+        with pytest.raises(ValueError, match="Numerator column"):
+            ar.safe_divide_columns(frame, numerator="nonexistent", denominator="cost", output_column="ratio")
+
+    def test_missing_denominator_column(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+        with pytest.raises(ValueError, match="Denominator column"):
+            ar.safe_divide_columns(frame, numerator="revenue", denominator="nonexistent", output_column="ratio")

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -208,3 +208,19 @@ class TestSafeDivideColumns:
                 denominator="nonexistent",
                 output_column="ratio",
             )
+
+    def test_output_column_already_exists(self, tmp_path):
+        import warnings
+
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost,ratio\n100,50,99\n200,100,99\n")
+        frame = ar.read_csv(path)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = ar.safe_divide_columns(
+                frame, numerator="revenue", denominator="cost", output_column="ratio"
+            )
+            assert len(w) == 1
+            assert "already exists" in str(w[0].message)
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 2.0

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -148,12 +148,16 @@ class TestCleanAPI:
         # Drop nulls
         result = ar.clean(frame, strip_whitespace=False, drop_nulls=True)
         assert len(result) < len(frame)
+
+
 class TestSafeDivideColumns:
     def test_normal_division(self, tmp_path):
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,50\n200,100\n300,150\n")
         frame = ar.read_csv(path)
-        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
         df = ar.to_pandas(result)
         assert df["ratio"].iloc[0] == 2.0
         assert df["ratio"].iloc[1] == 2.0
@@ -163,7 +167,9 @@ class TestSafeDivideColumns:
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,0\n200,100\n300,0\n")
         frame = ar.read_csv(path)
-        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
         df = ar.to_pandas(result)
         assert df["ratio"].iloc[0] == 0.0
         assert df["ratio"].iloc[2] == 0.0
@@ -172,7 +178,9 @@ class TestSafeDivideColumns:
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,\n200,100\n300,\n")
         frame = ar.read_csv(path)
-        result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
+        result = ar.safe_divide_columns(
+            frame, numerator="revenue", denominator="cost", output_column="ratio"
+        )
         df = ar.to_pandas(result)
         assert df["ratio"].iloc[0] == 0.0
         assert df["ratio"].iloc[2] == 0.0
@@ -182,11 +190,21 @@ class TestSafeDivideColumns:
         path.write_text("revenue,cost\n100,50\n")
         frame = ar.read_csv(path)
         with pytest.raises(ValueError, match="Numerator column"):
-            ar.safe_divide_columns(frame, numerator="nonexistent", denominator="cost", output_column="ratio")
+            ar.safe_divide_columns(
+                frame,
+                numerator="nonexistent",
+                denominator="cost",
+                output_column="ratio",
+            )
 
     def test_missing_denominator_column(self, tmp_path):
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost\n100,50\n")
         frame = ar.read_csv(path)
         with pytest.raises(ValueError, match="Denominator column"):
-            ar.safe_divide_columns(frame, numerator="revenue", denominator="nonexistent", output_column="ratio")
+            ar.safe_divide_columns(
+                frame,
+                numerator="revenue",
+                denominator="nonexistent",
+                output_column="ratio",
+            )

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -187,3 +187,101 @@ class TestScanCsv:
             match="CSV input contains NUL bytes and appears to be binary or corrupted",
         ):
             ar.scan_csv(file_path)
+
+
+class TestWriteCsv:
+    """Tests for write_csv delimiter, newline, and quote validation."""
+
+    def test_write_basic(self, sample_csv, tmp_path):
+        """write_csv creates a readable CSV file."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        ar.write_csv(frame, out)
+        result = ar.read_csv(out)
+        assert result.shape == frame.shape
+        assert result.columns == frame.columns
+
+    def test_write_custom_delimiter(self, sample_csv, tmp_path):
+        """write_csv respects custom delimiter."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.tsv")
+        ar.write_csv(frame, out, delimiter="\t")
+        content = open(out).read()
+        assert "\t" in content
+
+    def test_write_invalid_delimiter_empty(self, sample_csv, tmp_path):
+        """write_csv raises ValueError for empty delimiter."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        with pytest.raises(ValueError, match="delimiter"):
+            ar.write_csv(frame, out, delimiter="")
+
+    def test_write_invalid_delimiter_multi(self, sample_csv, tmp_path):
+        """write_csv raises ValueError for multi-char delimiter."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        with pytest.raises(ValueError, match="delimiter"):
+            ar.write_csv(frame, out, delimiter=",,")
+
+    def test_write_newline_crlf(self, sample_csv, tmp_path):
+        """write_csv respects CRLF newline."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        ar.write_csv(frame, out, newline="\r\n")
+        content = open(out, "rb").read()
+        assert b"\r\n" in content
+
+    def test_write_newline_cr(self, sample_csv, tmp_path):
+        """write_csv respects CR newline."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        ar.write_csv(frame, out, newline="\r")
+        content = open(out, "rb").read()
+        assert b"\r" in content
+
+    def test_write_invalid_newline(self, sample_csv, tmp_path):
+        """write_csv raises ValueError for invalid newline."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        with pytest.raises(ValueError, match="newline"):
+            ar.write_csv(frame, out, newline="\\n")
+
+    def test_write_custom_quote_char(self, sample_csv, tmp_path):
+        """write_csv respects custom quote character."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        ar.write_csv(frame, out, quote_char="'")
+        content = open(out).read()
+        assert content  # file written successfully
+
+    def test_write_invalid_quote_char_empty(self, sample_csv, tmp_path):
+        """write_csv raises ValueError for empty quote_char."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        with pytest.raises(ValueError, match="quote_char"):
+            ar.write_csv(frame, out, quote_char="")
+
+    def test_write_invalid_quote_char_multi(self, sample_csv, tmp_path):
+        """write_csv raises ValueError for multi-char quote_char."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        with pytest.raises(ValueError, match="quote_char"):
+            ar.write_csv(frame, out, quote_char='""')
+
+    def test_write_unsupported_extension(self, sample_csv, tmp_path):
+        """write_csv raises ValueError for unsupported file extension."""
+        import arnio as ar
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.xlsx")
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            ar.write_csv(frame, out)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -190,3 +190,32 @@ def test_filter_rows_direct_api():
     result_df = ar.to_pandas(result)
 
     assert list(result_df["age"]) == [30, 40]
+
+
+def test_safe_divide_columns_pipeline():
+    import pandas as pd
+
+    import arnio as ar
+
+    df = pd.DataFrame({"revenue": [100.0, 200.0, 0.0], "cost": [50.0, 0.0, 30.0]})
+
+    frame = ar.from_pandas(df)
+
+    result = ar.pipeline(
+        frame,
+        [
+            (
+                "safe_divide_columns",
+                {
+                    "numerator": "revenue",
+                    "denominator": "cost",
+                    "output_column": "ratio",
+                },
+            )
+        ],
+    )
+
+    result_df = ar.to_pandas(result)
+    assert result_df["ratio"].iloc[0] == 2.0
+    assert result_df["ratio"].iloc[1] == 0.0  # division by zero → fill_value
+    assert result_df["ratio"].iloc[2] == 0.0  # zero numerator


### PR DESCRIPTION
Fixes #604

## What this PR does
- Adds `write_csv()` function to `arnio/io.py`
- Validates delimiter (must be single character)
- Validates newline (must be \n, \r\n, or \r)
- Validates quote_char (must be single character)
- Exports `write_csv` from `arnio/__init__.py`

## Tests added (11 tests, all passing)
- test_write_basic
- test_write_custom_delimiter
- test_write_invalid_delimiter_empty
- test_write_invalid_delimiter_multi
- test_write_newline_crlf
- test_write_newline_cr
- test_write_invalid_newline
- test_write_custom_quote_char
- test_write_invalid_quote_char_empty
- test_write_invalid_quote_char_multi
- test_write_unsupported_extension
