### PR TITLE
fix: reject extra CSV fields in permissive mode

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -480,6 +480,8 @@ Frame CsvReader::read(const std::string& path) const {
 
             if (trailing_empty_only) {
                 fields.resize(expected_cols.value());
+            } else {
+                validate_row_width(record_number, expected_cols.value(), fields.size());
             }
         }
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1119,6 +1119,17 @@ def test_permissive_mode_allows_missing_columns(tmp_path):
     assert pd.isna(df["name"].iloc[1])
 
 
+def test_permissive_mode_rejects_extra_columns(tmp_path):
+    csv_path = tmp_path / "permissive_extra.csv"
+    csv_path.write_text("id,name\n1,Alice,extra\n")
+
+    with pytest.raises(
+        ar.CsvReadError,
+        match="CSV row 2 has 3 fields; expected 2",
+    ):
+        ar.read_csv(csv_path, mode="permissive")
+
+
 def test_invalid_parser_mode(tmp_path):
     csv_path = tmp_path / "invalid_mode.csv"
     csv_path.write_text("id,name\n1,Alice\n")


### PR DESCRIPTION
## Summary
- reject CSV rows that contain non-empty extra fields even when `mode="permissive"` is used
- preserve the existing upstream behavior that trims trailing empty extra fields
- add regression coverage so permissive mode still allows missing trailing values but never silently truncates real data

Fixes #942

## Validation
- `/tmp/arnio-pr942/bin/python -m pip install -e .`
- `/tmp/arnio-pr942/bin/python -m pytest tests/test_csv.py -q` -> 180 passed
- `/tmp/arnio-pr942/bin/python -m ruff check tests/test_csv.py`
- `git diff --check`