### PR TITLE
docs: add schema validation tutorial example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,8 @@ payload = schema.to_json()
 restored = ar.Schema.from_json(payload)
 ```
 
+See [examples/schema_validation.py](examples/schema_validation.py) for a complete runnable tutorial covering `Schema`, field types, invalid-row reporting, and `ValidationResult` output.
+
 `ValidationResult.to_markdown()` is useful in CI logs, GitHub comments, or data quality reports because it renders a compact validation summary plus a GitHub-friendly issue table.
 
 For multi-column uniqueness (composite keys):
@@ -1208,7 +1210,7 @@ Expected cleaned output with `mode="strict"`:
 
 `mode="safe"` only trims whitespace. Use `mode="strict"` when you also want deterministic built-in cleanup such as exact duplicate removal.
 
-See [examples/auto_clean_tutorial.py](examples/auto_clean_tutorial.py) for a runnable version of this walkthrough.
+See [examples/auto_clean_tutorial.py](examples/auto_clean_tutorial.py) for a runnable version of this walkthrough, and [examples/schema_validation.py](examples/schema_validation.py) for a focused validation tutorial.
 
 > For strict mode data-loss risks and safe workflow, see [AUTO_CLEAN_GUIDE.md](AUTO_CLEAN_GUIDE.md).
 
@@ -1688,4 +1690,3 @@ arnio/
 <sub>Built with C++ and pybind11 · Licensed under MIT · Maintained by <a href="https://github.com/im-anishraj">@im-anishraj</a></sub>
 
 </div>
-

--- a/examples/schema_validation.py
+++ b/examples/schema_validation.py
@@ -7,8 +7,9 @@ This script shows an end-to-end schema validation workflow:
 - inspect ValidationResult summaries and markdown output
 """
 
-import arnio as ar
 import pandas as pd
+
+import arnio as ar
 
 
 def main():

--- a/examples/schema_validation.py
+++ b/examples/schema_validation.py
@@ -1,0 +1,70 @@
+"""
+Schema Validation Tutorial for Arnio
+------------------------------------
+This script shows an end-to-end schema validation workflow:
+- define a Schema with typed fields
+- validate intentionally mixed-quality data
+- inspect ValidationResult summaries and markdown output
+"""
+
+import arnio as ar
+import pandas as pd
+
+
+def main():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            [
+                {
+                    "user_id": 101,
+                    "email": "alice@example.com",
+                    "age": 31,
+                    "signup_date": "2026-05-01T09:30:00",
+                    "country": "IN",
+                    "is_active": True,
+                },
+                {
+                    "user_id": 101,
+                    "email": "broken-email",
+                    "age": -4,
+                    "signup_date": "not-a-date",
+                    "country": None,
+                    "is_active": "yes",
+                },
+                {
+                    "user_id": None,
+                    "email": "charlie@example.com",
+                    "age": 22,
+                    "signup_date": "2026-05-03T12:15:00",
+                    "country": "USA",
+                    "is_active": False,
+                },
+            ]
+        )
+    )
+
+    schema = ar.Schema(
+        {
+            "user_id": ar.Int64(nullable=False),
+            "email": ar.Email(nullable=False),
+            "age": ar.Int64(nullable=False, min=0),
+            "signup_date": ar.DateTime(nullable=False, format="%Y-%m-%dT%H:%M:%S"),
+            "country": ar.CountryCode(nullable=True),
+            "is_active": ar.Bool(nullable=False),
+        },
+        unique=["user_id"],
+        strict=True,
+    )
+
+    result = ar.validate(frame, schema)
+
+    print("Validation passed:", result.passed)
+    print("Issue count:", result.issue_count)
+    print("\nIssues by rule:")
+    print(result.summary()["issues_by_rule"])
+    print("\nValidation report:")
+    print(result.to_markdown(max_issues=10))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a runnable schema validation tutorial under examples/
- link the tutorial from the schema validation and auto-clean sections in the README

Fixes #272

## Testing

- python examples/schema_validation.py
- git diff --check