### PR TITLE
fix(csv-reader): support Unicode file paths on Windows

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <locale>
@@ -434,7 +435,7 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype) const {
 
 Frame CsvReader::read(const std::string& path) const {
     const CsvConfig& config = parser_.config();
-    std::ifstream file(path, std::ios::binary);
+    std::ifstream file(std::filesystem::u8path(path), std::ios::binary);
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
     }
@@ -567,7 +568,7 @@ Frame CsvReader::read(const std::string& path) const {
 std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     const std::string& path) const {
     const CsvConfig& config = parser_.config();
-    std::ifstream file(path, std::ios::binary);
+    std::ifstream file(std::filesystem::u8path(path), std::ios::binary);
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
     }
@@ -719,7 +720,7 @@ void CsvChunkReader::open(const std::string& path) {
     const CsvConfig& config = parser_.config();
     close();
 
-    file_.open(path, std::ios::binary);
+    file_.open(std::filesystem::u8path(path), std::ios::binary);
     if (!file_.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,3 +61,9 @@ def large_csv(tmp_path):
     path = tmp_path / "large.csv"
     path.write_text("\n".join(lines))
     return str(path)
+
+
+@pytest.fixture
+def unicode_csv():
+    """CSV content for Unicode file path testing."""
+    return "name,value\nAlice,1\nBob,2\n"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1705,3 +1705,53 @@ class TestEdgeCaseCsvShapes:
         schema = ar.scan_csv(csv_path)
         assert "score" in schema
         assert len(schema) == 1
+
+
+class TestUnicodeFilePath:
+    """read_csv and scan_csv must work with non-ASCII characters in the path."""
+
+    def test_read_csv_unicode_filename(self, tmp_path, unicode_csv):
+        csv_path = tmp_path / "用户数据.csv"
+        csv_path.write_text(unicode_csv, encoding="utf-8")
+        frame = ar.read_csv(str(csv_path))
+        assert frame.columns == ["name", "value"]
+        assert frame.shape == (2, 2)
+
+    def test_scan_csv_unicode_filename(self, tmp_path, unicode_csv):
+        csv_path = tmp_path / "用户数据.csv"
+        csv_path.write_text(unicode_csv, encoding="utf-8")
+        schema = ar.scan_csv(str(csv_path))
+        assert schema == {"name": "string", "value": "int64"}
+
+    def test_read_csv_unicode_directory(self, tmp_path, unicode_csv):
+        folder = tmp_path / "données"
+        folder.mkdir()
+        csv_path = folder / "data.csv"
+        csv_path.write_text(unicode_csv, encoding="utf-8")
+        frame = ar.read_csv(str(csv_path))
+        assert frame.shape == (2, 2)
+
+    def test_scan_csv_unicode_directory(self, tmp_path, unicode_csv):
+        folder = tmp_path / "données"
+        folder.mkdir()
+        csv_path = folder / "data.csv"
+        csv_path.write_text(unicode_csv, encoding="utf-8")
+        schema = ar.scan_csv(str(csv_path))
+        assert schema == {"name": "string", "value": "int64"}
+
+    def test_chunked_read_unicode_path(self, tmp_path, unicode_csv):
+        folder = tmp_path / "用户"
+        folder.mkdir()
+
+        csv_path = folder / "数据.csv"
+        csv_path.write_text(unicode_csv, encoding="utf-8")
+
+        chunks = ar.read_csv_chunked(str(csv_path), chunksize=1)
+        chunks = list(chunks)
+
+        assert len(chunks) > 0
+
+        assert chunks[0].shape[1] == 2
+
+        total_rows = sum(chunk.shape[0] for chunk in chunks)
+        assert total_rows == 2


### PR DESCRIPTION
## Summary

Fix Unicode file path handling in the CSV reader on Windows by replacing `std::ifstream(std::string)` with `std::ifstream(std::filesystem::path)`.

This ensures paths containing non-ASCII characters (e.g. `用户`, `Données`) work correctly on Windows while preserving compatibility on Linux/macOS.

Also added tests for non-ASCII file paths.

## Linked issue

Fixes #50

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [x] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [x] `make test`
* [ ] `make lint`
* [x] Other:


## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Uses C++17 `std::filesystem::path` for portable Unicode path handling across platforms.
