### PR TITLE
chore: align Python version metadata with supported wheels and CI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -61,7 +61,7 @@ jobs:
           ref: ${{ inputs.tag_name || github.ref }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.2
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository
@@ -79,32 +79,6 @@ jobs:
           file: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  python314_smoke:
-    name: Python 3.14 Smoke Test
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-          cache: 'pip'
-
-      - name: Upgrade pip and setuptools
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Install dependencies and arnio
-        run: |
-          pip install -e .[dev]
-
-      - name: Run smoke test
-        run: |
-          python -c "import arnio; print('arnio import OK')"
 
   notebook_smoke:
     name: Notebook Smoke Test

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -30,6 +30,10 @@ jobs:
           - python-version: "3.12"
             pandas-version: "2.2.3"
             numpy-version: "2.0.0"
+          # Newest Python — pandas 2.3.3 and numpy 2.4 are the first releases cp314 wheels.
+          - python-version: "3.14"
+            pandas-version: "2.3.3"
+            numpy-version: "2.4.0"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/macos-arm64-wheel-smoke.yml
+++ b/.github/workflows/macos-arm64-wheel-smoke.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install cibuildwheel
-        run: pip install cibuildwheel==2.22.0
+        run: pip install "cibuildwheel>=3.2,<4"
 
       - name: Build macOS arm64 wheel
         run: cibuildwheel --only cp312-macosx_arm64 --output-dir wheelhouse

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels via cibuildwheel
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.2
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: >-

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install cibuildwheel
-        run: pip install cibuildwheel==2.22.0
+        run: pip install "cibuildwheel>=3.2,<4"
 
       - name: Build manylinux wheel
         run: cibuildwheel --only cp312-manylinux_x86_64 --output-dir wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: C++",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -91,7 +92,7 @@ testpaths = ["tests"]
 addopts = "-v --tb=short"
 
 [tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 test-requires = ["pytest", "pandas>=1.5", "numpy>=1.23", "hypothesis>=6.0"]
 test-command = "pytest {project}/tests/ -v --tb=short -x"


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->
- cp314-* added to cibuildwheel build list
- `3.14` added to main matrix; deleted the python314_smoke job
- added 3.14 cell with pandas 2.3.3 + numpy 2.4.0 (the first releases that actually ship cp314 wheels)

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
Fixes #943 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [x] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test`
- [x] `make lint`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
