### PR TITLE
test: add regression coverage for MultiIndex pandas columns

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1059,6 +1059,27 @@ class TestTrimColumnNames:
         assert result.columns == ["name"]
 
 
+def test_from_pandas_multiindex_columns_are_stringified():
+    df = pd.DataFrame(
+        [[1, 2]],
+        columns=pd.MultiIndex.from_tuples(
+            [
+                ("a", "x"),
+                ("b", "y"),
+            ]
+        ),
+    )
+
+    frame = ar.from_pandas(df)
+
+    result = ar.to_pandas(frame)
+
+    assert list(result.columns) == ["('a', 'x')", "('b', 'y')"]
+    assert not isinstance(result.columns, pd.MultiIndex)
+
+    assert result.iloc[0].tolist() == [1, 2]
+
+
 class TestCastTypes:
     def test_cast_int_to_string(self, sample_csv):
         frame = ar.read_csv(sample_csv)


### PR DESCRIPTION
## Summary
Adds deterministic regression coverage for `from_pandas` behavior with pandas `MultiIndex` columns.

## Linked issue
Fixes #624 

## Type of change
- [x] Tests

## Area
- [x] pandas interoperability

## Testing
- [x] Other:

* `pytest tests/test_cleaning.py -k multiindex -q`
* `pytest tests/test_cleaning.py -q`
* `pytest -q`
* `ruff check .`
* `black --check .`

Results:
* Targeted MultiIndex regression test passed
* Full test_cleaning.py suite passed
* Full test suite passed (917 passed, 1 skipped)
* Ruff and Black checks passed

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
None.