### PR TITLE
feat: support namespaced pipeline steps (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,10 +368,14 @@ def remove_outliers(df, column="revenue", threshold=100_000):
     return df[df[column] <= threshold]
 
 ar.register_step("remove_outliers", remove_outliers)
+ar.register_step("team:drop_nulls", remove_outliers)  # namespaced custom step
+
+# Use builtin: for an explicit built-in step, and your own prefixes
+# like team: or plugin_name: to avoid name collisions.
 
 # Now use it in any pipeline alongside native C++ steps
 clean = ar.pipeline(frame, [
-    ("strip_whitespace",),
+    ("builtin:strip_whitespace",),
     ("remove_outliers", {"column": "revenue", "threshold": 50000}),
     ("drop_duplicates",),
 ])

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -16,6 +16,9 @@ from .convert import from_pandas, to_pandas
 from .exceptions import PipelineStepError, UnknownStepError
 from .frame import ArFrame
 
+_BUILTIN_STEP_NAMESPACE = "builtin"
+_STEP_NAMESPACE_SEPARATOR = ":"
+
 # Map step names to cleaning functions
 _STEP_REGISTRY: dict[str, Callable] = {
     "drop_nulls": cleaning.drop_nulls,
@@ -41,6 +44,38 @@ _REGISTRY_LOCK = Lock()
 _PYTHON_STEP_REGISTRY: dict[str, Callable] = {
     "standardize_missing_tokens": cleaning.standardize_missing_tokens
 }
+
+
+def _is_builtin_python_step(name: str, fn: Callable) -> bool:
+    """Return True when a Python-registered step is part of Arnio core."""
+    return getattr(fn, "__module__", "").startswith("arnio.cleaning") or (
+        name == "standardize_missing_tokens"
+    )
+
+
+def _get_builtin_step_registry(
+    python_step_registry: dict[str, Callable],
+) -> dict[str, Callable]:
+    """Return all built-in pipeline steps, including Python-backed ones."""
+    builtin_steps = dict(_STEP_REGISTRY)
+    builtin_steps.update(
+        {
+            name: fn
+            for name, fn in python_step_registry.items()
+            if _is_builtin_python_step(name, fn)
+        }
+    )
+    return builtin_steps
+
+
+def _get_namespaced_builtin_steps(
+    python_step_registry: dict[str, Callable],
+) -> dict[str, str]:
+    """Map namespaced built-in step names to canonical step names."""
+    return {
+        f"{_BUILTIN_STEP_NAMESPACE}{_STEP_NAMESPACE_SEPARATOR}{name}": name
+        for name in _get_builtin_step_registry(python_step_registry)
+    }
 
 
 def register_step(name: str, fn: Callable, overwrite: bool = False):
@@ -73,6 +108,12 @@ def register_step(name: str, fn: Callable, overwrite: bool = False):
     >>> ar.register_step("custom_clean", new_custom_clean, overwrite=True)
     """
     with _REGISTRY_LOCK:
+        if name.startswith(f"{_BUILTIN_STEP_NAMESPACE}{_STEP_NAMESPACE_SEPARATOR}"):
+            raise ValueError(
+                f"Cannot register '{name}': "
+                f"'{_BUILTIN_STEP_NAMESPACE}{_STEP_NAMESPACE_SEPARATOR}' "
+                "is reserved for built-in pipeline steps."
+            )
         if name in _STEP_REGISTRY:
             raise ValueError(
                 f"Cannot register '{name}': conflicts with built-in C++ step. "
@@ -92,7 +133,11 @@ def _validate_pipeline_steps(
 ) -> None:
     """Validate pipeline steps before execution begins."""
 
-    available_steps = set(_STEP_REGISTRY) | set(python_step_registry)
+    available_steps = (
+        set(_STEP_REGISTRY)
+        | set(python_step_registry)
+        | set(_get_namespaced_builtin_steps(python_step_registry))
+    )
 
     for step in steps:
         if not isinstance(step, tuple) or not (1 <= len(step) <= 2):
@@ -169,6 +214,7 @@ def pipeline(
     """
     with _REGISTRY_LOCK:
         python_step_registry = dict(_PYTHON_STEP_REGISTRY)
+        namespaced_builtin_steps = _get_namespaced_builtin_steps(python_step_registry)
 
     _validate_pipeline_steps(
         steps,
@@ -192,6 +238,8 @@ def pipeline(
             raise ValueError(
                 f"Invalid step format: {step}. Expected (name,) or (name, kwargs)"
             )
+
+        name = namespaced_builtin_steps.get(name, name)
 
         if name in _STEP_REGISTRY:
             # C++ backed step - fast path
@@ -234,10 +282,7 @@ def pipeline(
             df = to_pandas(result)
 
             # Isolate genuine custom steps from internal core library functions
-            is_builtin = (
-                getattr(fn, "__module__", "").startswith("arnio.cleaning")
-                or name == "standardize_missing_tokens"
-            )
+            is_builtin = _is_builtin_python_step(name, fn)
 
             try:
                 returned = fn(df, **kwargs)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -204,6 +204,38 @@ class TestPipeline:
 
         assert pd.isna(df["value"].iloc[2])
 
+    def test_pipeline_supports_namespaced_builtin_steps(self, csv_with_whitespace):
+        frame = ar.read_csv(csv_with_whitespace)
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("builtin:strip_whitespace",),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert df["name"].iloc[0] == "Alice"
+
+    def test_pipeline_supports_namespaced_custom_steps_with_builtin_basename(self):
+        def custom_drop_nulls(df):
+            df["marker"] = "custom"
+            return df
+
+        ar.register_step("team:drop_nulls", custom_drop_nulls)
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, None]}))
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("team:drop_nulls",),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert list(df["marker"]) == ["custom", "custom"]
+        assert df["value"].isna().sum() == 1
+
     def test_pipeline_mapping_shorthand(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(
@@ -1102,3 +1134,11 @@ def test_register_step_overwrite_cannot_bypass_builtin_protection():
 
     with pytest.raises(ValueError, match="conflicts with built-in C\\+\\+ step"):
         ar.register_step("drop_nulls", dummy_step, overwrite=True)
+
+
+def test_register_step_rejects_reserved_builtin_namespace():
+    def dummy_step(df):
+        return df
+
+    with pytest.raises(ValueError, match="reserved for built-in pipeline steps"):
+        ar.register_step("builtin:custom_step", dummy_step)


### PR DESCRIPTION
## Summary
- add explicit `builtin:` step resolution while keeping existing unqualified pipeline step names working
- allow custom namespaced step names like `team:drop_nulls` to coexist with built-in step basenames
- reserve the `builtin:` namespace for Arnio core steps and add focused tests plus README examples

## Testing
- python -m pytest tests/test_pipeline.py -k "namespaced or reserved_builtin_namespace or overwrite_cannot_bypass_builtin_protection"
- python -m ruff check arnio/pipeline.py tests/test_pipeline.py
- python -m black --check arnio/pipeline.py tests/test_pipeline.py

Fixes #168
