### PR TITLE
refactor: share duplicated csv path validation (#82)

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -17,6 +17,8 @@ from ._core import _CsvChunkReader, _CsvConfig, _CsvReader, _CsvWriteConfig, _Cs
 from .exceptions import CsvReadError, JsonlReadError
 from .frame import ArFrame
 
+_SUPPORTED_CSV_EXTENSIONS = (".csv", ".txt", ".tsv")
+
 
 def _is_utf8_encoding(encoding: str) -> bool:
     """Return whether the encoding should be treated as raw UTF-8 input."""
@@ -293,6 +295,22 @@ def _reject_utf8_nul_bytes(path: str) -> None:
         pass  # Let C++ backend handle or raise standard error
 
 
+def _validate_csv_path_extension(path: str) -> None:
+    """Validate that the path uses a supported CSV-like extension."""
+    path_lower = path.lower()
+    if not path_lower.endswith(_SUPPORTED_CSV_EXTENSIONS):
+        raise ValueError(
+            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
+        )
+
+
+def _validate_csv_read_path(path: str, encoding: str) -> None:
+    """Validate a CSV input path before native read or schema scan."""
+    _validate_csv_path_extension(path)
+    if _is_utf8_encoding(encoding):
+        _reject_utf8_nul_bytes(path)
+
+
 def read_csv(
     path: str | os.PathLike[str],
     *,
@@ -361,18 +379,7 @@ def read_csv(
     >>> frame = ar.read_csv("data.csv", delimiter=",", has_header=True)
     """
     path, should_cleanup = _materialize_csv_input(path)
-    path_lower = path.lower()
-    if not (
-        path_lower.endswith(".csv")
-        or path_lower.endswith(".txt")
-        or path_lower.endswith(".tsv")
-    ):
-        raise ValueError(
-            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
-        )
-
-    if _is_utf8_encoding(encoding):
-        _reject_utf8_nul_bytes(path)
+    _validate_csv_read_path(path, encoding)
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")
@@ -480,15 +487,7 @@ def read_csv_chunked(
     ...     process(df)
     """
     path = os.fspath(path)
-    path_lower = path.lower()
-    if not (
-        path_lower.endswith(".csv")
-        or path_lower.endswith(".txt")
-        or path_lower.endswith(".tsv")
-    ):
-        raise ValueError(
-            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
-        )
+    _validate_csv_path_extension(path)
 
     try:
         if os.path.getsize(path) == 0:
@@ -575,15 +574,7 @@ def write_csv(
     >>> ar.write_csv(frame, "output.tsv", delimiter="\\t")
     """
     path = os.fspath(path)
-    path_lower = path.lower()
-    if not (
-        path_lower.endswith(".csv")
-        or path_lower.endswith(".txt")
-        or path_lower.endswith(".tsv")
-    ):
-        raise ValueError(
-            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
-        )
+    _validate_csv_path_extension(path)
 
     if not isinstance(delimiter, str):
         raise TypeError("delimiter must be a string")
@@ -667,18 +658,7 @@ def scan_csv(
     {'name': 'string', 'age': 'int64'}
     """
     path = os.fspath(path)
-    path_lower = path.lower()
-    if not (
-        path_lower.endswith(".csv")
-        or path_lower.endswith(".txt")
-        or path_lower.endswith(".tsv")
-    ):
-        raise ValueError(
-            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
-        )
-
-    if _is_utf8_encoding(encoding):
-        _reject_utf8_nul_bytes(path)
+    _validate_csv_read_path(path, encoding)
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -336,6 +336,15 @@ class TestReadCsv:
         with pytest.raises(ValueError, match="Unsupported file format"):
             ar.read_csv(file_path)
 
+    def test_read_and_scan_csv_unsupported_extension_parity(self, tmp_path):
+        file_path = str(tmp_path / "data.json")
+        with open(file_path, "w") as f:
+            f.write('{"a": 1}')
+
+        for fn in (ar.read_csv, ar.scan_csv):
+            with pytest.raises(ValueError, match="Unsupported file format"):
+                fn(file_path)
+
     def test_binary_file_rejection(self, tmp_path):
         file_path = str(tmp_path / "data.csv")
         with open(file_path, "wb") as f:


### PR DESCRIPTION
## Summary
- extract shared CSV path-extension validation into a private helper
- extract shared read/scan path validation so UTF-8 NUL-byte rejection stays aligned
- add a focused read/scan unsupported-extension parity test

## Testing
- `python -m pytest tests/test_csv.py -k "unsupported_extension or binary_file_rejection or missing_file_passthrough or scan_missing_file_passthrough"`
- `python -m ruff check arnio/io.py tests/test_csv.py`
- `python -m black --check arnio/io.py tests/test_csv.py`

Fixes #82