### PR TITLE
fix: reject unsupported object scalars

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -138,10 +138,10 @@ def _series_to_python_values(series: pd.Series, col_name: object) -> list[object
                 "numeric duration before from_pandas()"
             )
 
-        if isinstance(raw, complex):
+        if isinstance(raw, (complex, np.complexfloating)):
             raise TypeError(
                 f"Column '{col_name}' contains unsupported scalar value "
-                f"of type 'complex' at value {raw!r}. "
+                f"of type '{type(raw).__name__}' at value {raw!r}. "
                 f'Fix: split df["{col_name}"] into real/imag columns or '
                 "convert it to strings before from_pandas()"
             )

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -123,6 +123,29 @@ def _series_to_python_values(series: pd.Series, col_name: object) -> list[object
                 "Convert nested objects to strings or flatten them first."
             )
 
+        if isinstance(raw, pd.Timestamp):
+            raise TypeError(
+                f"Column '{col_name}' contains unsupported scalar value "
+                f"of type 'Timestamp' at value {raw!r}. "
+                f'Fix: df["{col_name}"] = df["{col_name}"].astype(str)'
+            )
+
+        if isinstance(raw, pd.Timedelta):
+            raise TypeError(
+                f"Column '{col_name}' contains unsupported scalar value "
+                f"of type 'Timedelta' at value {raw!r}. "
+                f'Fix: convert df["{col_name}"] to strings or a supported '
+                "numeric duration before from_pandas()"
+            )
+
+        if isinstance(raw, complex):
+            raise TypeError(
+                f"Column '{col_name}' contains unsupported scalar value "
+                f"of type 'complex' at value {raw!r}. "
+                f'Fix: split df["{col_name}"] into real/imag columns or '
+                "convert it to strings before from_pandas()"
+            )
+
         value = _normalize_scalar(raw)
         values.append(value)
         if value is not None:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -291,6 +291,14 @@ class TestFromPandas:
 
         assert "Fix:" in str(exc_info.value)
 
+    def test_from_pandas_object_numpy_complex_raises_clear_error(self):
+        df = pd.DataFrame({"signal": pd.Series([np.complex64(1 + 2j)], dtype=object)})
+
+        with pytest.raises(TypeError, match="Column 'signal'") as exc_info:
+            ar.from_pandas(df)
+
+        assert "Fix:" in str(exc_info.value)
+
     def test_from_pandas_preserves_column_order(self):
         df = pd.DataFrame(
             {

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -259,6 +259,38 @@ class TestFromPandas:
         with pytest.raises(TypeError, match="Column 'created_at'"):
             ar.from_pandas(df)
 
+    def test_from_pandas_object_timestamp_raises_clear_error(self):
+        df = pd.DataFrame(
+            {
+                "created_at": pd.Series(
+                    [pd.Timestamp("2026-05-14 12:30:00")], dtype=object
+                )
+            }
+        )
+
+        with pytest.raises(TypeError, match="Column 'created_at'") as exc_info:
+            ar.from_pandas(df)
+
+        assert "Fix:" in str(exc_info.value)
+
+    def test_from_pandas_object_timedelta_raises_clear_error(self):
+        df = pd.DataFrame(
+            {"duration": pd.Series([pd.Timedelta("2 days")], dtype=object)}
+        )
+
+        with pytest.raises(TypeError, match="Column 'duration'") as exc_info:
+            ar.from_pandas(df)
+
+        assert "Fix:" in str(exc_info.value)
+
+    def test_from_pandas_object_complex_raises_clear_error(self):
+        df = pd.DataFrame({"signal": pd.Series([1 + 2j], dtype=object)})
+
+        with pytest.raises(TypeError, match="Column 'signal'") as exc_info:
+            ar.from_pandas(df)
+
+        assert "Fix:" in str(exc_info.value)
+
     def test_from_pandas_preserves_column_order(self):
         df = pd.DataFrame(
             {


### PR DESCRIPTION
## Summary

- Added targeted rejection for unsupported object-dtype scalar values in `from_pandas`.
- Object-dtype `pd.Timestamp`, `pd.Timedelta`, and `complex` values now raise clear `TypeError`s instead of being silently stringified.
- Error messages include the column name and pandas-side conversion guidance.
- Preserved existing behavior for plain object string columns and mixed primitive object columns.
- Added regression tests for unsupported scalars inside object dtype.

## Linked issue

Fixes #716

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [x] `make lint`
- [x] Other:
  - `pytest tests/test_convert.py -v` — 70 passed
  - `git diff --check` — passed

## Screenshots / Media

N/A — no UI or visual changes.

## Performance Impact

N/A — this only adds narrow per-scalar validation during `from_pandas` conversion.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

- The change is limited to `from_pandas` scalar normalization in `arnio/convert.py`.
- Whole-column unsupported dtype guards are unchanged.
- Nested value rejection behavior is unchanged.
- Plain object string columns still work.
- Mixed primitive object columns still work.
- I used AI assistance to inspect repo patterns and draft changes, then reviewed, formatted, and tested locally.