### PR TITLE
feat: warn on deprecated pipeline step aliases (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1448,6 +1448,10 @@ ar.register_step("remove_special_chars", remove_special_chars)
 # 3. Write tests, open a PR. That's it.
 ```
 
+If Arnio renames a built-in or registered pipeline step in a future release,
+the old step name can stay temporarily available and will emit a
+`DeprecationWarning` while routing execution to the new canonical step.
+
 ### If you do know C++
 
 The biggest performance wins are in:

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -309,7 +309,7 @@ def pipeline(
 
     step_timings: list[dict[str, Any]] = []
     applied_steps: list[str] = []
-    row_counts: list[dict[str, int]] = []
+    row_counts: list[dict[str, int | str]] = []
     for step in steps:
         if len(step) == 1:
             name = step[0]

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -122,6 +122,11 @@ def register_step(name: str, fn: Callable, overwrite: bool = False):
                 f"Cannot register '{name}': conflicts with built-in C++ step. "
                 f"Use a different name."
             )
+        if name in _DEPRECATED_STEP_ALIASES:
+            raise ValueError(
+                f"Cannot register '{name}': that name is reserved as a deprecated "
+                "pipeline step alias."
+            )
         if name in _PYTHON_STEP_REGISTRY and not overwrite:
             raise ValueError(
                 f"Step '{name}' is already registered as a custom Python step. "

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -6,6 +6,7 @@ Chained cleaning pipeline.
 from __future__ import annotations
 
 import inspect
+import warnings
 from threading import Lock
 from time import perf_counter
 from typing import Any, Callable
@@ -42,6 +43,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
 }
 
 _REGISTRY_LOCK = Lock()
+_DEPRECATED_STEP_ALIASES: dict[str, str] = {}
 _PYTHON_STEP_REGISTRY: dict[str, Callable] = {
     "standardize_missing_tokens": cleaning.standardize_missing_tokens
 }
@@ -165,15 +167,52 @@ def list_steps() -> list[str]:
     return sorted(set(_STEP_REGISTRY) | set(python_step_names))
 
 
+def _register_deprecated_step_alias(old_name: str, new_name: str) -> None:
+    """Register a deprecated step alias that warns and forwards to `new_name`."""
+    with _REGISTRY_LOCK:
+        available_steps = set(_STEP_REGISTRY) | set(_PYTHON_STEP_REGISTRY)
+
+        if new_name not in available_steps:
+            raise UnknownStepError(new_name, sorted(available_steps))
+        if old_name in available_steps:
+            raise ValueError(
+                f"Cannot deprecate '{old_name}': that step name is already registered."
+            )
+
+        existing_target = _DEPRECATED_STEP_ALIASES.get(old_name)
+        if existing_target is not None and existing_target != new_name:
+            raise ValueError(
+                f"Deprecated alias '{old_name}' already points to '{existing_target}'."
+            )
+
+        _DEPRECATED_STEP_ALIASES[old_name] = new_name
+
+
+def _resolve_step_name(name: str, deprecated_step_aliases: dict[str, str]) -> str:
+    """Resolve deprecated step aliases to their canonical names."""
+    canonical_name = deprecated_step_aliases.get(name)
+    if canonical_name is None:
+        return name
+
+    warnings.warn(
+        f"Pipeline step '{name}' is deprecated; use '{canonical_name}' instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return canonical_name
+
+
 def _validate_pipeline_steps(
     steps: list[tuple],
     python_step_registry: dict[str, Callable],
+    deprecated_step_aliases: dict[str, str],
 ) -> None:
     """Validate pipeline steps before execution begins."""
 
     available_steps = (
         set(_STEP_REGISTRY)
         | set(python_step_registry)
+        | set(deprecated_step_aliases)
         | set(_get_namespaced_builtin_steps(python_step_registry))
     )
 
@@ -253,10 +292,12 @@ def pipeline(
     with _REGISTRY_LOCK:
         python_step_registry = dict(_PYTHON_STEP_REGISTRY)
         namespaced_builtin_steps = _get_namespaced_builtin_steps(python_step_registry)
+        deprecated_step_aliases = dict(_DEPRECATED_STEP_ALIASES)
 
     _validate_pipeline_steps(
         steps,
         python_step_registry,
+        deprecated_step_aliases,
     )
 
     result = frame
@@ -279,6 +320,7 @@ def pipeline(
                 f"Invalid step format: {step}. Expected (name,) or (name, kwargs)"
             )
 
+        name = _resolve_step_name(name, deprecated_step_aliases)
         name = namespaced_builtin_steps.get(name, name)
 
         if name in _STEP_REGISTRY:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -23,12 +23,15 @@ def restore_python_step_registry():
     """
     with pipeline_module._REGISTRY_LOCK:
         original_registry = dict(pipeline_module._PYTHON_STEP_REGISTRY)
+        original_aliases = dict(pipeline_module._DEPRECATED_STEP_ALIASES)
 
     yield
 
     with pipeline_module._REGISTRY_LOCK:
         pipeline_module._PYTHON_STEP_REGISTRY.clear()
         pipeline_module._PYTHON_STEP_REGISTRY.update(original_registry)
+        pipeline_module._DEPRECATED_STEP_ALIASES.clear()
+        pipeline_module._DEPRECATED_STEP_ALIASES.update(original_aliases)
 
 
 class TestPipeline:
@@ -218,6 +221,31 @@ class TestPipeline:
 
         assert df["name"].iloc[0] == "Alice"
 
+    def test_pipeline_warns_for_deprecated_builtin_step_alias(
+        self,
+        csv_with_whitespace,
+    ):
+        pipeline_module._register_deprecated_step_alias(
+            "trim_whitespace",
+            "strip_whitespace",
+        )
+        frame = ar.read_csv(csv_with_whitespace)
+
+        with pytest.warns(
+            DeprecationWarning,
+            match="trim_whitespace.*strip_whitespace",
+        ):
+            result = ar.pipeline(
+                frame,
+                [
+                    ("trim_whitespace",),
+                ],
+            )
+
+        df = ar.to_pandas(result)
+
+        assert df["name"].iloc[0] == "Alice"
+
     def test_pipeline_supports_namespaced_custom_steps_with_builtin_basename(self):
         def custom_drop_nulls(df):
             df["marker"] = "custom"
@@ -236,6 +264,20 @@ class TestPipeline:
 
         assert list(df["marker"]) == ["custom", "custom"]
         assert df["value"].isna().sum() == 1
+
+    def test_register_deprecated_step_alias_rejects_unknown_target(self):
+        with pytest.raises(ar.UnknownStepError, match="missing_step"):
+            pipeline_module._register_deprecated_step_alias(
+                "legacy_step",
+                "missing_step",
+            )
+
+    def test_register_deprecated_step_alias_rejects_registered_name_conflict(self):
+        with pytest.raises(ValueError, match="already registered"):
+            pipeline_module._register_deprecated_step_alias(
+                "drop_nulls",
+                "strip_whitespace",
+            )
 
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -279,6 +279,18 @@ class TestPipeline:
                 "strip_whitespace",
             )
 
+    def test_register_step_rejects_reserved_deprecated_alias_name(self):
+        pipeline_module._register_deprecated_step_alias(
+            "legacy_strip",
+            "strip_whitespace",
+        )
+
+        def custom_step(df):
+            return df
+
+        with pytest.raises(ValueError, match="deprecated pipeline step alias"):
+            ar.register_step("legacy_strip", custom_step)
+
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(


### PR DESCRIPTION
## Summary
- add a deprecated pipeline-step alias registry that resolves old step names to canonical names
- emit a `DeprecationWarning` when a renamed step alias is used during pipeline execution
- add regression tests and a short README migration note

## Testing
- python -m pytest tests/test_pipeline.py -k "warns_for_deprecated_builtin_step_alias or register_deprecated_step_alias or standardize_missing_tokens"
- python -m ruff check arnio/pipeline.py tests/test_pipeline.py
- python -m black --check arnio/pipeline.py tests/test_pipeline.py

Fixes #169
