### PR TITLE
test: cover strict auto_clean suggested-cast safety (#620)

### DIFF
--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -457,8 +457,8 @@ def test_auto_clean_rejects_unknown_mode(sample_csv):
 def test_auto_clean_strict_casts_ambiguous_numeric_strings():
     df = pd.DataFrame(
         {
-            "code": ["007", "008"],          # Not identifier-like, but has leading zeros
-            "user_id": ["001", "002"],       # Identifier-like, has leading zeros
+            "code": ["007", "008"],  # Not identifier-like, but has leading zeros
+            "user_id": ["001", "002"],  # Identifier-like, has leading zeros
         }
     )
     frame = ar.from_pandas(df)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -454,6 +454,32 @@ def test_auto_clean_rejects_unknown_mode(sample_csv):
         assert "mode must be" in str(exc)
 
 
+def test_auto_clean_strict_casts_ambiguous_numeric_strings():
+    df = pd.DataFrame(
+        {
+            "code": ["007", "008"],          # Not identifier-like, but has leading zeros
+            "user_id": ["001", "002"],       # Identifier-like, has leading zeros
+        }
+    )
+    frame = ar.from_pandas(df)
+
+    # Verify that without allow_lossy_casts, strict mode fails
+    with pytest.raises(ValueError, match="would apply type casts"):
+        ar.auto_clean(frame, mode="strict")
+
+    # Apply strict mode with allow_lossy_casts
+    clean = ar.auto_clean(frame, mode="strict", allow_lossy_casts=True)
+    result = ar.to_pandas(clean)
+
+    # "code" is cast to int64, losing leading zeros
+    assert list(result["code"]) == [7, 8]
+    assert pd.api.types.is_integer_dtype(result["code"])
+
+    # "user_id" is protected and retains leading zeros
+    assert list(result["user_id"]) == ["001", "002"]
+    assert pd.api.types.is_string_dtype(result["user_id"])
+
+
 def test_profile_sample_size(tmp_path):
     path = tmp_path / "sample.csv"
     path.write_text("id\n1\n2\n3\n4\n5\n6\n7\n")


### PR DESCRIPTION
## Summary
Added missing test coverage for `strict` mode `auto_clean` to ensure safety around ambiguous numeric-looking strings. The test verifies that `strict` mode correctly protects identifier-like columns while dropping leading zeros (casting to `int64`) for non-identifiers only when `allow_lossy_casts=True` is provided.

## Linked issue
Fixes #620

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [ ] `make lint`
- [x] Other: `pytest tests/test_quality.py -k test_auto_clean_strict_casts_ambiguous_numeric_strings`

## Screenshots / Media
N/A (Backend test coverage only)

## Performance Impact
N/A

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
No migration notes. This PR solely improves test coverage for the existing `auto_clean` data-loss guardrails.
