### PR TITLE
refactor: centralize cleaning column validation (#683)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1537,7 +1537,6 @@ def coalesce_columns(
         subset,
         available_columns=column_names,
         argument_name="subset",
-        allow_empty=False,
         missing_message=lambda missing, available: (
             f"Missing columns for coalesce_columns: {missing}. "
             f"Available columns: {available}"

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import copy
 import unicodedata
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from ._core import (
@@ -56,14 +56,15 @@ def validate_columns_exist(
     KeyError
         If any requested column is missing.
     """
-    requested_columns = _validate_column_sequence(columns, argument_name="columns")
-    missing = [column for column in requested_columns if column not in frame.columns]
-    if missing:
-        available = ", ".join(frame.columns) or "<none>"
-        context = f" for {operation}" if operation else ""
-        raise KeyError(
-            f"Missing columns{context}: {missing}. Available columns: {available}"
-        )
+    _validate_existing_column_sequence(
+        columns,
+        available_columns=frame.columns,
+        argument_name="columns",
+        missing_message=lambda missing, available: (
+            f"Missing columns{f' for {operation}' if operation else ''}: {missing}. "
+            f"Available columns: {available}"
+        ),
+    )
     return frame
 
 
@@ -100,6 +101,30 @@ def _validate_mapping(
     normalized = dict(mapping)
     if not normalized and not allow_empty:
         raise ValueError(f"{argument_name} must not be empty")
+
+
+def _validate_existing_column_sequence(
+    columns: Sequence[str],
+    *,
+    available_columns: Sequence[str],
+    argument_name: str,
+    allow_empty: bool = True,
+    missing_error: type[Exception] = KeyError,
+    missing_message: Callable[[list[str], str], str] | None = None,
+) -> list[str]:
+    normalized = _validate_column_sequence(columns, argument_name=argument_name)
+
+    if not normalized and not allow_empty:
+        raise ValueError(f"{argument_name} cannot be empty")
+
+    missing = [column for column in normalized if column not in available_columns]
+    if missing:
+        available = ", ".join(map(str, available_columns)) or "<none>"
+        if missing_message is None:
+            message = f"Missing columns: {missing}. Available columns: {available}"
+        else:
+            message = missing_message(missing, available)
+        raise missing_error(message)
 
     return normalized
 
@@ -160,15 +185,19 @@ def drop_nulls(
     >>> clean = ar.drop_nulls(frame, subset=["age", "name"])
     """
     if subset is not None:
-        requested_columns = _validate_column_sequence(subset, argument_name="subset")
-        if len(requested_columns) == 0:
+        subset = _validate_column_sequence(subset, argument_name="subset")
+        if len(subset) == 0:
             raise ValueError(
                 "drop_nulls: subset cannot be empty; pass subset=None to check all columns"
             )
-        validate_columns_exist(
-            frame,
-            requested_columns,
-            operation="drop_nulls",
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for drop_nulls: {missing}. "
+                f"Available columns: {available}"
+            ),
         )
     result = _drop_nulls(frame._frame, subset=subset)
     return ArFrame(result)
@@ -200,13 +229,17 @@ def drop_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
     --------
     >>> frame = ar.drop_columns(frame, ["debug_col"])
     """
-    requested_columns = _validate_column_sequence(columns, argument_name="columns")
+    requested_columns = _validate_existing_column_sequence(
+        columns,
+        available_columns=frame.columns,
+        argument_name="columns",
+        missing_error=ValueError,
+        missing_message=lambda missing, _available: (
+            f"Columns not found in frame: {missing}"
+        ),
+    )
     if len(requested_columns) == 0:
         return frame
-
-    missing = [column for column in requested_columns if column not in frame.columns]
-    if missing:
-        raise ValueError(f"Columns not found in frame: {missing}")
     if len(requested_columns) == len(frame.columns):
         raise ValueError("drop_columns cannot remove all columns from the frame")
 
@@ -268,15 +301,18 @@ def keep_rows_with_nulls(
     is_arframe = not isinstance(frame, pd.DataFrame)
     df = to_pandas(frame) if is_arframe else frame
 
-    cols = subset if subset is not None else df.columns.tolist()
-
-    # validate that all subset columns actually exist
     if subset is not None:
-        validate_columns_exist(
-            frame,
-            _validate_column_sequence(subset, argument_name="subset"),
-            operation="keep_rows_with_nulls",
+        cols = _validate_existing_column_sequence(
+            subset,
+            available_columns=df.columns,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for keep_rows_with_nulls: {missing}. "
+                f"Available columns: {available}"
+            ),
         )
+    else:
+        cols = df.columns.tolist()
 
     mask = df[cols].isnull().any(axis=1)
     result = df[mask].reset_index(drop=True)
@@ -317,10 +353,14 @@ def fill_nulls(
     >>> filled = ar.fill_nulls(frame, 0, subset=["age"])
     """
     if subset is not None:
-        validate_columns_exist(
-            frame,
-            _validate_column_sequence(subset, argument_name="subset"),
-            operation="fill_nulls",
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for fill_nulls: {missing}. "
+                f"Available columns: {available}"
+            ),
         )
     result = _fill_nulls(frame._frame, value, subset=subset)
     return ArFrame(result)
@@ -355,15 +395,19 @@ def drop_duplicates(
     >>> unique = ar.drop_duplicates(frame, subset=["name"], keep="first")
     """
     if subset is not None:
-        requested_columns = _validate_column_sequence(subset, argument_name="subset")
-        if len(requested_columns) == 0:
+        subset = _validate_column_sequence(subset, argument_name="subset")
+        if len(subset) == 0:
             raise ValueError(
                 "drop_duplicates: subset cannot be empty; pass subset=None to compare all columns"
             )
-        validate_columns_exist(
-            frame,
-            requested_columns,
-            operation="drop_duplicates",
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for drop_duplicates: {missing}. "
+                f"Available columns: {available}"
+            ),
         )
     if keep is True:
         raise ValueError("keep must be one of 'first', 'last', 'none', or False")
@@ -542,10 +586,14 @@ def strip_whitespace(
     >>> clean = ar.strip_whitespace(frame, subset=["name"])
     """
     if subset is not None:
-        validate_columns_exist(
-            frame,
-            _validate_column_sequence(subset, argument_name="subset"),
-            operation="strip_whitespace",
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for strip_whitespace: {missing}. "
+                f"Available columns: {available}"
+            ),
         )
     result = _strip_whitespace(frame._frame, subset=subset)
     return ArFrame(result)
@@ -619,15 +667,16 @@ def parse_bool_strings(
         )
 
     if subset is not None:
-        columns = _validate_column_sequence(subset, argument_name="subset")
-
-        if len(columns) == 0:
-            raise ValueError("subset cannot be empty")
-
-        missing = [col for col in columns if col not in df.columns]
-
-        if missing:
-            raise ValueError(f"Columns not found in frame: {missing}")
+        columns = _validate_existing_column_sequence(
+            subset,
+            available_columns=df.columns,
+            argument_name="subset",
+            allow_empty=False,
+            missing_error=ValueError,
+            missing_message=lambda missing, _available: (
+                f"Columns not found in frame: {missing}"
+            ),
+        )
     else:
         columns = df.select_dtypes(include=["object", "string"]).columns.tolist()
 
@@ -679,10 +728,14 @@ def normalize_case(
     >>> lower = ar.normalize_case(frame, case_type="lower")
     """
     if subset is not None:
-        validate_columns_exist(
-            frame,
-            _validate_column_sequence(subset, argument_name="subset"),
-            operation="normalize_case",
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for normalize_case: {missing}. "
+                f"Available columns: {available}"
+            ),
         )
     result = _normalize_case(frame._frame, subset=subset, case_type=case_type)
     return ArFrame(result)
@@ -704,10 +757,14 @@ def normalize_unicode(
     if form not in valid_forms:
         raise ValueError(f"Unsupported Unicode normalization form: {form}")
     if subset is not None:
-        validate_columns_exist(
-            frame,
-            _validate_column_sequence(subset, argument_name="subset"),
-            operation="normalize_unicode",
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for normalize_unicode: {missing}. "
+                f"Available columns: {available}"
+            ),
         )
     cpp_frame = frame._frame
     num_cols = cpp_frame.num_cols()
@@ -1014,13 +1071,16 @@ def round_numeric_columns(
     df = to_pandas(frame) if is_arframe else frame.copy()
 
     if subset is not None:
-        missing = [col for col in subset if col not in df.columns]
-        if missing:
-            raise ValueError(
-                f"round_numeric_columns: unknown column(s) in subset: {missing}. "
-                f"Available columns: {list(df.columns)}"
-            )
-        cols_to_round = subset
+        cols_to_round = _validate_existing_column_sequence(
+            subset,
+            available_columns=df.columns,
+            argument_name="subset",
+            missing_error=ValueError,
+            missing_message=lambda missing, _available: (
+                "round_numeric_columns: unknown column(s) in subset: "
+                f"{missing}. Available columns: {list(df.columns)}"
+            ),
+        )
     else:
         cols_to_round = df.select_dtypes(include=["number"]).columns
 
@@ -1074,13 +1134,15 @@ def combine_columns(
     if subset is None:
         subset_columns = list(column_names)
     else:
-        subset_columns = _validate_column_sequence(subset, argument_name="subset")
-        missing = [column for column in subset_columns if column not in column_names]
-        if missing:
-            available = ", ".join(column_names) or "<none>"
-            raise KeyError(
-                f"Missing columns for combine_columns: {missing}. Available columns: {available}"
-            )
+        subset_columns = _validate_existing_column_sequence(
+            subset,
+            available_columns=column_names,
+            argument_name="subset",
+            missing_message=lambda missing, available: (
+                f"Missing columns for combine_columns: {missing}. "
+                f"Available columns: {available}"
+            ),
+        )
 
     if not subset_columns:
         raise ValueError("subset must contain at least one column")
@@ -1413,13 +1475,21 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
             df = df.replace(tokens, float("nan"))
 
     else:
-        unknown_columns = [column for column in subset if column not in df.columns]
-        if unknown_columns:
-            raise ValueError(f"Unknown columns in subset: {unknown_columns}")
+        subset_columns = _validate_existing_column_sequence(
+            subset,
+            available_columns=df.columns,
+            argument_name="subset",
+            missing_error=ValueError,
+            missing_message=lambda missing, _available: (
+                f"Unknown columns in subset: {missing}"
+            ),
+        )
         if tokens is None:
-            df[subset] = df[subset].replace(default_tokens, float("nan"))
+            df[subset_columns] = df[subset_columns].replace(
+                default_tokens, float("nan")
+            )
         else:
-            df[subset] = df[subset].replace(tokens, float("nan"))
+            df[subset_columns] = df[subset_columns].replace(tokens, float("nan"))
 
     return from_pandas(df) if is_arframe else df
 
@@ -1463,14 +1533,16 @@ def coalesce_columns(
         raise TypeError("frame must be an ArFrame or a pandas DataFrame")
 
     column_names = list(frame.columns)
-    subset_columns = _validate_column_sequence(subset, argument_name="subset")
-
-    missing = [column for column in subset_columns if column not in column_names]
-    if missing:
-        available = ", ".join(column_names) or "<none>"
-        raise KeyError(
-            f"Missing columns for coalesce_columns: {missing}. Available columns: {available}"
-        )
+    subset_columns = _validate_existing_column_sequence(
+        subset,
+        available_columns=column_names,
+        argument_name="subset",
+        allow_empty=False,
+        missing_message=lambda missing, available: (
+            f"Missing columns for coalesce_columns: {missing}. "
+            f"Available columns: {available}"
+        ),
+    )
 
     if output_column in column_names:
         raise ValueError(f"Output column '{output_column}' already exists.")

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -102,6 +102,8 @@ def _validate_mapping(
     if not normalized and not allow_empty:
         raise ValueError(f"{argument_name} must not be empty")
 
+    return normalized
+
 
 def _validate_existing_column_sequence(
     columns: Sequence[str],

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -176,6 +176,99 @@ class TestValidateColumnsExist:
             ar.rename_columns(frame, {"missing": "new_name"})
 
 
+class TestSharedColumnSequenceValidation:
+    @pytest.mark.parametrize(
+        ("func", "kwargs", "error_type", "message"),
+        [
+            (
+                "keep_rows_with_nulls",
+                {"subset": ["missing"]},
+                KeyError,
+                "Missing columns for keep_rows_with_nulls",
+            ),
+            (
+                "fill_nulls",
+                {"value": 0, "subset": ["missing"]},
+                KeyError,
+                "Missing columns for fill_nulls",
+            ),
+            (
+                "drop_duplicates",
+                {"subset": ["missing"]},
+                KeyError,
+                "Missing columns for drop_duplicates",
+            ),
+            (
+                "strip_whitespace",
+                {"subset": ["missing"]},
+                KeyError,
+                "Missing columns for strip_whitespace",
+            ),
+            (
+                "normalize_case",
+                {"subset": ["missing"]},
+                KeyError,
+                "Missing columns for normalize_case",
+            ),
+            (
+                "normalize_unicode",
+                {"subset": ["missing"]},
+                KeyError,
+                "Missing columns for normalize_unicode",
+            ),
+            (
+                "standardize_missing_tokens",
+                {"subset": ["missing"]},
+                ValueError,
+                "Unknown columns in subset",
+            ),
+            (
+                "coalesce_columns",
+                {"subset": ["missing"]},
+                KeyError,
+                "Missing columns for coalesce_columns",
+            ),
+        ],
+    )
+    def test_shared_subset_validation_rejects_missing_columns(
+        self,
+        sample_csv,
+        func,
+        kwargs,
+        error_type,
+        message,
+    ):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(error_type, match=message):
+            getattr(ar, func)(frame, **kwargs)
+
+    def test_coalesce_columns_selects_first_non_null_value(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "nickname": [None, "Bee", None],
+                    "name": ["Alice", "Bob", "Cara"],
+                }
+            )
+        )
+
+        result = ar.coalesce_columns(
+            frame,
+            subset=["nickname", "name"],
+            output_column="display_name",
+        )
+        df = ar.to_pandas(result)
+
+        assert df["display_name"].tolist() == ["Alice", "Bee", "Cara"]
+
+    def test_coalesce_columns_rejects_empty_subset(self):
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice"]}))
+
+        with pytest.raises(ValueError, match="subset must contain at least one column"):
+            ar.coalesce_columns(frame, subset=[])
+
+
 class TestDropDuplicates:
     def test_drop_dupes_first(self, csv_with_duplicates):
         frame = ar.read_csv(csv_with_duplicates)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -268,6 +268,80 @@ class TestSharedColumnSequenceValidation:
         with pytest.raises(ValueError, match="subset must contain at least one column"):
             ar.coalesce_columns(frame, subset=[])
 
+    @pytest.mark.parametrize(
+        ("func", "kwargs", "message"),
+        [
+            ("drop_columns", {"columns": 123}, "must be a sequence of column names"),
+            (
+                "fill_nulls",
+                {"value": 0, "subset": 123},
+                "must be a sequence of column names",
+            ),
+            ("drop_duplicates", {"subset": 123}, "must be a sequence of column names"),
+            (
+                "strip_whitespace",
+                {"subset": 123},
+                "must be a sequence of column names",
+            ),
+            ("normalize_case", {"subset": 123}, "must be a sequence of column names"),
+            (
+                "normalize_unicode",
+                {"subset": 123},
+                "must be a sequence of column names",
+            ),
+            (
+                "combine_columns",
+                {"subset": 123, "separator": "-", "output_column": "combined"},
+                "must be a sequence of column names",
+            ),
+            (
+                "coalesce_columns",
+                {"subset": 123, "output_column": "combined"},
+                "must be a list of column names",
+            ),
+        ],
+    )
+    def test_shared_subset_validation_rejects_non_sequence_types(
+        self,
+        sample_csv,
+        func,
+        kwargs,
+        message,
+    ):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match=message):
+            getattr(ar, func)(frame, **kwargs)
+
+    def test_drop_columns_allows_duplicate_entries(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "debug": ["x", "y"],
+                    "name": ["Alice", "Bob"],
+                }
+            )
+        )
+
+        result = ar.drop_columns(frame, ["debug", "debug"])
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["id", "name"]
+
+    def test_combine_columns_preserves_duplicate_subset_entries(self):
+        frame = ar.from_pandas(pd.DataFrame({"word": ["go"], "suffix": ["!"]}))
+
+        result = ar.combine_columns(
+            frame,
+            subset=["word", "word", "suffix"],
+            separator="-",
+            output_column="combined",
+        )
+        df = ar.to_pandas(result)
+
+        assert df["combined"].tolist() == ["go-go-!"]
+
 
 class TestDropDuplicates:
     def test_drop_dupes_first(self, csv_with_duplicates):


### PR DESCRIPTION
## Summary
- add a shared internal helper for validating column-name sequences against available columns
- route duplicated subset and column checks in cleaning helpers through the shared path while preserving existing public behavior and error contracts
- add focused regression coverage for the shared missing-column path and `coalesce_columns` behavior

## Testing
- `python -m pytest tests/test_cleaning.py -k "SharedColumnSequenceValidation or TestValidateColumnsExist or TestCombineColumns or coalesce_columns or keep_rows_with_nulls or normalize_unicode or standardize_missing_tokens or parse_bool_strings or round_numeric_columns"`
- `python -m ruff check arnio/cleaning.py tests/test_cleaning.py`
- `python -m black --check arnio/cleaning.py tests/test_cleaning.py`

Fixes #683
