### PR TITLE
Fix: ensure consistent KeyError behavior in keep_rows_with_nulls (#586)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -217,7 +217,7 @@ def keep_rows_with_nulls(
     ------
     TypeError
         If subset is passed as a string instead of a list.
-    ValueError
+    KeyError
         If any column in subset does not exist in the frame.
 
     Examples
@@ -243,11 +243,11 @@ def keep_rows_with_nulls(
     cols = subset if subset is not None else df.columns.tolist()
 
     # validate that all subset columns actually exist
-    unknown = [c for c in cols if c not in df.columns]
-    if unknown:
-        raise ValueError(
-            f"keep_rows_with_nulls: unknown column(s) in subset: {unknown}. "
-            f"Available columns: {df.columns.tolist()}"
+    if subset is not None:
+        validate_columns_exist(
+            frame,
+            _validate_column_sequence(subset, argument_name="subset"),
+            operation="keep_rows_with_nulls",
         )
 
     mask = df[cols].isnull().any(axis=1)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -52,7 +52,7 @@ class TestKeepRowsWithNulls:
     def test_subset_unknown_column_raises(self, csv_with_nulls):
         # passing a column that doesn't exist should raise ValueError
         frame = ar.read_csv(csv_with_nulls)
-        with pytest.raises(ValueError, match="unknown column"):
+        with pytest.raises(KeyError):
             ar.keep_rows_with_nulls(frame, subset=["nonexistent"])
 
     def test_index_is_reset(self, csv_with_nulls):


### PR DESCRIPTION
## Summary
- Replaced manual column validation with:
  - `_validate_column_sequence` for input validation
  - `validate_columns_exist` for existence checks
- Ensured `KeyError` is raised for missing columns, consistent with other helpers
- Removed duplicate/manual validation logic

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #586 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test`
- [ ] `make lint`
- [x] Ran `pytest` on the cleaning module. The updated regression test successfully catches the `KeyError`, and all existing pipeline tests pass.

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
