### PR TITLE
feat: enrich pipeline execution metadata (#166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ clean, metadata = ar.pipeline(
 )
 
 print(metadata["step_timings"])
+print(metadata["applied_steps"])
+print(metadata["row_counts"])
 ```
 
 ## Quick Example

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -178,6 +178,8 @@ def pipeline(
     result = frame
 
     step_timings: list[dict[str, Any]] = []
+    applied_steps: list[str] = []
+    row_counts: list[dict[str, int]] = []
     for step in steps:
         if len(step) == 1:
             name = step[0]
@@ -196,6 +198,7 @@ def pipeline(
         if name in _STEP_REGISTRY:
             # C++ backed step - fast path
             fn = _STEP_REGISTRY[name]
+            rows_before = result.shape[0]
 
             started_at = perf_counter()
             if name == "rename_columns" and "mapping" not in kwargs:
@@ -219,6 +222,14 @@ def pipeline(
                     result = step_result
 
             if return_metadata:
+                applied_steps.append(name)
+                row_counts.append(
+                    {
+                        "step": name,
+                        "before": rows_before,
+                        "after": step_result.shape[0],
+                    }
+                )
                 step_timings.append(
                     {
                         "step": name,
@@ -228,6 +239,7 @@ def pipeline(
         elif name in python_step_registry:
             # Pure Python step - slower but contributor-friendly
             started_at = perf_counter()
+            rows_before = result.shape[0]
 
             fn = python_step_registry[name]
 
@@ -262,6 +274,14 @@ def pipeline(
                 result = step_result
 
             if return_metadata:
+                applied_steps.append(name)
+                row_counts.append(
+                    {
+                        "step": name,
+                        "before": rows_before,
+                        "after": step_result.shape[0],
+                    }
+                )
                 step_timings.append(
                     {
                         "step": name,
@@ -273,7 +293,11 @@ def pipeline(
             raise UnknownStepError(name, available)
 
     if return_metadata:
-        return result, {"step_timings": step_timings}
+        return result, {
+            "applied_steps": applied_steps,
+            "row_counts": row_counts,
+            "step_timings": step_timings,
+        }
     return result
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -365,7 +365,12 @@ class TestPipeline:
         )
 
         assert isinstance(result, ar.ArFrame)
-        assert list(metadata.keys()) == ["step_timings"]
+        assert list(metadata.keys()) == ["applied_steps", "row_counts", "step_timings"]
+        assert metadata["applied_steps"] == ["strip_whitespace", "normalize_case"]
+        assert len(metadata["row_counts"]) == 2
+        assert metadata["row_counts"][0]["step"] == "strip_whitespace"
+        assert metadata["row_counts"][0]["before"] == frame.shape[0]
+        assert metadata["row_counts"][0]["after"] == result.shape[0]
         assert len(metadata["step_timings"]) == 2
         assert metadata["step_timings"][0]["step"] == "strip_whitespace"
         assert metadata["step_timings"][1]["step"] == "normalize_case"
@@ -390,6 +395,14 @@ class TestPipeline:
 
         df = ar.to_pandas(result)
         assert set(df["marker"]) == {"done"}
+        assert metadata["applied_steps"] == ["timed_python_step"]
+        assert metadata["row_counts"] == [
+            {
+                "step": "timed_python_step",
+                "before": frame.shape[0],
+                "after": result.shape[0],
+            }
+        ]
         assert len(metadata["step_timings"]) == 1
         assert metadata["step_timings"][0]["step"] == "timed_python_step"
         assert metadata["step_timings"][0]["seconds"] >= 0


### PR DESCRIPTION
## Summary
- extend `return_metadata=True` to include applied step names and per-step row counts alongside timings
- keep the default `ar.pipeline(...)` return type unchanged
- add focused regression coverage and update the README metadata example

## Testing
- python -m pytest tests/test_pipeline.py -k "return_metadata"
- python -m ruff check arnio/pipeline.py tests/test_pipeline.py
- python -m black --check arnio/pipeline.py tests/test_pipeline.py

Fixes #166
