### PR TITLE
feat: add near-constant column detection to quality reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1442,10 +1442,9 @@ DataQualityReport(
       "dtype": "string",
       "semantic_type": "categorical",
       "null_count": 0,
-      "warnings": ["near_constant"],
       "top_values": [
-        {"value": "London", "count": 95, "ratio": 0.95},
-        {"value": "Paris", "count": 5, "ratio": 0.05}
+        {"value": "London", "count": 3, "ratio": 0.5},
+        {"value": "Paris", "count": 2, "ratio": 0.333}
       ]
     }
   },
@@ -1460,6 +1459,19 @@ DataQualityReport(
 }
 ```
 Columns where a single non-null value represents at least 95% of rows are reported with a `near_constant` warning.
+
+Example near-constant distribution:
+
+```json
+{
+  "row_count": 100,
+  "top_values": [
+    {"value": "London", "count": 95, "ratio": 0.95},
+    {"value": "Paris", "count": 5, "ratio": 0.05}
+  ],
+  "warnings": ["near_constant"]
+}
+```
 
 ### 3. Example Summary Table
 *A manually formatted Markdown table representing the core metrics:*

--- a/README.md
+++ b/README.md
@@ -1444,8 +1444,8 @@ DataQualityReport(
       "null_count": 0,
       "warnings": ["near_constant"],
       "top_values": [
-        {"value": "London", "count": 3, "ratio": 0.5},
-        {"value": "Paris", "count": 2, "ratio": 0.333}
+        {"value": "London", "count": 95, "ratio": 0.95},
+        {"value": "Paris", "count": 5, "ratio": 0.05}
       ]
     }
   },
@@ -1459,6 +1459,7 @@ DataQualityReport(
   ]
 }
 ```
+Columns where a single non-null value represents at least 95% of rows are reported with a `near_constant` warning.
 
 ### 3. Example Summary Table
 *A manually formatted Markdown table representing the core metrics:*

--- a/README.md
+++ b/README.md
@@ -1442,6 +1442,7 @@ DataQualityReport(
       "dtype": "string",
       "semantic_type": "categorical",
       "null_count": 0,
+      "warnings": ["near_constant"],
       "top_values": [
         {"value": "London", "count": 3, "ratio": 0.5},
         {"value": "Paris", "count": 2, "ratio": 0.333}

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1659,6 +1659,11 @@ def _profile_column(
     non_null = series.dropna()
     unique_count = int(non_null.nunique(dropna=True))
     unique_ratio = _ratio(unique_count, len(non_null))
+    dominant_ratio = 0.0
+
+    if len(non_null):
+        value_counts = non_null.value_counts(dropna=True)
+        dominant_ratio = _ratio(int(value_counts.iloc[0]), len(non_null))
     sample_values = non_null.head(sample_size).tolist()
 
     empty_string_count = 0
@@ -1749,6 +1754,7 @@ def _profile_column(
         unique_count=unique_count,
         whitespace_count=whitespace_count,
         empty_string_count=empty_string_count,
+        dominant_ratio=dominant_ratio,
     )
 
     return ColumnProfile(
@@ -1854,6 +1860,7 @@ def _column_warnings(
     unique_count: int,
     whitespace_count: int,
     empty_string_count: int,
+    dominant_ratio: float,
 ) -> list[str]:
     warnings: list[str] = []
     if null_count:
@@ -1862,6 +1869,8 @@ def _column_warnings(
         warnings.append("all_null")
     if row_count and unique_count == 1:
         warnings.append("constant")
+    if row_count and unique_count > 1 and dominant_ratio >= _NEAR_CONSTANT_THRESHOLD:
+        warnings.append("near_constant")
     if whitespace_count:
         warnings.append("leading_or_trailing_whitespace")
     if empty_string_count:
@@ -1903,6 +1912,7 @@ def _clean_scalar(value: Any) -> Any:
 
 
 _APPROX_TOP_VALUES_SEED = 0
+_NEAR_CONSTANT_THRESHOLD = 0.95
 
 
 def _top_values(

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -807,6 +807,56 @@ def test_identifier_numeric_cast_prevention():
     assert list(result["zip_code"]) == ["01234", "02345", "03456"]
 
 
+def test_profile_detects_near_constant_column():
+    frame = ar.from_pandas(
+        pd.DataFrame({"status": (["active"] * 95 + ["inactive"] * 5)})
+    )
+
+    report = ar.profile(frame)
+
+    assert "near_constant" in report.columns["status"].warnings
+    assert "constant" not in report.columns["status"].warnings
+
+
+def test_profile_constant_column_not_marked_near_constant():
+    frame = ar.from_pandas(pd.DataFrame({"status": ["active"] * 100}))
+
+    report = ar.profile(frame)
+
+    assert "constant" in report.columns["status"].warnings
+    assert "near_constant" not in report.columns["status"].warnings
+
+
+def test_profile_balanced_column_not_marked_near_constant():
+    frame = ar.from_pandas(
+        pd.DataFrame({"status": (["active"] * 50 + ["inactive"] * 50)})
+    )
+
+    report = ar.profile(frame)
+
+    assert "near_constant" not in report.columns["status"].warnings
+
+
+def test_profile_near_constant_ignores_nulls():
+    frame = ar.from_pandas(
+        pd.DataFrame({"status": (["active"] * 95 + ["inactive"] * 5 + [None] * 20)})
+    )
+
+    report = ar.profile(frame)
+
+    assert "near_constant" in report.columns["status"].warnings
+
+
+def test_profile_near_constant_threshold_boundary():
+    frame = ar.from_pandas(
+        pd.DataFrame({"status": (["active"] * 95 + ["inactive"] * 5)})
+    )
+
+    report = ar.profile(frame)
+
+    assert "near_constant" in report.columns["status"].warnings
+
+
 # ── string length statistics tests ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- add near-constant detection to profile reporting for columns where a dominant value exceeds a 95% ratio
- preserve existing constant warnings while surfacing low-information columns as near_constant
- add focused tests for constant, near-constant, balanced, null-heavy, and threshold-boundary distributions
- update the README profiling example to document the new near_constant warning output

## Linked issue
Fixes #177 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
      1. `pytest tests/test_quality.py` -> passed
      2. `ruff check arnio tests` -> passed
      3. `black --check arnio tests` -> passed

## Screenshots / Media
NA

## Performance Impact
NA

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

- Near-constant detection is integrated into the existing profiling/reporting flow and intentionally scoped to report warnings only. Constant columns continue to use the existing constant warning behavior, while dominant-value distributions above the threshold are surfaced as near_constant.
- targeted quality tests passed
- full test suite passed except for unrelated existing failures in tests/test_csv.py and tests/test_frame.py
- lint and formatting checks passed