### PR TITLE
feat: add skiprows parameter to read_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -300,6 +300,7 @@ def read_csv(
     has_header: bool = True,
     usecols: list[str] | None = None,
     nrows: int | None = None,
+    skiprows: int | None = None,
     encoding: str = "utf-8",
     trim_headers: bool = True,
     thousands_separator: str | None = None,
@@ -398,6 +399,9 @@ def read_csv(
 
     if nrows is not None:
         config.nrows = _validate_nrows(nrows)
+
+    if skiprows is not None:
+        config.skip_rows = _validate_nrows(skiprows)
 
     reader = _CsvReader(config)
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -322,6 +322,10 @@ def read_csv(
         Columns to read. If None, reads all columns.
     nrows : int, optional
         Number of rows to read. If None, reads all rows.
+    skiprows : int, optional
+        Number of lines to skip before reading the header. Useful for
+        CSV files with metadata preambles before the actual data.
+        If None, no lines are skipped.
     encoding : str, default "utf-8"
         File encoding.
     trim_headers : bool, default True
@@ -401,7 +405,7 @@ def read_csv(
         config.nrows = _validate_nrows(nrows)
 
     if skiprows is not None:
-        config.skip_rows = _validate_nrows(skiprows)
+        config.skip_rows = _validate_skip_rows(skiprows)
 
     reader = _CsvReader(config)
 

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -397,6 +397,15 @@ Frame CsvReader::read(const std::string& path) const {
 
     size_t record_number = 0;
 
+    if (config.skip_rows.has_value()) {
+        size_t to_skip = config.skip_rows.value();
+        size_t skipped = 0;
+        while (skipped < to_skip && read_record(file, line)) {
+            ++record_number;
+            ++skipped;
+        }
+    }
+
     // Read header
     if (config.has_header && read_record(file, line)) {
         ++record_number;

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1364,3 +1364,64 @@ class TestArFrameGetItem:
         frame = ar.read_csv(csv_path)
         result = frame["first name"]
         assert result == ["John"]
+
+
+class TestReadCsvSkipRows:
+    def test_skiprows_basic(self, tmp_path):
+        csv_path = tmp_path / "meta.csv"
+        csv_path.write_text("skip1\nskip2\nname,age\nAlice,30\nBob,25\n")
+        frame = ar.read_csv(csv_path, skiprows=2)
+        assert frame.columns == ["name", "age"]
+        assert frame.shape == (2, 2)
+        df = ar.to_pandas(frame)
+        assert df["name"].tolist() == ["Alice", "Bob"]
+
+    def test_skiprows_with_no_header(self, tmp_path):
+        """skiprows with has_header=False skips data rows, columns are auto-named."""
+        csv_path = tmp_path / "noheader.csv"
+        csv_path.write_text("junk\n1,Alice\n2,Bob\n")
+        frame = ar.read_csv(csv_path, skiprows=1, has_header=False)
+        assert frame.shape == (2, 2)
+        df = ar.to_pandas(frame)
+        assert df["col_0"].tolist() == [1, 2]
+
+    def test_skiprows_with_nrows(self, tmp_path):
+        csv_path = tmp_path / "combo.csv"
+        csv_path.write_text("skip\nname,age\nAlice,30\nBob,25\nCharlie,35\n")
+        frame = ar.read_csv(csv_path, skiprows=1, nrows=2)
+        assert frame.shape == (2, 2)
+        df = ar.to_pandas(frame)
+        assert df["name"].tolist() == ["Alice", "Bob"]
+
+    def test_skiprows_zero_is_noop(self, tmp_path):
+        """skiprows=0 behaves identically to not passing skiprows."""
+        csv_path = tmp_path / "noop.csv"
+        csv_path.write_text("name,age\nAlice,30\n")
+        frame = ar.read_csv(csv_path, skiprows=0)
+        assert frame.shape == (1, 2)
+
+    def test_skiprows_skips_all_data_rows(self, tmp_path):
+        """Skipping past all data rows yields an empty frame with correct columns."""
+        csv_path = tmp_path / "skipall.csv"
+        csv_path.write_text("name,age\nAlice,30\n")
+        frame = ar.read_csv(csv_path, skiprows=0)
+        assert frame.shape == (1, 2)
+        assert frame.columns == ["name", "age"]
+
+    def test_skiprows_invalid_negative(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(ValueError, match="non-negative"):
+            ar.read_csv(csv_path, skiprows=-1)
+
+    def test_skiprows_invalid_bool(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(TypeError, match="integer"):
+            ar.read_csv(csv_path, skiprows=True)
+
+    def test_skiprows_invalid_float(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(TypeError, match="integer"):
+            ar.read_csv(csv_path, skiprows=1.5)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1401,12 +1401,11 @@ class TestReadCsvSkipRows:
         assert frame.shape == (1, 2)
 
     def test_skiprows_skips_all_data_rows(self, tmp_path):
-        """Skipping past all data rows yields an empty frame with correct columns."""
+        """Skipping more rows than exist yields an empty frame."""
         csv_path = tmp_path / "skipall.csv"
-        csv_path.write_text("name,age\nAlice,30\n")
-        frame = ar.read_csv(csv_path, skiprows=0)
-        assert frame.shape == (1, 2)
-        assert frame.columns == ["name", "age"]
+        csv_path.write_text("skip1\nskip2\nname,age\nAlice,30\n")
+        frame = ar.read_csv(csv_path, skiprows=10)
+        assert frame.shape == (0, 0)
 
     def test_skiprows_invalid_negative(self, tmp_path):
         csv_path = tmp_path / "data.csv"

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1498,6 +1498,8 @@ class TestReadCsvSkipRows:
         csv_path.write_text("a,b\n1,2\n")
         with pytest.raises(TypeError, match="integer"):
             ar.read_csv(csv_path, skiprows=1.5)
+
+
 class TestInferTypeLocaleAndNumericEdgeCases:
     def test_float_decimal_dot(self, tmp_path):
         path = tmp_path / "decimal.csv"


### PR DESCRIPTION
## Summary
Adds `skiprows` parameter to `read_csv` to skip a specified number of lines before the header. This is useful for CSV files with metadata preambles before the actual data.

## Linked issue
Fixes #96 

## Type of change
- [x] Feature
- [x] Tests

## Area
- [x] CSV parser / I/O
- [x] Python API / ArFrame

## Testing
- 172 tests pass including 8 new tests in `TestReadCsvSkipRows`
- Tests cover: basic skip, skip + has_header=False, skip + nrows, zero skip noop, invalid inputs (negative, bool, float)

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Skip happens before the header read, matching pandas behavior - `skiprows=N` skips N lines then reads the header from line N+1.
