### PR TITLE
feat: add __getitem__ to ArFrame for column access

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -309,6 +309,43 @@ class ArFrame:
     def __contains__(self, item: object) -> bool:
         return isinstance(item, str) and item in self.columns
 
+    def __getitem__(self, key: str) -> list:
+        """Return column data as a list.
+
+        Parameters
+        ----------
+        key : str
+            Column name to access.
+
+        Returns
+        -------
+        list
+            Column values as a Python list.
+
+        Raises
+        ------
+        TypeError
+            If key is not a string.
+        KeyError
+            If the column does not exist.
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> frame["name"]
+        ['Alice', 'Bob', 'Charlie']
+        """
+        if not isinstance(key, str):
+            raise TypeError(f"column key must be a string, got {type(key).__name__!r}")
+
+        if key not in self.columns:
+            raise KeyError(
+                f"Column {key!r} not found. Available columns: {self.columns}"
+            )
+
+        col_index = self.columns.index(key)
+        return [self._frame.column_by_index(col_index).at(i) for i in range(len(self))]
+
     def preview(self, n: int = 5) -> str:
         """Return a lightweight string preview of the first ``n`` rows.
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1227,3 +1227,55 @@ class TestSniffDelimiter:
             match="Could not determine CSV delimiter from sample: multiple candidate delimiters",
         ):
             ar.sniff_delimiter(csv_path)
+
+
+class TestArFrameGetItem:
+    def test_getitem_existing_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = frame["name"]
+        assert isinstance(result, list)
+        assert result == ["Alice", "Bob", "Charlie"]
+
+    def test_getitem_integer_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = frame["age"]
+        assert isinstance(result, list)
+        assert result == [30, 25, 35]
+
+    def test_getitem_bool_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = frame["active"]
+        assert isinstance(result, list)
+        assert result == [True, False, True]
+
+    def test_getitem_missing_column_raises_keyerror(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        with pytest.raises(KeyError):
+            frame["nonexistent"]
+
+    def test_getitem_non_string_key_raises_typeerror(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        with pytest.raises(TypeError):
+            frame[0]
+        with pytest.raises(TypeError):
+            frame[["name"]]
+
+    def test_getitem_empty_frame(self, tmp_path):
+        csv_path = tmp_path / "empty_rows.csv"
+        csv_path.write_text("name,age\n")
+        frame = ar.read_csv(csv_path)
+        result = frame["name"]
+        assert result == []
+
+    def test_getitem_column_with_nulls(self, csv_with_nulls):
+        frame = ar.read_csv(csv_with_nulls)
+        result = frame["name"]
+        assert isinstance(result, list)
+        assert result[0] == "Alice"
+
+    def test_getitem_column_with_spaces(self, tmp_path):
+        csv_path = tmp_path / "spaces.csv"
+        csv_path.write_text("first name,last name\nJohn,Doe\n")
+        frame = ar.read_csv(csv_path)
+        result = frame["first name"]
+        assert result == ["John"]


### PR DESCRIPTION
## Summary
Adds `__getitem__` to `ArFrame` so users can access column data directly via `frame["col"]` without converting to pandas. Reads directly from the C++ frame and returns a Python list.

## Linked issue
Refs #35

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
pytest tests/test_csv.py::TestArFrameGetItem -v
8/8 passed.

pytest tests/test_csv.py -v
Full suite passed with no new failures.

ruff check .
black .
- [ ] `make test`
- [ ] `make lint`
- [ ] Other:

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
