### PR TITLE
fix(csv): normalize trailing empty fields

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -416,6 +416,21 @@ Frame CsvReader::read(const std::string& path) const {
             expected_cols = fields.size();
         }
 
+        if (expected_cols.has_value() && fields.size() > expected_cols.value()) {
+            bool trailing_empty_only = true;
+
+            for (size_t i = expected_cols.value(); i < fields.size(); ++i) {
+                if (!fields[i].empty()) {
+                    trailing_empty_only = false;
+                    break;
+                }
+            }
+
+            if (trailing_empty_only) {
+                fields.resize(expected_cols.value());
+            }
+        }
+
         if (config.mode == "strict" && expected_cols.has_value()) {
             validate_row_width(record_number, expected_cols.value(), fields.size());
         }
@@ -524,6 +539,20 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
 
         if (line.empty()) continue;
         auto fields = parser_.parse_line(line);
+        if (fields.size() > num_cols) {
+            bool trailing_empty_only = true;
+
+            for (size_t i = num_cols; i < fields.size(); ++i) {
+                if (!fields[i].empty()) {
+                    trailing_empty_only = false;
+                    break;
+                }
+            }
+
+            if (trailing_empty_only) {
+                fields.resize(num_cols);
+            }
+        }
         validate_row_width(sample_count + 2, num_cols, fields.size());
         for (size_t i = 0; i < num_cols && i < fields.size(); ++i) {
             col_types[i] = CsvParser::promote_type(col_types[i], parser_.infer_type(fields[i]));
@@ -580,6 +609,21 @@ bool CsvChunkReader::read_one_data_row(std::vector<std::string>& fields_out) {
 
         if (!config.has_header && !expected_cols_.has_value()) {
             expected_cols_ = fields_out.size();
+        }
+
+        if (expected_cols_.has_value() && fields_out.size() > expected_cols_.value()) {
+            bool trailing_empty_only = true;
+
+            for (size_t i = expected_cols_.value(); i < fields_out.size(); ++i) {
+                if (!fields_out[i].empty()) {
+                    trailing_empty_only = false;
+                    break;
+                }
+            }
+
+            if (trailing_empty_only) {
+                fields_out.resize(expected_cols_.value());
+            }
         }
 
         if (config.mode == "strict" && expected_cols_.has_value()) {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -756,6 +756,49 @@ def test_quoted_field_with_embedded_cr(tmp_path):
     assert df["note"][0] == "line1\rline2"
 
 
+def test_trailing_delimiter_creates_empty_field(tmp_path):
+    csv_path = tmp_path / "trailing.csv"
+
+    csv_path.write_text("id,name,value\n1,Alice,\n")
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df.shape == (1, 3)
+    assert df["id"].iloc[0] == 1
+    assert df["name"].iloc[0] == "Alice"
+    assert pd.isna(df["value"].iloc[0])
+
+
+def test_multiple_trailing_delimiters_create_empty_fields(tmp_path):
+    csv_path = tmp_path / "multiple_trailing.csv"
+
+    csv_path.write_text("a,b,c,d\n1,2,,\n")
+
+    frame = ar.read_csv(csv_path)
+
+    df = ar.to_pandas(frame)
+
+    assert df.shape == (1, 4)
+    assert df["a"].iloc[0] == 1
+    assert df["b"].iloc[0] == 2
+    assert pd.isna(df["c"].iloc[0])
+    assert pd.isna(df["d"].iloc[0])
+
+
+def test_extra_non_empty_field_still_rejected(tmp_path):
+    csv_path = tmp_path / "extra_non_empty.csv"
+
+    csv_path.write_text("id,name\n1,Alice,EXTRA\n")
+
+    with pytest.raises(
+        ar.CsvReadError,
+        match="expected 2",
+    ):
+        ar.read_csv(csv_path)
+
+
 class TestArFrameHeadTail:
     def test_head_default(self, sample_csv):
         frame = ar.read_csv(sample_csv)


### PR DESCRIPTION
## Summary

This PR fixes inconsistent handling of rows ending with trailing delimiters during strict row-width validation.

Previously, rows such as:

```csv
id,name
1,Alice,
```

were parsed with an extra empty trailing field and then rejected by strict width validation, even though the additional field was empty.

This change normalizes trailing empty fields before validation so rows ending with delimiters are handled consistently across:

* `read_csv`
* `scan_csv`
* chunked CSV reading paths

Non-empty extra fields are still rejected as malformed input.

---

## Linked issue

Fixes #116

---

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

---

## Area

* [x] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

---

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash
py -3.12 -m pytest tests/test_csv.py -v
```

Result:

* 136 tests passed locally

Added regression coverage for:

* trailing delimiters creating empty final fields
* multiple trailing empty fields
* rejection of non-empty extra trailing fields

---

## Performance Impact

No measurable performance impact expected. The normalization only applies when parsed field counts exceed the expected column count.

---

