### PR TITLE
fix(frame): add size and duplicate-name guards to Frame::add_column

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -351,6 +351,25 @@ def test_cpp_frame_explicit_zero_rows_rejects_nonempty_first_column():
         frame.add_column(column)
 
 
+def test_add_column_rejects_duplicate_name():
+    from arnio._arnio_cpp import Column, DType, Frame
+
+    frame = Frame()
+
+    c1 = Column("a", DType.INT64)
+    c1.push_back(1)
+    c1.push_back(2)
+
+    c2 = Column("a", DType.INT64)
+    c2.push_back(3)
+    c2.push_back(4)
+
+    frame.add_column(c1)
+
+    with pytest.raises(ValueError, match="already exists"):
+        frame.add_column(c2)
+
+
 # ArFrame.describe() Tests
 
 


### PR DESCRIPTION
## Summary

Fixes #925

## Problem

`Frame::add_column` lacked row-count validation and duplicate-name checking, causing memory corruption and inconsistent frame state.

## Changes

Both C++ guards (size validation + duplicate-name check) are already present in `main`. This PR adds the missing **regression test**:

### `tests/test_frame.py`
- Added `test_add_column_rejects_duplicate_name` — ensures adding a column with an existing name raises `ValueError`.

Existing tests already cover:
- ✅ valid same-length columns accepted
- ✅ mismatched-length columns rejected with `ValueError`
- ✅ first column in empty frame accepted at any size
- ✅ zero-row explicit frame rejects nonempty first column

## Diff scope

1 file changed — `tests/test_frame.py` (+19 lines)