### PR TITLE
fix: raise ValueError for empty subset in drop_duplicates and drop_nulls

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -141,9 +141,14 @@ def drop_nulls(
     >>> clean = ar.drop_nulls(frame, subset=["age", "name"])
     """
     if subset is not None:
+        requested_columns = _validate_column_sequence(subset, argument_name="subset")
+        if len(requested_columns) == 0:
+            raise ValueError(
+                "drop_nulls: subset cannot be empty; pass subset=None to check all columns"
+            )
         validate_columns_exist(
             frame,
-            _validate_column_sequence(subset, argument_name="subset"),
+            requested_columns,
             operation="drop_nulls",
         )
     result = _drop_nulls(frame._frame, subset=subset)
@@ -326,9 +331,14 @@ def drop_duplicates(
     >>> unique = ar.drop_duplicates(frame, subset=["name"], keep="first")
     """
     if subset is not None:
+        requested_columns = _validate_column_sequence(subset, argument_name="subset")
+        if len(requested_columns) == 0:
+            raise ValueError(
+                "drop_duplicates: subset cannot be empty; pass subset=None to compare all columns"
+            )
         validate_columns_exist(
             frame,
-            _validate_column_sequence(subset, argument_name="subset"),
+            requested_columns,
             operation="drop_duplicates",
         )
     if keep is True:

--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -191,6 +191,10 @@ static Frame select_rows(const Frame& frame, const std::vector<size_t>& row_indi
 }
 
 Frame drop_nulls(const Frame& frame, const std::optional<std::vector<std::string>>& subset) {
+    if (subset.has_value() && subset->empty()) {
+        throw std::invalid_argument("drop_nulls subset cannot be empty");
+    }
+
     auto col_indices = resolve_subset(frame, subset);
     std::vector<size_t> keep_rows;
     for (size_t r = 0; r < frame.num_rows(); ++r) {
@@ -235,6 +239,10 @@ Frame fill_nulls(const Frame& frame, const CellValue& value,
 
 Frame drop_duplicates(const Frame& frame, const std::optional<std::vector<std::string>>& subset,
                       const std::string& keep) {
+    if (subset.has_value() && subset->empty()) {
+        throw std::invalid_argument("drop_duplicates subset cannot be empty");
+    }
+
     auto col_indices = resolve_subset(frame, subset);
 
     if (keep == "first") {

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -21,6 +21,25 @@ class TestDropNulls:
         # Only row 2 has null name
         assert result.shape[0] == 3
 
+    def test_drop_nulls_empty_subset_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", None, "Charlie"]}))
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.drop_nulls(frame, subset=[])
+
+    def test_drop_nulls_pipeline_empty_subset_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", None, "Charlie"]}))
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.pipeline(frame, [("drop_nulls", {"subset": []})])
+
+    def test_drop_nulls_subset_none_still_works(self):
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", None, "Charlie"]}))
+
+        result = ar.drop_nulls(frame)
+
+        assert result.shape[0] == 2
+
 
 class TestKeepRowsWithNulls:
     def test_keeps_only_null_rows(self, csv_with_nulls):
@@ -193,6 +212,36 @@ class TestDropDuplicates:
         frame = ar.read_csv(csv_with_duplicates)
         result = ar.drop_duplicates(frame, subset=["name"])
         assert result.shape[0] == 3
+
+    def test_drop_duplicates_empty_subset_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]}))
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.drop_duplicates(frame, subset=[])
+
+    def test_drop_duplicates_pipeline_empty_subset_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]}))
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.pipeline(frame, [("drop_duplicates", {"subset": []})])
+
+    def test_drop_duplicates_valid_subset_still_works(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Alice", "Bob"]})
+        )
+
+        result = ar.drop_duplicates(frame, subset=["name"])
+        df = ar.to_pandas(result)
+
+        assert result.shape[0] < frame.shape[0]
+        assert "name" in df.columns
+
+    def test_drop_duplicates_subset_none_still_works(self):
+        frame = ar.from_pandas(pd.DataFrame({"id": [1, 1, 2], "name": ["a", "a", "b"]}))
+
+        result = ar.drop_duplicates(frame)
+
+        assert result.shape[0] == 2
 
     def test_drop_dupes_regression_keep_true(self, csv_with_duplicates):
         frame = ar.read_csv(csv_with_duplicates)


### PR DESCRIPTION

## Summary
Reject explicit empty `subset=[]` inputs for `drop_duplicates` and `drop_nulls`.

This prevents `drop_duplicates(subset=[])` from silently treating every row as a duplicate and keeping only the first row. The Python API now raises a clear `ValueError`, and the C++ `drop_duplicates` implementation includes a defensive guard as well.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #718

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [x] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `pytest tests/test_cleaning.py -k "drop_duplicates or drop_nulls"`

Result: `13 passed, 197 deselected`.

## Screenshots / Media
N/A

## Performance Impact
N/A. This adds constant-time validation guards before existing cleaning logic.

## Contributor checklist
- [ ] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The normal `subset=None` behavior is unchanged and still compares/checks all columns. Non-empty subset behavior is also unchanged.
