### PR TITLE
feat: implement duplicate custom step registration policy with overwrite flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,31 @@ Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Pyth
 </details>
 
 <details>
+<summary><b>🔄 Custom Step Overwrite Policy</b></summary>
+<br>
+
+By default, trying to register a custom step with a name that is already taken by another custom Python step will raise a `ValueError` to prevent silent overwriting.
+
+To intentionally replace an existing custom **Python** step, pass `overwrite=True`:
+
+```python
+def custom_logging(df):
+    print("Running step v1")
+    return df
+
+ar.register_step("log_data", custom_logging)
+
+# This will succeed and safely overwrite the original logic
+def custom_logging_v2(df):
+    print("Running step v2")
+    return df
+
+ar.register_step("log_data", custom_logging_v2, overwrite=True)
+```
+> Note: Built-in C++ pipeline steps (like "drop_nulls") can never be overwritten, even if overwrite=True is explicitly supplied.
+</details>
+
+<details>
 <summary><b>✂️ Slice rows with head() and tail()</b></summary>
 <br>
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -43,7 +43,7 @@ _PYTHON_STEP_REGISTRY: dict[str, Callable] = {
 }
 
 
-def register_step(name: str, fn: Callable):
+def register_step(name: str, fn: Callable, overwrite: bool = False):
     """Register a custom Python pipeline step.
 
     Parameters
@@ -52,18 +52,36 @@ def register_step(name: str, fn: Callable):
         Name of the step for use in pipelines.
     fn : Callable
         Function to call for this step. Should accept (df, **kwargs) and return modified df.
+    overwrite : bool, default False
+        If True, allows replacing an existing custom Python step with the same name.
+        Cannot be used to overwrite built-in C++ steps.
+
+    Raises
+    ------
+    ValueError
+        If the step name conflicts with a built-in C++ step name, or if the name
+        conflicts with an existing custom Python step and `overwrite` is False.
 
     Examples
     --------
     >>> def custom_clean(df, threshold=0.5):
     ...     return df.dropna(thresh=threshold)
     >>> ar.register_step("custom_clean", custom_clean)
+    # Overwriting an existing custom step intentionally
+    >>> def new_custom_clean(df):
+    ...     return df
+    >>> ar.register_step("custom_clean", new_custom_clean, overwrite=True)
     """
     with _REGISTRY_LOCK:
         if name in _STEP_REGISTRY:
             raise ValueError(
                 f"Cannot register '{name}': conflicts with built-in C++ step. "
                 f"Use a different name."
+            )
+        if name in _PYTHON_STEP_REGISTRY and not overwrite:
+            raise ValueError(
+                f"Step '{name}' is already registered as a custom Python step. "
+                "To intentionally overwrite it, set 'overwrite=True'."
             )
         _PYTHON_STEP_REGISTRY[name] = fn
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1056,3 +1056,49 @@ def test_register_step_success():
 
     processed_df = ar.to_pandas(result_frame)
     assert processed_df["name"].tolist() == ["BAR", "BOO", "BAZ"]
+
+
+def test_register_step_duplicate_custom_raises_value_error():
+    def step_v1(df):
+        return df
+
+    def step_v2(df):
+        return df
+
+    step_name = "test_policy_duplicate_reject"
+    ar.register_step(step_name, step_v1)
+
+    with pytest.raises(ValueError, match="already registered as a custom Python step"):
+        ar.register_step(step_name, step_v2)
+
+
+def test_register_step_explicit_overwrite_success():
+    import pandas as pd
+
+    def add_one(df):
+        df["val"] = df["val"] + 1
+        return df
+
+    def add_ten(df):
+        df["val"] = df["val"] + 10
+        return df
+
+    step_name = "test_policy_overwrite_mutation"
+
+    ar.register_step(step_name, add_one)
+    ar.register_step(step_name, add_ten, overwrite=True)
+
+    df = pd.DataFrame({"val": [0]})
+    frame = ar.from_pandas(df)
+    result = ar.pipeline(frame, [(step_name,)])
+
+    processed_df = ar.to_pandas(result)
+    assert processed_df["val"].tolist() == [10]
+
+
+def test_register_step_overwrite_cannot_bypass_builtin_protection():
+    def dummy_step(df):
+        return df
+
+    with pytest.raises(ValueError, match="conflicts with built-in C\\+\\+ step"):
+        ar.register_step("drop_nulls", dummy_step, overwrite=True)


### PR DESCRIPTION
## Summary
Defined and implemented a duplicate registration policy for custom Python pipeline steps within `register_step()`. 

- **Default Behavior (`overwrite=False`):** Registering a custom step with a name that already exists in `_PYTHON_STEP_REGISTRY` now throws a descriptive `ValueError` instead of silently overwriting it.
- **Intentional Replacement (`overwrite=True`):** Users can explicitly pass the new boolean parameter to safely update or override an existing custom step mapping under the safety of `_REGISTRY_LOCK`.
- **Built-in Step Protection:** Preserved strict protection rules ensuring built-in C++ core steps (like `"drop_nulls"`) can never be overwritten or shadowed, even if `overwrite=True` is supplied.
- Added docstring documentation and a clean code snippet example to the `README.md` under a collapsible "Custom Step Overwrite Policy" subsection.

## Linked issue
Fixes #160

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (All 934 test blocks passed flawlessly, including the 3 new regression tests verifying rejection, overwrite capability, and protected built-in constants)
- [x] `make lint` (All checks passes)

## Screenshots / Media
N/A

## Performance Impact
None

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
N/A