### PR TITLE
refactor(cleaning): centralize mapping validation

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -87,18 +87,37 @@ def _validate_column_sequence(
     return normalized
 
 
+def _validate_mapping(
+    mapping: Mapping[Any, Any],
+    *,
+    argument_name: str,
+    allow_empty: bool = True,
+    non_mapping_message: str | None = None,
+) -> dict[Any, Any]:
+    if not isinstance(mapping, Mapping):
+        raise TypeError(non_mapping_message or f"{argument_name} must be a mapping")
+
+    normalized = dict(mapping)
+    if not normalized and not allow_empty:
+        raise ValueError(f"{argument_name} must not be empty")
+
+    return normalized
+
+
 def _validate_string_mapping(
     mapping: Mapping[str, str],
     *,
     argument_name: str,
     allow_empty: bool = True,
 ) -> dict[str, str]:
-    if not isinstance(mapping, Mapping):
-        raise TypeError(f"{argument_name} must be a mapping of string keys to strings")
-
-    normalized = dict(mapping)
-    if not normalized and not allow_empty:
-        raise ValueError(f"{argument_name} must not be empty")
+    normalized = _validate_mapping(
+        mapping,
+        argument_name=argument_name,
+        allow_empty=allow_empty,
+        non_mapping_message=(
+            f"{argument_name} must be a mapping of string keys to strings"
+        ),
+    )
 
     invalid_keys = [key for key in normalized if not isinstance(key, str)]
     if invalid_keys:
@@ -1277,14 +1296,15 @@ def replace_values(frame, mapping, column=None):
 
     from .convert import from_pandas, to_pandas
 
-    if not isinstance(mapping, dict):
-        raise TypeError(
+    mapping = _validate_mapping(
+        mapping,
+        argument_name="mapping",
+        allow_empty=False,
+        non_mapping_message=(
             "mapping must be a dict-like mapping of {old_value: new_value}, "
             f"not {type(mapping).__name__}."
-        )
-    if not mapping:
-        raise ValueError("mapping must not be empty")
-
+        ),
+    )
     is_arframe = not isinstance(frame, pd.DataFrame)
     # Avoid mutating the caller's DataFrame in the direct pandas API path.
     df = to_pandas(frame) if is_arframe else frame.copy()

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1112,7 +1112,9 @@ class TestRenameColumns:
     def test_rename_rejects_non_mapping(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(TypeError, match="mapping must be a mapping"):
+        with pytest.raises(
+            TypeError, match="mapping must be a mapping of string keys to strings"
+        ):
             ar.rename_columns(frame, [("name", "full_name")])
 
     def test_rename_rejects_non_string_target(self, sample_csv):
@@ -1255,7 +1257,9 @@ class TestCastTypes:
     def test_cast_rejects_non_mapping_with_clear_error(self, sample_csv, mapping):
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(TypeError, match="mapping must be a mapping"):
+        with pytest.raises(
+            TypeError, match="mapping must be a mapping of string keys to strings"
+        ):
             ar.cast_types(frame, mapping)
 
     def test_cast_bool_rejects_unknown_strings(self):
@@ -1332,6 +1336,44 @@ class TestFilterRows:
             TypeError, match="filter_rows: cannot compare column 'name'"
         ):
             ar.filter_rows(df, "name", ">", 1)
+
+
+class TestMappingValidation:
+    def test_rename_columns_rejects_invalid_mapping_value_type(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="mapping values must be non-empty strings"):
+            ar.rename_columns(frame, {"name": 123})
+
+    def test_replace_values_rejects_missing_column(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(KeyError, match="Column 'missing' not found"):
+            ar.replace_values(frame, {"Alice": "Alicia"}, column="missing")
+
+    def test_replace_values_rejects_non_mapping_input(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="mapping must be a dict-like mapping"):
+            ar.replace_values(frame, [("Alice", "Alicia")])
+
+    def test_replace_values_rejects_empty_mapping(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(ValueError, match="mapping must not be empty"):
+            ar.replace_values(frame, {})
+
+    def test_rename_columns_rejects_non_mapping_input(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="mapping must be a mapping"):
+            ar.rename_columns(frame, [("name", "full_name")])
+
+    def test_cast_types_rejects_non_mapping_input(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+
+        with pytest.raises(TypeError, match="mapping must be a mapping"):
+            ar.cast_types(frame, [("age", "string")])
 
 
 class TestReplaceValues:


### PR DESCRIPTION
Fixes #684

## Summary
Centralizes shared mapping validation used by `rename_columns`, `cast_types`, and `replace_values`.

## Changes
* Added shared `_validate_mapping(...)` usage for `replace_values`
* Preserved existing string-specific validation for `rename_columns` and `cast_types`
* Kept public behavior unchanged for valid inputs
* Added focused regression tests for:
  * non-mapping inputs
  * empty mappings
  * invalid mapping value types
  * missing columns
  * deterministic error messages

## Validation
Ran:
* `pytest tests/test_cleaning.py -q`
