### PR TITLE
feat: add pipeline step registry introspection (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,9 @@ ar.register_step("team:drop_nulls", remove_outliers)  # namespaced custom step
 # Use builtin: for an explicit built-in step, and your own prefixes
 # like team: or plugin_name: to avoid name collisions.
 
+# Introspect built-in and custom step names without reaching into internals.
+print(ar.list_steps())
+
 # Now use it in any pipeline alongside native C++ steps
 clean = ar.pipeline(frame, [
     ("builtin:strip_whitespace",),

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -55,7 +55,12 @@ from .io import (
     sniff_delimiter,
     write_csv,
 )
-from .pipeline import get_builtin_step_signatures, pipeline, register_step
+from .pipeline import (
+    get_builtin_step_signatures,
+    list_steps,
+    pipeline,
+    register_step,
+)
 from .quality import (
     CleanExplanation,
     CleanStepRecord,
@@ -137,6 +142,7 @@ __all__ = [
     "pipeline",
     "register_step",
     "get_builtin_step_signatures",
+    "list_steps",
     # Data quality
     "profile",
     "compare_profiles",

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -157,6 +157,14 @@ def get_builtin_step_signatures() -> dict[str, inspect.Signature]:
     return dict(sorted(signatures.items()))
 
 
+def list_steps() -> list[str]:
+    """Return available pipeline step names in deterministic order."""
+    with _REGISTRY_LOCK:
+        python_step_names = list(_PYTHON_STEP_REGISTRY)
+
+    return sorted(set(_STEP_REGISTRY) | set(python_step_names))
+
+
 def _validate_pipeline_steps(
     steps: list[tuple],
     python_step_registry: dict[str, Callable],

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1179,3 +1179,23 @@ def test_register_step_rejects_reserved_builtin_namespace():
 
     with pytest.raises(ValueError, match="reserved for built-in pipeline steps"):
         ar.register_step("builtin:custom_step", dummy_step)
+
+
+def test_list_steps_includes_builtins_in_deterministic_order():
+    steps = ar.list_steps()
+
+    assert steps == sorted(steps)
+    assert "drop_nulls" in steps
+    assert "strip_whitespace" in steps
+    assert "standardize_missing_tokens" in steps
+
+
+def test_list_steps_includes_registered_custom_steps():
+    def custom_step(df):
+        return df
+
+    ar.register_step("list_steps_probe", custom_step)
+
+    steps = ar.list_steps()
+
+    assert "list_steps_probe" in steps


### PR DESCRIPTION
## Summary
- add a small `list_steps()` helper for deterministic pipeline step introspection
- export it from `arnio.__init__` so callers can discover built-in and registered custom steps without using internals
- add focused regression tests and a short README example

## Testing
- python -m pytest tests/test_pipeline.py -k "list_steps or register_step_overwrite_cannot_bypass_builtin_protection"
- python -m ruff check arnio/pipeline.py arnio/__init__.py tests/test_pipeline.py
- python -m black --check arnio/pipeline.py arnio/__init__.py tests/test_pipeline.py

Fixes #157
