### PR TITLE
feat: expose built-in pipeline step signatures (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,14 @@ clean = ar.pipeline(frame, [
 ])
 ```
 
+Need to inspect the built-in kwargs a step accepts before assembling a pipeline?
+
+```python
+signatures = ar.get_builtin_step_signatures()
+print(signatures["drop_nulls"])   # (*, subset: list[str] | None = None)
+print(signatures["filter_rows"])  # (column, op, value)
+```
+
 Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Python, then optionally migrate hot paths to C++ for full speed.
 </details>
 

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ Need to inspect the built-in kwargs a step accepts before assembling a pipeline?
 
 ```python
 signatures = ar.get_builtin_step_signatures()
-print(signatures["drop_nulls"])   # (*, subset: list[str] | None = None)
-print(signatures["filter_rows"])  # (column, op, value)
+print(list(signatures["drop_nulls"].parameters))  # ["subset"]
+print(list(signatures["filter_rows"].parameters))  # ["column", "op", "value"]
 ```
 
 Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Python, then optionally migrate hot paths to C++ for full speed.

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -55,7 +55,7 @@ from .io import (
     sniff_delimiter,
     write_csv,
 )
-from .pipeline import pipeline, register_step
+from .pipeline import get_builtin_step_signatures, pipeline, register_step
 from .quality import (
     CleanExplanation,
     CleanStepRecord,
@@ -136,6 +136,7 @@ __all__ = [
     # Pipeline
     "pipeline",
     "register_step",
+    "get_builtin_step_signatures",
     # Data quality
     "profile",
     "compare_profiles",

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -5,6 +5,7 @@ Chained cleaning pipeline.
 
 from __future__ import annotations
 
+import inspect
 from threading import Lock
 from time import perf_counter
 from typing import Any, Callable
@@ -62,6 +63,35 @@ def register_step(name: str, fn: Callable):
     with _REGISTRY_LOCK:
 
         _PYTHON_STEP_REGISTRY[name] = fn
+
+
+def get_builtin_step_signatures() -> dict[str, inspect.Signature]:
+    """Return normalized signatures for built-in pipeline steps.
+
+    The returned signatures exclude the leading frame/dataframe positional
+    argument so callers can inspect the kwargs they are expected to pass in
+    pipeline step specs.
+    """
+    with _REGISTRY_LOCK:
+        python_step_registry = dict(_PYTHON_STEP_REGISTRY)
+
+    builtin_steps = dict(_STEP_REGISTRY)
+    builtin_steps.update(
+        {
+            name: fn
+            for name, fn in python_step_registry.items()
+            if getattr(fn, "__module__", "").startswith("arnio.cleaning")
+            or name == "standardize_missing_tokens"
+        }
+    )
+
+    signatures: dict[str, inspect.Signature] = {}
+    for name, fn in builtin_steps.items():
+        signature = inspect.signature(fn)
+        parameters = tuple(list(signature.parameters.values())[1:])
+        signatures[name] = signature.replace(parameters=parameters)
+
+    return dict(sorted(signatures.items()))
 
 
 def _validate_pipeline_steps(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,7 @@
 import importlib
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from inspect import Signature
 
 import pandas as pd
 import pytest
@@ -587,6 +588,29 @@ class TestPipeline:
             )
 
         assert calls == []
+
+
+def test_get_builtin_step_signatures_returns_normalized_signatures():
+    signatures = ar.get_builtin_step_signatures()
+
+    assert isinstance(signatures, dict)
+    assert "drop_nulls" in signatures
+    assert isinstance(signatures["drop_nulls"], Signature)
+    assert "frame" not in signatures["drop_nulls"].parameters
+    assert list(signatures["drop_nulls"].parameters) == ["subset"]
+
+
+def test_get_builtin_step_signatures_includes_builtin_python_steps_only():
+    def custom_step(df, threshold=1):
+        return df
+
+    ar.register_step("custom_signature_probe", custom_step)
+
+    signatures = ar.get_builtin_step_signatures()
+
+    assert "filter_rows" in signatures
+    assert "replace_values" in signatures
+    assert "custom_signature_probe" not in signatures
 
 
 def test_filter_rows_greater_than():


### PR DESCRIPTION
## Summary
- add `get_builtin_step_signatures()` to expose normalized built-in pipeline step signatures without the leading frame/dataframe argument
- export the helper publicly and cover built-in C++ and Python-backed steps in tests
- add a short README example showing how to inspect supported pipeline kwargs

## Verification
- python -m pytest tests/test_pipeline.py -k "get_builtin_step_signatures"
- python -m ruff check arnio/pipeline.py arnio/__init__.py tests/test_pipeline.py
- python -m black --check arnio/pipeline.py arnio/__init__.py tests/test_pipeline.py

Fixes #170
