### PR TITLE
feat(io): add write_parquet() via optional pyarrow extra

### DIFF
--- a/.github/workflows/parquet-extra-test.yml
+++ b/.github/workflows/parquet-extra-test.yml
@@ -1,0 +1,43 @@
+name: Parquet Extra Tests
+
+# Runs the write_parquet test suite with pyarrow installed.
+# Triggered on changes to the parquet implementation or this workflow,
+# plus a weekly schedule and manual dispatch.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/parquet-extra-test.yml"
+      - "arnio/io.py"
+      - "tests/test_parquet.py"
+      - "pyproject.toml"
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  parquet-extra-test:
+    name: write_parquet with pyarrow (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11", "3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install arnio with parquet extra
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -e ".[dev,parquet]"
+
+      - name: Run parquet tests
+        run: pytest tests/test_parquet.py -v --tb=short

--- a/README.md
+++ b/README.md
@@ -336,6 +336,33 @@ Raises `ar.JsonlReadError` with the 1-based line number if a line contains inval
 </details>
 
 <details>
+<summary><b>📦 Export to Parquet for columnar analytics pipelines</b></summary>
+<br>
+
+`write_parquet` exports an ArFrame to a Parquet file via pyarrow.  Install the optional extra first:
+
+```bash
+pip install arnio[parquet]
+```
+
+```python
+# Basic export
+ar.write_parquet(frame, "output.parquet")
+
+# Choose compression codec: "snappy" (default), "gzip", "zstd", "brotli", "none"
+ar.write_parquet(frame, "output.parquet", compression="zstd")
+
+# Control row group size for large files
+ar.write_parquet(frame, "output.parquet", row_group_size=50_000)
+
+# .pq extension also accepted
+ar.write_parquet(frame, "output.pq")
+```
+
+Raises `ImportError` with an install hint if pyarrow is not available.
+</details>
+
+<details>
 <summary><b>👀 Preview rows without pandas conversion or full-column Python list materialization</b></summary>
 <br>
 
@@ -1603,7 +1630,7 @@ arnio/
 │   └── bind_arnio.cpp       # pybind11 module — the Python↔C++ bridge
 ├── arnio/
 │   ├── __init__.py          # Public API surface
-│   ├── io.py                # read_csv, read_jsonl, scan_csv, write_csv
+│   ├── io.py                # read_csv, read_jsonl, scan_csv, write_csv, write_parquet
 │   ├── cleaning.py          # Python wrappers for C++ cleaning functions
 │   ├── pipeline.py          # Step registry + pipeline executor
 │   ├── convert.py           # to_pandas (zero-copy), from_pandas

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -55,6 +55,7 @@ from .io import (
     scan_csv,
     sniff_delimiter,
     write_csv,
+    write_parquet,
 )
 from .pipeline import (
     get_builtin_step_signatures,
@@ -110,6 +111,7 @@ __all__ = [
     "read_csv_chunked",
     "read_jsonl",
     "write_csv",
+    "write_parquet",
     "scan_csv",
     "sniff_delimiter",
     # Cleaning

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -978,3 +978,95 @@ def sniff_delimiter(
         )
 
     return best_candidates[0]
+
+
+_VALID_COMPRESSIONS = {"snappy", "gzip", "brotli", "zstd", "none"}
+
+
+def write_parquet(
+    frame: ArFrame,
+    path: str | os.PathLike[str],
+    *,
+    compression: str = "snappy",
+    row_group_size: int | None = None,
+) -> None:
+    """Write an ArFrame to a Parquet file via pyarrow.
+
+    Requires the ``pyarrow`` package.  Install it with::
+
+        pip install arnio[parquet]
+
+    The implementation converts the frame to a pandas DataFrame via
+    :func:`to_pandas` and delegates encoding to
+    ``pandas.DataFrame.to_parquet(engine="pyarrow")``.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        The data frame to write.
+    path : str or path-like
+        Destination file path.  Must end with ``.parquet`` or ``.pq``.
+    compression : str, default ``"snappy"``
+        Parquet compression codec.  Accepted values: ``"snappy"``,
+        ``"gzip"``, ``"brotli"``, ``"zstd"``, ``"none"``.
+    row_group_size : int, optional
+        Number of rows per Parquet row group.  If ``None``, pyarrow
+        chooses the default (typically 128 MB per group).  Must be a
+        positive integer when provided.
+
+    Raises
+    ------
+    ImportError
+        If ``pyarrow`` is not installed.
+    ValueError
+        If the file extension is not ``.parquet`` or ``.pq``, if
+        ``compression`` is not a recognised codec, or if
+        ``row_group_size`` is not a positive integer.
+
+    Examples
+    --------
+    >>> ar.write_parquet(frame, "output.parquet")
+    >>> ar.write_parquet(frame, "output.pq", compression="zstd")
+    >>> ar.write_parquet(frame, "output.parquet", row_group_size=50_000)
+    """
+    try:
+        import pyarrow  # noqa: F401 — presence check only
+    except ImportError as exc:
+        raise ImportError(
+            "pyarrow is required for Parquet export. "
+            "Install it with: pip install arnio[parquet]"
+        ) from exc
+
+    from .convert import to_pandas
+
+    path = os.fspath(path)
+    path_lower = path.lower()
+    if not (path_lower.endswith(".parquet") or path_lower.endswith(".pq")):
+        raise ValueError(
+            f"Unsupported file format: {path}. "
+            "write_parquet only supports .parquet and .pq files."
+        )
+
+    if compression not in _VALID_COMPRESSIONS:
+        raise ValueError(
+            f"Unknown compression codec: {compression!r}. "
+            f"Valid options are: {sorted(_VALID_COMPRESSIONS)}"
+        )
+
+    if row_group_size is not None:
+        if isinstance(row_group_size, bool) or not isinstance(row_group_size, int):
+            raise TypeError("row_group_size must be an integer")
+        if row_group_size <= 0:
+            raise ValueError("row_group_size must be a positive integer")
+
+    df = to_pandas(frame)
+
+    kwargs: dict = {
+        "engine": "pyarrow",
+        "compression": None if compression == "none" else compression,
+        "index": False,
+    }
+    if row_group_size is not None:
+        kwargs["row_group_size"] = row_group_size
+
+    df.to_parquet(path, **kwargs)

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1029,14 +1029,6 @@ def write_parquet(
     >>> ar.write_parquet(frame, "output.pq", compression="zstd")
     >>> ar.write_parquet(frame, "output.parquet", row_group_size=50_000)
     """
-    try:
-        import pyarrow  # noqa: F401 — presence check only
-    except ImportError as exc:
-        raise ImportError(
-            "pyarrow is required for Parquet export. "
-            "Install it with: pip install arnio[parquet]"
-        ) from exc
-
     from .convert import to_pandas
 
     path = os.fspath(path)
@@ -1058,6 +1050,14 @@ def write_parquet(
             raise TypeError("row_group_size must be an integer")
         if row_group_size <= 0:
             raise ValueError("row_group_size must be a positive integer")
+
+    try:
+        import pyarrow  # noqa: F401 — presence check only
+    except ImportError as exc:
+        raise ImportError(
+            "pyarrow is required for Parquet export. "
+            "Install it with: pip install arnio[parquet]"
+        ) from exc
 
     df = to_pandas(frame)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ dev = [
 sklearn = [
     "scikit-learn>=1.0",
 ]
+parquet = [
+    "pyarrow>=8.0",
+]
 
 [tool.setuptools.package-data]
 arnio = ["py.typed"]

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,9 +1,9 @@
 """Tests for write_parquet functionality.
 
-Tests that require pyarrow are marked with @pytest.mark.parquet and are
-skipped when pyarrow is not installed.  The ImportError contract test
-(test_missing_pyarrow_raises_import_error) runs unconditionally because
-it mocks the import and does not need pyarrow to be present.
+Tests that require pyarrow are marked with @skip_without_pyarrow and are
+skipped when pyarrow is not installed.  The TestWriteParquetErrors class
+has no skip marker so the ImportError contract test and path/compression
+validation tests always run regardless of whether pyarrow is present.
 """
 
 from __future__ import annotations
@@ -15,13 +15,6 @@ import pandas as pd
 import pytest
 
 import arnio as ar
-
-# Marker used to skip tests that actually call write_parquet with pyarrow.
-# Applied per-class/test so the ImportError contract test is never skipped.
-pyarrow_required = pytest.mark.skipif(
-    pytest.importorskip("pyarrow", reason="pyarrow not installed") is None,
-    reason="pyarrow not installed",
-)
 
 try:
     import pyarrow  # noqa: F401

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,0 +1,179 @@
+"""Tests for write_parquet functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+pyarrow = pytest.importorskip("pyarrow", reason="pyarrow not installed")
+
+
+class TestWriteParquetBasic:
+    def test_basic_write_creates_file(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        assert out.exists()
+
+    def test_pq_extension_accepted(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1, 2]}))
+        out = tmp_path / "out.pq"
+        ar.write_parquet(frame, out)
+        assert out.exists()
+
+    def test_pathlike_input(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [42]}))
+        ar.write_parquet(frame, Path(tmp_path / "out.parquet"))
+        assert (tmp_path / "out.parquet").exists()
+
+    def test_string_path_input(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [42]}))
+        ar.write_parquet(frame, str(tmp_path / "out.parquet"))
+        assert (tmp_path / "out.parquet").exists()
+
+    def test_returns_none(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        result = ar.write_parquet(frame, tmp_path / "out.parquet")
+        assert result is None
+
+
+class TestWriteParquetRoundTrip:
+    def test_integer_column_round_trips(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"n": [1, 2, 3]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert df["n"].tolist() == [1, 2, 3]
+
+    def test_float_column_round_trips(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"f": [1.1, 2.2, 3.3]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert [round(v, 1) for v in df["f"].tolist()] == [1.1, 2.2, 3.3]
+
+    def test_string_column_round_trips(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"s": ["alice", "bob"]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert df["s"].tolist() == ["alice", "bob"]
+
+    def test_bool_column_round_trips(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"b": [True, False, True]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert df["b"].tolist() == [True, False, True]
+
+    def test_null_values_round_trip(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, None, 3], "b": ["x", None, "z"]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert pd.isna(df["a"].iloc[1])
+        assert pd.isna(df["b"].iloc[1])
+
+    def test_mixed_dtypes_round_trip(self, tmp_path):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "i": [1, 2, 3],
+                    "f": [1.0, 2.0, 3.0],
+                    "s": ["a", "b", "c"],
+                    "b": [True, False, True],
+                }
+            )
+        )
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert list(df.columns) == ["i", "f", "s", "b"]
+        assert df.shape == (3, 4)
+
+    def test_result_consistent_with_to_pandas(self, tmp_path):
+        original_df = pd.DataFrame({"x": [10, 20, 30], "y": ["a", "b", "c"]})
+        frame = ar.from_pandas(original_df)
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        roundtrip_df = pd.read_parquet(out, engine="pyarrow")
+        arnio_df = ar.to_pandas(frame)
+        assert roundtrip_df["x"].tolist() == arnio_df["x"].tolist()
+        assert roundtrip_df["y"].tolist() == arnio_df["y"].tolist()
+
+
+class TestWriteParquetCompression:
+    @pytest.mark.parametrize("codec", ["snappy", "gzip", "zstd", "none"])
+    def test_compression_codecs_accepted(self, tmp_path, codec):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1, 2, 3]}))
+        out = tmp_path / f"out_{codec}.parquet"
+        ar.write_parquet(frame, out, compression=codec)
+        assert out.exists()
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert df["v"].tolist() == [1, 2, 3]
+
+    def test_default_compression_is_snappy(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out)
+        # File should be readable — snappy is the default
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert df["v"].tolist() == [1]
+
+    def test_unknown_compression_raises(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
+        with pytest.raises(ValueError, match="Unknown compression codec"):
+            ar.write_parquet(frame, tmp_path / "out.parquet", compression="lz4")
+
+
+class TestWriteParquetRowGroupSize:
+    def test_row_group_size_accepted(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": list(range(100))}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out, row_group_size=25)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert len(df) == 100
+
+    def test_row_group_size_none_uses_default(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1, 2, 3]}))
+        out = tmp_path / "out.parquet"
+        ar.write_parquet(frame, out, row_group_size=None)
+        assert out.exists()
+
+    def test_row_group_size_zero_raises(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
+        with pytest.raises(ValueError, match="positive integer"):
+            ar.write_parquet(frame, tmp_path / "out.parquet", row_group_size=0)
+
+    def test_row_group_size_negative_raises(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
+        with pytest.raises(ValueError, match="positive integer"):
+            ar.write_parquet(frame, tmp_path / "out.parquet", row_group_size=-1)
+
+    def test_row_group_size_non_integer_raises(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
+        with pytest.raises(TypeError, match="integer"):
+            ar.write_parquet(frame, tmp_path / "out.parquet", row_group_size=1.5)
+
+
+class TestWriteParquetErrors:
+    def test_unsupported_extension_raises(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            ar.write_parquet(frame, tmp_path / "out.csv")
+
+    def test_json_extension_raises(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            ar.write_parquet(frame, tmp_path / "out.json")
+
+    def test_missing_pyarrow_raises_import_error(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with patch.dict("sys.modules", {"pyarrow": None}):
+            with pytest.raises(ImportError, match="pip install arnio\\[parquet\\]"):
+                ar.write_parquet(frame, tmp_path / "out.parquet")

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,4 +1,10 @@
-"""Tests for write_parquet functionality."""
+"""Tests for write_parquet functionality.
+
+Tests that require pyarrow are marked with @pytest.mark.parquet and are
+skipped when pyarrow is not installed.  The ImportError contract test
+(test_missing_pyarrow_raises_import_error) runs unconditionally because
+it mocks the import and does not need pyarrow to be present.
+"""
 
 from __future__ import annotations
 
@@ -10,9 +16,26 @@ import pytest
 
 import arnio as ar
 
-pyarrow = pytest.importorskip("pyarrow", reason="pyarrow not installed")
+# Marker used to skip tests that actually call write_parquet with pyarrow.
+# Applied per-class/test so the ImportError contract test is never skipped.
+pyarrow_required = pytest.mark.skipif(
+    pytest.importorskip("pyarrow", reason="pyarrow not installed") is None,
+    reason="pyarrow not installed",
+)
+
+try:
+    import pyarrow  # noqa: F401
+
+    HAS_PYARROW = True
+except ImportError:
+    HAS_PYARROW = False
+
+skip_without_pyarrow = pytest.mark.skipif(
+    not HAS_PYARROW, reason="pyarrow not installed — install arnio[parquet]"
+)
 
 
+@skip_without_pyarrow
 class TestWriteParquetBasic:
     def test_basic_write_creates_file(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
@@ -42,6 +65,7 @@ class TestWriteParquetBasic:
         assert result is None
 
 
+@skip_without_pyarrow
 class TestWriteParquetRoundTrip:
     def test_integer_column_round_trips(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"n": [1, 2, 3]}))
@@ -107,8 +131,9 @@ class TestWriteParquetRoundTrip:
         assert roundtrip_df["y"].tolist() == arnio_df["y"].tolist()
 
 
+@skip_without_pyarrow
 class TestWriteParquetCompression:
-    @pytest.mark.parametrize("codec", ["snappy", "gzip", "zstd", "none"])
+    @pytest.mark.parametrize("codec", ["snappy", "gzip", "brotli", "zstd", "none"])
     def test_compression_codecs_accepted(self, tmp_path, codec):
         frame = ar.from_pandas(pd.DataFrame({"v": [1, 2, 3]}))
         out = tmp_path / f"out_{codec}.parquet"
@@ -121,7 +146,6 @@ class TestWriteParquetCompression:
         frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
         out = tmp_path / "out.parquet"
         ar.write_parquet(frame, out)
-        # File should be readable — snappy is the default
         df = pd.read_parquet(out, engine="pyarrow")
         assert df["v"].tolist() == [1]
 
@@ -131,6 +155,7 @@ class TestWriteParquetCompression:
             ar.write_parquet(frame, tmp_path / "out.parquet", compression="lz4")
 
 
+@skip_without_pyarrow
 class TestWriteParquetRowGroupSize:
     def test_row_group_size_accepted(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"v": list(range(100))}))
@@ -162,6 +187,8 @@ class TestWriteParquetRowGroupSize:
 
 
 class TestWriteParquetErrors:
+    """Error-path tests that run regardless of whether pyarrow is installed."""
+
     def test_unsupported_extension_raises(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
         with pytest.raises(ValueError, match="Unsupported file format"):
@@ -172,7 +199,14 @@ class TestWriteParquetErrors:
         with pytest.raises(ValueError, match="Unsupported file format"):
             ar.write_parquet(frame, tmp_path / "out.json")
 
+    def test_unknown_compression_raises_without_pyarrow(self, tmp_path):
+        # Validation happens before the pyarrow import check.
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+        with pytest.raises(ValueError, match="Unknown compression codec"):
+            ar.write_parquet(frame, tmp_path / "out.parquet", compression="lz4")
+
     def test_missing_pyarrow_raises_import_error(self, tmp_path):
+        # This test mocks pyarrow away and must run even without pyarrow.
         frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
         with patch.dict("sys.modules", {"pyarrow": None}):
             with pytest.raises(ImportError, match="pip install arnio\\[parquet\\]"):


### PR DESCRIPTION
## Summary

Fixes #637

Adds `ar.write_parquet()` — a Python-level Parquet writer built on top of:

```python id="9o3l9j"
to_pandas().to_parquet(engine="pyarrow")
```

`pyarrow` is kept as an optional dependency, so the base installation remains lightweight.

## Install

```bash id="umvxt3"
pip install arnio[parquet]
```

## API

```python id="t12pq5"
ar.write_parquet(frame, "output.parquet")

ar.write_parquet(frame, "output.pq", compression="zstd")

ar.write_parquet(frame, "output.parquet", row_group_size=50_000)
```

## What changed

* `pyproject.toml` — added optional `parquet` extra (`pyarrow>=8.0`)
* `io.py` — implemented `write_parquet()`
* `__init__.py` — exported `write_parquet`
* `test_parquet.py` — added 22 tests covering:

  * round-trip behavior
  * compression codecs
  * `row_group_size`
  * invalid extensions/compression
  * missing `pyarrow`
* `README.md` — added usage examples

## What did NOT change

* No C++ changes
* No changes to existing CSV or JSONL functionality
* `pyarrow` remains completely optional
