### PR TITLE
perf(frame): implement native select_columns path

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -172,12 +172,7 @@ class ArFrame:
         if missing:
             raise ValueError(f"Unknown columns: {missing}")
 
-        from .convert import from_pandas, to_pandas
-
-        df = to_pandas(self)
-        selected_df = df[columns]
-
-        return from_pandas(selected_df)
+        return ArFrame(self._frame.select_columns(columns))
 
     def select_dtypes(
         self,

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -141,6 +141,7 @@ PYBIND11_MODULE(_arnio_cpp, m) {
 
     // --- Frame ---
     py::class_<Frame>(m, "Frame")
+        .def("select_columns", &Frame::select_columns)
         .def(py::init<>())
         .def("shape", &Frame::shape)
         .def("num_rows", &Frame::num_rows)

--- a/cpp/include/arnio/frame.h
+++ b/cpp/include/arnio/frame.h
@@ -36,6 +36,7 @@ class Frame {
 
     // Clone
     Frame clone() const;
+    Frame select_columns(const std::vector<std::string>& columns) const;
 
    private:
     std::vector<Column> columns_;

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -89,6 +89,16 @@ Frame Frame::clone() const {
     return Frame(std::move(cloned));
 }
 
+Frame Frame::select_columns(const std::vector<std::string>& columns) const {
+    std::vector<Column> selected;
+    selected.reserve(columns.size());
+
+    for (const auto& name : columns) {
+        selected.push_back(column(name).clone());
+    }
+
+    return Frame(std::move(selected));
+}
 void Frame::rebuild_index() {
     name_index_.clear();
     for (size_t i = 0; i < columns_.size(); ++i) {

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -207,6 +207,32 @@ def test_select_columns_empty_frame():
     assert selected.shape == (0, 1)
 
 
+def test_select_columns_native_path_avoids_pandas_roundtrip(monkeypatch):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["alice", "bob"],
+                "salary": [100, 200],
+            }
+        )
+    )
+
+    from arnio import convert
+
+    original_to_pandas = convert.to_pandas
+
+    def fail_to_pandas(_):
+        raise AssertionError("native select_columns path should avoid to_pandas")
+
+    monkeypatch.setattr(convert, "to_pandas", fail_to_pandas)
+
+    selected = frame.select_columns(["salary", "name"])
+
+    df = original_to_pandas(selected)
+
+    assert list(df.columns) == ["salary", "name"]
+
+
 class TestArFrame:
     """Test ArFrame properties and methods."""
 


### PR DESCRIPTION
Fixes #655

## Summary
Implements a native `select_columns` path for `ArFrame` without a pandas round-trip.

## Changes
* Added native `Frame::select_columns(...)` implementation in the C++ core
* Exposed native selection through pybind bindings
* Updated `ArFrame.select_columns(...)` to use the native path directly
* Preserved existing validation and public behavior
* Added regression coverage ensuring the native path avoids `to_pandas`

## Validation
Ran:
* `pytest tests/test_frame.py -q`
* `pytest tests/test_pipeline.py -q`
