### PR TITLE
fix: resolve ChainedAssignmentError warnings in test_zero_copy for pandas 3.x CoW

### DIFF
--- a/tests/test_zero_copy.py
+++ b/tests/test_zero_copy.py
@@ -85,7 +85,7 @@ class TestIntLifetime:
         df1 = ar.to_pandas(frame)
         df2 = ar.to_pandas(frame)
         # mutate df1 in place
-        df1["a"].iloc[0] = 999
+        df1.loc[0, "a"] = 999
         # df2 must be unaffected
         assert df2["a"].iloc[0] == 1
 
@@ -117,7 +117,7 @@ class TestFloatLifetime:
         frame = make_frame_float()
         df1 = ar.to_pandas(frame)
         df2 = ar.to_pandas(frame)
-        df1["x"].iloc[0] = -999.0
+        df1.loc[0, "x"] = -999.0
         assert pytest.approx(df2["x"].iloc[0]) == 1.1
 
     def test_float_values_survive_multiple_gc_cycles(self):
@@ -237,7 +237,7 @@ class TestEdgeCaseLifetime:
         del frame
         gc.collect()
         # mutate first, rest untouched
-        dfs[0]["a"].iloc[0] = 999
+        dfs[0].loc[0, "a"] = 999
         assert dfs[1]["a"].iloc[0] == 1
         assert dfs[2]["a"].iloc[0] == 1
 


### PR DESCRIPTION
## Summary
Replace 3 deprecated chained assignments (`df["col"].iloc[0] = value`) with
CoW-safe `.loc` form (`df.loc[0, "col"] = value`) in tests/test_zero_copy.py.

pandas 3.0 introduced Copy-on-Write (CoW) by default, which causes chained
assignment to raise ChainedAssignmentError warnings and silently fail to mutate
the original DataFrame. This fix makes the tests compatible with pandas 3.x.

## Linked issue
No linked issue.

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] pandas interoperability

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: 
  - `pytest tests/test_zero_copy.py -v` → 18 passed, 0 warnings
  - `pytest tests/ --ignore=tests/test_benchmarks.py` → 367 passed, 0 warnings

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix:`).