### PR TITLE
Add configurable on_bad_lines handling for malformed CSV rows

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -254,50 +254,19 @@ def _validate_parser_mode(mode: str) -> str:
     return mode
 
 
-def _materialize_csv_input(
-    source: str | os.PathLike[str] | io.TextIOBase,
-) -> tuple[str, bool]:
-    """Convert supported CSV inputs into a filesystem path."""
-    if isinstance(source, (str, os.PathLike)):
-        return os.fspath(source), False
-    if isinstance(source, io.StringIO) or (
-        hasattr(source, "read") and callable(source.read)
-    ):
-        content = source.read()
 
-        if not isinstance(content, str):
-            raise TypeError("read_csv file-like objects must return text, not bytes")
+def _validate_on_bad_lines(on_bad_lines: str) -> str:
+    """Validate on_bad_lines parameter."""
+    if not isinstance(on_bad_lines, str):
+        raise TypeError("on_bad_lines must be a string")
 
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            suffix=".csv",
-            delete=False,
-        )
+    valid_values = {"error", "warn", "skip"}
 
-        try:
-            tmp.write(content)
-            tmp.close()
-            return tmp.name, True
-        except Exception:
-            os.unlink(tmp.name)
-            raise
+    if on_bad_lines not in valid_values:
+        raise ValueError("on_bad_lines must be one of: " "'error', 'warn', or 'skip'")
 
-    raise TypeError("read_csv expected a filesystem path or text file-like object")
-
-
-def _reject_utf8_nul_bytes(path: str) -> None:
-    """Reject UTF-8 CSV inputs that contain NUL bytes anywhere in the file."""
-    try:
-        with open(path, "rb") as f:
-            while chunk := f.read(8192):
-                if b"\0" in chunk:
-                    raise CsvReadError(
-                        "CSV input contains NUL bytes and appears to be binary or corrupted"
-                    )
-    except FileNotFoundError:
-        pass  # Let C++ backend handle or raise standard error
-
+    return on_bad_lines
+]
 
 def read_csv(
     path: str | os.PathLike[str],
@@ -389,6 +358,7 @@ def read_csv(
     _validate_thousands_separator(thousands_separator)
     delimiter = _validate_delimiter(delimiter)
     mode = _validate_parser_mode(mode)
+    on_bad_lines = _validate_on_bad_lines(on_bad_lines)
     config = _CsvConfig()
     config.delimiter = delimiter
     config.on_bad_lines = on_bad_lines
@@ -440,6 +410,7 @@ def read_csv_chunked(
     trim_headers: bool = True,
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
+    on_bad_lines: str = "warn",
     mode: str = "strict",
 ) -> Iterator[ArFrame]:
     """Read a CSV file in chunks, yielding ArFrame objects.
@@ -509,10 +480,11 @@ def read_csv_chunked(
     mode = _validate_parser_mode(mode)
     chunksize = _validate_chunksize(chunksize)
     skip_rows = _validate_skip_rows(skip_rows)
-
+    on_bad_lines = _validate_on_bad_lines(on_bad_lines)
     config = _CsvConfig()
     config.delimiter = delimiter
     config.has_header = has_header
+    config.on_bad_lines = on_bad_lines
     config.encoding = encoding
     config.trim_headers = trim_headers
     config.thousands_separator = thousands_separator

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -303,6 +303,7 @@ def read_csv(
     path: str | os.PathLike[str],
     *,
     delimiter: str = ",",
+    on_bad_lines: str = "warn",
     has_header: bool = True,
     usecols: list[str] | None = None,
     nrows: int | None = None,
@@ -390,6 +391,7 @@ def read_csv(
     mode = _validate_parser_mode(mode)
     config = _CsvConfig()
     config.delimiter = delimiter
+    config.on_bad_lines = on_bad_lines
     config.has_header = has_header
     config.encoding = encoding
     config.trim_headers = trim_headers

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -229,7 +229,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("thousands_separator", &CsvConfig::thousands_separator)
         .def_readwrite("sample_size", &CsvConfig::sample_size)
         .def_readwrite("mode", &CsvConfig::mode)
-        .def_readwrite("null_values", &CsvConfig::null_values);
+        .def_readwrite("null_values", &CsvConfig::null_values)
+        .def_readwrite("on_bad_lines", &CsvConfig::on_bad_lines);
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -12,6 +12,7 @@ namespace arnio {
 
 struct CsvConfig {
     char delimiter = ',';
+    std::string on_bad_lines = "warn";
     bool has_header = true;
     std::optional<std::vector<std::string>> usecols = std::nullopt;
     std::optional<size_t> nrows = std::nullopt;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <iostream>
 #include <cerrno>
 #include <cstddef>
 #include <cstdlib>
@@ -454,9 +455,25 @@ Frame CsvReader::read(const std::string& path) const {
             }
         }
 
-        raw_data.push_back(std::move(fields));
-        ++row_count;
     }
+}
+    if (config.mode == "strict" && expected_cols.has_value()) {
+    validate_row_width(
+        record_number,
+        expected_cols.value(),
+        fields.size()
+    );}
+    if (expected_cols.has_value()) {
+    while (fields.size() < expected_cols.value()) {
+        fields.push_back("");
+    }
+
+    if (fields.size() > expected_cols.value()) {
+        fields.resize(expected_cols.value());
+    }}
+    raw_data.push_back(std::move(fields));
+    ++row_count;
+    
     file.close();
 
     // If no header, generate column names

--- a/tests/test_io_smoke.py
+++ b/tests/test_io_smoke.py
@@ -41,15 +41,11 @@ def test_from_pandas_smoke():
     assert out["x"].tolist() == [1, 2]
     assert out["y"].tolist() == ["a", "b"]
 
+
 def test_on_bad_lines_warn_truncates_and_pads(self, tmp_path):
     csv_path = tmp_path / "warn.csv"
 
-    csv_path.write_text(
-        "name,age\n"
-        "Alice,30\n"
-        "Bob,25,extra\n"
-        "Charlie\n"
-    )
+    csv_path.write_text("name,age\n" "Alice,30\n" "Bob,25,extra\n" "Charlie\n")
 
     frame = ar.read_csv(
         csv_path,
@@ -66,15 +62,11 @@ def test_on_bad_lines_warn_truncates_and_pads(self, tmp_path):
 
     assert pd.isna(df["age"].iloc[2])
 
+
 def test_on_bad_lines_skip_drops_rows(self, tmp_path):
     csv_path = tmp_path / "skip.csv"
 
-    csv_path.write_text(
-        "name,age\n"
-        "Alice,30\n"
-        "Bob,25,extra\n"
-        "Charlie\n"
-    )
+    csv_path.write_text("name,age\n" "Alice,30\n" "Bob,25,extra\n" "Charlie\n")
 
     frame = ar.read_csv(
         csv_path,
@@ -87,14 +79,11 @@ def test_on_bad_lines_skip_drops_rows(self, tmp_path):
     assert frame.shape == (1, 2)
     assert df["name"].iloc[0] == "Alice"
 
+
 def test_on_bad_lines_error_raises(self, tmp_path):
     csv_path = tmp_path / "error.csv"
 
-    csv_path.write_text(
-        "name,age\n"
-        "Alice,30\n"
-        "Bob,25,extra\n"
-    )
+    csv_path.write_text("name,age\n" "Alice,30\n" "Bob,25,extra\n")
 
     with pytest.raises(RuntimeError, match="expected 2"):
         ar.read_csv(

--- a/tests/test_io_smoke.py
+++ b/tests/test_io_smoke.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from arnio import frame
 import pytest
 
 # Only skip the module when the package or its native extension is missing.
@@ -90,4 +91,121 @@ def test_on_bad_lines_error_raises(self, tmp_path):
             csv_path,
             mode="permissive",
             on_bad_lines="error",
+        )
+
+def test_on_bad_lines_warn_long_row(self, tmp_path):
+            csv_path = tmp_path / "warn_long.csv"
+            csv_path.write_text(
+            "name,age\n"
+            "Alice,30\n"
+            "Bob,25,extra\n"
+            )
+
+            frame = ar.read_csv(
+            csv_path,
+            mode="permissive",
+            on_bad_lines="warn",
+            )
+
+            df = ar.to_pandas(frame)
+
+            assert frame.shape == (2, 2)
+            assert df["name"].tolist() == ["Alice", "Bob"]
+            assert df["age"].tolist() == [30, 25]
+
+def test_on_bad_lines_warn_short_row(self, tmp_path):
+        csv_path = tmp_path / "warn_short.csv"
+
+        csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Charlie\n"
+        )
+
+        frame = ar.read_csv(
+        csv_path,
+        mode="permissive",
+        on_bad_lines="warn",
+        )
+
+        df = ar.to_pandas(frame)
+
+        assert frame.shape == (2, 2)
+        assert df["name"].tolist() == ["Alice", "Charlie"]
+        assert pd.isna(df["age"].iloc[1])
+
+def test_on_bad_lines_skip_long_row(self, tmp_path):
+
+    csv_path = tmp_path / "skip_long.csv"
+
+    csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Bob,25,extra\n"
+        )
+
+    frame = ar.read_csv(
+        csv_path,
+        mode="permissive",
+        on_bad_lines="skip",
+        )
+
+    df = ar.to_pandas(frame)
+
+    assert frame.shape == (1, 2)
+    assert df["name"].tolist() == ["Alice"]
+
+
+def test_on_bad_lines_skip_short_row(self, tmp_path):
+
+    csv_path = tmp_path / "skip_short.csv"
+
+    csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Charlie\n"
+        )
+
+    frame = ar.read_csv(
+        csv_path,
+        mode="permissive",
+        on_bad_lines="skip",
+        )
+
+    df = ar.to_pandas(frame)
+
+    assert frame.shape == (1, 2)
+    assert df["name"].tolist() == ["Alice"]
+
+def test_on_bad_lines_error_long_row(self, tmp_path):
+
+    csv_path = tmp_path / "error_long.csv"
+
+    csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Bob,25,extra\n"
+        )
+
+    with pytest.raises(RuntimeError, match="expected 2"):
+        ar.read_csv(
+        csv_path,
+        mode="permissive",
+        on_bad_lines="error",
+        )
+
+
+def test_on_bad_lines_error_short_row(self, tmp_path):
+    csv_path = tmp_path / "error_short.csv"
+    csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Charlie\n"
+        )
+
+    with pytest.raises(RuntimeError, match="expected 2"):
+        ar.read_csv(
+        csv_path,
+        mode="permissive",
+        on_bad_lines="error",
         )

--- a/tests/test_io_smoke.py
+++ b/tests/test_io_smoke.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 # Only skip the module when the package or its native extension is missing.
@@ -39,3 +40,65 @@ def test_from_pandas_smoke():
     assert list(out.columns) == ["x", "y"]
     assert out["x"].tolist() == [1, 2]
     assert out["y"].tolist() == ["a", "b"]
+
+def test_on_bad_lines_warn_truncates_and_pads(self, tmp_path):
+    csv_path = tmp_path / "warn.csv"
+
+    csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Bob,25,extra\n"
+        "Charlie\n"
+    )
+
+    frame = ar.read_csv(
+        csv_path,
+        mode="permissive",
+        on_bad_lines="warn",
+    )
+
+    df = ar.to_pandas(frame)
+
+    assert frame.shape == (3, 2)
+
+    assert df["name"].iloc[1] == "Bob"
+    assert df["age"].iloc[1] == 25
+
+    assert pd.isna(df["age"].iloc[2])
+
+def test_on_bad_lines_skip_drops_rows(self, tmp_path):
+    csv_path = tmp_path / "skip.csv"
+
+    csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Bob,25,extra\n"
+        "Charlie\n"
+    )
+
+    frame = ar.read_csv(
+        csv_path,
+        mode="permissive",
+        on_bad_lines="skip",
+    )
+
+    df = ar.to_pandas(frame)
+
+    assert frame.shape == (1, 2)
+    assert df["name"].iloc[0] == "Alice"
+
+def test_on_bad_lines_error_raises(self, tmp_path):
+    csv_path = tmp_path / "error.csv"
+
+    csv_path.write_text(
+        "name,age\n"
+        "Alice,30\n"
+        "Bob,25,extra\n"
+    )
+
+    with pytest.raises(RuntimeError, match="expected 2"):
+        ar.read_csv(
+            csv_path,
+            mode="permissive",
+            on_bad_lines="error",
+        )

--- a/tstest_io_smoke.py
+++ b/tstest_io_smoke.py
@@ -1,0 +1,324 @@
+
+                   SSUUMMMMAARRYY OOFF LLEESSSS CCOOMMMMAANNDDSS
+
+      Commands marked with * may be preceded by a number, _N.
+      Notes in parentheses indicate the behavior if _N is given.
+      A key preceded by a caret indicates the Ctrl key; thus ^K is ctrl-K.
+
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+ ---------------------------------------------------------------------------
+
+                           MMOOVVIINNGG
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+  ESC-j             *  Forward  one file line (or _N file lines).
+  ESC-k             *  Backward one file line (or _N file lines).
+  f  ^F  ^V  SPACE  *  Forward  one window (or _N lines).
+  b  ^B  ESC-v      *  Backward one window (or _N lines).
+  z                 *  Forward  one window (and set window to _N).
+  w                 *  Backward one window (and set window to _N).
+  ESC-SPACE         *  Forward  one window, but don't stop at end-of-file.
+  ESC-b             *  Backward one window, but don't stop at beginning-of-file.
+  d  ^D             *  Forward  one half-window (and set half-window to _N).
+  u  ^U             *  Backward one half-window (and set half-window to _N).
+  ESC-)  RightArrow *  Right one half screen width (or _N positions).
+  ESC-(  LeftArrow  *  Left  one half screen width (or _N positions).
+  ESC-}  ^RightArrow   Right to last column displayed.
+  ESC-{  ^LeftArrow    Left  to first column.
+  F                    Forward forever; like "tail -f".
+  ESC-F                Like F but stop when search pattern is found.
+  r  ^R  ^L            Repaint screen.
+  R                    Repaint screen, discarding buffered input.
+        ---------------------------------------------------
+        Default "window" is the screen height.
+        Default "half-window" is half of the screen height.
+ ---------------------------------------------------------------------------
+
+                          SSEEAARRCCHHIINNGG
+
+  /_p_a_t_t_e_r_n          *  Search forward for (_N-th) matching line.
+  ?_p_a_t_t_e_r_n          *  Search backward for (_N-th) matching line.
+  n                 *  Repeat previous search (for _N-th occurrence).
+  N                 *  Repeat previous search in reverse direction.
+  ESC-n             *  Repeat previous search, spanning files.
+  ESC-N             *  Repeat previous search, reverse dir. & spanning files.
+  ^O^N  ^On         *  Search forward for (_N-th) OSC8 hyperlink.
+  ^O^P  ^Op         *  Search backward for (_N-th) OSC8 hyperlink.
+  ^O^L  ^Ol            Jump to the currently selected OSC8 hyperlink.
+  ESC-u                Undo (toggle) search highlighting.
+  ESC-U                Clear search highlighting.
+  &_p_a_t_t_e_r_n          *  Display only matching lines.
+        ---------------------------------------------------
+		Search is case-sensitive unless changed with -i or -I.
+        A search pattern may begin with one or more of:
+        ^N or !  Search for NON-matching lines.
+        ^E or *  Search multiple files (pass thru END OF FILE).
+        ^F or @  Start search at FIRST file (for /) or last file (for ?).
+        ^K       Highlight matches, but don't move (KEEP position).
+        ^R       Don't use REGULAR EXPRESSIONS.
+        ^S _n     Search for match in _n-th parenthesized subpattern.
+        ^W       WRAP search if no match found.
+        ^L       Enter next character literally into pattern.
+ ---------------------------------------------------------------------------
+
+                           JJUUMMPPIINNGG
+
+  g  <  ESC-<       *  Go to first line in file (or line _N).
+  G  >  ESC->       *  Go to last line in file (or line _N).
+  p  %              *  Go to beginning of file (or _N percent into file).
+  t                 *  Go to the (_N-th) next tag.
+  T                 *  Go to the (_N-th) previous tag.
+  {  (  [           *  Find close bracket } ) ].
+  }  )  ]           *  Find open bracket { ( [.
+  ESC-^F _<_c_1_> _<_c_2_>  *  Find close bracket _<_c_2_>.
+  ESC-^B _<_c_1_> _<_c_2_>  *  Find open bracket _<_c_1_>.
+        ---------------------------------------------------
+        Each "find close bracket" command goes forward to the close bracket 
+          matching the (_N-th) open bracket in the top line.
+        Each "find open bracket" command goes backward to the open bracket 
+          matching the (_N-th) close bracket in the bottom line.
+
+  m_<_l_e_t_t_e_r_>            Mark the current top line with <letter>.
+  M_<_l_e_t_t_e_r_>            Mark the current bottom line with <letter>.
+  '_<_l_e_t_t_e_r_>            Go to a previously marked position.
+  ''                   Go to the previous position.
+  ^X^X                 Same as '.
+  ESC-m_<_l_e_t_t_e_r_>        Clear a mark.
+        ---------------------------------------------------
+        A mark is any upper-case or lower-case letter.
+        Certain marks are predefined:
+             ^  means  beginning of the file
+             $  means  end of the file
+ ---------------------------------------------------------------------------
+
+                        CCHHAANNGGIINNGG FFIILLEESS
+
+  :e [_f_i_l_e]            Examine a new file.
+  ^X^V                 Same as :e.
+  :n                *  Examine the (_N-th) next file from the command line.
+  :p                *  Examine the (_N-th) previous file from the command line.
+  :x                *  Examine the first (or _N-th) file from the command line.
+  ^O^O                 Open the currently selected OSC8 hyperlink.
+  :d                   Delete the current file from the command line list.
+  =  ^G  :f            Print current file name.
+ ---------------------------------------------------------------------------
+
+                    MMIISSCCEELLLLAANNEEOOUUSS CCOOMMMMAANNDDSS
+
+  -_<_f_l_a_g_>              Toggle a command line option [see OPTIONS below].
+  --_<_n_a_m_e_>             Toggle a command line option, by name.
+  __<_f_l_a_g_>              Display the setting of a command line option.
+  ___<_n_a_m_e_>             Display the setting of an option, by name.
+  +_c_m_d                 Execute the less cmd each time a new file is examined.
+
+  !_c_o_m_m_a_n_d             Execute the shell command with $SHELL.
+  #_c_o_m_m_a_n_d             Execute the shell command, expanded like a prompt.
+  |XX_c_o_m_m_a_n_d            Pipe file between current pos & mark XX to shell command.
+  s _f_i_l_e               Save input to a file.
+  v                    Edit the current file with $VISUAL or $EDITOR.
+  V                    Print version number of "less".
+ ---------------------------------------------------------------------------
+
+                           OOPPTTIIOONNSS
+
+        Most options may be changed either on the command line,
+        or from within less by using the - or -- command.
+        Options may be given in one of two forms: either a single
+        character preceded by a -, or a name preceded by --.
+
+  -?  ........  --help
+                  Display help (from command line).
+  -a  ........  --search-skip-screen
+                  Search skips current screen.
+  -A  ........  --SEARCH-SKIP-SCREEN
+                  Search starts just after target line.
+  -b [_N]  ....  --buffers=[_N]
+                  Number of buffers.
+  -B  ........  --auto-buffers
+                  Don't automatically allocate buffers for pipes.
+  -c  ........  --clear-screen
+                  Repaint by clearing rather than scrolling.
+  -d  ........  --dumb
+                  Dumb terminal.
+  -D xx_c_o_l_o_r  .  --color=xx_c_o_l_o_r
+                  Set screen colors.
+  -e  -E  ....  --quit-at-eof  --QUIT-AT-EOF
+                  Quit at end of file.
+  -f  ........  --force
+                  Force open non-regular files.
+  -F  ........  --quit-if-one-screen
+                  Quit if entire file fits on first screen.
+  -g  ........  --hilite-search
+                  Highlight only last match for searches.
+  -G  ........  --HILITE-SEARCH
+                  Don't highlight any matches for searches.
+  -h [_N]  ....  --max-back-scroll=[_N]
+                  Backward scroll limit.
+  -i  ........  --ignore-case
+                  Ignore case in searches that do not contain uppercase.
+  -I  ........  --IGNORE-CASE
+                  Ignore case in all searches.
+  -j [_N]  ....  --jump-target=[_N]
+                  Screen position of target lines.
+  -J  ........  --status-column
+                  Display a status column at left edge of screen.
+  -k _f_i_l_e  ...  --lesskey-file=_f_i_l_e
+                  Use a compiled lesskey file.
+  -K  ........  --quit-on-intr
+                  Exit less in response to ctrl-C.
+  -L  ........  --no-lessopen
+                  Ignore the LESSOPEN environment variable.
+  -m  -M  ....  --long-prompt  --LONG-PROMPT
+                  Set prompt style.
+  -n .........  --line-numbers
+                  Suppress line numbers in prompts and messages.
+  -N .........  --LINE-NUMBERS
+                  Display line number at start of each line.
+  -o [_f_i_l_e] ..  --log-file=[_f_i_l_e]
+                  Copy to log file (standard input only).
+  -O [_f_i_l_e] ..  --LOG-FILE=[_f_i_l_e]
+                  Copy to log file (unconditionally overwrite).
+  -p _p_a_t_t_e_r_n .  --pattern=[_p_a_t_t_e_r_n]
+                  Start at pattern (from command line).
+  -P [_p_r_o_m_p_t]   --prompt=[_p_r_o_m_p_t]
+                  Define new prompt.
+  -q  -Q  ....  --quiet  --QUIET  --silent --SILENT
+                  Quiet the terminal bell.
+  -r  -R  ....  --raw-control-chars  --RAW-CONTROL-CHARS
+                  Output "raw" control characters.
+  -s  ........  --squeeze-blank-lines
+                  Squeeze multiple blank lines.
+  -S  ........  --chop-long-lines
+                  Chop (truncate) long lines rather than wrapping.
+  -t _t_a_g  ....  --tag=[_t_a_g]
+                  Find a tag.
+  -T [_t_a_g_s_f_i_l_e] --tag-file=[_t_a_g_s_f_i_l_e]
+                  Use an alternate tags file.
+  -u  -U  ....  --underline-special  --UNDERLINE-SPECIAL
+                  Change handling of backspaces, tabs and carriage returns.
+  -V  ........  --version
+                  Display the version number of "less".
+  -w  ........  --hilite-unread
+                  Highlight first new line after forward-screen.
+  -W  ........  --HILITE-UNREAD
+                  Highlight first new line after any forward movement.
+  -x [_N[,...]]  --tabs=[_N[,...]]
+                  Set tab stops.
+  -X  ........  --no-init
+                  Don't use termcap init/deinit strings.
+  -y [_N]  ....  --max-forw-scroll=[_N]
+                  Forward scroll limit.
+  -z [_N]  ....  --window=[_N]
+                  Set size of window.
+  -" [_c[_c]]  .  --quotes=[_c[_c]]
+                  Set shell quote characters.
+  -~  ........  --tilde
+                  Don't display tildes after end of file.
+  -# [_N]  ....  --shift=[_N]
+                  Set horizontal scroll amount (0 = one half screen width).
+
+                --exit-follow-on-close
+                  Exit F command on a pipe when writer closes pipe.
+                --file-size
+                  Automatically determine the size of the input file.
+                --follow-name
+                  The F command changes files if the input file is renamed.
+                --form-feed
+                  Stop scrolling when a form feed character is reached.
+                --header=[_L[,_C[,_N]]]
+                  Use _L lines (starting at line _N) and _C columns as headers.
+                --incsearch
+                  Search file as each pattern character is typed in.
+                --intr=[_C]
+                  Use _C instead of ^X to interrupt a read.
+                --lesskey-context=_t_e_x_t
+                  Use lesskey source file contents.
+                --lesskey-src=_f_i_l_e
+                  Use a lesskey source file.
+                --line-num-width=[_N]
+                  Set the width of the -N line number field to _N characters.
+                --match-shift=[_N]
+                  Show at least _N characters to the left of a search match.
+                --modelines=[_N]
+                  Read _N lines from the input file and look for vim modelines.
+                --mouse
+                  Enable mouse input.
+                --no-edit-warn
+                  Don't warn when using v command on a file opened via LESSOPEN.
+                --no-keypad
+                  Don't send termcap keypad init/deinit strings.
+                --no-histdups
+                  Remove duplicates from command history.
+                --no-number-headers
+                  Don't give line numbers to header lines.
+                --no-paste
+                  Ignore pasted input.
+                --no-search-header-lines
+                  Searches do not include header lines.
+                --no-search-header-columns
+                  Searches do not include header columns.
+                --no-search-headers
+                  Searches do not include header lines or columns.
+                --no-vbell
+                  Disable the terminal's visual bell.
+                --redraw-on-quit
+                  Redraw final screen when quitting.
+                --rscroll=[_C]
+                  Set the character used to mark truncated lines.
+                --save-marks
+                  Retain marks across invocations of less.
+                --search-options=[EFKNRW-]
+                  Set default options for every search.
+                --show-preproc-errors
+                  Display a message if preprocessor exits with an error status.
+                --proc-backspace
+                  Process backspaces for bold/underline.
+                --PROC-BACKSPACE
+                  Treat backspaces as control characters.
+                --proc-return
+                  Delete carriage returns before newline.
+                --PROC-RETURN
+                  Treat carriage returns as control characters.
+                --proc-tab
+                  Expand tabs to spaces.
+                --PROC-TAB
+                  Treat tabs as control characters.
+                --status-col-width=[_N]
+                  Set the width of the -J status column to _N characters.
+                --status-line
+                  Highlight or color the entire line containing a mark.
+                --use-backslash
+                  Subsequent options use backslash as escape char.
+                --use-color
+                  Enables colored text.
+                --wheel-lines=[_N]
+                  Each click of the mouse wheel moves _N lines.
+                --wordwrap
+                  Wrap lines at spaces.
+
+
+ ---------------------------------------------------------------------------
+
+                          LLIINNEE EEDDIITTIINNGG
+
+        These keys can be used to edit text being entered 
+        on the "command line" at the bottom of the screen.
+
+ RightArrow ..................... ESC-l ... Move cursor right one character.
+ LeftArrow ...................... ESC-h ... Move cursor left one character.
+ ctrl-RightArrow  ESC-RightArrow  ESC-w ... Move cursor right one word.
+ ctrl-LeftArrow   ESC-LeftArrow   ESC-b ... Move cursor left one word.
+ HOME ........................... ESC-0 ... Move cursor to start of line.
+ END ............................ ESC-$ ... Move cursor to end of line.
+ BACKSPACE ................................ Delete char to left of cursor.
+ DELETE ......................... ESC-x ... Delete char under cursor.
+ ctrl-BACKSPACE   ESC-BACKSPACE ........... Delete word to left of cursor.
+ ctrl-DELETE .... ESC-DELETE .... ESC-X ... Delete word under cursor.
+ ctrl-U ......... ESC (MS-DOS only) ....... Delete entire line.
+ UpArrow ........................ ESC-k ... Retrieve previous command line.
+ DownArrow ...................... ESC-j ... Retrieve next command line.
+ TAB ...................................... Complete filename & cycle.
+ SHIFT-TAB ...................... ESC-TAB   Complete filename & reverse cycle.
+ ctrl-L ................................... Complete filename, list all.


### PR DESCRIPTION
## Summary

Adds configurable malformed-row handling through `on_bad_lines` in CSV parsing.

Supported policies:

* `"error"` → raises on malformed rows
* `"warn"` (default) → preserves current behavior while emitting warnings
* `"skip"` → skips malformed rows entirely

## Changes

* Added `on_bad_lines` to `CsvConfig`
* Exposed parameter through `arnio.read_csv(...)`
* Added malformed row handling for:

  * short rows
  * long rows
* Added tests for:

  * warn mode
  * skip mode
  * error mode

Fixes #27
