### PR TITLE
add regression test for column order preservation

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -142,6 +142,7 @@ class TestFromPandas:
 
         assert frame.columns == ["z_name", "a_score", "m_active", "b_id"]
         assert list(result.columns) == ["z_name", "a_score", "m_active", "b_id"]
+
     def test_basic_roundtrip(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         df = ar.to_pandas(frame)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -127,6 +127,21 @@ class TestToPandas:
 
 
 class TestFromPandas:
+    def test_column_order_preserved_with_non_alphabetical_mixed_dtypes(self):
+        df = pd.DataFrame(
+            {
+                "z_name": ["Alice", "Bob"],
+                "a_score": [95.5, 88.0],
+                "m_active": [True, False],
+                "b_id": [1, 2],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert frame.columns == ["z_name", "a_score", "m_active", "b_id"]
+        assert list(result.columns) == ["z_name", "a_score", "m_active", "b_id"]
     def test_basic_roundtrip(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         df = ar.to_pandas(frame)


### PR DESCRIPTION
## Summary
Added a regression test to ensure column order remains stable across pandas conversion boundaries, including mixed dtype and non-alphabetical column ordering scenarios.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #245

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [** ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [** ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [** ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->
N/A

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->
No performance impact.

## Contributor checklist
- [ **] I read the contributing guide.
- [ **] I kept the PR focused on one issue or one logical change.
- [ **] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [** ] I checked that generated files, logs, and local build artifacts are not committed.
- [** ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
This PR only adds regression coverage and does not modify runtime behavior.
