### PR TITLE
perf(cleaning): add native safe_divide_columns numeric path

### DIFF
--- a/arnio/_core.py
+++ b/arnio/_core.py
@@ -15,6 +15,7 @@ try:
         Frame as _Frame,  # noqa: F401
         cast_types as _cast_types,  # noqa: F401
         clip_numeric as _clip_numeric,  # noqa: F401
+        safe_divide_columns as _safe_divide_columns,  # noqa: F401
         drop_duplicates as _drop_duplicates,  # noqa: F401
         drop_nulls as _drop_nulls,  # noqa: F401
         fill_nulls as _fill_nulls,  # noqa: F401

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -17,6 +17,7 @@ from ._core import (
     _fill_nulls,
     _normalize_case,
     _rename_columns,
+    _safe_divide_columns,
     _strip_whitespace,
 )
 from .exceptions import TypeCastError
@@ -1091,16 +1092,17 @@ def safe_divide_columns(
 
     from .convert import from_pandas, to_pandas
 
-    is_arframe = not isinstance(frame, pd.DataFrame)
-    df = to_pandas(frame) if is_arframe else frame
+    is_arframe = isinstance(frame, ArFrame)
 
-    if numerator not in df.columns:
+    columns = frame.columns if is_arframe else frame.columns
+
+    if numerator not in columns:
         raise ValueError(f"Numerator column '{numerator}' not found in frame.")
-    if denominator not in df.columns:
+    if denominator not in columns:
         raise ValueError(f"Denominator column '{denominator}' not found in frame.")
     if not isinstance(output_column, str) or not output_column.strip():
         raise ValueError("output_column must be a non-empty string.")
-    if output_column in df.columns:
+    if output_column in columns:
         import warnings
 
         warnings.warn(
@@ -1109,11 +1111,41 @@ def safe_divide_columns(
             stacklevel=2,
         )
 
-    numerator_values = pd.to_numeric(df[numerator], errors="coerce")
-    denominator_values = pd.to_numeric(df[denominator], errors="coerce")
+    if is_arframe:
+        numerator_dtype = frame.dtypes.get(numerator)
+        denominator_dtype = frame.dtypes.get(denominator)
 
-    bad_numerator = numerator_values.isna() & df[numerator].notna()
-    bad_denominator = denominator_values.isna() & df[denominator].notna()
+        numeric_types = {"int64", "float64"}
+
+        if numerator_dtype in numeric_types and denominator_dtype in numeric_types:
+            return ArFrame(
+                _safe_divide_columns(
+                    frame._frame,
+                    numerator,
+                    denominator,
+                    output_column,
+                    fill_value,
+                )
+            )
+
+    df = to_pandas(frame) if is_arframe else frame
+
+    numerator_series = df[numerator]
+    denominator_series = df[denominator]
+
+    if pd.api.types.is_numeric_dtype(
+        numerator_series
+    ) and pd.api.types.is_numeric_dtype(denominator_series):
+        numerator_values = numerator_series
+        denominator_values = denominator_series
+        bad_numerator = numerator_values.isna() & numerator_series.notna()
+        bad_denominator = denominator_values.isna() & denominator_series.notna()
+    else:
+        numerator_values = pd.to_numeric(numerator_series, errors="coerce")
+        denominator_values = pd.to_numeric(denominator_series, errors="coerce")
+
+        bad_numerator = numerator_values.isna() & numerator_series.notna()
+        bad_denominator = denominator_values.isna() & denominator_series.notna()
     if bad_numerator.any():
         bad_values = df.loc[bad_numerator, numerator].head(3).tolist()
         raise ValueError(

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -360,4 +360,14 @@ PYBIND11_MODULE(_arnio_cpp, m) {
             return combine_columns(frame, subset, separator, output_column);
         },
         py::arg("frame"), py::arg("subset"), py::arg("separator"), py::arg("output_column"));
+
+    m.def(
+        "safe_divide_columns",
+        [](const Frame& frame, const std::string& numerator, const std::string& denominator,
+           const std::string& output_column, double fill_value) {
+            py::gil_scoped_release release;
+            return safe_divide_columns(frame, numerator, denominator, output_column, fill_value);
+        },
+        py::arg("frame"), py::arg("numerator"), py::arg("denominator"), py::arg("output_column"),
+        py::arg("fill_value") = 0.0);
 }

--- a/cpp/include/arnio/cleaning.h
+++ b/cpp/include/arnio/cleaning.h
@@ -44,9 +44,14 @@ Frame cast_types(const Frame& frame, const std::unordered_map<std::string, std::
 // unchanged.  Null values are preserved as-is.
 Frame clip_numeric(const Frame& frame, std::optional<double> lower, std::optional<double> upper,
                    const std::optional<std::vector<std::string>>& subset = std::nullopt);
-
 // Combine multiple columns into a single string column
 Frame combine_columns(const Frame& frame, const std::vector<std::string>& subset,
                       const std::string& separator, const std::string& output_column);
 
+// Safely divide one numeric column by another.
+// Denominator nulls/zero values produce fill_value.
+// Output is stored as FLOAT64.
+Frame safe_divide_columns(const Frame& frame, const std::string& numerator,
+                          const std::string& denominator, const std::string& output_column,
+                          double fill_value);
 }  // namespace arnio

--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -582,6 +582,73 @@ Frame clip_numeric(const Frame& frame, std::optional<double> lower, std::optiona
 
     return Frame(std::move(new_cols));
 }
+Frame safe_divide_columns(const Frame& frame, const std::string& numerator,
+                          const std::string& denominator, const std::string& output_column,
+                          double fill_value) {
+    const auto numerator_index = frame.column_index(numerator);
+    const auto denominator_index = frame.column_index(denominator);
+
+    const auto& numerator_col = frame.column(numerator_index);
+    const auto& denominator_col = frame.column(denominator_index);
+
+    if ((numerator_col.dtype() != DType::INT64 && numerator_col.dtype() != DType::FLOAT64) ||
+        (denominator_col.dtype() != DType::INT64 && denominator_col.dtype() != DType::FLOAT64)) {
+        throw std::invalid_argument(
+            "safe_divide_columns native path requires INT64 or FLOAT64 columns");
+    }
+
+    Column result_col(output_column, DType::FLOAT64);
+
+    for (size_t r = 0; r < frame.num_rows(); ++r) {
+        if (numerator_col.is_null(r) || denominator_col.is_null(r)) {
+            result_col.push_back(fill_value);
+            continue;
+        }
+
+        double numerator_value = 0.0;
+        double denominator_value = 0.0;
+
+        if (numerator_col.dtype() == DType::INT64) {
+            numerator_value =
+                static_cast<double>(std::get<std::vector<int64_t>>(numerator_col.data())[r]);
+        } else {
+            numerator_value = std::get<std::vector<double>>(numerator_col.data())[r];
+        }
+
+        if (denominator_col.dtype() == DType::INT64) {
+            denominator_value =
+                static_cast<double>(std::get<std::vector<int64_t>>(denominator_col.data())[r]);
+        } else {
+            denominator_value = std::get<std::vector<double>>(denominator_col.data())[r];
+        }
+
+        if (denominator_value == 0.0) {
+            result_col.push_back(fill_value);
+        } else {
+            result_col.push_back(numerator_value / denominator_value);
+        }
+    }
+
+    std::vector<Column> new_cols;
+    new_cols.reserve(frame.num_cols() + 1);
+
+    bool replaced_existing_output = false;
+
+    for (size_t ci = 0; ci < frame.num_cols(); ++ci) {
+        if (frame.column(ci).name() == output_column) {
+            new_cols.push_back(result_col.clone());
+            replaced_existing_output = true;
+        } else {
+            new_cols.push_back(frame.column(ci).clone());
+        }
+    }
+
+    if (!replaced_existing_output) {
+        new_cols.push_back(std::move(result_col));
+    }
+
+    return Frame(std::move(new_cols));
+}
 
 Frame combine_columns(const Frame& frame, const std::vector<std::string>& subset,
                       const std::string& separator, const std::string& output_column) {
@@ -626,5 +693,4 @@ Frame combine_columns(const Frame& frame, const std::vector<std::string>& subset
 
     return Frame(std::move(new_cols));
 }
-
 }  // namespace arnio

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1635,6 +1635,114 @@ class TestSafeDivideColumns:
                 output_column="ratio",
             )
 
+    def test_zero_and_null_semantics_are_preserved(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "revenue": [10, 10, 0, 0, None, 10, None],
+                    "cost": [2, 0, 10, 0, 10, None, None],
+                }
+            )
+        )
+
+        result = ar.safe_divide_columns(
+            frame,
+            numerator="revenue",
+            denominator="cost",
+            output_column="ratio",
+            fill_value=-1.0,
+        )
+        df = ar.to_pandas(result)
+
+        assert list(df["ratio"]) == [5.0, -1.0, 0.0, -1.0, -1.0, -1.0, -1.0]
+
+    def test_float_and_negative_values_are_preserved(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "revenue": [7.5, -9.0, 9.0],
+                    "cost": [2.5, 3.0, -3.0],
+                }
+            )
+        )
+
+        result = ar.safe_divide_columns(
+            frame,
+            numerator="revenue",
+            denominator="cost",
+            output_column="ratio",
+        )
+        df = ar.to_pandas(result)
+
+        assert list(df["ratio"]) == [3.0, -3.0, -3.0]
+
+    def test_pandas_dataframe_input_returns_pandas_dataframe(self):
+        frame = pd.DataFrame({"revenue": [100, 200], "cost": [25, 0]})
+
+        result = ar.safe_divide_columns(
+            frame,
+            numerator="revenue",
+            denominator="cost",
+            output_column="ratio",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result["ratio"]) == [4.0, 0.0]
+
+    def test_native_numeric_arframe_path_avoids_pandas_roundtrip(self, monkeypatch):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "revenue": [100, 200],
+                    "cost": [10, 20],
+                }
+            )
+        )
+
+        from arnio import convert
+
+        original_to_pandas = convert.to_pandas
+
+        def fail_to_pandas(_):
+            raise AssertionError("native numeric path should avoid to_pandas")
+
+        monkeypatch.setattr(convert, "to_pandas", fail_to_pandas)
+
+        result = ar.safe_divide_columns(
+            frame,
+            numerator="revenue",
+            denominator="cost",
+            output_column="ratio",
+        )
+
+        df = original_to_pandas(result)
+
+        assert list(df["ratio"]) == [10.0, 10.0]
+
+    def test_native_output_column_overwrite_preserves_column_order(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "revenue": [100, 200],
+                    "ratio": [99, 99],
+                    "cost": [25, 50],
+                }
+            )
+        )
+
+        with pytest.warns(UserWarning, match="already exists"):
+            result = ar.safe_divide_columns(
+                frame,
+                numerator="revenue",
+                denominator="cost",
+                output_column="ratio",
+            )
+
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["revenue", "ratio", "cost"]
+        assert list(df["ratio"]) == [4.0, 4.0]
+
 
 class TestClipNumericNativeRegression:
     """Regression tests verifying the native C++ clip_numeric hot-path.


### PR DESCRIPTION
Fixes #660

Summary
- Avoid unnecessary pd.to_numeric conversion for already-numeric safe_divide_columns inputs.
- Preserve existing pandas fallback behavior for mixed/string/non-numeric inputs.
- Add characterization coverage for null, zero-division, float, negative, and pandas DataFrame behavior.

Validation
- pytest tests/test_cleaning.py::TestSafeDivideColumns -q
- pytest tests/test_pipeline.py::test_safe_divide_columns_pipeline -q
- pytest tests/test_cleaning.py tests/test_pipeline.py -q
