### PR TITLE
fix: preserve filter_rows column context on invalid comparisons (#588)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -902,7 +902,14 @@ def filter_rows(frame, column, op, value):
     if column not in df.columns:
         raise ValueError(f"Unknown column: {column}")
 
-    mask = getattr(df[column], ops[op])(value)
+    try:
+        mask = getattr(df[column], ops[op])(value)
+    except TypeError as exc:
+        raise TypeError(
+            f"filter_rows: cannot compare column {column!r} with value "
+            f"{value!r} using operator {op!r}: {exc}"
+        ) from exc
+
     mask = mask.fillna(False).astype(bool)
     filtered = df[mask]
     if is_arframe:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1180,6 +1180,14 @@ class TestFilterRows:
         assert list(df.index) == [0, 1]
         assert list(df["age"]) == [30, 40]
 
+    def test_filter_rows_invalid_comparison_raises_column_aware_type_error(self):
+        df = pd.DataFrame({"name": ["Alice", "Bob"]})
+
+        with pytest.raises(
+            TypeError, match="filter_rows: cannot compare column 'name'"
+        ):
+            ar.filter_rows(df, "name", ">", 1)
+
 
 class TestReplaceValues:
     def test_replace_values_null_key_replaces_existing_nulls_in_target_column(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -676,6 +676,18 @@ def test_filter_rows_direct_api():
     assert list(result_df["age"]) == [30, 40]
 
 
+def test_filter_rows_pipeline_invalid_comparison_keeps_column_context():
+    import pandas as pd
+    import pytest
+
+    import arnio as ar
+
+    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob"]}))
+
+    with pytest.raises(TypeError, match="filter_rows: cannot compare column 'name'"):
+        ar.pipeline(frame, [("filter_rows", {"column": "name", "op": ">", "value": 1})])
+
+
 def test_round_numeric_columns_pipeline():
     import pandas as pd
 


### PR DESCRIPTION
## Summary
- wrap invalid pandas comparison TypeErrors inside filter_rows with a clearer Arnio error that includes the column, operator, and value
- add direct API regression coverage for incompatible comparisons
- add pipeline regression coverage so the step no longer leaks a raw pandas comparison failure without context

## Verification
- python -m pytest tests/test_cleaning.py -k filter_rows
- python -m pytest tests/test_pipeline.py -k filter_rows
- python -m ruff check arnio/cleaning.py tests/test_cleaning.py tests/test_pipeline.py
- python -m black --check arnio/cleaning.py tests/test_cleaning.py tests/test_pipeline.py

Fixes #588