### PR TITLE
fix(frame): enforce consistent column lengths

### DIFF
--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -68,6 +68,12 @@ size_t Frame::column_index(const std::string& name) const {
 }
 
 void Frame::add_column(Column col) {
+    if (!columns_.empty() && col.size() != num_rows()) {
+        throw std::invalid_argument("Column '" + col.name() + "' has " +
+                                    std::to_string(col.size()) + " rows, expected " +
+                                    std::to_string(num_rows()));
+    }
+
     name_index_[col.name()] = columns_.size();
     columns_.push_back(std::move(col));
 }

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -265,7 +265,7 @@ def test_str_keeps_normal_column_names():
 
 
 def test_add_column_accepts_matching_lengths():
-    from arnio._arnio_cpp import Frame, Column, DType
+    from arnio._arnio_cpp import Column, DType, Frame
 
     frame = Frame()
 
@@ -284,7 +284,7 @@ def test_add_column_accepts_matching_lengths():
 
 
 def test_add_column_rejects_mismatched_lengths():
-    from arnio._arnio_cpp import Frame, Column, DType
+    from arnio._arnio_cpp import Column, DType, Frame
 
     frame = Frame()
 
@@ -303,7 +303,7 @@ def test_add_column_rejects_mismatched_lengths():
 
 
 def test_add_column_allows_first_column_in_empty_frame():
-    from arnio._arnio_cpp import Frame, Column, DType
+    from arnio._arnio_cpp import Column, DType, Frame
 
     frame = Frame()
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -262,3 +262,54 @@ def test_str_keeps_normal_column_names():
 
     assert "name" in result
     assert "..." not in result
+
+
+def test_add_column_accepts_matching_lengths():
+    from arnio._arnio_cpp import Frame, Column, DType
+
+    frame = Frame()
+
+    c1 = Column("a", DType.INT64)
+    c1.push_back(1)
+    c1.push_back(2)
+
+    c2 = Column("b", DType.INT64)
+    c2.push_back(10)
+    c2.push_back(20)
+
+    frame.add_column(c1)
+    frame.add_column(c2)
+
+    assert frame.shape() == (2, 2)
+
+
+def test_add_column_rejects_mismatched_lengths():
+    from arnio._arnio_cpp import Frame, Column, DType
+
+    frame = Frame()
+
+    c1 = Column("a", DType.INT64)
+    c1.push_back(1)
+    c1.push_back(2)
+    c1.push_back(3)
+
+    c2 = Column("b", DType.INT64)
+    c2.push_back(10)
+
+    frame.add_column(c1)
+
+    with pytest.raises(ValueError, match="expected"):
+        frame.add_column(c2)
+
+
+def test_add_column_allows_first_column_in_empty_frame():
+    from arnio._arnio_cpp import Frame, Column, DType
+
+    frame = Frame()
+
+    c1 = Column("a", DType.INT64)
+    c1.push_back(1)
+
+    frame.add_column(c1)
+
+    assert frame.shape() == (1, 1)


### PR DESCRIPTION
## Summary

Enforce consistent column lengths in `Frame::add_column` to prevent constructing ragged frames with inconsistent row counts.

## Changes

* Added row-count invariant validation in `Frame::add_column`
* Preserved empty-frame behavior
* Added regression tests for:

  * matching column lengths
  * mismatched column lengths
  * empty-frame insertion behavior

Fixes #88
