### PR TITLE
feat: add select_columns cleaning primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,16 @@ Example contract files are included under `examples/contracts/`.
 Use `select_columns()` to create a new `ArFrame` with only the required columns before converting to pandas.
 
 ```python
-selected = frame.select_columns(["name", "revenue"])
+selected = ar.select_columns(frame, ["name", "revenue"])
 
 print(selected.columns)
 # ['name', 'revenue']
 ```
 
+- Preserves the requested column order.
+- Returns a new `ArFrame`.
+- Raises `ValueError` if any requested column does not exist.
+- Raises `TypeError` if `columns` is not a sequence of strings.
 
 ### Handling missing values
 
@@ -815,6 +819,7 @@ Most operations below run natively in C++. Currently, `filter_rows`, `replace_va
 | `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 | `drop_columns_matching` | Drop columns whose names match a regex pattern | `ar.drop_columns_matching(frame, pattern="^temp_")` |
 | `trim_column_names` | Strip leading/trailing whitespace from column names | `ar.trim_column_names(frame)` |
+| `select_columns` | Return a new frame containing only selected columns | `ar.select_columns(frame, ["id", "name"])` |
 
 #### `ArFrame.select_dtypes` — type-based column selection
 

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -32,6 +32,7 @@ from .cleaning import (
     replace_values,
     round_numeric_columns,
     safe_divide_columns,
+    select_columns,
     standardize_missing_tokens,
     strip_whitespace,
     trim_column_names,
@@ -115,6 +116,7 @@ __all__ = [
     # Cleaning
     "drop_nulls",
     "drop_columns",
+    "select_columns",
     "keep_rows_with_nulls",
     "fill_nulls",
     "validate_columns_exist",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -261,46 +261,8 @@ def keep_rows_with_nulls(
 
 
 def select_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
-    """Return a new frame containing only the requested columns.
-
-    Parameters
-    ----------
-    frame : ArFrame
-        Input data frame.
-    columns : sequence of str
-        Column names to keep in the requested order.
-
-    Returns
-    -------
-    ArFrame
-        New frame with only the selected columns.
-
-    Raises
-    ------
-    TypeError
-        If columns is a string/bytes value or contains non-string items.
-    ValueError
-        If any requested column is missing.
-
-    Examples
-    --------
-    >>> selected = ar.select_columns(frame, ["id", "name"])
-    """
-    requested_columns = _validate_column_sequence(
-        columns,
-        argument_name="columns",
-    )
-
-    missing = [column for column in requested_columns if column not in frame.columns]
-
-    if missing:
-        raise ValueError(f"Columns not found in frame: {missing}")
-
-    from .convert import from_pandas, to_pandas
-
-    df = to_pandas(frame)
-
-    return from_pandas(df.loc[:, requested_columns])
+    """Return a new frame containing only the requested columns."""
+    return frame.select_columns(columns)
 
 
 def fill_nulls(

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -260,6 +260,49 @@ def keep_rows_with_nulls(
     return from_pandas(result) if is_arframe else result
 
 
+def select_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
+    """Return a new frame containing only the requested columns.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    columns : sequence of str
+        Column names to keep in the requested order.
+
+    Returns
+    -------
+    ArFrame
+        New frame with only the selected columns.
+
+    Raises
+    ------
+    TypeError
+        If columns is a string/bytes value or contains non-string items.
+    ValueError
+        If any requested column is missing.
+
+    Examples
+    --------
+    >>> selected = ar.select_columns(frame, ["id", "name"])
+    """
+    requested_columns = _validate_column_sequence(
+        columns,
+        argument_name="columns",
+    )
+
+    missing = [column for column in requested_columns if column not in frame.columns]
+
+    if missing:
+        raise ValueError(f"Columns not found in frame: {missing}")
+
+    from .convert import from_pandas, to_pandas
+
+    df = to_pandas(frame)
+
+    return from_pandas(df.loc[:, requested_columns])
+
+
 def fill_nulls(
     frame: ArFrame,
     value: Any,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -226,17 +226,19 @@ def _validate_pipeline_steps(
     for step in steps:
         if not isinstance(step, tuple) or not (1 <= len(step) <= 2):
             raise ValueError(
-                f"Invalid step format: {step!r}. Expected (name,) or (name, kwargs)"
+                f"Invalid step format: {step!r}. " "Expected (name,) or (name, kwargs)"
             )
 
         name = step[0]
 
         if not isinstance(name, str):
-            raise ValueError(f"Invalid pipeline step name: {name!r}. Expected a string")
+            raise ValueError(
+                f"Invalid pipeline step name: {name!r}. " "Expected a string"
+            )
 
         if len(step) == 2 and not isinstance(step[1], dict):
             raise ValueError(
-                f"Invalid step kwargs for '{name}': {step[1]!r}. Expected a dict"
+                f"Invalid step kwargs for '{name}': " f"{step[1]!r}. Expected a dict"
             )
 
         if name not in available_steps:

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -25,6 +25,7 @@ _STEP_NAMESPACE_SEPARATOR = ":"
 _STEP_REGISTRY: dict[str, Callable] = {
     "drop_nulls": cleaning.drop_nulls,
     "drop_columns": cleaning.drop_columns,
+    "select_columns": cleaning.select_columns,
     "keep_rows_with_nulls": cleaning.keep_rows_with_nulls,
     "fill_nulls": cleaning.fill_nulls,
     "validate_columns_exist": cleaning.validate_columns_exist,
@@ -225,19 +226,17 @@ def _validate_pipeline_steps(
     for step in steps:
         if not isinstance(step, tuple) or not (1 <= len(step) <= 2):
             raise ValueError(
-                f"Invalid step format: {step!r}. " "Expected (name,) or (name, kwargs)"
+                f"Invalid step format: {step!r}. Expected (name,) or (name, kwargs)"
             )
 
         name = step[0]
 
         if not isinstance(name, str):
-            raise ValueError(
-                f"Invalid pipeline step name: {name!r}. " "Expected a string"
-            )
+            raise ValueError(f"Invalid pipeline step name: {name!r}. Expected a string")
 
         if len(step) == 2 and not isinstance(step[1], dict):
             raise ValueError(
-                f"Invalid step kwargs for '{name}': " f"{step[1]!r}. Expected a dict"
+                f"Invalid step kwargs for '{name}': {step[1]!r}. Expected a dict"
             )
 
         if name not in available_steps:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2200,28 +2200,27 @@ class TestSelectColumns:
             )
         )
 
-        result = ar.select_columns(frame, [])
-
-        df = ar.to_pandas(result)
-
-        assert list(df.columns) == []
+        with pytest.raises(ValueError, match="Column selection cannot be empty"):
+            ar.select_columns(frame, [])
 
     def test_select_columns_rejects_missing_columns(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(ValueError, match="Columns not found in frame"):
+        with pytest.raises(ValueError, match="Unknown columns"):
             ar.select_columns(frame, ["missing"])
 
     def test_select_columns_rejects_string_input(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(TypeError, match="not a string"):
+        with pytest.raises(
+            TypeError, match="columns must be a sequence of column names, not a string"
+        ):
             ar.select_columns(frame, "age")
 
     def test_select_columns_rejects_non_string_items(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(TypeError, match="only string column names"):
+        with pytest.raises(TypeError, match="All column names must be strings"):
             ar.select_columns(frame, ["age", 1])
 
     def test_select_columns_rejects_empty(self):
@@ -2234,7 +2233,7 @@ class TestSelectColumns:
             )
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Column selection cannot be empty"):
             ar.select_columns(frame, [])
 
     def test_select_columns_rejects_duplicates(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2191,18 +2191,6 @@ class TestSelectColumns:
         assert list(df.columns) == ["name", "id"]
         assert list(df["name"]) == ["Alice", "Bob"]
 
-    def test_select_columns_allows_empty_input(self):
-        frame = ar.from_pandas(
-            pd.DataFrame(
-                {
-                    "id": [1, 2],
-                    "name": ["Alice", "Bob"],
-                }
-            )
-        )
-
-        with pytest.raises(ValueError, match="Column selection cannot be empty"):
-            ar.select_columns(frame, [])
 
     def test_select_columns_rejects_missing_columns(self, sample_csv):
         frame = ar.read_csv(sample_csv)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2191,7 +2191,6 @@ class TestSelectColumns:
         assert list(df.columns) == ["name", "id"]
         assert list(df["name"]) == ["Alice", "Bob"]
 
-
     def test_select_columns_rejects_missing_columns(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2169,3 +2169,57 @@ def test_fill_nulls_validation_lossy_and_non_finite():
         ar.pipeline(
             float_frame, [("fill_nulls", {"value": float("inf"), "subset": ["x"]})]
         )
+
+
+class TestSelectColumns:
+    def test_select_columns_keeps_requested_columns_and_preserves_order(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "debug": ["x", "y"],
+                    "name": ["Alice", "Bob"],
+                    "flag": [True, False],
+                }
+            )
+        )
+
+        result = ar.select_columns(frame, ["name", "id"])
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["name", "id"]
+        assert list(df["name"]) == ["Alice", "Bob"]
+
+    def test_select_columns_allows_empty_input(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "name": ["Alice", "Bob"],
+                }
+            )
+        )
+
+        result = ar.select_columns(frame, [])
+
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == []
+
+    def test_select_columns_rejects_missing_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(ValueError, match="Columns not found in frame"):
+            ar.select_columns(frame, ["missing"])
+
+    def test_select_columns_rejects_string_input(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="not a string"):
+            ar.select_columns(frame, "age")
+
+    def test_select_columns_rejects_non_string_items(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="only string column names"):
+            ar.select_columns(frame, ["age", 1])

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2223,3 +2223,29 @@ class TestSelectColumns:
 
         with pytest.raises(TypeError, match="only string column names"):
             ar.select_columns(frame, ["age", 1])
+
+    def test_select_columns_rejects_empty(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "name": ["Alice", "Bob"],
+                }
+            )
+        )
+
+        with pytest.raises(ValueError):
+            ar.select_columns(frame, [])
+
+    def test_select_columns_rejects_duplicates(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "name": ["Alice", "Bob"],
+                }
+            )
+        )
+
+        with pytest.raises(ValueError):
+            ar.select_columns(frame, ["id", "id"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -375,28 +375,40 @@ class TestPipeline:
 
         assert result.columns == ["email", "name"]
 
-    def test_pipeline_select_columns_allows_empty_columns(self, sample_csv):
-        frame = ar.read_csv(sample_csv)
-
-        result = ar.pipeline(
-            frame,
-            [
-                ("select_columns", {"columns": []}),
-            ],
-        )
-
-        assert result.columns == []
-
     def test_pipeline_select_columns_rejects_missing_columns(self, sample_csv):
         import pytest
 
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(ValueError, match="Columns not found in frame"):
+        with pytest.raises(ValueError, match="Unknown columns"):
             ar.pipeline(
                 frame,
                 [
                     ("select_columns", {"columns": ["missing"]}),
+                ],
+            )
+
+    def test_pipeline_select_columns_allows_empty_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(ValueError, match="Column selection cannot be empty"):
+            ar.pipeline(
+                frame,
+                [
+                    ("select_columns", {"columns": []}),
+                ],
+            )
+
+    def test_pipeline_select_columns_rejects_duplicates(self, sample_csv):
+        import pytest
+
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(ValueError, match="Duplicate column names are not allowed"):
+            ar.pipeline(
+                frame,
+                [
+                    ("select_columns", {"columns": ["name", "name"]}),
                 ],
             )
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -388,7 +388,7 @@ class TestPipeline:
                 ],
             )
 
-    def test_pipeline_select_columns_allows_reject_columns(self, sample_csv):
+    def test_pipeline_select_columns_reject_empty_columns(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
         with pytest.raises(ValueError, match="Column selection cannot be empty"):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -388,7 +388,7 @@ class TestPipeline:
                 ],
             )
 
-    def test_pipeline_select_columns_allows_empty_columns(self, sample_csv):
+    def test_pipeline_select_columns_allows_reject_columns(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
         with pytest.raises(ValueError, match="Column selection cannot be empty"):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -363,6 +363,43 @@ class TestPipeline:
                 [("drop_columns", {"columns": ["missing"]})],
             )
 
+    def test_pipeline_select_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("select_columns", {"columns": ["email", "name"]}),
+            ],
+        )
+
+        assert result.columns == ["email", "name"]
+
+    def test_pipeline_select_columns_allows_empty_columns(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("select_columns", {"columns": []}),
+            ],
+        )
+
+        assert result.columns == []
+
+    def test_pipeline_select_columns_rejects_missing_columns(self, sample_csv):
+        import pytest
+
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(ValueError, match="Columns not found in frame"):
+            ar.pipeline(
+                frame,
+                [
+                    ("select_columns", {"columns": ["missing"]}),
+                ],
+            )
+
     def test_pipeline_validate_columns_exist_rejects_missing_columns(self, sample_csv):
         import pytest
 


### PR DESCRIPTION
## Summary

Adds a new `select_columns` primitive for selecting specific columns from an `ArFrame`.

### Changes included

* Added `ar.select_columns()` helper
* Added `ArFrame.select_columns()` support
* Added validation for missing/non-string column names
* Added pipeline integration support
* Added tests for selection behavior and validation errors
* Updated README documentation with examples and primitive listing

## Linked issue

Fixes #767 

## Type of change

* [x] Feature
* [x] Documentation
* [x] Tests

## Area

* [x] Python API / ArFrame
* [x] Pipeline / custom steps
* [x] Docs / website

## Testing

* [x] `make lint`
* [x] `make test`
* [x] Other:

  * Added unit tests for valid selection, missing columns, and invalid input types.

## Screenshots / Media

N/A

## Performance Impact

No significant performance impact. Current implementation uses pandas conversion internally.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Future optimization opportunity:
`select_columns` currently uses pandas conversion internally and could later be implemented directly in the C++ frame layer for zero-copy column projection.
