### PR TITLE
feat: add reset_steps for pipeline test isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,16 +399,6 @@ ar.register_step("team:drop_nulls", remove_outliers)  # namespaced custom step
 # Introspect built-in and custom step names without reaching into internals.
 print(ar.list_steps())
 
-Need to restore the registry to built-in steps only (for example in tests)?
-
-```python
-ar.reset_steps()
-
-print(ar.list_steps())  # only built-in steps remain
-```
-
-This removes all registered custom Python steps while preserving built-in pipeline steps.
-
 # Now use it in any pipeline alongside native C++ steps
 clean = ar.pipeline(frame, [
     ("builtin:strip_whitespace",),
@@ -423,6 +413,15 @@ Need to inspect the built-in kwargs a step accepts before assembling a pipeline?
 signatures = ar.get_builtin_step_signatures()
 print(list(signatures["drop_nulls"].parameters))  # ["subset"]
 print(list(signatures["filter_rows"].parameters))  # ["column", "op", "value"]
+```
+
+Need to restore the registry back to built-in steps only during tests?
+
+```python
+ar.reset_steps()
+
+print(ar.list_steps())
+# Only built-in steps remain
 ```
 
 Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Python, then optionally migrate hot paths to C++ for full speed.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,16 @@ ar.register_step("team:drop_nulls", remove_outliers)  # namespaced custom step
 # Introspect built-in and custom step names without reaching into internals.
 print(ar.list_steps())
 
+Need to restore the registry to built-in steps only (for example in tests)?
+
+```python
+ar.reset_steps()
+
+print(ar.list_steps())  # only built-in steps remain
+```
+
+This removes all registered custom Python steps while preserving built-in pipeline steps.
+
 # Now use it in any pipeline alongside native C++ steps
 clean = ar.pipeline(frame, [
     ("builtin:strip_whitespace",),

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -61,6 +61,7 @@ from .pipeline import (
     list_steps,
     pipeline,
     register_step,
+    reset_steps,
 )
 from .quality import (
     CleanExplanation,
@@ -145,6 +146,7 @@ __all__ = [
     "register_step",
     "get_builtin_step_signatures",
     "list_steps",
+    "reset_steps",
     # Data quality
     "profile",
     "compare_profiles",

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -394,3 +394,11 @@ register_step("filter_rows", cleaning.filter_rows)
 register_step("drop_columns_matching", cleaning.drop_columns_matching)
 register_step("safe_divide_columns", cleaning.safe_divide_columns)
 register_step("replace_values", cleaning.replace_values)
+_BUILTIN_PYTHON_STEP_REGISTRY = dict(_PYTHON_STEP_REGISTRY)
+
+
+def reset_steps() -> None:
+    """Restore the Python pipeline registry to built-in steps only."""
+    with _REGISTRY_LOCK:
+        _PYTHON_STEP_REGISTRY.clear()
+        _PYTHON_STEP_REGISTRY.update(_BUILTIN_PYTHON_STEP_REGISTRY)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1140,7 +1140,7 @@ def test_list_steps_includes_registered_custom_steps():
 
     assert "list_steps_probe" in steps
 
-    
+
 def test_reset_steps_removes_custom_registered_steps():
     import pandas as pd
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1121,6 +1121,7 @@ def test_register_step_rejects_reserved_builtin_namespace():
         ar.register_step("builtin:custom_step", dummy_step)
 
 
+<<<<<<< HEAD
 def test_list_steps_includes_builtins_in_deterministic_order():
     steps = ar.list_steps()
 
@@ -1139,3 +1140,95 @@ def test_list_steps_includes_registered_custom_steps():
     steps = ar.list_steps()
 
     assert "list_steps_probe" in steps
+=======
+def test_reset_steps_removes_custom_registered_steps():
+    import pandas as pd
+
+    def custom_step(df, **kwargs):
+        return df
+
+    ar.register_step("custom_step", custom_step)
+
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = ar.pipeline(
+        frame,
+        [
+            ("custom_step",),
+        ],
+    )
+
+    assert ar.to_pandas(result)["a"].tolist() == [1, 2, 3]
+
+    ar.reset_steps()
+
+    with pytest.raises(ar.UnknownStepError):
+        ar.pipeline(
+            frame,
+            [
+                ("custom_step",),
+            ],
+        )
+
+
+def test_reset_steps_preserves_builtin_python_steps():
+    import pandas as pd
+
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "value": [" yes ", " no "],
+            }
+        )
+    )
+
+    ar.reset_steps()
+
+    result = ar.pipeline(
+        frame,
+        [
+            ("strip_whitespace",),
+        ],
+    )
+
+    cleaned = ar.to_pandas(result)
+
+    assert cleaned["value"].tolist() == ["yes", "no"]
+
+
+def test_reset_steps_removes_overwritten_custom_steps():
+    import pandas as pd
+
+    def first(df, **kwargs):
+        return df
+
+    def second(df, **kwargs):
+        return df
+
+    ar.register_step("temp_step", first)
+    ar.register_step("temp_step", second, overwrite=True)
+
+    ar.reset_steps()
+
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1],
+            }
+        )
+    )
+
+    with pytest.raises(ar.UnknownStepError):
+        ar.pipeline(
+            frame,
+            [
+                ("temp_step",),
+            ],
+        )
+>>>>>>> 738a0ef (feat: add reset_steps for pipeline test isolation)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1121,7 +1121,6 @@ def test_register_step_rejects_reserved_builtin_namespace():
         ar.register_step("builtin:custom_step", dummy_step)
 
 
-<<<<<<< HEAD
 def test_list_steps_includes_builtins_in_deterministic_order():
     steps = ar.list_steps()
 
@@ -1140,7 +1139,8 @@ def test_list_steps_includes_registered_custom_steps():
     steps = ar.list_steps()
 
     assert "list_steps_probe" in steps
-=======
+
+    
 def test_reset_steps_removes_custom_registered_steps():
     import pandas as pd
 
@@ -1231,4 +1231,3 @@ def test_reset_steps_removes_overwritten_custom_steps():
                 ("temp_step",),
             ],
         )
->>>>>>> 738a0ef (feat: add reset_steps for pipeline test isolation)


### PR DESCRIPTION
## Summary
- add `reset_steps()` to restore the pipeline registry to built-in steps only
- add regression tests for custom-step cleanup and built-in preservation
- document `reset_steps()` usage in the README

## Linked issue
Fixes #159  

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing

- [ ] `make test`
- [ ] `make lint`
- [x] Other:
          1. `pytest tests/test_pipeline.py` ->passed
          2. `ruff check arnio tests` -> passed

## Screenshots / Media
NA

## Performance Impact
NA

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
`reset_steps()` restores the Python step registry back to built-in steps using the existing registry lock for deterministic test isolation and repeatable pipeline behavior.
