### PR TITLE
feat : added append mode to write_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -552,6 +552,7 @@ def write_csv(
     delimiter: str = ",",
     write_header: bool = True,
     line_terminator: str = "\n",
+    mode: str = "w",
 ) -> None:
     """Write an ArFrame to a CSV file via C++ backend.
 
@@ -567,18 +568,20 @@ def write_csv(
         Whether to write the column header row.
     line_terminator : str, default "\\n"
         Line terminator to use between rows.
+    mode : {"w", "a"}, default "w"
+        File writing mode. Use "w" to overwrite/create, and "a" to append.
 
     Raises
     ------
     ValueError
-        If file format is unsupported.
+        If file format is unsupported or mode is invalid.
     RuntimeError
         If the file cannot be opened or written.
 
     Examples
     --------
     >>> ar.write_csv(frame, "output.csv")
-    >>> ar.write_csv(frame, "output.tsv", delimiter="\\t")
+    >>> ar.write_csv(frame, "output.csv", mode="a")
     """
     path = os.fspath(path)
     path_lower = path.lower()
@@ -590,6 +593,9 @@ def write_csv(
         raise ValueError(
             f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
         )
+
+    if mode not in {"w", "a"}:
+        raise ValueError("mode must be 'w' or 'a'")
 
     if not isinstance(delimiter, str):
         raise TypeError("delimiter must be a string")
@@ -604,16 +610,41 @@ def write_csv(
     if line_terminator == "":
         raise ValueError("line_terminator must not be empty")
 
+    should_append = mode == "a" and os.path.exists(path) and os.path.getsize(path) > 0
+
     config = _CsvWriteConfig()
     config.delimiter = delimiter
-    config.write_header = write_header
+    config.write_header = False if should_append else write_header
     config.line_terminator = line_terminator
 
     writer = _CsvWriter(config)
-    try:
-        writer.write(frame._frame, path)
-    except RuntimeError as e:
-        raise RuntimeError(str(e)) from e
+
+    if should_append:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as temp_file:
+            temp_path = temp_file.name
+
+        try:
+            writer.write(frame._frame, temp_path)
+            with open(path, "ab+") as dest, open(temp_path, "rb") as src:
+                dest.seek(0, os.SEEK_END)
+                if dest.tell() > 0:
+                    dest.seek(dest.tell() - 1)
+                    last_char = dest.read(1)
+                    if last_char not in (b"\n", b"\r"):
+                        dest.write(line_terminator.encode("utf-8"))
+                dest.write(src.read())
+        except RuntimeError as e:
+            raise RuntimeError(str(e)) from e
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+    else:
+        try:
+            writer.write(frame._frame, path)
+        except RuntimeError as e:
+            raise RuntimeError(str(e)) from e
 
 
 def scan_csv(

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -161,3 +161,65 @@ class TestWriteCsvLineTerminatorBytes:
         df = ar.to_pandas(frame2)
         assert df["note"].iloc[0] == "line1\nline2"
         assert df["note"].iloc[1] == "plain"
+
+
+class TestWriteCsvAppendMode:
+    """Unit tests for write_csv append mode."""
+
+    def test_append_mode_exists_and_non_empty(self, tmp_path):
+        frame1 = ar.from_pandas(pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+        frame2 = ar.from_pandas(pd.DataFrame({"a": [3, 4], "b": ["z", "w"]}))
+
+        out = tmp_path / "append.csv"
+        # First write: normal mode="w" (default)
+        ar.write_csv(frame1, out)
+
+        # Second write: append mode="a"
+        ar.write_csv(frame2, out, mode="a")
+
+        # Read back
+        res = ar.read_csv(out)
+        df = ar.to_pandas(res)
+
+        expected = pd.DataFrame({"a": [1, 2, 3, 4], "b": ["x", "y", "z", "w"]})
+        pd.testing.assert_frame_equal(df, expected, check_dtype=False)
+
+    def test_append_mode_non_existent(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        out = tmp_path / "non_existent.csv"
+
+        # If file does not exist, mode="a" should write header and content
+        ar.write_csv(frame, out, mode="a")
+
+        res = ar.read_csv(out)
+        df = ar.to_pandas(res)
+        pd.testing.assert_frame_equal(df, ar.to_pandas(frame), check_dtype=False)
+
+    def test_append_mode_empty_file(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        out = tmp_path / "empty.csv"
+        # Create empty file
+        out.touch()
+
+        # Append to empty file should write header
+        ar.write_csv(frame, out, mode="a")
+
+        res = ar.read_csv(out)
+        df = ar.to_pandas(res)
+        pd.testing.assert_frame_equal(df, ar.to_pandas(frame), check_dtype=False)
+
+    def test_append_mode_no_header(self, tmp_path):
+        frame1 = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        frame2 = ar.from_pandas(pd.DataFrame({"a": [2]}))
+
+        out = tmp_path / "no_header_append.csv"
+        ar.write_csv(frame1, out, write_header=False)
+        ar.write_csv(frame2, out, mode="a", write_header=False)
+
+        content = out.read_text().splitlines()
+        assert content == ["1", "2"]
+
+    def test_invalid_mode_rejected(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with pytest.raises(ValueError, match="mode must be 'w' or 'a'"):
+            ar.write_csv(frame, tmp_path / "out.csv", mode="invalid")


### PR DESCRIPTION
Fixes #644

### Context
Cleaned rows often need to be appended to an existing CSV file as a first-class operation rather than rewriting/overwriting files.

### Solution
Added  parameter support to  (accepting  and ).
* Appends data to existing, non-empty CSV files while automatically suppressing duplicate headers.
* Ensures new content starts on a new line by checking for trailing newlines/line terminators in existing files.
Added thorough unit test coverage in .