### PR TITLE
feat(schema): treat empty and whitespace strings as nulls

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1353,18 +1353,22 @@ def _validate_column(
                 )
             )
 
+    is_null_mask = series.isna()
+    if actual_dtype in ("object", "string"):
+        is_null_mask = is_null_mask | (series.fillna("").astype(str).str.strip() == "")
+
     if not field_def.nullable:
         issues.extend(
             _row_issues(
-                series[series.isna()],
+                series[is_null_mask],
                 column=name,
                 rule="nullable",
-                message=f"Column {name!r} contains null values",
+                message=f"Column {name!r} contains null or empty values",
                 severity=field_def.severity,
             )
         )
 
-    non_null = series.dropna()
+    non_null = series[~is_null_mask]
 
     if field_def.required_if is not None:
         condition_column, expected_value = field_def.required_if

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2074,16 +2074,17 @@ def test_schema_from_json_rejects_non_object_field_definition():
 
 
 def test_empty_string_fails_when_not_nullable():
-    df = pd.DataFrame({
-        "user_id": [1, 2, 3, 4, 5],
-        "username": ["alice", "", "   ", None, float('nan')]
-    })
-    schema = ar.Schema({
-        "user_id": ar.Int64(nullable=False),
-        "username": ar.String(nullable=False)
-    })
+    df = pd.DataFrame(
+        {
+            "user_id": [1, 2, 3, 4, 5],
+            "username": ["alice", "", "   ", None, float("nan")],
+        }
+    )
+    schema = ar.Schema(
+        {"user_id": ar.Int64(nullable=False), "username": ar.String(nullable=False)}
+    )
     result = ar.validate(ar.from_pandas(df), schema)
-    
+
     assert result.issue_count == 4
     for issue in result.issues:
         assert issue.column == "username"
@@ -2091,14 +2092,15 @@ def test_empty_string_fails_when_not_nullable():
 
 
 def test_empty_string_passes_when_nullable():
-    df = pd.DataFrame({
-        "user_id": [1, 2, 3, 4, 5],
-        "username": ["alice", "", "   ", None, float('nan')]
-    })
-    schema = ar.Schema({
-        "user_id": ar.Int64(nullable=False),
-        "username": ar.String(nullable=True)
-    })
+    df = pd.DataFrame(
+        {
+            "user_id": [1, 2, 3, 4, 5],
+            "username": ["alice", "", "   ", None, float("nan")],
+        }
+    )
+    schema = ar.Schema(
+        {"user_id": ar.Int64(nullable=False), "username": ar.String(nullable=True)}
+    )
     result = ar.validate(ar.from_pandas(df), schema)
-    
+
     assert result.issue_count == 0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 """Tests for schema validation."""
 
 import pytest
+import pandas as pd
 
 import arnio as ar
 
@@ -2070,3 +2071,34 @@ def test_schema_to_json_rejects_rules():
 def test_schema_from_json_rejects_non_object_field_definition():
     with pytest.raises(TypeError, match="must be an object"):
         ar.Schema.from_json('{"fields":{"id":"string"},"strict":false,"unique":null}')
+
+
+def test_empty_string_fails_when_not_nullable():
+    df = pd.DataFrame({
+        "user_id": [1, 2, 3, 4, 5],
+        "username": ["alice", "", "   ", None, float('nan')]
+    })
+    schema = ar.Schema({
+        "user_id": ar.Int64(nullable=False),
+        "username": ar.String(nullable=False)
+    })
+    result = ar.validate(ar.from_pandas(df), schema)
+    
+    assert result.issue_count == 4
+    for issue in result.issues:
+        assert issue.column == "username"
+        assert issue.rule == "nullable"
+
+
+def test_empty_string_passes_when_nullable():
+    df = pd.DataFrame({
+        "user_id": [1, 2, 3, 4, 5],
+        "username": ["alice", "", "   ", None, float('nan')]
+    })
+    schema = ar.Schema({
+        "user_id": ar.Int64(nullable=False),
+        "username": ar.String(nullable=True)
+    })
+    result = ar.validate(ar.from_pandas(df), schema)
+    
+    assert result.issue_count == 0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,7 @@
 """Tests for schema validation."""
 
-import pytest
 import pandas as pd
+import pytest
 
 import arnio as ar
 


### PR DESCRIPTION
## Summary
Updated the `_validate_column` logic in `arnio/schema.py` to correctly identify and treat empty strings (`""`) and whitespace-only strings (`"   "`) as null values when evaluating `nullable` constraints. Previously, only `NaN` or `None` were caught. 

Also added comprehensive `pytest` coverage in `tests/test_schema.py` to verify the new behavior for both `nullable=False` and `nullable=True` edge cases.

## Linked issue
Fixes #286

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `python -m pytest tests/test_schema.py` (All schema tests pass locally)

## Screenshots / Media
N/A - Backend validation logic only. 

## Performance Impact
Negligible. Replaced standard `.dropna()` with an efficient boolean mask combining `.isna()` and vectorized string operations (`.str.strip() == ""`) for object/string columns. 

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
