### PR TITLE
Fix/markdown newline escaping

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1198,7 +1198,13 @@ def _markdown_cell(value: Any) -> str:
     if value is None:
         return "-"
     text = str(_clean_scalar(value))
-    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
+    return (
+        text.replace("\\", "\\\\")
+            .replace("|", "\\|")
+            .replace("\r\n", "<br>")
+            .replace("\r", "<br>")
+            .replace("\n", "<br>")
+    )
 
 
 def _compare_column_profiles(

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1200,10 +1200,10 @@ def _markdown_cell(value: Any) -> str:
     text = str(_clean_scalar(value))
     return (
         text.replace("\\", "\\\\")
-            .replace("|", "\\|")
-            .replace("\r\n", "<br>")
-            .replace("\r", "<br>")
-            .replace("\n", "<br>")
+        .replace("|", "\\|")
+        .replace("\r\n", "<br>")
+        .replace("\r", "<br>")
+        .replace("\n", "<br>")
     )
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -888,6 +888,7 @@ def test_report_to_markdown_escapes_pipe_characters_in_column_cells():
     assert "free\\|text" in md
     assert "contains \\| pipe" in md
 
+
 def test_report_to_markdown_escapes_newlines_in_cell_values():
     """Newlines in column names or warnings must not break Markdown table rows."""
     from arnio.quality import ColumnProfile, DataQualityReport

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -888,6 +888,47 @@ def test_report_to_markdown_escapes_pipe_characters_in_column_cells():
     assert "free\\|text" in md
     assert "contains \\| pipe" in md
 
+def test_report_to_markdown_escapes_newlines_in_cell_values():
+    """Newlines in column names or warnings must not break Markdown table rows."""
+    from arnio.quality import ColumnProfile, DataQualityReport
+
+    report = DataQualityReport(
+        row_count=2,
+        column_count=1,
+        memory_usage=128,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={
+            "col\nname": ColumnProfile(
+                name="col\nname",
+                dtype="string\r\nwith newline",
+                semantic_type="text\rwith CR",
+                row_count=2,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=2,
+                unique_ratio=1.0,
+                warnings=["warn\nwith newline", "warn\r\nwith CRLF"],
+            )
+        },
+        suggestions=[],
+    )
+
+    md = report.to_markdown()
+
+    # Newlines must be replaced with <br>
+    assert "<br>" in md
+    assert "col\nname" not in md
+    assert "warn\nwith newline" not in md
+    assert "warn\r\nwith CRLF" not in md
+    assert "string\r\nwith newline" not in md
+    assert "text\rwith CR" not in md
+
+    # col name and warning content should still appear, escaped
+    assert "col<br>name" in md
+    assert "warn<br>with newline" in md
+    assert "warn<br>with CRLF" in md
+
 
 def test_report_to_markdown_empty_sections():
     report = ar.DataQualityReport(


### PR DESCRIPTION
## Summary
`_markdown_cell` did not escape newline characters (`\n`, `\r\n`, `\r`), so a
column name, dtype, semantic type, or warning containing a newline would split
a Markdown table row across multiple lines and break rendering.
`_markdown_cell` now replaces all three newline variants with `<br>`.

## Linked issue
Fixes #598

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `pytest tests/test_quality.py -v`

Added `test_report_to_markdown_escapes_newlines_in_cell_values` which constructs
a `DataQualityReport` with `\n`, `\r\n`, and `\r` in column name, dtype,
semantic type, and warnings, then asserts all newlines are replaced with `<br>`
and the raw newline characters are absent from the output.

## Screenshots / Media
N/A — no UI or terminal output changes.

## Performance Impact
None. The change adds two `.replace()` calls to `_markdown_cell`, which is
called once per cell during report rendering.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
No API changes. No behaviour change for cells without newlines — existing
`\\` and `|` escaping is preserved and the new replacements run before `\n`
so `\r\n` is collapsed to a single `<br>` rather than `<br><br>`.