### PR TITLE
fix : raise ValueError on existing safe_divide_columns output_column

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1094,8 +1094,7 @@ def safe_divide_columns(
         Column name to use as the denominator.
     output_column : str
         Name of the new column to store the division result. Must be a
-        non-empty string. If the column already exists, it will be
-        overwritten and a ``UserWarning`` is raised.
+        non-empty string. If the column already exists, a ``ValueError`` is raised.
     fill_value : float, optional
         Value to use when denominator is zero or null. Defaults to 0.0.
 
@@ -1123,13 +1122,7 @@ def safe_divide_columns(
     if not isinstance(output_column, str) or not output_column.strip():
         raise ValueError("output_column must be a non-empty string.")
     if output_column in columns:
-        import warnings
-
-        warnings.warn(
-            f"Output column '{output_column}' already exists and will be overwritten.",
-            UserWarning,
-            stacklevel=2,
-        )
+        raise ValueError(f"Output column '{output_column}' already exists.")
 
     if is_arframe:
         numerator_dtype = frame.dtypes.get(numerator)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1843,7 +1843,7 @@ class TestSafeDivideColumns:
 
         assert list(df["ratio"]) == [10.0, 10.0]
 
-    def test_native_output_column_overwrite_preserves_column_order(self):
+    def test_native_output_column_overwrite_raises_value_error(self):
         frame = ar.from_pandas(
             pd.DataFrame(
                 {
@@ -1854,18 +1854,13 @@ class TestSafeDivideColumns:
             )
         )
 
-        with pytest.warns(UserWarning, match="already exists"):
-            result = ar.safe_divide_columns(
+        with pytest.raises(ValueError, match="already exists"):
+            ar.safe_divide_columns(
                 frame,
                 numerator="revenue",
                 denominator="cost",
                 output_column="ratio",
             )
-
-        df = ar.to_pandas(result)
-
-        assert list(df.columns) == ["revenue", "ratio", "cost"]
-        assert list(df["ratio"]) == [4.0, 4.0]
 
 
 class TestClipNumericNativeRegression:


### PR DESCRIPTION
Fixes #592

### Context
 previously raised a  and overwrote columns if the  already existed, while other cleaning primitives rejected existing output columns with a .

### Solution
Updated  to consistently reject existing output columns by raising a .
Updated unit tests to assert the correct error contract.