### PR TITLE
feat(benchmarks): add per-operation tracking and correctness parity verification

### DIFF
--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 import arnio as ar
 
@@ -93,50 +94,20 @@ def ensure_dataset_exists(path):
         )
 
 
-def benchmark_pandas(path):
-    ensure_dataset_exists(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    rss_samples = []
-    start_rss = get_process_rss_mb()
-    if start_rss is not None:
-        rss_samples.append(start_rss)
+def verify_correctness(path):
+    # Pandas pipeline
+    df_pd = pd.read_csv(path)
+    df_pd.columns = df_pd.columns.str.strip()
+    for col in df_pd.select_dtypes(include=["object", "string"]).columns:
+        df_pd[col] = df_pd[col].astype(str).str.strip().str.lower()
+    df_pd = df_pd.dropna()
+    df_pd = df_pd.drop_duplicates()
+    df_pd = df_pd.reset_index(drop=True)
 
-    df = pd.read_csv(path)
-    rss = get_process_rss_mb()
-    if rss is not None:
-        rss_samples.append(rss)
-    df.columns = df.columns.str.strip()
-    df = df.dropna()
-    df = df.drop_duplicates()
-    for col in df.select_dtypes(include=["object", "string"]).columns:
-        df[col] = df[col].astype(str).str.strip().str.lower()
-    rss = get_process_rss_mb()
-    if rss is not None:
-        rss_samples.append(rss)
-
-    elapsed = time.perf_counter() - t0
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    peak_rss = max(rss_samples) if rss_samples else None
-    return elapsed, peak / 1024 / 1024, peak_rss
-
-
-def benchmark_arnio(path):
-    ensure_dataset_exists(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    rss_samples = []
-    start_rss = get_process_rss_mb()
-    if start_rss is not None:
-        rss_samples.append(start_rss)
-
-    frame = ar.read_csv(path)
-    rss = get_process_rss_mb()
-    if rss is not None:
-        rss_samples.append(rss)
-    clean = ar.pipeline(
-        frame,
+    # Arnio pipeline
+    frame_ar = ar.read_csv(path)
+    clean_ar = ar.pipeline(
+        frame_ar,
         [
             ("strip_whitespace",),
             ("normalize_case", {"case_type": "lower"}),
@@ -144,19 +115,120 @@ def benchmark_arnio(path):
             ("drop_duplicates",),
         ],
     )
-    rss = get_process_rss_mb()
-    if rss is not None:
-        rss_samples.append(rss)
-    ar.to_pandas(clean)
+    df_ar = ar.to_pandas(clean_ar).reset_index(drop=True)
+
+    # Note: Column order and dtypes might have slight expected variations,
+    # but values should match strictly. We use check_dtype=False for robust comparison.
+    assert_frame_equal(df_pd, df_ar, check_dtype=False)
+    print(f"Correctness verification passed for {path}")
+
+
+def benchmark_pandas(path):
+    ensure_dataset_exists(path)
+    tracemalloc.start()
+    t_start = time.perf_counter()
+    rss_samples = []
+    start_rss = get_process_rss_mb()
+    if start_rss is not None:
+        rss_samples.append(start_rss)
+
+    t0 = time.perf_counter()
+    df = pd.read_csv(path)
+    t_read_csv = time.perf_counter() - t0
+
     rss = get_process_rss_mb()
     if rss is not None:
         rss_samples.append(rss)
 
-    elapsed = time.perf_counter() - t0
+    t0 = time.perf_counter()
+    df.columns = df.columns.str.strip()
+    for col in df.select_dtypes(include=["object", "string"]).columns:
+        df[col] = df[col].astype(str).str.strip().str.lower()
+    t_clean_strings = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    df = df.dropna()
+    t_drop_nulls = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    df = df.drop_duplicates()
+    t_drop_duplicates = time.perf_counter() - t0
+
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
+
+    elapsed = time.perf_counter() - t_start
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     peak_rss = max(rss_samples) if rss_samples else None
-    return elapsed, peak / 1024 / 1024, peak_rss
+
+    ops = {
+        "read_csv": t_read_csv,
+        "clean_strings": t_clean_strings,
+        "drop_nulls": t_drop_nulls,
+        "drop_duplicates": t_drop_duplicates,
+        "to_pandas": 0.0,  # N/A for pandas
+    }
+    return elapsed, peak / 1024 / 1024, peak_rss, ops
+
+
+def benchmark_arnio(path):
+    ensure_dataset_exists(path)
+    tracemalloc.start()
+    t_start = time.perf_counter()
+    rss_samples = []
+    start_rss = get_process_rss_mb()
+    if start_rss is not None:
+        rss_samples.append(start_rss)
+
+    t0 = time.perf_counter()
+    frame = ar.read_csv(path)
+    t_read_csv = time.perf_counter() - t0
+
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
+
+    t0 = time.perf_counter()
+    # To benchmark operations individually, we do them one by one
+    frame1 = ar.strip_whitespace(frame)
+    frame2 = ar.normalize_case(frame1, case_type="lower")
+    t_clean_strings = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    frame3 = ar.drop_nulls(frame2)
+    t_drop_nulls = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    frame4 = ar.drop_duplicates(frame3)
+    t_drop_duplicates = time.perf_counter() - t0
+
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
+
+    t0 = time.perf_counter()
+    _ = ar.to_pandas(frame4)
+    t_to_pandas = time.perf_counter() - t0
+
+    rss = get_process_rss_mb()
+    if rss is not None:
+        rss_samples.append(rss)
+
+    elapsed = time.perf_counter() - t_start
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    peak_rss = max(rss_samples) if rss_samples else None
+
+    ops = {
+        "read_csv": t_read_csv,
+        "clean_strings": t_clean_strings,
+        "drop_nulls": t_drop_nulls,
+        "drop_duplicates": t_drop_duplicates,
+        "to_pandas": t_to_pandas,
+    }
+    return elapsed, peak / 1024 / 1024, peak_rss, ops
 
 
 def avg(values):
@@ -199,20 +271,48 @@ def calculate_regression(current, baseline):
     ) * 100  # How much slower current benchmark is compared to baseline
 
 
-def run_case(case):
+def run_case(case, skip_correctness=False):
     baseline_data = load_baseline()
 
     print(case.name)
-    print(f"{'Metric':<20} {'pandas':>12} {'arnio':>12}")
-    print("-" * 46)
+
+    if not skip_correctness:
+        # Verify correctness in parent process before benchmark runs.
+        # Parity failure should fail the benchmark/run instead of continuing silently.
+        verify_correctness(case.path)
+
+    print(f"{'Metric':<20} {'pandas':>12} {'arnio':>12} {'speedup':>10}")
+    print("-" * 57)
 
     pd_times, ar_times = [], []
     pd_trace_rams, ar_trace_rams = [], []
     pd_rss_rams, ar_rss_rams = [], []
 
+    pd_ops_list = {
+        k: []
+        for k in [
+            "read_csv",
+            "clean_strings",
+            "drop_nulls",
+            "drop_duplicates",
+            "to_pandas",
+        ]
+    }
+    ar_ops_list = {
+        k: []
+        for k in [
+            "read_csv",
+            "clean_strings",
+            "drop_nulls",
+            "drop_duplicates",
+            "to_pandas",
+        ]
+    }
+
     for i in range(RUNS):
         pd_result = run_subprocess("pandas", case.path)
         ar_result = run_subprocess("arnio", case.path)
+
         pt, pr_trace, pr_rss = (
             pd_result["elapsed"],
             pd_result["peak_trace_mb"],
@@ -232,7 +332,33 @@ def run_case(case):
         if ar_rss is not None:
             ar_rss_rams.append(ar_rss)
 
-    print(f"{'Exec Time (avg)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s")
+        for k in pd_ops_list:
+            if k in pd_result.get("ops", {}):
+                pd_ops_list[k].append(pd_result["ops"][k])
+            if k in ar_result.get("ops", {}):
+                ar_ops_list[k].append(ar_result["ops"][k])
+
+    for op in [
+        "read_csv",
+        "clean_strings",
+        "drop_nulls",
+        "drop_duplicates",
+        "to_pandas",
+    ]:
+        if pd_ops_list[op] and ar_ops_list[op]:
+            p_avg = avg(pd_ops_list[op])
+            a_avg = avg(ar_ops_list[op])
+            speedup = (
+                f"{p_avg/a_avg:.1f}x" if a_avg > 0 and op != "to_pandas" else "N/A"
+            )
+            p_str = f"{p_avg:>11.2f}s" if op != "to_pandas" else f"{'N/A':>12}"
+            print(f"{op:<20} {p_str} {a_avg:>11.2f}s {speedup:>10}")
+
+    print("-" * 57)
+
+    print(
+        f"{'Exec Time (Total)':<20} {avg(pd_times):>11.2f}s {avg(ar_times):>11.2f}s {(avg(pd_times)/avg(ar_times)):>9.1f}x"
+    )
     if pd_rss_rams and ar_rss_rams:
         pd_rss_avg = avg(pd_rss_rams)
         ar_rss_avg = avg(ar_rss_rams)
@@ -274,9 +400,9 @@ def run_case(case):
 
 def run_child(engine, case_path):
     if engine == "pandas":
-        elapsed, peak_trace_mb, peak_rss_mb = benchmark_pandas(case_path)
+        elapsed, peak_trace_mb, peak_rss_mb, ops = benchmark_pandas(case_path)
     elif engine == "arnio":
-        elapsed, peak_trace_mb, peak_rss_mb = benchmark_arnio(case_path)
+        elapsed, peak_trace_mb, peak_rss_mb, ops = benchmark_arnio(case_path)
     else:
         raise ValueError(f"Unknown engine: {engine}")
 
@@ -284,6 +410,7 @@ def run_child(engine, case_path):
         "elapsed": elapsed,
         "peak_trace_mb": peak_trace_mb,
         "peak_rss_mb": peak_rss_mb,
+        "ops": ops,
     }
     print(json.dumps(payload))
 

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -95,16 +95,13 @@ def ensure_dataset_exists(path):
 
 
 def verify_correctness(path):
-    from pathlib import Path
-
-    if not Path(path).exists():
-        return  # Skip when path is a test fixture that doesn't exist on disk
+    ensure_dataset_exists(path)
 
     # Pandas pipeline
     df_pd = pd.read_csv(path)
     df_pd.columns = df_pd.columns.str.strip()
     for col in df_pd.select_dtypes(include=["object", "string"]).columns:
-        df_pd[col] = df_pd[col].str.strip().str.lower()
+        df_pd[col] = df_pd[col].apply(lambda x: x.strip().lower() if isinstance(x, str) else x)
     df_pd = df_pd.dropna()
     df_pd = df_pd.drop_duplicates()
     df_pd = df_pd.reset_index(drop=True)
@@ -148,7 +145,7 @@ def benchmark_pandas(path):
     t0 = time.perf_counter()
     df.columns = df.columns.str.strip()
     for col in df.select_dtypes(include=["object", "string"]).columns:
-        df[col] = df[col].str.strip().str.lower()
+        df[col] = df[col].apply(lambda x: x.strip().lower() if isinstance(x, str) else x)
     t_clean_strings = time.perf_counter() - t0
 
     t0 = time.perf_counter()

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -101,7 +101,9 @@ def verify_correctness(path):
     df_pd = pd.read_csv(path)
     df_pd.columns = df_pd.columns.str.strip()
     for col in df_pd.select_dtypes(include=["object", "string"]).columns:
-        df_pd[col] = df_pd[col].apply(lambda x: x.strip().lower() if isinstance(x, str) else x)
+        df_pd[col] = df_pd[col].apply(
+            lambda x: x.strip().lower() if isinstance(x, str) else x
+        )
     df_pd = df_pd.dropna()
     df_pd = df_pd.drop_duplicates()
     df_pd = df_pd.reset_index(drop=True)
@@ -145,7 +147,9 @@ def benchmark_pandas(path):
     t0 = time.perf_counter()
     df.columns = df.columns.str.strip()
     for col in df.select_dtypes(include=["object", "string"]).columns:
-        df[col] = df[col].apply(lambda x: x.strip().lower() if isinstance(x, str) else x)
+        df[col] = df[col].apply(
+            lambda x: x.strip().lower() if isinstance(x, str) else x
+        )
     t_clean_strings = time.perf_counter() - t0
 
     t0 = time.perf_counter()

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -104,7 +104,7 @@ def verify_correctness(path):
     df_pd = pd.read_csv(path)
     df_pd.columns = df_pd.columns.str.strip()
     for col in df_pd.select_dtypes(include=["object", "string"]).columns:
-        df_pd[col] = df_pd[col].astype(str).str.strip().str.lower()
+        df_pd[col] = df_pd[col].str.strip().str.lower()
     df_pd = df_pd.dropna()
     df_pd = df_pd.drop_duplicates()
     df_pd = df_pd.reset_index(drop=True)
@@ -148,7 +148,7 @@ def benchmark_pandas(path):
     t0 = time.perf_counter()
     df.columns = df.columns.str.strip()
     for col in df.select_dtypes(include=["object", "string"]).columns:
-        df[col] = df[col].astype(str).str.strip().str.lower()
+        df[col] = df[col].str.strip().str.lower()
     t_clean_strings = time.perf_counter() - t0
 
     t0 = time.perf_counter()

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -95,6 +95,11 @@ def ensure_dataset_exists(path):
 
 
 def verify_correctness(path):
+    from pathlib import Path
+
+    if not Path(path).exists():
+        return  # Skip when path is a test fixture that doesn't exist on disk
+
     # Pandas pipeline
     df_pd = pd.read_csv(path)
     df_pd.columns = df_pd.columns.str.strip()

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -65,7 +65,8 @@ def test_run_case_benchmarks_the_selected_case_path(monkeypatch):
     monkeypatch.setattr(benchmark_vs_pandas, "run_subprocess", fake_run_subprocess)
 
     benchmark_vs_pandas.run_case(
-        benchmark_vs_pandas.BenchmarkCase("Wide fixture", "wide.csv")
+        benchmark_vs_pandas.BenchmarkCase("Wide fixture", "wide.csv"),
+        skip_correctness=True,
     )
 
     assert seen_calls == [


### PR DESCRIPTION
Fixes #48

### Changes Implemented:
1. **Per-Operation Benchmarking**: Broken down `benchmark_arnio` and `benchmark_pandas` to track individual operations (`read_csv`, `clean_strings`, `drop_nulls`, `drop_duplicates`, `to_pandas`) separately.
2. **Correctness Parity Verification**: Added a `verify_correctness` check using `pandas.testing.assert_frame_equal(check_dtype=False)` to guarantee that `arnio` outputs strictly match `pandas` output data.
3. **Enhanced CLI Format**: Updated the console result table to render timing comparisons and speedups for each operation.
