### PR TITLE
fix: Relax file extension restriction and auto-detect TSV delimiter

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -302,7 +302,7 @@ def _reject_utf8_nul_bytes(path: str) -> None:
 def read_csv(
     path: str | os.PathLike[str],
     *,
-    delimiter: str = ",",
+    delimiter: str | None = None,
     has_header: bool = True,
     usecols: list[str] | None = None,
     nrows: int | None = None,
@@ -318,9 +318,15 @@ def read_csv(
     ----------
     path : str or file-like object
         Filesystem path or text file-like object containing CSV data.
-        Supports .csv, .txt, and .tsv extensions for path inputs.
-    delimiter : str, default ","
-        Field delimiter character.
+        Any file extension is accepted. For ``.tsv`` files, the delimiter
+        is automatically set to ``'\t'`` when ``delimiter`` is omitted.
+    delimiter : str or None, default None
+        Field delimiter character.  When ``None`` (the default) the
+        delimiter is inferred from the file extension: ``'\t'`` for
+        ``.tsv`` files and ``','`` for everything else.  Passing an
+        explicit value always takes precedence — for example,
+        ``delimiter=','`` reads a comma-delimited ``.tsv`` file without
+        any auto-detection.
     has_header : bool, default True
         Whether the file has a header row.
     usecols : list[str], optional
@@ -354,28 +360,30 @@ def read_csv(
     Raises
     ------
     ValueError
-        If file format is unsupported or if thousands_separator is invalid.
+        If thousands_separator is invalid.
 
     TypeError
-        If thousands_separator is not a string or None.
+        If delimiter is not a string or None, or thousands_separator is
+        not a string or None.
 
     CsvReadError
         If CSV input contains NUL bytes and appears binary or corrupted.
 
     Examples
     --------
-    >>> frame = ar.read_csv("data.csv", delimiter=",", has_header=True)
+    >>> frame = ar.read_csv("data.csv")           # comma delimiter
+    >>> frame = ar.read_csv("data.tsv")           # tab auto-detected
+    >>> frame = ar.read_csv("data.tsv", delimiter=",")  # explicit comma honoured
+    >>> frame = ar.read_csv("data.dat")           # non-standard extension accepted
     """
     path, should_cleanup = _materialize_csv_input(path)
     path_lower = path.lower()
-    if not (
-        path_lower.endswith(".csv")
-        or path_lower.endswith(".txt")
-        or path_lower.endswith(".tsv")
-    ):
-        raise ValueError(
-            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
-        )
+
+    # Resolve the sentinel: auto-detect tab for .tsv only when the caller
+    # truly omitted delimiter (None).  An explicit delimiter="," is always
+    # honoured, even for .tsv paths.
+    if delimiter is None:
+        delimiter = "\t" if path_lower.endswith(".tsv") else ","
 
     if _is_utf8_encoding(encoding):
         _reject_utf8_nul_bytes(path)
@@ -619,7 +627,7 @@ def write_csv(
 def scan_csv(
     path: str | os.PathLike[str],
     *,
-    delimiter: str = ",",
+    delimiter: str | None = None,
     encoding: str = "utf-8",
     trim_headers: bool = True,
     thousands_separator: str | None = None,
@@ -632,9 +640,14 @@ def scan_csv(
     Parameters
     ----------
     path : str
-        Path to the CSV file. Supports .csv, .txt, and .tsv extensions.
-    delimiter : str, default ","
-        Field delimiter character.
+        Path to the CSV file. Any file extension is accepted. For ``.tsv``
+        files, the delimiter is automatically set to ``'\t'`` when
+        ``delimiter`` is omitted.
+    delimiter : str or None, default None
+        Field delimiter character.  When ``None`` (the default) the
+        delimiter is inferred from the file extension: ``'\t'`` for
+        ``.tsv`` files and ``','`` for everything else.  Passing an
+        explicit value always takes precedence.
     encoding : str, default "utf-8"
         File encoding. For non-UTF-8 inputs, a sample of the file is
         transcoded to infer the schema.
@@ -665,10 +678,11 @@ def scan_csv(
     Raises
     ------
     ValueError
-        If file format is unsupported or if thousands_separator is invalid.
+        If thousands_separator is invalid.
 
     TypeError
-        If thousands_separator is not a string or None.
+        If delimiter is not a string or None, or thousands_separator is
+        not a string or None.
 
     CsvReadError
         If CSV input contains NUL bytes and appears binary or corrupted.
@@ -678,17 +692,18 @@ def scan_csv(
     >>> schema = ar.scan_csv("data.csv")
     >>> print(schema)
     {'name': 'string', 'age': 'int64'}
+    >>> schema = ar.scan_csv("data.tsv")              # tab auto-detected
+    >>> schema = ar.scan_csv("data.tsv", delimiter=",")  # explicit comma honoured
+    >>> schema = ar.scan_csv("data.dat")              # non-standard extension accepted
     """
     path = os.fspath(path)
     path_lower = path.lower()
-    if not (
-        path_lower.endswith(".csv")
-        or path_lower.endswith(".txt")
-        or path_lower.endswith(".tsv")
-    ):
-        raise ValueError(
-            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
-        )
+
+    # Resolve the sentinel: auto-detect tab for .tsv only when the caller
+    # truly omitted delimiter (None).  An explicit delimiter="," is always
+    # honoured, even for .tsv paths.
+    if delimiter is None:
+        delimiter = "\t" if path_lower.endswith(".tsv") else ","
 
     if _is_utf8_encoding(encoding):
         _reject_utf8_nul_bytes(path)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -326,15 +326,38 @@ class TestReadCsv:
         assert " score " in schema
         assert " active " in schema
 
-    def test_unsupported_extension(self, tmp_path):
-        import pytest
+    def test_non_standard_extension_accepted(self, tmp_path):
+        """Non-standard extensions no longer raise ValueError (fixes #34)."""
+        for ext in (".dat", ".log", ".data", ".pipe"):
+            p = tmp_path / f"data{ext}"
+            p.write_text("name,age\nAlice,30\n")
+            frame = ar.read_csv(str(p))
+            assert isinstance(frame, ar.ArFrame)
+            assert frame.columns == ["name", "age"]
 
-        file_path = str(tmp_path / "data.json")
-        with open(file_path, "w") as f:
-            f.write('{"a": 1}')
+    def test_tsv_auto_delimiter(self, tmp_path):
+        """read_csv auto-uses tab delimiter for .tsv files (fixes #34)."""
+        tsv = tmp_path / "data.tsv"
+        tsv.write_text("name\tage\nAlice\t30\nBob\t25\n")
+        frame = ar.read_csv(str(tsv))
+        assert frame.columns == ["name", "age"]
+        assert frame.shape == (2, 2)
 
-        with pytest.raises(ValueError, match="Unsupported file format"):
-            ar.read_csv(file_path)
+    def test_tsv_explicit_delimiter_honoured(self, tmp_path):
+        """Explicitly supplied delimiter is never overridden for .tsv (fixes #34)."""
+        tsv = tmp_path / "pipe.tsv"
+        tsv.write_text("name|age\nAlice|30\n")
+        frame = ar.read_csv(str(tsv), delimiter="|")
+        assert frame.columns == ["name", "age"]
+        assert frame.shape == (1, 2)
+
+    def test_tsv_explicit_comma_delimiter_honoured(self, tmp_path):
+        """Passing delimiter=',' to a .tsv file must preserve comma parsing (fixes #34)."""
+        tsv = tmp_path / "comma.tsv"
+        tsv.write_text("name,age\nAlice,30\n")
+        frame = ar.read_csv(str(tsv), delimiter=",")
+        assert frame.columns == ["name", "age"]
+        assert frame.shape == (1, 2)
 
     def test_binary_file_rejection(self, tmp_path):
         file_path = str(tmp_path / "data.csv")
@@ -740,6 +763,35 @@ class TestScanCsv:
     def test_scan_missing_file_passthrough(self, tmp_path):
         with pytest.raises(ar.CsvReadError):
             ar.scan_csv(str(tmp_path / "nonexistent.csv"))
+
+    def test_scan_non_standard_extension_accepted(self, tmp_path):
+        """Non-standard extensions no longer raise ValueError in scan_csv (fixes #34)."""
+        for ext in (".dat", ".log", ".data"):
+            p = tmp_path / f"data{ext}"
+            p.write_text("name,age\nAlice,30\n")
+            schema = ar.scan_csv(str(p))
+            assert set(schema.keys()) == {"name", "age"}
+
+    def test_scan_tsv_auto_delimiter(self, tmp_path):
+        """scan_csv auto-uses tab delimiter for .tsv files (fixes #34)."""
+        tsv = tmp_path / "data.tsv"
+        tsv.write_text("name\tage\nAlice\t30\nBob\t25\n")
+        schema = ar.scan_csv(str(tsv))
+        assert set(schema.keys()) == {"name", "age"}
+
+    def test_scan_tsv_explicit_delimiter_honoured(self, tmp_path):
+        """Explicitly supplied delimiter is never overridden for .tsv (fixes #34)."""
+        tsv = tmp_path / "pipe.tsv"
+        tsv.write_text("name|age\nAlice|30\n")
+        schema = ar.scan_csv(str(tsv), delimiter="|")
+        assert set(schema.keys()) == {"name", "age"}
+
+    def test_scan_tsv_explicit_comma_delimiter_honoured(self, tmp_path):
+        """Passing delimiter=',' to a .tsv file must preserve comma parsing (fixes #34)."""
+        tsv = tmp_path / "comma.tsv"
+        tsv.write_text("name,age\nAlice,30\n")
+        schema = ar.scan_csv(str(tsv), delimiter=",")
+        assert set(schema.keys()) == {"name", "age"}
 
     def test_scan_null_values_invalid_type(self):
         with pytest.raises(


### PR DESCRIPTION
Fixes #34

## Changes

### `arnio/io.py`
- Removed the hard `.csv`/`.txt`/`.tsv` extension check from `read_csv()` and `scan_csv()`
- `.tsv` files now auto-use `delimiter="\t"` unless explicitly overridden by caller
- Binary NUL-byte check preserved

### `tests/test_csv.py`
- `test_non_standard_extension_accepted`: verifies `.dat`, `.log`, `.data`, `.pipe` are accepted
- `test_tsv_auto_delimiter`: verifies `.tsv` auto-uses tab delimiter  
- `test_tsv_explicit_delimiter_honoured`: verifies explicit delimiter is never overridden
- Same 3 tests mirrored for `scan_csv()`