### PR TITLE
test : added edge case unit tests for combine_columns with empty subset

### DIFF
--- a/tests/test_combine_columns_extra.py
+++ b/tests/test_combine_columns_extra.py
@@ -1,0 +1,23 @@
+"""Extra validation tests for combine_columns edge cases."""
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+def test_combine_columns_empty_subset():
+    # combine_columns should raise ValueError if subset list is empty
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(ValueError, match="subset must not be empty"):
+        ar.combine_columns(frame, subset=[], target="c")
+
+
+def test_combine_columns_invalid_target_type():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    frame = ar.from_pandas(df)
+
+    with pytest.raises(TypeError, match="target must be a string"):
+        ar.combine_columns(frame, subset=["a", "b"], target=123)  # type: ignore

--- a/tests/test_combine_columns_extra.py
+++ b/tests/test_combine_columns_extra.py
@@ -6,18 +6,18 @@ import pytest
 import arnio as ar
 
 
-def test_combine_columns_empty_subset():
+def test_combine_columns_empty_subset() -> None:
     # combine_columns should raise ValueError if subset list is empty
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     frame = ar.from_pandas(df)
 
-    with pytest.raises(ValueError, match="subset must not be empty"):
-        ar.combine_columns(frame, subset=[], target="c")
+    with pytest.raises(ValueError, match="subset must contain at least one column"):
+        ar.combine_columns(frame, subset=[], output_column="c")
 
 
-def test_combine_columns_invalid_target_type():
+def test_combine_columns_invalid_target_type() -> None:
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     frame = ar.from_pandas(df)
 
-    with pytest.raises(TypeError, match="target must be a string"):
-        ar.combine_columns(frame, subset=["a", "b"], target=123)  # type: ignore
+    with pytest.raises(ValueError, match="output_column must be a non-empty string"):
+        ar.combine_columns(frame, subset=["a", "b"], output_column=123)  # type: ignore


### PR DESCRIPTION
Closes #881.

Summary of What Has Been Done:
Implemented unit tests for combine_columns to verify error raising on empty subset list parameter inputs and invalid target type formats.

Changes Made:
- Added tests/test_combine_columns_extra.py containing test_combine_columns_empty_subset and test_combine_columns_invalid_target_type tests.

Impact it Made:
Validates robust parameter safety limits for column combining/merging operations without changing the underlying package logic.