### PR TITLE
test : added validation tests for replace_values with empty mapping

### DIFF
--- a/tests/test_replace_values_extra.py
+++ b/tests/test_replace_values_extra.py
@@ -1,0 +1,24 @@
+"""Extra validation tests for replace_values parameter bounds."""
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+def test_replace_values_empty_mapping():
+    # replace_values should raise ValueError when mapping is empty
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="mapping must not be empty"):
+        ar.replace_values(frame, {})
+
+
+def test_replace_values_non_dict_mapping():
+    # replace_values should raise TypeError when mapping is not a dict
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="mapping must be a dict-like mapping"):
+        ar.replace_values(frame, [1, 2, 3])  # type: ignore


### PR DESCRIPTION
Closes #877.

Summary of What Has Been Done:
Implemented unit tests for replace_values parameter bounds to explicitly verify empty mapping and non-dictionary mapping error checks.

Changes Made:
- Added tests/test_replace_values_extra.py containing test_replace_values_empty_mapping and test_replace_values_non_dict_mapping tests.

Impact it Made:
Verifies robust, secure input argument validation behavior without modifying the core runtime code.