### PR TITLE
test: cover non-UTF-8 quoted multiline read_csv (#607)

### DIFF
--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -866,6 +866,20 @@ def test_scan_csv_non_utf8_multiline_boundary(tmp_path):
     assert schema == {"id": "int64", "text": "string"}
 
 
+def test_read_csv_non_utf8_quoted_multiline_round_trips(tmp_path):
+    """read_csv must preserve quoted multiline records through non-UTF-8 transcoding."""
+    csv_file = tmp_path / "test_multiline_latin1.csv"
+    csv_file.write_bytes(
+        'id,text\n1,"line1\ncaf\xe9\nline3"\n2,done\n'.encode("latin-1")
+    )
+
+    df = ar.to_pandas(ar.read_csv(str(csv_file), encoding="latin-1"))
+
+    assert list(df["id"]) == [1, 2]
+    assert df["text"].iloc[0] == "line1\ncafé\nline3"
+    assert df["text"].iloc[1] == "done"
+
+
 def test_scan_csv_type_evidence_after_limit(tmp_path):
     """Type evidence after sample window must not affect inference."""
     csv_file = tmp_path / "test_type_evidence.csv"


### PR DESCRIPTION
## Summary
- add focused read_csv coverage for a quoted multiline record flowing through the non-UTF-8 transcode path
- verify the multiline text survives intact and the following row still parses correctly
- keep the test adjacent to the existing non-UTF-8 multiline schema coverage

## Verification
- python -m pytest tests/test_csv.py -k "non_utf8 and multiline"
- python -m ruff check tests/test_csv.py
- python -m black --check tests/test_csv.py

Fixes #607
