### PR TITLE
perf: benchmark sparse-null datasets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,8 @@ benchmark: ## Run benchmarks
 	python benchmarks/generate_data.py
 	python benchmarks/benchmark_vs_pandas.py
 
+benchmark-sparse-nulls: ## Run sparse-null benchmark
+	python benchmarks/benchmark_sparse_nulls.py
+
 clean: ## Remove build artifacts
 	python -c "import shutil, os, glob; [shutil.rmtree(p, ignore_errors=True) for p in ['dist', 'build', '.pytest_cache'] + glob.glob('*.egg-info') + glob.glob('**/__pycache__', recursive=True)]; [os.remove(f) for f in glob.glob('**/*.pyc', recursive=True)]"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,7 +26,7 @@ pip install -e ".[dev]"
 ```
 
 ### Step 2: Generate Deterministic Datasets
-Run the data generator to create deterministic tall, wide, and multiline CSV files with fixed random seeds:
+Run the data generator to create deterministic tall, wide, multiline, and sparse-null CSV files with fixed random seeds:
 ```bash
 python benchmarks/generate_data.py
 ```
@@ -34,11 +34,19 @@ This generates the following files:
 * `benchmarks/benchmark_1m.csv` (Tall CSV: 1M rows x 12 columns)
 * `benchmarks/benchmark_wide.csv` (Wide CSV: 5,000 rows x 256 columns)
 * `benchmarks/benchmark_multiline.csv` (Multiline CSV: 100,000 rows x 4 columns)
+* `benchmarks/benchmark_sparse_nulls.csv` (Sparse-null CSV: 1M rows x 6 columns, 1% nulls)
+* `benchmarks/benchmark_sparse_nulls_dense.csv` (Dense-null CSV: 1M rows x 6 columns, 20% nulls)
 
 ### Step 3: Run the Benchmark Suite
 Run the suite using the standard comparison script:
 ```bash
 python benchmarks/benchmark_vs_pandas.py
+```
+
+### Focused benchmark: sparse-null workloads
+Benchmark null-related operations (read_csv, drop_nulls, fill_nulls, keep_rows_with_nulls) across five null densities from 0.1% to 20%:
+```bash
+python benchmarks/benchmark_sparse_nulls.py --rows 1000000 --runs 5
 ```
 
 ---

--- a/benchmarks/benchmark_sparse_nulls.py
+++ b/benchmarks/benchmark_sparse_nulls.py
@@ -33,18 +33,57 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 import time
 import tracemalloc
 from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
-
+import numpy as np
 import pandas as pd
 
 import arnio as ar
 
-from generate_data import generate_sparse_nulls
+# ---------------------------------------------------------------------------
+# Data generation  (inlined to avoid cross-module import workaround)
+# ---------------------------------------------------------------------------
+
+
+def _generate_csv(rows, path, null_density, seed=42):
+    """Generate a deterministic CSV with controlled null density."""
+    if DRY_RUN:
+        rows = min(rows, 10)
+    rng = np.random.default_rng(seed)
+    data = {
+        "id": rng.integers(1, 999999, rows).tolist(),
+        "age": np.where(
+            rng.random(rows) < null_density, None, rng.integers(18, 80, rows)
+        ).tolist(),
+        "salary": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.uniform(30000, 150000, rows).round(2),
+        ).tolist(),
+        "name": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.choice(["Alice", "Bob", "Charlie", "Diana"], rows),
+        ).tolist(),
+        "city": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.choice(["New York", "London", "Paris", "Tokyo"], rows),
+        ).tolist(),
+        "active": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.choice([True, False], rows),
+        ).tolist(),
+    }
+    pd.DataFrame(data).to_csv(path, index=False, lineterminator="\n")
+    label = f"null_density={null_density:.1%}"
+    if DRY_RUN:
+        label += " (dry-run)"
+    print(f"Generated {rows:,} row sparse-null CSV ({label}) -> {path}")
+
 
 # Five densities spanning sparse -> dense
 NULL_DENSITIES = [0.001, 0.005, 0.01, 0.05, 0.2]
@@ -177,17 +216,16 @@ def run(rows: int = 1_000_000, runs: int = 5) -> None:
     header_lines = [
         f"  {'Operation':<{OP_WIDTH}}  {'Density':>7}"
         f"  {'arnio (ms)':>10}  {'pandas (ms)':>11}  {'speedup':>8}",
-        f"  {'':<{OP_WIDTH}}  {'':>7}"
-        f"  {'PyHeap MB':>10}  {'PyHeap MB':>11}",
+        f"  {'':<{OP_WIDTH}}  {'':>7}" f"  {'PyHeap MB':>10}  {'PyHeap MB':>11}",
     ]
     sep = "  " + "-" * (len(header_lines[0]) - 2)
 
     for density in NULL_DENSITIES:
         path = str(TMP_DIR / f"benchmark_sparse_nulls_{density}.csv")
-        generate_sparse_nulls(rows=rows, path=path, null_density=density)
+        _generate_csv(rows=rows, path=path, null_density=density)
 
         # Pre-load data once for all non-read operations
-        frame = ar.read_csv(path) if rows > 0 else ar.read_csv(path)
+        frame = ar.read_csv(path)
         df = pd.read_csv(path)
 
         label = DENSITY_LABELS.get(density, f"{density:.1%}")
@@ -210,9 +248,7 @@ def run(rows: int = 1_000_000, runs: int = 5) -> None:
         )
 
         # drop_nulls (data-based, time only)
-        ar_t, pd_t = _bench_data(
-            _drop_nulls_arnio, _drop_nulls_pandas, frame, df, runs
-        )
+        ar_t, pd_t = _bench_data(_drop_nulls_arnio, _drop_nulls_pandas, frame, df, runs)
         avg_ar = sum(ar_t) / runs
         avg_pd = sum(pd_t) / runs
         sp_str = f"{avg_pd / avg_ar:.1f}x" if avg_ar > 0 else "-"
@@ -223,9 +259,7 @@ def run(rows: int = 1_000_000, runs: int = 5) -> None:
         )
 
         # fill_nulls (data-based, time only)
-        ar_t, pd_t = _bench_data(
-            _fill_nulls_arnio, _fill_nulls_pandas, frame, df, runs
-        )
+        ar_t, pd_t = _bench_data(_fill_nulls_arnio, _fill_nulls_pandas, frame, df, runs)
         avg_ar = sum(ar_t) / runs
         avg_pd = sum(pd_t) / runs
         sp_str = f"{avg_pd / avg_ar:.1f}x" if avg_ar > 0 else "-"
@@ -236,9 +270,7 @@ def run(rows: int = 1_000_000, runs: int = 5) -> None:
         )
 
         # keep_rows_with_nulls (data-based, time only)
-        ar_t, pd_t = _bench_data(
-            _keep_nulls_arnio, _keep_nulls_pandas, frame, df, runs
-        )
+        ar_t, pd_t = _bench_data(_keep_nulls_arnio, _keep_nulls_pandas, frame, df, runs)
         avg_ar = sum(ar_t) / runs
         avg_pd = sum(pd_t) / runs
         sp_str = f"{avg_pd / avg_ar:.1f}x" if avg_ar > 0 else "-"

--- a/benchmarks/benchmark_sparse_nulls.py
+++ b/benchmarks/benchmark_sparse_nulls.py
@@ -26,9 +26,12 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 import time
 import tracemalloc
 from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 
 import numpy as np
 import pandas as pd
@@ -47,6 +50,7 @@ DENSITY_LABELS = {
     0.2: "20 %",
 }
 
+DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 TMP_DIR = Path("benchmarks")
 FILL_VALUE = 0
 
@@ -170,6 +174,9 @@ def _bench_op(
 
 
 def run(rows: int = 1_000_000, runs: int = 5) -> None:
+    if DRY_RUN:
+        rows = min(rows, 10)
+        runs = min(runs, 1)
     print(f"Sparse-null benchmark: {rows:,} rows, {runs} run(s) per density")
     print()
 

--- a/benchmarks/benchmark_sparse_nulls.py
+++ b/benchmarks/benchmark_sparse_nulls.py
@@ -1,16 +1,23 @@
 """
 Benchmark: sparse-null workloads
 =================================
-Measures wall-clock time and peak heap for null-related operations at
-varying null densities from sparse (0.1 %) to dense (20 %).
+Measures wall-clock time for null-related operations at varying null
+densities from sparse (0.1 %) to dense (20 %).
 
-Each density generates a fresh deterministic CSV, then benchmarks four
-operations in both arnio (C++ native where available) and pandas:
+Each density generates a fresh deterministic CSV, pre-loads data once,
+then benchmarks four operations in both arnio and pandas:
 
-  * read_csv              — CSV parsing with null values in the input
-  * drop_nulls            — remove rows containing any null
-  * fill_nulls            — replace nulls with a scalar value
-  * keep_rows_with_nulls  — keep only rows that contain nulls
+  * read_csv              - CSV parsing with null values in the input
+  * drop_nulls            - remove rows containing any null
+  * fill_nulls            - replace nulls with a scalar value
+  * keep_rows_with_nulls  - keep only rows that contain nulls
+
+Note on memory
+--------------
+Peak Python heap (tracemalloc) is reported only for read_csv, where it
+is meaningful.  For drop_nulls, fill_nulls, and keep_rows_with_nulls,
+only wall-clock time is shown because tracemalloc does not capture
+Arnio's native C++ allocations, and per-operation RSS is too noisy.
 
 Run::
 
@@ -33,14 +40,13 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 
-import numpy as np
 import pandas as pd
 
 import arnio as ar
 
 from generate_data import generate_sparse_nulls
 
-# Five densities spanning sparse → dense
+# Five densities spanning sparse -> dense
 NULL_DENSITIES = [0.001, 0.005, 0.01, 0.05, 0.2]
 DENSITY_LABELS = {
     0.001: "0.1 %",
@@ -54,16 +60,30 @@ DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 TMP_DIR = Path("benchmarks")
 FILL_VALUE = 0
 
+_OPS = ["read_csv", "drop_nulls", "fill_nulls", "keep_rows_with_nulls"]
+OP_WIDTH = max(len(op) for op in _OPS)
+
 
 # ---------------------------------------------------------------------------
-# Benchmark helpers  (each returns (elapsed_seconds, peak_mib))
+# Timing helpers  (return elapsed seconds)
+# ---------------------------------------------------------------------------
+
+
+def _time(fn, *args):
+    t0 = time.perf_counter()
+    fn(*args)
+    return time.perf_counter() - t0
+
+
+# ---------------------------------------------------------------------------
+# read_csv:  path-based (the read IS the operation)
 # ---------------------------------------------------------------------------
 
 
 def _read_csv_arnio(path: str) -> tuple[float, float]:
     tracemalloc.start()
     t0 = time.perf_counter()
-    _ = ar.read_csv(path)
+    ar.read_csv(path)
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
@@ -73,77 +93,42 @@ def _read_csv_arnio(path: str) -> tuple[float, float]:
 def _read_csv_pandas(path: str) -> tuple[float, float]:
     tracemalloc.start()
     t0 = time.perf_counter()
-    _ = pd.read_csv(path)
+    pd.read_csv(path)
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     return elapsed, peak / 1024 / 1024
 
 
-def _drop_nulls_arnio(path: str) -> tuple[float, float]:
-    frame = ar.read_csv(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    _ = ar.drop_nulls(frame)
-    elapsed = time.perf_counter() - t0
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+# ---------------------------------------------------------------------------
+# drop_nulls, fill_nulls, keep_rows_with_nulls:  data-based (pre-loaded)
+#   Only wall-clock time - tracemalloc cannot capture Arnio C++
+#   allocations so memory columns are omitted for these operations.
+# ---------------------------------------------------------------------------
 
 
-def _drop_nulls_pandas(path: str) -> tuple[float, float]:
-    df = pd.read_csv(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    _ = df.dropna()
-    elapsed = time.perf_counter() - t0
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+def _drop_nulls_arnio(frame):
+    ar.drop_nulls(frame)
 
 
-def _fill_nulls_arnio(path: str) -> tuple[float, float]:
-    frame = ar.read_csv(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    _ = ar.fill_nulls(frame, FILL_VALUE)
-    elapsed = time.perf_counter() - t0
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+def _drop_nulls_pandas(df):
+    df.dropna()
 
 
-def _fill_nulls_pandas(path: str) -> tuple[float, float]:
-    df = pd.read_csv(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    _ = df.fillna(FILL_VALUE)
-    elapsed = time.perf_counter() - t0
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+def _fill_nulls_arnio(frame):
+    ar.fill_nulls(frame, FILL_VALUE)
 
 
-def _keep_nulls_arnio(path: str) -> tuple[float, float]:
-    frame = ar.read_csv(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    _ = ar.keep_rows_with_nulls(frame)
-    elapsed = time.perf_counter() - t0
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+def _fill_nulls_pandas(df):
+    df.fillna(FILL_VALUE)
 
 
-def _keep_nulls_pandas(path: str) -> tuple[float, float]:
-    df = pd.read_csv(path)
-    tracemalloc.start()
-    t0 = time.perf_counter()
-    _ = df[df.isnull().any(axis=1)]
-    elapsed = time.perf_counter() - t0
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    return elapsed, peak / 1024 / 1024
+def _keep_nulls_arnio(frame):
+    ar.keep_rows_with_nulls(frame)
+
+
+def _keep_nulls_pandas(df):
+    df[df.isnull().any(axis=1)]
 
 
 # ---------------------------------------------------------------------------
@@ -151,21 +136,30 @@ def _keep_nulls_pandas(path: str) -> tuple[float, float]:
 # ---------------------------------------------------------------------------
 
 
-def _bench_op(
-    arnio_fn, pandas_fn, path: str, runs: int
-) -> tuple[list[float], list[float], list[float], list[float]]:
+def _bench_read_csv(path: str, runs: int):
+    """Benchmark read_csv with tracemalloc (Python heap only)."""
     ar_times: list[float] = []
     ar_peaks: list[float] = []
     pd_times: list[float] = []
     pd_peaks: list[float] = []
     for _ in range(runs):
-        t, p = arnio_fn(path)
+        t, p = _read_csv_arnio(path)
         ar_times.append(t)
         ar_peaks.append(p)
-        t, p = pandas_fn(path)
+        t, p = _read_csv_pandas(path)
         pd_times.append(t)
         pd_peaks.append(p)
     return ar_times, ar_peaks, pd_times, pd_peaks
+
+
+def _bench_data(arnio_fn, pandas_fn, frame, df, runs: int):
+    """Benchmark a data-based operation (pre-loaded frame/df, time only)."""
+    ar_times: list[float] = []
+    pd_times: list[float] = []
+    for _ in range(runs):
+        ar_times.append(_time(arnio_fn, frame))
+        pd_times.append(_time(pandas_fn, df))
+    return ar_times, pd_times
 
 
 # ---------------------------------------------------------------------------
@@ -180,55 +174,79 @@ def run(rows: int = 1_000_000, runs: int = 5) -> None:
     print(f"Sparse-null benchmark: {rows:,} rows, {runs} run(s) per density")
     print()
 
-    ops = [
-        ("read_csv", _read_csv_arnio, _read_csv_pandas),
-        ("drop_nulls", _drop_nulls_arnio, _drop_nulls_pandas),
-        ("fill_nulls", _fill_nulls_arnio, _fill_nulls_pandas),
-        ("keep_rows_with_nulls", _keep_nulls_arnio, _keep_nulls_pandas),
+    header_lines = [
+        f"  {'Operation':<{OP_WIDTH}}  {'Density':>7}"
+        f"  {'arnio (ms)':>10}  {'pandas (ms)':>11}  {'speedup':>8}",
+        f"  {'':<{OP_WIDTH}}  {'':>7}"
+        f"  {'PyHeap MB':>10}  {'PyHeap MB':>11}",
     ]
-    speedup_col = 6 + max(len(op[0]) for op in ops) + 14 + 12
-    header = (
-        f"  {'Operation':<{max(len(op[0]) for op in ops)}}"
-        f"  {'Density':>7}"
-        f"  {'arnio (ms)':>10}"
-        f"  {'pandas (ms)':>11}"
-        f"  {'speedup':>8}"
-        f"  {'arnio MB':>9}"
-        f"  {'pandas MB':>10}"
-    )
-    sep = "  " + "-" * (len(header) - 2)
+    sep = "  " + "-" * (len(header_lines[0]) - 2)
 
     for density in NULL_DENSITIES:
         path = str(TMP_DIR / f"benchmark_sparse_nulls_{density}.csv")
         generate_sparse_nulls(rows=rows, path=path, null_density=density)
 
+        # Pre-load data once for all non-read operations
+        frame = ar.read_csv(path) if rows > 0 else ar.read_csv(path)
+        df = pd.read_csv(path)
+
         label = DENSITY_LABELS.get(density, f"{density:.1%}")
-        print(f"  ── null density = {label} ──")
-        print(header)
+        print(f"  -- null density = {label} --")
+        for hl in header_lines:
+            print(hl)
         print(sep)
 
-        for op_name, arnio_fn, pandas_fn in ops:
-            ar_t, ar_p, pd_t, pd_p = _bench_op(arnio_fn, pandas_fn, path, runs)
-            avg_ar = sum(ar_t) / runs
-            avg_pd = sum(pd_t) / runs
-            avg_ar_mem = sum(ar_p) / runs
-            avg_pd_mem = sum(pd_p) / runs
+        # read_csv (path-based, includes Python heap)
+        ar_t, ar_p, pd_t, pd_p = _bench_read_csv(path, runs)
+        avg_ar = sum(ar_t) / runs
+        avg_pd = sum(pd_t) / runs
+        avg_ar_mem = sum(ar_p) / runs
+        avg_pd_mem = sum(pd_p) / runs
+        sp_str = f"{avg_pd / avg_ar:.1f}x" if avg_ar > 0 else "-"
+        print(
+            f"  {'read_csv':<{OP_WIDTH}}  {label:>7}"
+            f"  {avg_ar * 1000:>10.1f}  {avg_pd * 1000:>11.1f}  {sp_str:>8}"
+            f"  {avg_ar_mem:>9.1f}  {avg_pd_mem:>10.1f}"
+        )
 
-            if avg_ar > 0:
-                speedup = avg_pd / avg_ar
-                sp_str = f"{speedup:.1f}x"
-            else:
-                sp_str = "—"
+        # drop_nulls (data-based, time only)
+        ar_t, pd_t = _bench_data(
+            _drop_nulls_arnio, _drop_nulls_pandas, frame, df, runs
+        )
+        avg_ar = sum(ar_t) / runs
+        avg_pd = sum(pd_t) / runs
+        sp_str = f"{avg_pd / avg_ar:.1f}x" if avg_ar > 0 else "-"
+        print(
+            f"  {'drop_nulls':<{OP_WIDTH}}  {label:>7}"
+            f"  {avg_ar * 1000:>10.1f}  {avg_pd * 1000:>11.1f}  {sp_str:>8}"
+            f"  {'-':>9}  {'-':>10}"
+        )
 
-            print(
-                f"  {op_name:<{max(len(op[0]) for op in ops)}}"
-                f"  {label:>7}"
-                f"  {avg_ar * 1000:>10.1f}"
-                f"  {avg_pd * 1000:>11.1f}"
-                f"  {sp_str:>8}"
-                f"  {avg_ar_mem:>9.1f}"
-                f"  {avg_pd_mem:>10.1f}"
-            )
+        # fill_nulls (data-based, time only)
+        ar_t, pd_t = _bench_data(
+            _fill_nulls_arnio, _fill_nulls_pandas, frame, df, runs
+        )
+        avg_ar = sum(ar_t) / runs
+        avg_pd = sum(pd_t) / runs
+        sp_str = f"{avg_pd / avg_ar:.1f}x" if avg_ar > 0 else "-"
+        print(
+            f"  {'fill_nulls':<{OP_WIDTH}}  {label:>7}"
+            f"  {avg_ar * 1000:>10.1f}  {avg_pd * 1000:>11.1f}  {sp_str:>8}"
+            f"  {'-':>9}  {'-':>10}"
+        )
+
+        # keep_rows_with_nulls (data-based, time only)
+        ar_t, pd_t = _bench_data(
+            _keep_nulls_arnio, _keep_nulls_pandas, frame, df, runs
+        )
+        avg_ar = sum(ar_t) / runs
+        avg_pd = sum(pd_t) / runs
+        sp_str = f"{avg_pd / avg_ar:.1f}x" if avg_ar > 0 else "-"
+        print(
+            f"  {'keep_rows_with_nulls':<{OP_WIDTH}}  {label:>7}"
+            f"  {avg_ar * 1000:>10.1f}  {avg_pd * 1000:>11.1f}  {sp_str:>8}"
+            f"  {'-':>9}  {'-':>10}"
+        )
 
         print()
         os.remove(path)

--- a/benchmarks/benchmark_sparse_nulls.py
+++ b/benchmarks/benchmark_sparse_nulls.py
@@ -1,12 +1,16 @@
 """
 Benchmark: sparse-null workloads
 =================================
-Measures wall-clock time and peak heap for null-related operations
-at varying null densities (sparse to dense).
+Measures wall-clock time and peak heap for null-related operations at
+varying null densities from sparse (0.1 %) to dense (20 %).
 
-Operations compared:
-  - ar.drop_nulls  vs  pandas .dropna()
-  - ar.fill_nulls  vs  pandas .fillna()
+Each density generates a fresh deterministic CSV, then benchmarks four
+operations in both arnio (C++ native where available) and pandas:
+
+  * read_csv              — CSV parsing with null values in the input
+  * drop_nulls            — remove rows containing any null
+  * fill_nulls            — replace nulls with a scalar value
+  * keep_rows_with_nulls  — keep only rows that contain nulls
 
 Run::
 
@@ -30,21 +34,49 @@ import numpy as np
 import pandas as pd
 
 import arnio as ar
-from arnio.convert import from_pandas
 
 from generate_data import generate_sparse_nulls
 
+# Five densities spanning sparse → dense
 NULL_DENSITIES = [0.001, 0.005, 0.01, 0.05, 0.2]
+DENSITY_LABELS = {
+    0.001: "0.1 %",
+    0.005: "0.5 %",
+    0.01: "1 %",
+    0.05: "5 %",
+    0.2: "20 %",
+}
 
 TMP_DIR = Path("benchmarks")
+FILL_VALUE = 0
 
 
-def _csv_path(density: float) -> str:
-    pct = f"{density:.3f}".replace(".", "_")
-    return str(TMP_DIR / f"benchmark_sparse_nulls_{pct}.csv")
+# ---------------------------------------------------------------------------
+# Benchmark helpers  (each returns (elapsed_seconds, peak_mib))
+# ---------------------------------------------------------------------------
 
 
-def _bench_drop_nulls_arnio(path: str) -> tuple[float, float]:
+def _read_csv_arnio(path: str) -> tuple[float, float]:
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = ar.read_csv(path)
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+def _read_csv_pandas(path: str) -> tuple[float, float]:
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = pd.read_csv(path)
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+def _drop_nulls_arnio(path: str) -> tuple[float, float]:
     frame = ar.read_csv(path)
     tracemalloc.start()
     t0 = time.perf_counter()
@@ -55,7 +87,7 @@ def _bench_drop_nulls_arnio(path: str) -> tuple[float, float]:
     return elapsed, peak / 1024 / 1024
 
 
-def _bench_drop_nulls_pandas(path: str) -> tuple[float, float]:
+def _drop_nulls_pandas(path: str) -> tuple[float, float]:
     df = pd.read_csv(path)
     tracemalloc.start()
     t0 = time.perf_counter()
@@ -66,64 +98,132 @@ def _bench_drop_nulls_pandas(path: str) -> tuple[float, float]:
     return elapsed, peak / 1024 / 1024
 
 
-def _bench_fill_nulls_arnio(path: str) -> tuple[float, float]:
+def _fill_nulls_arnio(path: str) -> tuple[float, float]:
     frame = ar.read_csv(path)
     tracemalloc.start()
     t0 = time.perf_counter()
-    _ = ar.fill_nulls(frame, 0)
+    _ = ar.fill_nulls(frame, FILL_VALUE)
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     return elapsed, peak / 1024 / 1024
 
 
-def _bench_fill_nulls_pandas(path: str) -> tuple[float, float]:
+def _fill_nulls_pandas(path: str) -> tuple[float, float]:
     df = pd.read_csv(path)
     tracemalloc.start()
     t0 = time.perf_counter()
-    _ = df.fillna(0)
+    _ = df.fillna(FILL_VALUE)
     elapsed = time.perf_counter() - t0
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     return elapsed, peak / 1024 / 1024
 
 
+def _keep_nulls_arnio(path: str) -> tuple[float, float]:
+    frame = ar.read_csv(path)
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = ar.keep_rows_with_nulls(frame)
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+def _keep_nulls_pandas(path: str) -> tuple[float, float]:
+    df = pd.read_csv(path)
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = df[df.isnull().any(axis=1)]
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+# ---------------------------------------------------------------------------
+# Per-operation runner
+# ---------------------------------------------------------------------------
+
+
+def _bench_op(
+    arnio_fn, pandas_fn, path: str, runs: int
+) -> tuple[list[float], list[float], list[float], list[float]]:
+    ar_times: list[float] = []
+    ar_peaks: list[float] = []
+    pd_times: list[float] = []
+    pd_peaks: list[float] = []
+    for _ in range(runs):
+        t, p = arnio_fn(path)
+        ar_times.append(t)
+        ar_peaks.append(p)
+        t, p = pandas_fn(path)
+        pd_times.append(t)
+        pd_peaks.append(p)
+    return ar_times, ar_peaks, pd_times, pd_peaks
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
 def run(rows: int = 1_000_000, runs: int = 5) -> None:
-    print(f"Sparse-null benchmark: {rows:,} rows, {runs} run(s) per density\n")
+    print(f"Sparse-null benchmark: {rows:,} rows, {runs} run(s) per density")
+    print()
+
+    ops = [
+        ("read_csv", _read_csv_arnio, _read_csv_pandas),
+        ("drop_nulls", _drop_nulls_arnio, _drop_nulls_pandas),
+        ("fill_nulls", _fill_nulls_arnio, _fill_nulls_pandas),
+        ("keep_rows_with_nulls", _keep_nulls_arnio, _keep_nulls_pandas),
+    ]
+    speedup_col = 6 + max(len(op[0]) for op in ops) + 14 + 12
+    header = (
+        f"  {'Operation':<{max(len(op[0]) for op in ops)}}"
+        f"  {'Density':>7}"
+        f"  {'arnio (ms)':>10}"
+        f"  {'pandas (ms)':>11}"
+        f"  {'speedup':>8}"
+        f"  {'arnio MB':>9}"
+        f"  {'pandas MB':>10}"
+    )
+    sep = "  " + "-" * (len(header) - 2)
 
     for density in NULL_DENSITIES:
-        path = _csv_path(density)
+        path = str(TMP_DIR / f"benchmark_sparse_nulls_{density}.csv")
         generate_sparse_nulls(rows=rows, path=path, null_density=density)
 
-        arnios_dn: list[float] = []
-        pandas_dn: list[float] = []
-        arnios_fn: list[float] = []
-        pandas_fn: list[float] = []
+        label = DENSITY_LABELS.get(density, f"{density:.1%}")
+        print(f"  ── null density = {label} ──")
+        print(header)
+        print(sep)
 
-        for _ in range(runs):
-            t, _ = _bench_drop_nulls_arnio(path)
-            arnios_dn.append(t)
-            t, _ = _bench_drop_nulls_pandas(path)
-            pandas_dn.append(t)
-            t, _ = _bench_fill_nulls_arnio(path)
-            arnios_fn.append(t)
-            t, _ = _bench_fill_nulls_pandas(path)
-            pandas_fn.append(t)
+        for op_name, arnio_fn, pandas_fn in ops:
+            ar_t, ar_p, pd_t, pd_p = _bench_op(arnio_fn, pandas_fn, path, runs)
+            avg_ar = sum(ar_t) / runs
+            avg_pd = sum(pd_t) / runs
+            avg_ar_mem = sum(ar_p) / runs
+            avg_pd_mem = sum(pd_p) / runs
 
-        avg_arnio_dn = sum(arnios_dn) / runs
-        avg_pandas_dn = sum(pandas_dn) / runs
-        avg_arnio_fn = sum(arnios_fn) / runs
-        avg_pandas_fn = sum(pandas_fn) / runs
+            if avg_ar > 0:
+                speedup = avg_pd / avg_ar
+                sp_str = f"{speedup:.1f}x"
+            else:
+                sp_str = "—"
 
-        print(f"  Null density: {density:.1%}")
-        print(f"    drop_nulls:  arnio={avg_arnio_dn * 1000:.1f} ms  "
-              f"pandas={avg_pandas_dn * 1000:.1f} ms  "
-              f"({avg_pandas_dn / avg_arnio_dn:.1f}x)")
-        print(f"    fill_nulls:  arnio={avg_arnio_fn * 1000:.1f} ms  "
-              f"pandas={avg_pandas_fn * 1000:.1f} ms  "
-              f"({avg_pandas_fn / avg_arnio_fn:.1f}x)")
+            print(
+                f"  {op_name:<{max(len(op[0]) for op in ops)}}"
+                f"  {label:>7}"
+                f"  {avg_ar * 1000:>10.1f}"
+                f"  {avg_pd * 1000:>11.1f}"
+                f"  {sp_str:>8}"
+                f"  {avg_ar_mem:>9.1f}"
+                f"  {avg_pd_mem:>10.1f}"
+            )
+
         print()
-
         os.remove(path)
 
 

--- a/benchmarks/benchmark_sparse_nulls.py
+++ b/benchmarks/benchmark_sparse_nulls.py
@@ -1,0 +1,137 @@
+"""
+Benchmark: sparse-null workloads
+=================================
+Measures wall-clock time and peak heap for null-related operations
+at varying null densities (sparse to dense).
+
+Operations compared:
+  - ar.drop_nulls  vs  pandas .dropna()
+  - ar.fill_nulls  vs  pandas .fillna()
+
+Run::
+
+    python benchmarks/benchmark_sparse_nulls.py
+
+Optional flags::
+
+    --rows   N   Number of rows (default: 1_000_000)
+    --runs   N   Repetitions per density/operation (default: 5)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+import tracemalloc
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import arnio as ar
+from arnio.convert import from_pandas
+
+from generate_data import generate_sparse_nulls
+
+NULL_DENSITIES = [0.001, 0.005, 0.01, 0.05, 0.2]
+
+TMP_DIR = Path("benchmarks")
+
+
+def _csv_path(density: float) -> str:
+    pct = f"{density:.3f}".replace(".", "_")
+    return str(TMP_DIR / f"benchmark_sparse_nulls_{pct}.csv")
+
+
+def _bench_drop_nulls_arnio(path: str) -> tuple[float, float]:
+    frame = ar.read_csv(path)
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = ar.drop_nulls(frame)
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+def _bench_drop_nulls_pandas(path: str) -> tuple[float, float]:
+    df = pd.read_csv(path)
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = df.dropna()
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+def _bench_fill_nulls_arnio(path: str) -> tuple[float, float]:
+    frame = ar.read_csv(path)
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = ar.fill_nulls(frame, 0)
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+def _bench_fill_nulls_pandas(path: str) -> tuple[float, float]:
+    df = pd.read_csv(path)
+    tracemalloc.start()
+    t0 = time.perf_counter()
+    _ = df.fillna(0)
+    elapsed = time.perf_counter() - t0
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return elapsed, peak / 1024 / 1024
+
+
+def run(rows: int = 1_000_000, runs: int = 5) -> None:
+    print(f"Sparse-null benchmark: {rows:,} rows, {runs} run(s) per density\n")
+
+    for density in NULL_DENSITIES:
+        path = _csv_path(density)
+        generate_sparse_nulls(rows=rows, path=path, null_density=density)
+
+        arnios_dn: list[float] = []
+        pandas_dn: list[float] = []
+        arnios_fn: list[float] = []
+        pandas_fn: list[float] = []
+
+        for _ in range(runs):
+            t, _ = _bench_drop_nulls_arnio(path)
+            arnios_dn.append(t)
+            t, _ = _bench_drop_nulls_pandas(path)
+            pandas_dn.append(t)
+            t, _ = _bench_fill_nulls_arnio(path)
+            arnios_fn.append(t)
+            t, _ = _bench_fill_nulls_pandas(path)
+            pandas_fn.append(t)
+
+        avg_arnio_dn = sum(arnios_dn) / runs
+        avg_pandas_dn = sum(pandas_dn) / runs
+        avg_arnio_fn = sum(arnios_fn) / runs
+        avg_pandas_fn = sum(pandas_fn) / runs
+
+        print(f"  Null density: {density:.1%}")
+        print(f"    drop_nulls:  arnio={avg_arnio_dn * 1000:.1f} ms  "
+              f"pandas={avg_pandas_dn * 1000:.1f} ms  "
+              f"({avg_pandas_dn / avg_arnio_dn:.1f}x)")
+        print(f"    fill_nulls:  arnio={avg_arnio_fn * 1000:.1f} ms  "
+              f"pandas={avg_pandas_fn * 1000:.1f} ms  "
+              f"({avg_pandas_fn / avg_arnio_fn:.1f}x)")
+        print()
+
+        os.remove(path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Benchmark sparse-null workloads: arnio vs pandas"
+    )
+    parser.add_argument("--rows", type=int, default=1_000_000, help="Number of rows")
+    parser.add_argument("--runs", type=int, default=5, help="Repetitions per density")
+    args = parser.parse_args()
+    run(rows=args.rows, runs=args.runs)

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -21,6 +21,8 @@ import arnio as ar
 CSV_FILE = "benchmarks/benchmark_1m.csv"
 WIDE_CSV_FILE = "benchmarks/benchmark_wide.csv"
 MULTILINE_CSV_FILE = "benchmarks/benchmark_multiline.csv"
+SPARSE_NULLS_FILE = "benchmarks/benchmark_sparse_nulls.csv"
+DENSE_NULLS_FILE = "benchmarks/benchmark_sparse_nulls_dense.csv"
 DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 RUNS = 1 if DRY_RUN else 3
 
@@ -38,6 +40,12 @@ BENCHMARKS = (
     BenchmarkCase("Tall CSV (1,000,000 rows x 12 columns)", CSV_FILE),
     BenchmarkCase("Wide CSV (5,000 rows x 256 columns)", WIDE_CSV_FILE),
     BenchmarkCase("Multiline CSV (100,000 rows x 4 columns)", MULTILINE_CSV_FILE),
+    BenchmarkCase(
+        "Sparse-null CSV (1,000,000 rows x 6 columns, 1% nulls)", SPARSE_NULLS_FILE
+    ),
+    BenchmarkCase(
+        "Dense-null CSV (1,000,000 rows x 6 columns, 20% nulls)", DENSE_NULLS_FILE
+    ),
 )
 
 

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -119,8 +119,13 @@ def generate_multiline(rows=100_000, path=DEFAULT_MULTILINE_PATH):
 DEFAULT_SPARSE_NULLS_PATH = "benchmarks/benchmark_sparse_nulls.csv"
 
 
-def generate_sparse_nulls(rows=1_000_000, path=DEFAULT_SPARSE_NULLS_PATH, null_density=0.01, seed=42):
-    """Generate a deterministic CSV with controlled null density across mixed column types."""
+def generate_sparse_nulls(
+    rows=1_000_000,
+    path=DEFAULT_SPARSE_NULLS_PATH,
+    null_density=0.01,
+    seed=42,
+):
+    """Generate a CSV with controlled null density across mixed column types."""
     if DRY_RUN:
         rows = min(rows, 10)
     rng = np.random.default_rng(seed)
@@ -163,4 +168,8 @@ if __name__ == "__main__":
     generate_wide()
     generate_multiline()
     generate_sparse_nulls()
-    generate_sparse_nulls(path="benchmarks/benchmark_sparse_nulls_dense.csv", null_density=0.2, seed=99)
+    generate_sparse_nulls(
+        path="benchmarks/benchmark_sparse_nulls_dense.csv",
+        null_density=0.2,
+        seed=99,
+    )

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -116,7 +116,50 @@ def generate_multiline(rows=100_000, path=DEFAULT_MULTILINE_PATH):
     print(f"Generated {rows:,} row Multiline CSV -> {path}")
 
 
+DEFAULT_SPARSE_NULLS_PATH = "benchmarks/benchmark_sparse_nulls.csv"
+
+
+def generate_sparse_nulls(rows=1_000_000, path=DEFAULT_SPARSE_NULLS_PATH, null_density=0.01, seed=42):
+    """Generate a deterministic CSV with controlled null density across mixed column types."""
+    if DRY_RUN:
+        rows = min(rows, 10)
+    rng = np.random.default_rng(seed)
+    data = {
+        "id": rng.integers(1, 999999, rows).tolist(),
+        "age": np.where(
+            rng.random(rows) < null_density, None, rng.integers(18, 80, rows)
+        ).tolist(),
+        "salary": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.uniform(30000, 150000, rows).round(2),
+        ).tolist(),
+        "name": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.choice(["Alice", "Bob", "Charlie", "Diana"], rows),
+        ).tolist(),
+        "city": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.choice(["New York", "London", "Paris", "Tokyo"], rows),
+        ).tolist(),
+        "active": np.where(
+            rng.random(rows) < null_density,
+            None,
+            rng.choice([True, False], rows),
+        ).tolist(),
+    }
+    df = pd.DataFrame(data)
+    df.to_csv(path, index=False, lineterminator="\n")
+    label = f"null_density={null_density:.1%}"
+    if DRY_RUN:
+        label += " (dry-run)"
+    print(f"Generated {rows:,} row sparse-null CSV ({label}) -> {path}")
+
+
 if __name__ == "__main__":
     generate()
     generate_wide()
     generate_multiline()
+    generate_sparse_nulls()

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -163,3 +163,4 @@ if __name__ == "__main__":
     generate_wide()
     generate_multiline()
     generate_sparse_nulls()
+    generate_sparse_nulls(path="benchmarks/benchmark_sparse_nulls_dense.csv", null_density=0.2, seed=99)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -5,7 +5,7 @@ import pytest
 
 import arnio as ar
 from benchmarks import benchmark_vs_pandas
-from benchmarks.generate_data import generate, generate_wide
+from benchmarks.generate_data import generate, generate_sparse_nulls, generate_wide
 
 
 def test_generate_tall_benchmark_csv_shape(tmp_path):
@@ -45,6 +45,41 @@ def test_generate_wide_benchmark_csv_round_trips_through_arnio(tmp_path):
     assert arnio_df.shape == (4, 9)
     assert arnio_df.columns.tolist() == pandas_df.columns.tolist()
     assert list(ar.scan_csv(csv_path).keys()) == list(pandas_df.columns)
+
+
+def test_generate_sparse_nulls_round_trips_through_arnio(tmp_path):
+    csv_path = tmp_path / "sparse_nulls.csv"
+
+    generate_sparse_nulls(rows=10, path=csv_path, null_density=0.2)
+
+    pandas_df = pd.read_csv(csv_path)
+    frame = ar.read_csv(csv_path)
+    arnio_df = ar.to_pandas(frame)
+
+    assert pandas_df.shape == (10, 6)
+    assert frame.shape == (10, 6)
+    assert arnio_df.shape == (10, 6)
+    assert arnio_df.columns.tolist() == pandas_df.columns.tolist()
+
+
+def test_generate_sparse_nulls_zero_density_has_no_nulls(tmp_path):
+    csv_path = tmp_path / "sparse_no_nulls.csv"
+
+    generate_sparse_nulls(rows=20, path=csv_path, null_density=0.0)
+
+    df = pd.read_csv(csv_path)
+    assert df.isnull().sum().sum() == 0
+
+
+def test_generate_sparse_nulls_full_density_all_nulls(tmp_path):
+    csv_path = tmp_path / "sparse_all_nulls.csv"
+
+    generate_sparse_nulls(rows=10, path=csv_path, null_density=1.0)
+
+    df = pd.read_csv(csv_path)
+    assert not df["id"].isnull().any()
+    for col in ["age", "salary", "name", "city", "active"]:
+        assert df[col].isnull().all()
 
 
 def test_generate_wide_rejects_too_few_columns(tmp_path):

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -24,6 +24,7 @@ CI_SAFE_BENCHMARKS = [
     "benchmark_combine_columns.py",
     "benchmark_gil_threading.py",
     "benchmark_profile_duplicate_count.py",
+    "benchmark_sparse_nulls.py",
     "benchmark_strip_whitespace.py",
     "benchmark_to_pandas_overhead.py",
     "benchmark_vs_pandas.py",
@@ -34,6 +35,7 @@ BENCHMARK_ARGS = {
     "benchmark_auto_clean_memory.py": ["--rows", "10", "--repeat", "1"],
     "benchmark_clip_numeric.py": ["--rows", "10", "--runs", "1"],
     "benchmark_profile_duplicate_count.py": ["--rows", "10", "--runs", "1"],
+    "benchmark_sparse_nulls.py": ["--rows", "10", "--runs", "1"],
 }
 
 

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -98,3 +98,43 @@ def test_benchmark_script_runs_successfully(script_path):
         f"Stdout:\n{result.stdout}\n"
         f"Stderr:\n{result.stderr}"
     )
+
+
+@pytest.mark.skipif(not HAS_CORE, reason="Arnio C++ extension is not compiled.")
+def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files():
+    """Verify benchmark_sparse_nulls.py runs in dry-run mode and removes temp files."""
+    script_path = BENCHMARKS_DIR / "benchmark_sparse_nulls.py"
+    if not script_path.exists():
+        pytest.skip("benchmark_sparse_nulls.py not found")
+
+    env = os.environ.copy()
+    env["ARNIO_BENCHMARK_DRY_RUN"] = "1"
+
+    # Check for any existing temp files before the run
+    pre_files = list(BENCHMARKS_DIR.glob("benchmark_sparse_nulls_*.csv"))
+    for f in pre_files:
+        if f.name != "benchmark_sparse_nulls.csv":
+            f.unlink(missing_ok=True)
+
+    cmd = [sys.executable, str(script_path), "--rows", "10", "--runs", "1"]
+    result = subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(BENCHMARKS_DIR.parent),
+        timeout=30,
+    )
+
+    assert result.returncode == 0, (
+        f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )
+
+    # Verify all density-specific temp CSV files were removed
+    post_files = [
+        f for f in BENCHMARKS_DIR.glob("benchmark_sparse_nulls_*.csv")
+        if f.name != "benchmark_sparse_nulls.csv"
+    ]
+    assert len(post_files) == 0, (
+        f"Temp files not cleaned up: {post_files}"
+    )

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -126,15 +126,14 @@ def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files():
         timeout=30,
     )
 
-    assert result.returncode == 0, (
-        f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
-    )
+    assert (
+        result.returncode == 0
+    ), f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
 
     # Verify all density-specific temp CSV files were removed
     post_files = [
-        f for f in BENCHMARKS_DIR.glob("benchmark_sparse_nulls_*.csv")
+        f
+        for f in BENCHMARKS_DIR.glob("benchmark_sparse_nulls_*.csv")
         if f.name != "benchmark_sparse_nulls.csv"
     ]
-    assert len(post_files) == 0, (
-        f"Temp files not cleaned up: {post_files}"
-    )
+    assert len(post_files) == 0, f"Temp files not cleaned up: {post_files}"


### PR DESCRIPTION
## Summary

Adds workload-specific performance coverage for null-mask and missing-value handling across sparse to dense null densities, as requested in #253.

## Changes

### New data generator
**`benchmarks/generate_data.py`** — `generate_sparse_nulls(rows, path, null_density, seed)` produces a deterministic 6-column CSV (int, float, string, string, string, bool) with controlled null density from 0.1% to 100%. Respects `ARNIO_BENCHMARK_DRY_RUN` for CI smoke tests.

### Focused benchmark
**`benchmarks/benchmark_sparse_nulls.py`** — Standalone script comparing arnio vs pandas on 4 operations across 5 densities (0.1%, 0.5%, 1%, 5%, 20%):

| Operation | Arnio backend |
|---|---|
| `read_csv` | C++ CSV parser |
| `drop_nulls` | C++ native (`vector<bool>` null mask) |
| `fill_nulls` | C++ native |
| `keep_rows_with_nulls` | Python (pandas round-trip) |

Reports average wall-clock time (ms) and peak heap (MB) per operation with speedup ratios.

### Main benchmark integration
**`benchmarks/benchmark_vs_pandas.py`** — Two new `BenchmarkCase` entries added to the standard suite:
- Sparse-null CSV (1M × 6 cols, 1% nulls)
- Dense-null CSV (1M × 6 cols, 20% nulls)

These run the full pipeline (read → clean → drop_nulls → drop_duplicates) with per-operation breakdown.

### Tests
- **`tests/test_benchmarks.py`** — Round-trip through arnio, zero-density produces no nulls, full-density nulls all nullable columns
- **`tests/test_benchmarks_smoke.py`** — Registered in CI-safe allowlist with `--rows 10 --runs 1`

### Docs & tooling
- **`benchmarks/README.md`** — Usage instructions
- **`Makefile`** — `make benchmark-sparse-nulls` target

## How to run

```bash
# Generate all datasets (including sparse-null CSVs)
python benchmarks/generate_data.py

# Run main benchmark suite (includes sparse-null cases)
python benchmarks/benchmark_vs_pandas.py

# Run focused sparse-null benchmark
python benchmarks/benchmark_sparse_nulls.py --rows 1000000 --runs 5