### PR TITLE
test: strengthen CountryCode schema coverage (#622)

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -886,6 +886,36 @@ def test_country_code_enforces_uniqueness(tmp_path):
     assert result.issue_count == 2
     assert all(issue.rule == "unique" for issue in result.issues)
     assert [issue.row_index for issue in result.issues] == [1, 3]
+    assert [issue.value for issue in result.issues] == ["IN", "IN"]
+
+
+def test_country_code_unique_ignores_multiple_nulls(tmp_path):
+    path = tmp_path / "nullable_duplicate_countries.csv"
+    path.write_text('country\nIN\n""\n""\nUS\n')
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"country": ar.CountryCode(nullable=True, unique=True)},
+    )
+
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_country_code_rejects_unassigned_alpha_2_codes(tmp_path):
+    path = tmp_path / "unassigned_countries.csv"
+    path.write_text("country\nAA\nQM\nQZ\nXA\nZZ\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"country": ar.CountryCode(nullable=False)},
+    )
+
+    assert not result.passed
+    assert result.issue_count == 5
+    assert all(issue.rule == "country_code" for issue in result.issues)
+    assert [issue.row_index for issue in result.issues] == [1, 2, 3, 4, 5]
+    assert [issue.value for issue in result.issues] == ["AA", "QM", "QZ", "XA", "ZZ"]
 
 
 def test_country_code_nullable_behavior(tmp_path):


### PR DESCRIPTION
## Summary
- strengthen `CountryCode(unique=True)` coverage by asserting the duplicate issue values directly
- add focused coverage showing multiple nulls remain valid when `nullable=True` and `unique=True`
- add a dedicated regression test for uppercase but unassigned ISO-like alpha-2 codes such as `AA`, `QM`, `QZ`, `XA`, and `ZZ`

## Testing
- `python -m pytest tests/test_schema.py -k "country_code"`
- `python -m ruff check tests/test_schema.py`
- `python -m black --check tests/test_schema.py`

Fixes #622
