### PR TITLE
ci: add examples smoke job for all Python examples

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -1,90 +1,81 @@
-# .github/workflows/examples-smoke.yml
-#
-# Smoke-tests every Python example script to make sure they run
-# without errors on every push and pull request.
-#
-# Skipped scripts (with reasons):
-#   - arnio_with_duckdb.py        : requires 'duckdb', an optional dependency
-#                                   not included in core. Tested in a separate
-#                                   optional job below.
-#   - financial_csv_example.ipynb : requires a Jupyter runtime — not a
-#                                   plain Python script, out of scope for smoke CI.
-
-name: Examples Smoke Test
+name: Examples Smoke
 
 on:
   push:
-    branches: ["main"]
+    branches: [main]
   pull_request:
-    branches: ["main"]
+    branches: [main]
 
 jobs:
-  # -----------------------------------------------------------------------
-  # Job 1: Core examples — only need arnio + pandas + numpy + scikit-learn
-  # -----------------------------------------------------------------------
   examples-core:
     name: Smoke – core examples
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          cache: "pip"
+          python-version: "3.12"
 
-      - name: Install core dependencies
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install arnio pandas numpy scikit-learn
+          python -m pip install pybind11 numpy pandas scikit-learn
 
-      - name: Smoke – basic_usage.py
+      - name: Install local checkout
+        run: python -m pip install -e .
+
+      - name: Run basic_usage.py
+        timeout-minutes: 2
         run: python examples/basic_usage.py
 
-      - name: Smoke – auto_clean_tutorial.py
+      - name: Run auto_clean_tutorial.py
+        timeout-minutes: 2
         run: python examples/auto_clean_tutorial.py
 
-      - name: Smoke – custom_step.py
+      - name: Run custom_step.py
+        timeout-minutes: 2
         run: python examples/custom_step.py
 
-      - name: Smoke – arnio_with_pandas.py
+      - name: Run arnio_with_pandas.py
+        timeout-minutes: 2
         run: python examples/arnio_with_pandas.py
 
-      - name: Smoke – arnio_with_numpy.py
+      - name: Run arnio_with_numpy.py
+        timeout-minutes: 2
         run: python examples/arnio_with_numpy.py
 
-      - name: Smoke – arnio_with_sklearn.py
+      - name: Run arnio_with_sklearn.py
+        timeout-minutes: 2
         run: python examples/arnio_with_sklearn.py
 
-      - name: Smoke – sklearn_pipeline.py
+      - name: Run sklearn_pipeline.py
+        timeout-minutes: 2
         run: python examples/sklearn_pipeline.py
 
-  # -----------------------------------------------------------------------
-  # Job 2: Optional DuckDB example — runs separately so a missing optional
-  # dependency never blocks the core smoke job.
-  # -----------------------------------------------------------------------
   examples-duckdb:
-    name: Smoke – duckdb example (optional)
+    name: Smoke – duckdb example
     runs-on: ubuntu-latest
     continue-on-error: true
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          cache: "pip"
+          python-version: "3.12"
 
-      - name: Install core + duckdb
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install arnio pandas duckdb
+          python -m pip install pybind11 numpy pandas duckdb
 
-      - name: Smoke – arnio_with_duckdb.py
+      - name: Install local checkout
+        run: python -m pip install -e .
+
+      - name: Run arnio_with_duckdb.py
+        timeout-minutes: 2
         run: python examples/arnio_with_duckdb.py

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -1,0 +1,90 @@
+# .github/workflows/examples-smoke.yml
+#
+# Smoke-tests every Python example script to make sure they run
+# without errors on every push and pull request.
+#
+# Skipped scripts (with reasons):
+#   - arnio_with_duckdb.py        : requires 'duckdb', an optional dependency
+#                                   not included in core. Tested in a separate
+#                                   optional job below.
+#   - financial_csv_example.ipynb : requires a Jupyter runtime — not a
+#                                   plain Python script, out of scope for smoke CI.
+
+name: Examples Smoke Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  # -----------------------------------------------------------------------
+  # Job 1: Core examples — only need arnio + pandas + numpy + scikit-learn
+  # -----------------------------------------------------------------------
+  examples-core:
+    name: Smoke – core examples
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install core dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install arnio pandas numpy scikit-learn
+
+      - name: Smoke – basic_usage.py
+        run: python examples/basic_usage.py
+
+      - name: Smoke – auto_clean_tutorial.py
+        run: python examples/auto_clean_tutorial.py
+
+      - name: Smoke – custom_step.py
+        run: python examples/custom_step.py
+
+      - name: Smoke – arnio_with_pandas.py
+        run: python examples/arnio_with_pandas.py
+
+      - name: Smoke – arnio_with_numpy.py
+        run: python examples/arnio_with_numpy.py
+
+      - name: Smoke – arnio_with_sklearn.py
+        run: python examples/arnio_with_sklearn.py
+
+      - name: Smoke – sklearn_pipeline.py
+        run: python examples/sklearn_pipeline.py
+
+  # -----------------------------------------------------------------------
+  # Job 2: Optional DuckDB example — runs separately so a missing optional
+  # dependency never blocks the core smoke job.
+  # -----------------------------------------------------------------------
+  examples-duckdb:
+    name: Smoke – duckdb example (optional)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install core + duckdb
+        run: |
+          python -m pip install --upgrade pip
+          pip install arnio pandas duckdb
+
+      - name: Smoke – arnio_with_duckdb.py
+        run: python examples/arnio_with_duckdb.py


### PR DESCRIPTION
Fixes #679

Added a focused CI smoke job that runs all Python example scripts on every push and PR.

**Core job (examples-core):**
- basic_usage.py
- auto_clean_tutorial.py
- custom_step.py
- arnio_with_pandas.py
- arnio_with_numpy.py
- arnio_with_sklearn.py
- sklearn_pipeline.py

**Optional job (examples-duckdb):**
- arnio_with_duckdb.py runs in a separate job with continue-on-error: true
- duckdb is an optional dependency not in core — prevents it from blocking the main smoke check

**Skipped:**
- financial_csv_example.ipynb — requires Jupyter runtime, out of scope for smoke CI