### PR TITLE
fix(csv): support has_header in scan_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -625,6 +625,7 @@ def scan_csv(
     thousands_separator: str | None = None,
     sample_size: int | None = None,
     null_values: list[str] | None = None,
+    has_header: bool = True,
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
 
@@ -699,6 +700,7 @@ def scan_csv(
     config.encoding = encoding
     config.trim_headers = trim_headers
     config.thousands_separator = thousands_separator
+    config.has_header = has_header
 
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -650,6 +650,12 @@ def scan_csv(
         1,234 is interpreted as two separate fields.
     sample_size : int, optional
         Number of rows to read for type inference. If None, defaults to 100 rows.
+    has_header : bool, default True
+        Whether the CSV file contains a header row.
+
+        When False, synthetic column names are generated
+        in the form ``col_0``, ``col_1``, etc., matching
+        the behavior of ``read_csv(..., has_header=False)``.
 
     Returns
     -------

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -530,13 +530,28 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     std::string line;
     std::vector<std::string> header;
 
+    std::vector<std::string> first_row;
+
     if (read_record(file, line)) {
         strip_utf8_bom(line);
-        header = parser_.parse_line(line);
-        for (auto& h : header) {
-            if (config.trim_headers) trim_in_place(h);
+
+        if (config.has_header) {
+            header = parser_.parse_line(line);
+
+            for (auto& h : header) {
+                if (config.trim_headers) trim_in_place(h);
+            }
+
+            validate_header(header);
+        } else {
+            first_row = parser_.parse_line(line);
+
+            header.reserve(first_row.size());
+
+            for (size_t i = 0; i < first_row.size(); ++i) {
+                header.push_back("col_" + std::to_string(i));
+            }
         }
-        validate_header(header);
     }
 
     size_t num_cols = header.size();
@@ -544,6 +559,16 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     size_t sample_count = 0;
 
     size_t max_samples = config.sample_size.value_or(100);
+
+    if (!config.has_header && !first_row.empty()) {
+        validate_row_width(1, num_cols, first_row.size());
+
+        for (size_t i = 0; i < num_cols && i < first_row.size(); ++i) {
+            col_types[i] = CsvParser::promote_type(col_types[i], parser_.infer_type(first_row[i]));
+        }
+
+        ++sample_count;
+    }
 
     while (read_record(file, line)) {
         if (sample_count >= max_samples) {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -780,6 +780,43 @@ class TestScanCsv:
 
         assert ar.scan_csv(csv_path) == {"value": "string"}
 
+    def test_scan_csv_has_header_false_generates_synthetic_columns(self, tmp_path):
+        csv_content = "1,Alice\n2,Bob\n"
+
+        csv_file = tmp_path / "headerless.csv"
+        csv_file.write_text(csv_content)
+
+        schema = ar.scan_csv(csv_file, has_header=False)
+
+        assert schema == {
+            "col_0": "int64",
+            "col_1": "string",
+        }
+
+    def test_scan_csv_default_has_header_behavior(self, tmp_path):
+        csv_content = "id,name\n1,Alice\n"
+
+        csv_file = tmp_path / "with_header.csv"
+        csv_file.write_text(csv_content)
+
+        schema = ar.scan_csv(csv_file)
+
+        assert schema == {
+            "id": "int64",
+            "name": "string",
+        }
+
+    def test_scan_csv_has_header_false_matches_read_csv(self, tmp_path):
+        csv_content = "1,Alice\n2,Bob\n"
+
+        csv_file = tmp_path / "headerless_match.csv"
+        csv_file.write_text(csv_content)
+
+        frame = ar.read_csv(csv_file, has_header=False)
+        schema = ar.scan_csv(csv_file, has_header=False)
+
+        assert list(frame.columns) == list(schema.keys())
+
 
 # --- Issue #115: quoted multiline round-trip across line endings ---
 


### PR DESCRIPTION
Fixes #81

## Summary
- Added `has_header` support to `scan_csv`
- Passed `has_header` through the CSV config flow
- Added synthetic column generation (`col_0`, `col_1`, ...) for headerless CSV files
- Kept behavior aligned with `read_csv`
- Added focused regression tests for both headered and headerless CSV inputs

## Validation
- Ran `pytest tests/test_csv.py -v`
- All CSV tests pass locally