### PR TITLE
feat: add dtype support to read_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -501,6 +501,18 @@ def read_csv_chunked(
         during numeric parsing.
     null_values : list[str], optional
         Strings treated as null values.
+
+    dtype : dict[str, str], optional
+        Explicit column dtype mapping. Specified columns skip automatic
+        type inference and use the requested dtype directly.
+
+        Supported dtypes:
+        - "string"
+        - "int64"
+        - "float64"
+        - "bool"
+
+
     mode : {"strict", "permissive"}, default "strict"
         Controls malformed row handling.
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -197,6 +197,34 @@ def _validate_usecols(usecols: Sequence[str]) -> list[str]:
     return list(usecols)
 
 
+def _validate_dtype_mapping(dtype: dict[str, str]) -> dict[str, str]:
+    if not isinstance(dtype, dict):
+        raise TypeError(
+            "dtype must be a dictionary mapping column names to dtype strings"
+        )
+
+    allowed = {"string", "int64", "float64", "bool"}
+
+    validated: dict[str, str] = {}
+
+    for column, dtype_name in dtype.items():
+        if not isinstance(column, str):
+            raise TypeError("dtype column names must be strings")
+
+        if not isinstance(dtype_name, str):
+            raise TypeError("dtype values must be strings")
+
+        if dtype_name not in allowed:
+            raise ValueError(
+                f"Unsupported dtype {dtype_name!r}. "
+                f"Expected one of: {sorted(allowed)}"
+            )
+
+        validated[column] = dtype_name
+
+    return validated
+
+
 def _validate_nrows(nrows: int) -> int:
     """Validate nrows parameter."""
     if isinstance(nrows, bool) or not isinstance(nrows, int):
@@ -310,6 +338,7 @@ def read_csv(
     trim_headers: bool = True,
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
+    dtype: dict[str, str] | None = None,
     mode: str = "strict",
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
@@ -398,6 +427,8 @@ def read_csv(
 
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)
+    if dtype is not None:
+        config.dtype = _validate_dtype_mapping(dtype)
 
     if usecols is not None:
         config.usecols = _validate_usecols(usecols)

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -364,10 +364,22 @@ def read_csv(
         Single non-alphanumeric character used as a thousands separator
         during numeric parsing.
 
+
+
         Values containing delimiter characters must still be quoted
         properly in the CSV input. For example, when using a comma
         delimiter, the value "1,234" must be quoted, while unquoted
         1,234 is interpreted as two separate fields.
+
+    dtype : dict[str, str], optional
+        Explicit column dtype mapping. Specified columns skip automatic
+        type inference and use the requested dtype directly.
+
+        Supported dtypes:
+        - "string"
+        - "int64"
+        - "float64"
+        - "bool"
 
     mode : {"strict", "permissive"}, default "strict"
         Controls malformed row handling.
@@ -502,15 +514,6 @@ def read_csv_chunked(
     null_values : list[str], optional
         Strings treated as null values.
 
-    dtype : dict[str, str], optional
-        Explicit column dtype mapping. Specified columns skip automatic
-        type inference and use the requested dtype directly.
-
-        Supported dtypes:
-        - "string"
-        - "int64"
-        - "float64"
-        - "bool"
 
 
     mode : {"strict", "permissive"}, default "strict"

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -222,6 +222,7 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def(py::init<>())
         .def_readwrite("delimiter", &CsvConfig::delimiter)
         .def_readwrite("has_header", &CsvConfig::has_header)
+        .def_readwrite("dtype", &CsvConfig::dtype)
         .def_readwrite("usecols", &CsvConfig::usecols)
         .def_readwrite("nrows", &CsvConfig::nrows)
         .def_readwrite("skip_rows", &CsvConfig::skip_rows)

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -3,9 +3,9 @@
 #include <fstream>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
-#include <unordered_map>
 
 #include "frame.h"
 

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_map>
 
 #include "frame.h"
 
@@ -14,6 +15,7 @@ struct CsvConfig {
     char delimiter = ',';
     bool has_header = true;
     std::optional<std::vector<std::string>> usecols = std::nullopt;
+    std::optional<std::unordered_map<std::string, std::string>> dtype = std::nullopt;
     std::optional<size_t> nrows = std::nullopt;
     std::optional<size_t> skip_rows = std::nullopt;
     std::string encoding = "utf-8";  // Currently only utf-8 supported

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -486,10 +486,19 @@ Frame CsvReader::read(const std::string& path) const {
     }
     if (config.dtype.has_value()) {
         for (const auto& [column_name, dtype_name] : config.dtype.value()) {
-            auto it = std::find(header.begin(), header.end(), column_name);
+            auto header_it = std::find(header.begin(), header.end(), column_name);
 
-            if (it == header.end()) {
+            if (header_it == header.end()) {
                 throw std::runtime_error("Column not found in dtype mapping: " + column_name);
+            }
+
+            size_t column_index = static_cast<size_t>(std::distance(header.begin(), header_it));
+
+            bool selected = std::find(col_indices.begin(), col_indices.end(), column_index) !=
+                            col_indices.end();
+
+            if (!selected) {
+                throw std::runtime_error("dtype specified for non-selected column: " + column_name);
             }
         }
     }

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -484,11 +484,29 @@ Frame CsvReader::read(const std::string& path) const {
             col_indices.push_back(i);
         }
     }
+    if (config.dtype.has_value()) {
+        for (const auto& [column_name, dtype_name] : config.dtype.value()) {
+            auto it = std::find(header.begin(), header.end(), column_name);
 
+            if (it == header.end()) {
+                throw std::runtime_error(
+                "Column not found in dtype mapping: " + column_name
+                );
+            }
+        }
+    }
     // Infer types (first pass)
     std::vector<DType> col_types(num_cols, DType::NULL_TYPE);
-    for (const auto& row : raw_data) {
-        for (size_t ci : col_indices) {
+
+    for (size_t ci : col_indices) {
+        const std::string& column_name = header[ci];
+
+        if (config.dtype.has_value() && config.dtype->count(column_name)) {
+            col_types[ci] = string_to_dtype(config.dtype->at(column_name));
+            continue;
+        }
+
+        for (const auto& row : raw_data) {
             if (ci < row.size()) {
                 DType inferred = parser_.infer_type(row[ci]);
                 col_types[ci] = CsvParser::promote_type(col_types[ci], inferred);

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -489,9 +489,7 @@ Frame CsvReader::read(const std::string& path) const {
             auto it = std::find(header.begin(), header.end(), column_name);
 
             if (it == header.end()) {
-                throw std::runtime_error(
-                "Column not found in dtype mapping: " + column_name
-                );
+                throw std::runtime_error("Column not found in dtype mapping: " + column_name);
             }
         }
     }

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -39,6 +39,67 @@ class TestReadCsv:
         assert frame.dtypes["zip"] == "string"
         assert frame.dtypes["price"] == "float64"
 
+    def test_read_csv_dtype_rejects_non_string_mapping_entries(self, tmp_path):
+        path = tmp_path / "bad_dtype_mapping.csv"
+        path.write_text("age\n25\n")
+
+        with pytest.raises(TypeError, match="dtype column names must be strings"):
+            ar.read_csv(path, dtype={1: "int64"})
+
+        with pytest.raises(TypeError, match="dtype values must be strings"):
+            ar.read_csv(path, dtype={"age": int})
+
+    def test_read_csv_dtype_with_generated_column_names(self, tmp_path):
+        path = tmp_path / "no_header.csv"
+        path.write_text("07001,5\n" "08002,10\n")
+
+        frame = ar.read_csv(
+            path,
+            has_header=False,
+            dtype={"col_0": "string", "col_1": "int64"},
+        )
+
+        pdf = ar.to_pandas(frame)
+
+        assert frame.dtypes["col_0"] == "string"
+        assert frame.dtypes["col_1"] == "int64"
+        assert pdf["col_0"].tolist() == ["07001", "08002"]
+        assert pdf["col_1"].tolist() == [5, 10]
+
+    def test_read_csv_dtype_with_usecols(self, tmp_path):
+        path = tmp_path / "usecols_dtype.csv"
+        path.write_text("zip,quantity,price\n" "07001,5,12.5\n" "08002,10,20.0\n")
+
+        frame = ar.read_csv(
+            path,
+            usecols=["zip", "price"],
+            dtype={"zip": "string"},
+        )
+
+        pdf = ar.to_pandas(frame)
+
+        assert list(pdf.columns) == ["zip", "price"]
+        assert frame.dtypes["zip"] == "string"
+        assert frame.dtypes["price"] == "float64"
+        assert pdf["zip"].tolist() == ["07001", "08002"]
+
+    def test_read_csv_dtype_parse_failure_becomes_null(self, tmp_path):
+        path = tmp_path / "parse_failure.csv"
+        path.write_text(
+            "quantity\n"
+            "abc\n"
+        )
+
+        frame = ar.read_csv(
+            path,
+            dtype={"quantity": "int64"},
+        )
+
+        pdf = ar.to_pandas(frame)
+
+        assert frame.dtypes["quantity"] == "int64"
+        assert pdf["quantity"].isna().tolist() == [True]
+
     def test_read_csv_dtype_override_string_to_int64(self, tmp_path):
         path = tmp_path / "quantities.csv"
         path.write_text("quantity,label\n" "5,small\n" "10,large\n")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -13,6 +13,66 @@ MESSY_CSV = str(Path(__file__).parent / "fixtures" / "messy_sales_data.csv")
 
 
 class TestReadCsv:
+    def test_read_csv_dtype_override_string(self, tmp_path):
+        path = tmp_path / "zip_codes.csv"
+        path.write_text("zip,quantity\n" "07001,5\n" "08002,10\n")
+
+        frame = ar.read_csv(
+            path,
+            dtype={"zip": "string"},
+        )
+
+        pdf = ar.to_pandas(frame)
+
+        assert frame.dtypes["zip"] == "string"
+        assert pdf["zip"].tolist() == ["07001", "08002"]
+
+    def test_read_csv_dtype_mixed_inference(self, tmp_path):
+        path = tmp_path / "mixed_types.csv"
+        path.write_text("zip,price\n" "07001,12.5\n" "08002,20.0\n")
+
+        frame = ar.read_csv(
+            path,
+            dtype={"zip": "string"},
+        )
+
+        assert frame.dtypes["zip"] == "string"
+        assert frame.dtypes["price"] == "float64"
+
+    def test_read_csv_dtype_override_string_to_int64(self, tmp_path):
+        path = tmp_path / "quantities.csv"
+        path.write_text("quantity,label\n" "5,small\n" "10,large\n")
+
+        frame = ar.read_csv(
+            path,
+            dtype={"quantity": "int64"},
+        )
+
+        pdf = ar.to_pandas(frame)
+
+        assert frame.dtypes["quantity"] == "int64"
+        assert pdf["quantity"].tolist() == [5, 10]
+
+    def test_read_csv_invalid_dtype_name(self, tmp_path):
+        path = tmp_path / "invalid_dtype.csv"
+        path.write_text("age\n" "25\n")
+
+        with pytest.raises(ValueError, match="Unsupported dtype"):
+            ar.read_csv(
+                path,
+                dtype={"age": "datetime"},
+            )
+
+    def test_read_csv_dtype_unknown_column(self, tmp_path):
+        path = tmp_path / "unknown_column.csv"
+        path.write_text("age,name\n" "25,Alice\n")
+
+        with pytest.raises(ar.CsvReadError, match="Column not found in dtype mapping"):
+            ar.read_csv(
+                path,
+                dtype={"salary": "float64"},
+            )
+
     def test_basic_read(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         assert isinstance(frame, ar.ArFrame)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -85,10 +85,7 @@ class TestReadCsv:
 
     def test_read_csv_dtype_parse_failure_becomes_null(self, tmp_path):
         path = tmp_path / "parse_failure.csv"
-        path.write_text(
-            "quantity\n"
-            "abc\n"
-        )
+        path.write_text("quantity\n" "abc\n")
 
         frame = ar.read_csv(
             path,
@@ -99,6 +96,20 @@ class TestReadCsv:
 
         assert frame.dtypes["quantity"] == "int64"
         assert pdf["quantity"].isna().tolist() == [True]
+
+    def test_read_csv_dtype_non_selected_usecols_column(self, tmp_path):
+        path = tmp_path / "dtype_usecols_error.csv"
+        path.write_text("zip,price\n" "07001,12.5\n")
+
+        with pytest.raises(
+            ar.CsvReadError,
+            match="dtype specified for non-selected column",
+        ):
+            ar.read_csv(
+                path,
+                usecols=["zip"],
+                dtype={"price": "float64"},
+            )
 
     def test_read_csv_dtype_override_string_to_int64(self, tmp_path):
         path = tmp_path / "quantities.csv"


### PR DESCRIPTION
Fixes #86

## Summary

Adds explicit `dtype` support to `read_csv`, allowing users to specify column types during CSV loading instead of relying only on automatic inference.

## Changes

* Added `dtype` parameter to the Python `read_csv` API
* Added dtype validation for supported types:

  * `string`
  * `int64`
  * `float64`
  * `bool`
* Passed the dtype mapping through `CsvConfig` and pybind bindings
* Updated the C++ CSV reader so specified columns skip inference and use the requested dtype directly
* Preserved automatic inference for unspecified columns
* Added clear error handling for unknown dtype-mapped columns
* Added focused tests for:

  * string override preserving leading zeros
  * mixed explicit dtype and inferred columns
  * explicit int64 override
  * invalid dtype names
  * unknown dtype-mapped columns

## Validation

* `python -m pytest tests/test_csv.py`
* `python -m pytest tests/test_csv.py tests/test_cleaning.py tests/test_pipeline.py`
