### PR TITLE
fix(cleaning): safely handle tuple mapping keys in replace_values

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1246,9 +1246,10 @@ def drop_columns_matching(frame, pattern):
 
 from pandas.api.types import is_scalar
 import pandas as pd
+
 def _is_null_mapping_key(value):
     """
-    Safely determine whether a mapping key represents a null value.
+    Return True when a mapping key represents a scalar null value.
 
     Prevents ambiguous truth-value evaluation for tuple/list/array-like
     objects when using pandas.isna().
@@ -1321,7 +1322,8 @@ def replace_values(frame, mapping, column=None):
     normalized_mapping = {}
 
     for k, v in mapping.items():
-        # detect null-like keys (None, NaN, pd.NA)
+        # Handle scalar null-like keys safely without evaluating
+        # tuple/list/array-like objects in boolean context.
         if _is_null_mapping_key(k):
             null_key_present = True
             null_replacement = v

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1333,7 +1333,9 @@ def replace_values(frame, mapping, column=None):
         # Exclude tuple/list/ndarray/series/index keys which pandas.replace
         # does not support and can raise confusing errors (e.g. operand
         # length mismatch). Treat strings and true scalars as valid keys.
-        elif is_scalar(k) and not isinstance(k, (tuple, list, np.ndarray, pd.Series, pd.Index)):
+        elif is_scalar(k) and not isinstance(
+            k, (tuple, list, np.ndarray, pd.Series, pd.Index)
+        ):
             normalized_mapping[k] = v
         else:
             # pandas replace does not support non-scalar mapping keys like tuples

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1244,6 +1244,23 @@ def drop_columns_matching(frame, pattern):
 
     return from_pandas(result) if is_arframe else result
 
+from pandas.api.types import is_scalar
+import pandas as pd
+def _is_null_mapping_key(value):
+    """
+    Safely determine whether a mapping key represents a null value.
+
+    Prevents ambiguous truth-value evaluation for tuple/list/array-like
+    objects when using pandas.isna().
+    """
+    if value is None:
+        return True
+
+    # Avoid calling pd.isna on tuple/list/array-like values
+    if not is_scalar(value):
+        return False
+
+    return bool(pd.isna(value))
 
 def replace_values(frame, mapping, column=None):
     """Replace values based on a mapping dict.
@@ -1305,7 +1322,7 @@ def replace_values(frame, mapping, column=None):
 
     for k, v in mapping.items():
         # detect null-like keys (None, NaN, pd.NA)
-        if k is None or pd.isna(k):
+        if _is_null_mapping_key(k):
             null_key_present = True
             null_replacement = v
         else:

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -10,6 +10,9 @@ import unicodedata
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+import pandas as pd
+from pandas.api.types import is_scalar
+
 from ._core import (
     _cast_types,
     _clip_numeric,
@@ -1244,8 +1247,6 @@ def drop_columns_matching(frame, pattern):
 
     return from_pandas(result) if is_arframe else result
 
-from pandas.api.types import is_scalar
-import pandas as pd
 
 def _is_null_mapping_key(value):
     """
@@ -1262,6 +1263,7 @@ def _is_null_mapping_key(value):
         return False
 
     return bool(pd.isna(value))
+
 
 def replace_values(frame, mapping, column=None):
     """Replace values based on a mapping dict.

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -10,6 +10,7 @@ import unicodedata
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+import numpy as np
 import pandas as pd
 from pandas.api.types import is_scalar
 
@@ -1329,8 +1330,15 @@ def replace_values(frame, mapping, column=None):
         if _is_null_mapping_key(k):
             null_key_present = True
             null_replacement = v
-        else:
+        # Exclude tuple/list/ndarray/series/index keys which pandas.replace
+        # does not support and can raise confusing errors (e.g. operand
+        # length mismatch). Treat strings and true scalars as valid keys.
+        elif is_scalar(k) and not isinstance(k, (tuple, list, np.ndarray, pd.Series, pd.Index)):
             normalized_mapping[k] = v
+        else:
+            # pandas replace does not support non-scalar mapping keys like tuples
+            # and lists. Ignore those keys rather than raising a user-facing error.
+            continue
 
     if column:
         s = df[column]

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,5 +1,6 @@
 """Tests for data cleaning functions."""
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -770,8 +771,7 @@ class TestNormalizeUnicode:
         result_df = ar.to_pandas(result)
         assert result_df["score"].iloc[0] == 42
         assert (
-            result_df["flag"].iloc[0] is True
-            or result_df["flag"].iloc[0] == True  # noqa: E712
+            result_df["flag"].iloc[0] is True or result_df["flag"].iloc[0] == True  # noqa: E712
         )
 
     def test_normalize_unicode_subset_only_targets_specified_columns(self):
@@ -1380,36 +1380,21 @@ class TestReplaceValues:
         assert df.loc[2, "flag"] == "ok"
 
     def test_replace_values_tuple_mapping_key_does_not_crash(self):
-        frame = ar.from_pandas(
-            pd.DataFrame(
-                {
-                    "col": ["A", "B", "C"]
-                }
-            )
-        )
+        frame = ar.from_pandas(pd.DataFrame({"col": ["A", "B", "C"]}))
 
         result = ar.replace_values(
             frame,
-            {
-                ("A", "B"): "X"
-            },
+            {("A", "B"): "X"},
             column="col",
         )
 
         df = ar.to_pandas(result)
 
         assert list(df["col"]) == ["A", "B", "C"]
-    
-    import numpy as np
+
     def test_replace_values_mixed_tuple_and_null_keys(self):
 
-        frame = ar.from_pandas(
-            pd.DataFrame(
-                {
-                    "col": ["A", np.nan, "C"]
-                }
-            )
-        )
+        frame = ar.from_pandas(pd.DataFrame({"col": ["A", np.nan, "C"]}))
 
         result = ar.replace_values(
             frame,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1379,6 +1379,51 @@ class TestReplaceValues:
         assert pd.isna(df.loc[1, "flag"])
         assert df.loc[2, "flag"] == "ok"
 
+    def test_replace_values_tuple_mapping_key_does_not_crash(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "col": ["A", "B", "C"]
+                }
+            )
+        )
+
+        result = ar.replace_values(
+            frame,
+            {
+                ("A", "B"): "X"
+            },
+            column="col",
+        )
+
+        df = ar.to_pandas(result)
+
+        assert list(df["col"]) == ["A", "B", "C"]
+    
+    def test_replace_values_mixed_tuple_and_null_keys(self):
+        import numpy as np
+
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "col": ["A", np.nan, "C"]
+                }
+            )
+        )
+
+        result = ar.replace_values(
+            frame,
+            {
+                ("A", "B"): "X",
+                np.nan: "missing",
+            },
+            column="col",
+        )
+
+        df = ar.to_pandas(result)
+
+        assert list(df["col"]) == ["A", "missing", "C"]
+
 
 class TestRoundNumericColumns:
     def test_round_all_numeric(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -771,7 +771,8 @@ class TestNormalizeUnicode:
         result_df = ar.to_pandas(result)
         assert result_df["score"].iloc[0] == 42
         assert (
-            result_df["flag"].iloc[0] is True or result_df["flag"].iloc[0] == True  # noqa: E712
+            result_df["flag"].iloc[0] is True
+            or result_df["flag"].iloc[0] == True  # noqa: E712
         )
 
     def test_normalize_unicode_subset_only_targets_specified_columns(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1393,7 +1393,6 @@ class TestReplaceValues:
         assert list(df["col"]) == ["A", "B", "C"]
 
     def test_replace_values_mixed_tuple_and_null_keys(self):
-
         frame = ar.from_pandas(pd.DataFrame({"col": ["A", np.nan, "C"]}))
 
         result = ar.replace_values(

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1400,8 +1400,8 @@ class TestReplaceValues:
 
         assert list(df["col"]) == ["A", "B", "C"]
     
+    import numpy as np
     def test_replace_values_mixed_tuple_and_null_keys(self):
-        import numpy as np
 
         frame = ar.from_pandas(
             pd.DataFrame(


### PR DESCRIPTION
## Summary

Fixes a bug in `replace_values` where tuple mapping keys could trigger ambiguous boolean evaluation during null-key detection.

The issue occurred because `pd.isna(k)` was evaluated directly in a boolean context for every mapping key. For tuple or array-like keys, pandas returns an array-like object instead of a scalar boolean, causing runtime errors or inconsistent behavior.

This PR adds safe scalar validation before null checking and introduces focused regression tests to preserve deterministic behavior.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

---

## Linked issue

Fixes #593 

---

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

---

## Area

- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

---

## Testing

- [] `make test`
- [] `make lint`
- [x] Other:

Commands run locally:

```bash
ruff check .
pytest
```

Added regression coverage for:
- tuple mapping keys
- mixed tuple + null-key mappings

---

## Screenshots / Media

N/A

---

## Performance Impact

No measurable performance impact expected.

The change only affects scalar validation during null-key detection inside `replace_values`.

---

## Contributor checklist

- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

---

## Maintainer notes

The fix preserves existing behavior for:
- `None`
- `np.nan`
- `pd.NA`
- `pd.NaT`

Tuple/list/array-like mapping keys are now safely ignored during null-key detection instead of triggering ambiguous truth-value evaluation through `pd.isna`.