### PR TITLE
fix: preserve non-utf8 scan samples

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -53,14 +53,30 @@ def _utf8_csv_path(
                     row_count = 0
                     in_quotes = False
                     pending_quote = False
+                    pending_cr = False
                     last_char_was_terminator = False
+                    sample_complete = False
 
                     while chunk := src.read(8192):
                         chunk_len = len(chunk)
                         index = 0
                         while index < chunk_len:
                             char = chunk[index]
+
+                            if sample_complete:
+                                if pending_cr and char == "\n":
+                                    tmp.write(char)
+                                pending_cr = False
+                                break
+
                             tmp.write(char)
+
+                            if pending_cr:
+                                pending_cr = False
+                                if char == "\n":
+                                    last_char_was_terminator = True
+                                    index += 1
+                                    continue
 
                             if char == '"':
                                 if pending_quote:
@@ -78,21 +94,24 @@ def _utf8_csv_path(
                                 if not in_quotes and char in {"\n", "\r"}:
                                     row_count += 1
                                     last_char_was_terminator = True
-                                    if (
-                                        char == "\r"
-                                        and index + 1 < chunk_len
-                                        and chunk[index + 1] == "\n"
-                                    ):
-                                        tmp.write("\n")
-                                        index += 1
+                                    if char == "\r":
+                                        if (
+                                            index + 1 < chunk_len
+                                            and chunk[index + 1] == "\n"
+                                        ):
+                                            tmp.write("\n")
+                                            index += 1
+                                        else:
+                                            pending_cr = True
                                     if row_count >= sample_rows:
+                                        sample_complete = True
                                         break
                                 else:
                                     last_char_was_terminator = False
 
                             index += 1
 
-                        if row_count >= sample_rows:
+                        if sample_complete and not pending_cr:
                             break
 
                     if (

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -5,7 +5,6 @@ CSV reading and writing functions.
 
 from __future__ import annotations
 
-import csv
 import io
 import os
 import shutil
@@ -48,16 +47,63 @@ def _utf8_csv_path(
                 "w", encoding="utf-8", newline="", suffix=".csv", delete=False
             ) as tmp:
                 if sample_rows is not None:
-                    # Use csv.reader so we advance through complete CSV records
-                    # rather than raw physical lines. This prevents a quoted
-                    # multiline field from being split at the sampling boundary,
-                    # which would produce an invalid partial CSV for scan_schema.
-                    reader = csv.reader(src, delimiter=delimiter)
-                    writer = csv.writer(tmp, delimiter=delimiter)
-                    for row_count, row in enumerate(reader):
+                    # Preserve the original decoded CSV text while sampling
+                    # complete logical records so scan_schema does not see a
+                    # rewritten file with normalized quoting or line endings.
+                    row_count = 0
+                    in_quotes = False
+                    pending_quote = False
+                    last_char_was_terminator = False
+
+                    while chunk := src.read(8192):
+                        chunk_len = len(chunk)
+                        index = 0
+                        while index < chunk_len:
+                            char = chunk[index]
+                            tmp.write(char)
+
+                            if char == '"':
+                                if pending_quote:
+                                    pending_quote = False
+                                elif in_quotes:
+                                    pending_quote = True
+                                else:
+                                    in_quotes = True
+                                last_char_was_terminator = False
+                            else:
+                                if pending_quote:
+                                    in_quotes = False
+                                    pending_quote = False
+
+                                if not in_quotes and char in {"\n", "\r"}:
+                                    row_count += 1
+                                    last_char_was_terminator = True
+                                    if (
+                                        char == "\r"
+                                        and index + 1 < chunk_len
+                                        and chunk[index + 1] == "\n"
+                                    ):
+                                        tmp.write("\n")
+                                        index += 1
+                                    if row_count >= sample_rows:
+                                        break
+                                else:
+                                    last_char_was_terminator = False
+
+                            index += 1
+
                         if row_count >= sample_rows:
                             break
-                        writer.writerow(row)
+
+                    if (
+                        sample_rows > 0
+                        and not last_char_was_terminator
+                        and tmp.tell() > 0
+                    ):
+                        # Count a final record that reaches EOF without a line
+                        # terminator so sampling semantics match the previous
+                        # logical-record-based behavior.
+                        row_count += 1
                 else:
                     shutil.copyfileobj(src, tmp)
                 tmp_name = tmp.name
@@ -643,8 +689,7 @@ def scan_csv(
     try:
         # Schema inference only needs a sample, avoiding full-file transcode.
         # sample_rows is passed so _utf8_csv_path uses record-aware sampling
-        # via csv.reader, which correctly handles quoted multiline fields that
-        # straddle the boundary.
+        # without rewriting decoded CSV text before native parsing.
         with _utf8_csv_path(
             path,
             encoding,

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -657,6 +657,18 @@ class TestScanCsv:
                 'name,notes\r\nAlice,"café,\r\nline2"\r\n'
             )
 
+    def test_scan_non_utf8_crlf_split_across_chunk_boundary(self, tmp_path):
+        csv_path = tmp_path / "latin1_crlf_boundary.csv"
+        header = "pad,value\r\n"
+        row1 = f'{"x" * 8176},100\r\n'
+        row2 = "y,hello\r\n"
+        row3 = "z,200\r\n"
+        csv_path.write_bytes((header + row1 + row2 + row3).encode("latin-1"))
+
+        schema = ar.scan_csv(csv_path, encoding="latin-1", sample_size=3)
+
+        assert schema == {"pad": "string", "value": "string"}
+
     def test_scan_sample_size_non_utf8_does_not_leak_later_type_evidence(
         self, tmp_path
     ):

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -647,6 +647,16 @@ class TestScanCsv:
         with _utf8_csv_path(str(csv_path), "latin-1", sample_rows=2) as native_path:
             assert Path(native_path).read_text(encoding="utf-8") == "name\nAndré\n"
 
+    def test_non_utf8_sampling_preserves_quoted_field_text(self, tmp_path):
+        csv_path = tmp_path / "latin1_quoted.csv"
+        source_text = 'name,notes\r\nAlice,"caf\xe9,\r\nline2"\r\nBob,done\r\n'
+        csv_path.write_bytes(source_text.encode("latin-1"))
+
+        with _utf8_csv_path(str(csv_path), "latin-1", sample_rows=2) as native_path:
+            assert Path(native_path).read_bytes().decode("utf-8") == (
+                'name,notes\r\nAlice,"café,\r\nline2"\r\n'
+            )
+
     def test_scan_sample_size_non_utf8_does_not_leak_later_type_evidence(
         self, tmp_path
     ):
@@ -878,6 +888,17 @@ def test_scan_csv_non_utf8_multiline_boundary(tmp_path):
     assert schema == {"id": "int64", "text": "string"}
 
 
+def test_scan_csv_non_utf8_quoted_field_schema_preserved(tmp_path):
+    csv_file = tmp_path / "quoted_latin1.csv"
+    csv_file.write_bytes(
+        'id,text\r\n1,"caf\xe9,\r\nline2"\r\n2,done\r\n'.encode("latin-1")
+    )
+
+    schema = ar.scan_csv(str(csv_file), encoding="latin-1")
+
+    assert schema == {"id": "int64", "text": "string"}
+
+
 def test_read_csv_non_utf8_quoted_multiline_round_trips(tmp_path):
     """read_csv must preserve quoted multiline records through non-UTF-8 transcoding."""
     csv_file = tmp_path / "test_multiline_latin1.csv"
@@ -890,6 +911,15 @@ def test_read_csv_non_utf8_quoted_multiline_round_trips(tmp_path):
     assert list(df["id"]) == [1, 2]
     assert df["text"].iloc[0] == "line1\ncafé\nline3"
     assert df["text"].iloc[1] == "done"
+
+
+def test_scan_csv_utf8_quoted_field_behavior_unchanged(tmp_path):
+    csv_file = tmp_path / "quoted_utf8.csv"
+    csv_file.write_bytes(b'id,text\r\n1,"cafe,\r\nline2"\r\n2,done\r\n')
+
+    schema = ar.scan_csv(str(csv_file))
+
+    assert schema == {"id": "int64", "text": "string"}
 
 
 def test_scan_csv_type_evidence_after_limit(tmp_path):


### PR DESCRIPTION
## Summary

- Updated the non-UTF-8 `scan_csv` sampling path to preserve decoded CSV text instead of round-tripping sampled records through Python `csv.reader` / `csv.writer`.
- This prevents sampled CSV input from unintentionally normalizing quoting or line endings before native schema parsing.
- Added focused regression coverage for non-UTF-8 quoted fields and unchanged UTF-8 quoted-field scan behavior.

## Linked issue

Fixes #579

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test-only change
- [ ] Other

## Area

- [x] CSV parser / scanning
- [ ] Pandas interop
- [ ] Schema
- [ ] Data quality
- [ ] Packaging / CI
- [ ] Documentation
- [ ] Other

## Testing

- [x] `pytest tests/test_csv.py -v` — 152 passed
- [x] `git diff --check` — passed
- [x] `make lint` — passed

## Screenshots / Media

Not applicable.

## Performance impact

No expected performance impact. The change remains limited to temporary UTF-8 sampling for non-UTF-8 `scan_csv` input.

## Contributor checklist

- [x] I kept the PR focused on the assigned issue.
- [x] I added or updated focused regression tests.
- [x] I ran the relevant local checks.
- [x] I linked the issue with `Fixes #579`.

## Maintainer notes

I used AI assistance to inspect the existing `scan_csv` sampling flow and draft the focused implementation/tests, then reviewed the diff and verified the behavior locally.

This PR intentionally leaves `read_csv()` and UTF-8 scan behavior unchanged.