### PR TITLE
fix: improve numeric string compatibility messaging during schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ print(selected.columns)
 # ['name', 'revenue']
 ```
 
+
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 
 <br>
@@ -222,7 +223,6 @@ schema = ar.scan_csv("100GB_file.csv", sample_size=500)
 ```
 
 Useful for exploring datasets before committing memory.
-
 </details>
 
 <details>
@@ -239,7 +239,6 @@ print(frame.preview(n=10))  # first 10 rows
 ```
 
 Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
-
 </details>
 
 <details>
@@ -248,8 +247,8 @@ Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
 
 `arnio` provides support for converting Python `decimal.Decimal` objects.
 
-- **Behavior**: Python `Decimal` objects are automatically preserved as high-precision strings during serialization/binding to prevent floating-point precision loss.
-- **Caveat**: When reading back into Pandas, `to_pandas()` returns these as string (`object` dtype) columns. You will need to explicitly cast them back to `Decimal` objects on the resulting DataFrame if you want to resume exact math.
+* **Behavior**: Python `Decimal` objects are automatically preserved as high-precision strings during serialization/binding to prevent floating-point precision loss.
+* **Caveat**: When reading back into Pandas, `to_pandas()` returns these as string (`object` dtype) columns. You will need to explicitly cast them back to `Decimal` objects on the resulting DataFrame if you want to resume exact math.
 
 Example:
 
@@ -292,7 +291,6 @@ clean = ar.pipeline(frame, [
 ```
 
 Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Python, then optionally migrate hot paths to C++ for full speed.
-
 </details>
 
 <details>
@@ -328,13 +326,13 @@ Raises `ValueError` for negative or boolean `n`.
 Arnio is designed to make the rest of the Python data stack more productive,
 not to replace it.
 
-| Workflow           | How Arnio helps                                                     |
-| :----------------- | :------------------------------------------------------------------ |
-| **pandas**         | Clean, validate, and profile messy `DataFrame`s through `df.arnio`. |
-| **NumPy**          | Prepare typed numeric data before array/modeling workflows.         |
-| **scikit-learn**   | Use Arnio cleaning as a preprocessing layer before model training.  |
-| **DuckDB / Arrow** | Validate and prepare data before analytics and columnar exchange.   |
-| **notebooks**      | Inspect quality issues and cleaning suggestions before analysis.    |
+| Workflow | How Arnio helps |
+|:---|:---|
+| **pandas** | Clean, validate, and profile messy `DataFrame`s through `df.arnio`. |
+| **NumPy** | Prepare typed numeric data before array/modeling workflows. |
+| **scikit-learn** | Use Arnio cleaning as a preprocessing layer before model training. |
+| **DuckDB / Arrow** | Validate and prepare data before analytics and columnar exchange. |
+| **notebooks** | Inspect quality issues and cleaning suggestions before analysis. |
 
 ### Pandas accessor
 
@@ -369,7 +367,6 @@ They follow a simple workflow:
 - **Arnio + pandas**
   Clean and normalize messy tabular data using Arnio, then analyze it using pandas.
   Run:
-
 ```bash
   python examples/arnio_with_pandas.py
 ```
@@ -377,7 +374,6 @@ They follow a simple workflow:
 - **Arnio + NumPy**
   Prepare numeric data safely using Arnio, then perform computations using NumPy.
   Run:
-
 ```bash
   python examples/arnio_with_numpy.py
 ```
@@ -385,7 +381,6 @@ They follow a simple workflow:
 - **Arnio + scikit-learn**
   Prepare messy data with Arnio, then train a model with scikit-learn.
   Run:
-
 ```bash
   python examples/arnio_with_sklearn.py
 ```
@@ -393,10 +388,11 @@ They follow a simple workflow:
 - **Arnio + DuckDB**
   Clean data with Arnio, then run SQL queries using DuckDB.
   Run:
-
 ```bash
   python examples/arnio_with_duckdb.py
 ```
+
+
 
 <br>
 
@@ -426,7 +422,6 @@ Six lines. Four full-data passes. All in interpreted Python. This is fine for a 
 <td width="50%">
 
 ### Without Arnio
-
 ```python
 df = pd.read_csv(path)
 df.columns = df.columns.str.strip()
@@ -442,7 +437,6 @@ df = df.drop_duplicates()
 <td width="50%">
 
 ### With Arnio
-
 ```python
 frame = ar.read_csv(path)
 df = ar.to_pandas(ar.pipeline(frame, [
@@ -489,13 +483,13 @@ flowchart LR
 
 ### Design decisions that matter
 
-| Decision               | What it means                                                                                                                                                                                                  |
-| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Columnar storage**   | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready.                                                              |
-| **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks.                                                                                                 |
-| **Two-pass CSV read**  | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead.                                                                              |
-| **Zero-copy bridge**   | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol where supported. Numeric columns preserve the fast zero-copy path by default, while `copy=True` requests defensive pandas-owned buffers. |
-| **Step registry**      | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry.                                                                                        |
+| Decision | What it means |
+|:---|:---|
+| **Columnar storage** | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready. |
+| **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks. |
+| **Two-pass CSV read** | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead. |
+| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol where supported. Numeric columns preserve the fast zero-copy path by default, while `copy=True` requests defensive pandas-owned buffers. |
+| **Step registry** | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry. |
 
 > Full architecture documentation: **[ARCHITECTURE.md](ARCHITECTURE.md)**
 > API reference guide: **[Arnio API Reference](./API_REFERENCE.md)**
@@ -582,7 +576,6 @@ python benchmarks/benchmark_auto_clean_memory.py --rows 100000
 ```
 
 This script generates a reproducible synthetic dataset with mixed column types (strings, ints, floats, booleans, nulls, and duplicates) and measures:
-
 - `ar.read_csv` performance
 - `ar.auto_clean(mode="safe")` performance (low-risk cleanup like whitespace trimming)
 - `ar.auto_clean(mode="strict")` performance (includes type casting and deduplication)
@@ -591,7 +584,6 @@ The dataset is regenerated deterministically unless `--reuse-file` is provided.
 Each `auto_clean` benchmark run reloads the dataset to avoid mutation or caching effects between runs.
 
 Options:
-
 - `--repeat N` runs each operation multiple times and reports average (and min/max range).
 - `--seed N` changes the deterministic dataset seed.
 - `--reuse-file` reuses an existing dataset file instead of regenerating it.
@@ -608,7 +600,6 @@ ar.auto_clean(strict) 0.035 (0.034-0.036)    1.20 (1.18-1.22)
 --------------------------------------------------------------------
 Total avg (Read+Strict)       0.077             4.52
 ```
-
 <br>
 
 ---
@@ -619,7 +610,6 @@ Total avg (Read+Strict)       0.077             4.52
 
 Most operations below run natively in C++. Currently, `filter_rows`, `replace_values` and `standardize_missing_tokens` run via the Python (pandas) backend and may be optimized in C++ later.
 
-<<<<<<< HEAD
 | Primitive | What it does | Example |
 |:---|:---|:---|
 | `drop_nulls` | Remove rows with null/empty values | `ar.drop_nulls(frame, subset=["age"])` |
@@ -642,28 +632,6 @@ Most operations below run natively in C++. Currently, `filter_rows`, `replace_va
 | `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 | `drop_columns_matching` | Drop columns whose names match a regex pattern | `ar.drop_columns_matching(frame, pattern="^temp_")` |
 | `trim_column_names` | Strip leading/trailing whitespace from column names | `ar.trim_column_names(frame)` |
-=======
-| Primitive                    | What it does                                                                  | Example                                                                                         |
-| :--------------------------- | :---------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| `drop_nulls`                 | Remove rows with null/empty values                                            | `ar.drop_nulls(frame, subset=["age"])`                                                          |
-| `keep_rows_with_nulls`       | Keep only rows that contain at least one null                                 | `ar.keep_rows_with_nulls(frame, subset=["age"])`                                                |
-| `validate_columns_exist`     | Fail early when required columns are missing                                  | `ar.validate_columns_exist(frame, ["age"])`                                                     |
-| `filter_rows`                | Filter rows using comparison operators                                        | `ar.filter_rows(frame, column="age", op=">", value=18)`                                         |
-| `fill_nulls`                 | Replace nulls with a scalar                                                   | `ar.fill_nulls(frame, 0, subset=["revenue"])`                                                   |
-| `drop_duplicates`            | Deduplicate rows (first/last/none)                                            | `ar.drop_duplicates(frame, keep="first")`                                                       |
-| `drop_constant_columns`      | Remove columns with only one unique value                                     | `ar.drop_constant_columns(frame)`                                                               |
-| `clip_numeric`               | Clip numeric values to lower and/or upper bounds                              | `ar.clip_numeric(frame, lower=0, upper=100)`                                                    |
-| `strip_whitespace`           | Trim leading/trailing spaces from strings                                     | `ar.strip_whitespace(frame)`                                                                    |
-| `standardize_missing_tokens` | Replace common missing-value strings with NaN                                 | `ar.standardize_missing_tokens(frame)`                                                          |
-| `normalize_case`             | Force lower/upper/title case                                                  | `ar.normalize_case(frame, case_type="title")`                                                   |
-| `rename_columns`             | Rename columns via mapping                                                    | `ar.rename_columns(frame, {"old": "new"})`                                                      |
-| `cast_types`                 | Cast column types                                                             | `ar.cast_types(frame, {"age": "int64"})`                                                        |
-| `round_numeric_columns`      | Round numeric columns (non-numeric columns in subset ignored safely)          | `ar.round_numeric_columns(frame, decimals=2)`                                                   |
-| `replace_values`             | Replace values using a mapping (column or whole-frame). Handles `None`/`NaN`. | `ar.replace_values(frame, {"active": "A", "inactive": "I"}, column="status")`                   |
-| `clean`                      | Convenience shorthand                                                         | `ar.clean(frame, drop_nulls=True)`                                                              |
-| `safe_divide_columns`        | Divide one column by another, handling zero/null denominators                 | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
-| `trim_column_names`          | Strip leading/trailing whitespace from column names                           | `ar.trim_column_names(frame)`                                                                   |
->>>>>>> 63e1ff3 (Added numeric string compatibility and updated tests and README)
 
 #### `ArFrame.select_dtypes` — type-based column selection
 
@@ -815,17 +783,17 @@ This table helps users understand which pandas dtypes and workflows are fully su
 
 If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
 
-| Pandas Dtype                                | Support Status                    | Notes                                                                                                                        |
-| ------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `int64`                                     | ✅ Supported                      | Fully supported with native C++ columnar storage                                                                             |
-| `float64`                                   | ✅ Supported                      | Fully supported with zero-copy conversion where possible                                                                     |
-| `bool`                                      | ✅ Supported                      | Native supported boolean type                                                                                                |
-| `string`                                    | ✅ Supported                      | Recommended over `object` dtype for text workflows                                                                           |
-| `datetime64[ns]`                            | ❌ Unsupported for native storage | No native datetime parsing or conversion support yet. Use `ar.DateTime()` for schema validation of string timestamp columns. |
-| `category`                                  | ⚠️ Limited                        | Converted to string/object during processing                                                                                 |
-| `object` (mixed columns)                    | ⚠️ Limited                        | Mixed object columns may coerce to string and reduce type inference reliability                                              |
-| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited                        | Supported through pandas extension dtypes with null-mask handling                                                            |
-| `timedelta64[ns]`                           | ❌ Unsupported                    | Not currently supported                                                                                                      |
+| Pandas Dtype | Support Status | Notes |
+|---|---|---|
+| `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
+| `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
+| `bool` | ✅ Supported | Native supported boolean type |
+| `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
+| `datetime64[ns]` | ❌ Unsupported for native storage | No native datetime parsing or conversion support yet. Use `ar.DateTime()` for schema validation of string timestamp columns. |
+| `category` | ⚠️ Limited | Converted to string/object during processing |
+| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may coerce to string and reduce type inference reliability |
+| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited | Supported through pandas extension dtypes with null-mask handling |
+| `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
 
 ### Notes
 
@@ -837,7 +805,7 @@ If a dtype is partially supported, users may need conversion before processing. 
 - `ar.DateTime()` validates string timestamp columns with optional `format`, `min`, and `max`; it does not add native `datetime64[ns]` storage or automatic datetime conversion.
 - Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
 - Unsupported dtypes should raise clear user-facing errors instead of silent failures.
-  > **Note:** pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion. Converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
+> **Note:** pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion. Converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
 
 <br>
 
@@ -894,22 +862,29 @@ if not result.passed:
     print(result.to_pandas())
     print(result.to_markdown(max_issues=10))
 ```
+### Numeric string compatibility hints
 
-Validation messages also indicate when string values appear safely convertible to numeric dtypes.
+Validation messages indicate when string values appear safely convertible
+to numeric dtypes.
 
 ```python
-frame = ar.from_pandas(pd.DataFrame({
-    "age": ["1", "2", "3"]
-}))
+frame = ar.from_pandas(
+    pd.DataFrame(
+        {
+            "age": ["1", "2", "3"],
+        }
+    )
+)
 
-schema = ar.Schema({
-    "age": ar.Int64()
-})
+schema = ar.Schema(
+    {
+        "age": ar.Int64(),
+    }
+)
 
 result = ar.validate(frame, schema)
 
 print(result.issues[0].message)
-
 # Column 'age' has dtype 'string'; expected 'int64'.
 # Values appear safely convertible to 'int64'
 ```
@@ -970,10 +945,6 @@ schema = ar.Schema({
 result = ar.validate(frame, schema)
 ```
 
-<<<<<<< HEAD
-=======
-Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
->>>>>>> 63e1ff3 (Added numeric string compatibility and updated tests and README)
 
 For low-risk automatic cleanup:
 
@@ -1017,22 +988,22 @@ strict = ar.auto_clean(frame, mode="strict")
 
 Messy input:
 
-| order_id | customer  | city       |
-| :------- | :-------- | :--------- |
-| 1001     | `Ishan`   | `Paris`    |
-| 1002     | `Prasoon` | `London`   |
-| 1002     | `Prasoon` | `London`   |
-| 1003     | `Pranay`  | `New York` |
-| 1004     | `Dhruv`   | `Tokyo`    |
+| order_id | customer | city |
+|:--|:--|:--|
+| 1001 | ` Ishan ` | ` Paris ` |
+| 1002 | ` Prasoon ` | `London` |
+| 1002 | ` Prasoon ` | `London` |
+| 1003 | ` Pranay ` | ` New York ` |
+| 1004 | ` Dhruv ` | ` Tokyo ` |
 
 Expected cleaned output with `mode="strict"`:
 
-| order_id | customer | city     |
-| :------- | :------- | :------- |
-| 1001     | Ishan    | Paris    |
-| 1002     | Prasoon  | London   |
-| 1003     | Pranay   | New York |
-| 1004     | Dhruv    | Tokyo    |
+| order_id | customer | city |
+|:--|:--|:--|
+| 1001 | Ishan | Paris |
+| 1002 | Prasoon | London |
+| 1003 | Pranay | New York |
+| 1004 | Dhruv | Tokyo |
 
 `mode="safe"` only trims whitespace. Use `mode="strict"` when you also want deterministic built-in cleanup such as exact duplicate removal.
 
@@ -1144,8 +1115,7 @@ if not result.passed:
 > **Scoring Contract:** The `quality_score` starts at 100.0 and subtracts capped penalties for duplicates, nulls, and suggested dtype mismatches. The `score_components` field exposes these penalties as negative values. (Note: Semantic-validity penalties are intentionally out of scope for the current implementation.)
 
 ### 1. Terminal Representation (Simplified Example)
-
-_A simplified view of the standard string representation of the report object:_
+*A simplified view of the standard string representation of the report object:*
 
 ```text
 DataQualityReport(
@@ -1164,8 +1134,7 @@ DataQualityReport(
 ```
 
 ### 2. JSON Format (Excerpts from .to_dict())
-
-_Key fields from the structured JSON export for integration with APIs or dashboards:_
+*Key fields from the structured JSON export for integration with APIs or dashboards:*
 
 ```json
 {
@@ -1207,15 +1176,15 @@ _Key fields from the structured JSON export for integration with APIs or dashboa
       "semantic_type": "categorical",
       "null_count": 0,
       "top_values": [
-        { "value": "London", "count": 3, "ratio": 0.5 },
-        { "value": "Paris", "count": 2, "ratio": 0.333 }
+        {"value": "London", "count": 3, "ratio": 0.5},
+        {"value": "Paris", "count": 2, "ratio": 0.333}
       ]
     }
   },
   "suggestions": [
     {
       "step": "cast_types",
-      "kwargs": { "score": "float64" },
+      "kwargs": {"score": "float64"},
       "confidence_score": 0.95,
       "confidence_reason": "Column 'score' conforms perfectly to float64 structure."
     }
@@ -1224,17 +1193,15 @@ _Key fields from the structured JSON export for integration with APIs or dashboa
 ```
 
 ### 3. Example Summary Table
+*A manually formatted Markdown table representing the core metrics:*
 
-_A manually formatted Markdown table representing the core metrics:_
-
-| Metric            | Value     |
-| :---------------- | :-------- |
-| **Row Count**     | 4         |
-| **Column Count**  | 3         |
-| **Memory Usage**  | 733 bytes |
-| **Duplicates**    | 0 (0.0%)  |
-| **Quality Score** | 100.0     |
-
+| Metric | Value |
+| :--- | :--- |
+| **Row Count** | 4 |
+| **Column Count** | 3 |
+| **Memory Usage** | 733 bytes |
+| **Duplicates** | 0 (0.0%) |
+| **Quality Score** | 100.0 |
 <br>
 
 ### Bootstrapping a Schema from a Quality Report
@@ -1261,13 +1228,13 @@ null values were observed during profiling.
 
 ## 🗺️ Roadmap
 
-| Version  | Focus                                                                                   |    Status    |
-| :------: | :-------------------------------------------------------------------------------------- | :----------: |
-| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support |  ✅ Shipped  |
-| **v1.1** | Production readiness · release hardening · docs/tooling                                 |  ✅ Shipped  |
-| **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication         |  🔨 Active   |
-| **v1.3** | Chunked / streaming processing · Parquet & JSON readers                                 |  📋 Planned  |
-| **v1.4** | Parallel column processing · SIMD string operations                                     | 💭 Exploring |
+| Version | Focus | Status |
+|:---:|:---|:---:|
+| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
+| **v1.1** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
+| **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
+| **v1.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
+| **v1.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
 
 > For CLI command reference and examples, see [CLI_REFERENCE.md](CLI_REFERENCE.md).
 <br>
@@ -1317,7 +1284,6 @@ ar.register_step("remove_special_chars", remove_special_chars)
 ### If you do know C++
 
 The biggest performance wins are in:
-
 - **`drop_duplicates`** — replacing `std::ostringstream` row serialization with proper hash-based comparisons
 - **`strip_whitespace`** — converting from copy-on-write to in-place mutation
 - **Parallel column processing** — `std::thread` across independent columns

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ print(selected.columns)
 # ['name', 'revenue']
 ```
 
-
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 
 <br>
@@ -223,6 +222,7 @@ schema = ar.scan_csv("100GB_file.csv", sample_size=500)
 ```
 
 Useful for exploring datasets before committing memory.
+
 </details>
 
 <details>
@@ -239,6 +239,7 @@ print(frame.preview(n=10))  # first 10 rows
 ```
 
 Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
+
 </details>
 
 <details>
@@ -247,8 +248,8 @@ Raises `ValueError` for invalid `n` (zero, negative, or non-integer).
 
 `arnio` provides support for converting Python `decimal.Decimal` objects.
 
-* **Behavior**: Python `Decimal` objects are automatically preserved as high-precision strings during serialization/binding to prevent floating-point precision loss.
-* **Caveat**: When reading back into Pandas, `to_pandas()` returns these as string (`object` dtype) columns. You will need to explicitly cast them back to `Decimal` objects on the resulting DataFrame if you want to resume exact math.
+- **Behavior**: Python `Decimal` objects are automatically preserved as high-precision strings during serialization/binding to prevent floating-point precision loss.
+- **Caveat**: When reading back into Pandas, `to_pandas()` returns these as string (`object` dtype) columns. You will need to explicitly cast them back to `Decimal` objects on the resulting DataFrame if you want to resume exact math.
 
 Example:
 
@@ -291,6 +292,7 @@ clean = ar.pipeline(frame, [
 ```
 
 Custom steps run through a pandas↔ArFrame conversion bridge. Prototype in Python, then optionally migrate hot paths to C++ for full speed.
+
 </details>
 
 <details>
@@ -326,13 +328,13 @@ Raises `ValueError` for negative or boolean `n`.
 Arnio is designed to make the rest of the Python data stack more productive,
 not to replace it.
 
-| Workflow | How Arnio helps |
-|:---|:---|
-| **pandas** | Clean, validate, and profile messy `DataFrame`s through `df.arnio`. |
-| **NumPy** | Prepare typed numeric data before array/modeling workflows. |
-| **scikit-learn** | Use Arnio cleaning as a preprocessing layer before model training. |
-| **DuckDB / Arrow** | Validate and prepare data before analytics and columnar exchange. |
-| **notebooks** | Inspect quality issues and cleaning suggestions before analysis. |
+| Workflow           | How Arnio helps                                                     |
+| :----------------- | :------------------------------------------------------------------ |
+| **pandas**         | Clean, validate, and profile messy `DataFrame`s through `df.arnio`. |
+| **NumPy**          | Prepare typed numeric data before array/modeling workflows.         |
+| **scikit-learn**   | Use Arnio cleaning as a preprocessing layer before model training.  |
+| **DuckDB / Arrow** | Validate and prepare data before analytics and columnar exchange.   |
+| **notebooks**      | Inspect quality issues and cleaning suggestions before analysis.    |
 
 ### Pandas accessor
 
@@ -367,6 +369,7 @@ They follow a simple workflow:
 - **Arnio + pandas**
   Clean and normalize messy tabular data using Arnio, then analyze it using pandas.
   Run:
+
 ```bash
   python examples/arnio_with_pandas.py
 ```
@@ -374,6 +377,7 @@ They follow a simple workflow:
 - **Arnio + NumPy**
   Prepare numeric data safely using Arnio, then perform computations using NumPy.
   Run:
+
 ```bash
   python examples/arnio_with_numpy.py
 ```
@@ -381,6 +385,7 @@ They follow a simple workflow:
 - **Arnio + scikit-learn**
   Prepare messy data with Arnio, then train a model with scikit-learn.
   Run:
+
 ```bash
   python examples/arnio_with_sklearn.py
 ```
@@ -388,11 +393,10 @@ They follow a simple workflow:
 - **Arnio + DuckDB**
   Clean data with Arnio, then run SQL queries using DuckDB.
   Run:
+
 ```bash
   python examples/arnio_with_duckdb.py
 ```
-
-
 
 <br>
 
@@ -422,6 +426,7 @@ Six lines. Four full-data passes. All in interpreted Python. This is fine for a 
 <td width="50%">
 
 ### Without Arnio
+
 ```python
 df = pd.read_csv(path)
 df.columns = df.columns.str.strip()
@@ -437,6 +442,7 @@ df = df.drop_duplicates()
 <td width="50%">
 
 ### With Arnio
+
 ```python
 frame = ar.read_csv(path)
 df = ar.to_pandas(ar.pipeline(frame, [
@@ -483,13 +489,13 @@ flowchart LR
 
 ### Design decisions that matter
 
-| Decision | What it means |
-|:---|:---|
-| **Columnar storage** | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready. |
-| **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks. |
-| **Two-pass CSV read** | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead. |
-| **Zero-copy bridge** | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol where supported. Numeric columns preserve the fast zero-copy path by default, while `copy=True` requests defensive pandas-owned buffers. |
-| **Step registry** | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry. |
+| Decision               | What it means                                                                                                                                                                                                  |
+| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Columnar storage**   | Data lives in typed `std::vector`s — `vector<int64_t>`, `vector<double>`, `vector<string>` — not rows of variants. Cache-friendly and SIMD-ready.                                                              |
+| **Boolean null masks** | Nulls are tracked in a separate `vector<bool>`, keeping data vectors dense. No sentinel values, no NaN tricks.                                                                                                 |
+| **Two-pass CSV read**  | Pass 1 infers types across all rows. Pass 2 parses values directly into the correct typed column. No string→object→cast overhead.                                                                              |
+| **Zero-copy bridge**   | `to_pandas()` exposes C++ memory directly via NumPy's buffer protocol where supported. Numeric columns preserve the fast zero-copy path by default, while `copy=True` requests defensive pandas-owned buffers. |
+| **Step registry**      | Pipeline steps map to C++ function pointers. Adding a new cleaning primitive is a single function + one registry entry.                                                                                        |
 
 > Full architecture documentation: **[ARCHITECTURE.md](ARCHITECTURE.md)**
 > API reference guide: **[Arnio API Reference](./API_REFERENCE.md)**
@@ -576,6 +582,7 @@ python benchmarks/benchmark_auto_clean_memory.py --rows 100000
 ```
 
 This script generates a reproducible synthetic dataset with mixed column types (strings, ints, floats, booleans, nulls, and duplicates) and measures:
+
 - `ar.read_csv` performance
 - `ar.auto_clean(mode="safe")` performance (low-risk cleanup like whitespace trimming)
 - `ar.auto_clean(mode="strict")` performance (includes type casting and deduplication)
@@ -584,6 +591,7 @@ The dataset is regenerated deterministically unless `--reuse-file` is provided.
 Each `auto_clean` benchmark run reloads the dataset to avoid mutation or caching effects between runs.
 
 Options:
+
 - `--repeat N` runs each operation multiple times and reports average (and min/max range).
 - `--seed N` changes the deterministic dataset seed.
 - `--reuse-file` reuses an existing dataset file instead of regenerating it.
@@ -600,6 +608,7 @@ ar.auto_clean(strict) 0.035 (0.034-0.036)    1.20 (1.18-1.22)
 --------------------------------------------------------------------
 Total avg (Read+Strict)       0.077             4.52
 ```
+
 <br>
 
 ---
@@ -610,6 +619,7 @@ Total avg (Read+Strict)       0.077             4.52
 
 Most operations below run natively in C++. Currently, `filter_rows`, `replace_values` and `standardize_missing_tokens` run via the Python (pandas) backend and may be optimized in C++ later.
 
+<<<<<<< HEAD
 | Primitive | What it does | Example |
 |:---|:---|:---|
 | `drop_nulls` | Remove rows with null/empty values | `ar.drop_nulls(frame, subset=["age"])` |
@@ -632,6 +642,28 @@ Most operations below run natively in C++. Currently, `filter_rows`, `replace_va
 | `safe_divide_columns` | Divide one column by another, handling zero/null denominators | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
 | `drop_columns_matching` | Drop columns whose names match a regex pattern | `ar.drop_columns_matching(frame, pattern="^temp_")` |
 | `trim_column_names` | Strip leading/trailing whitespace from column names | `ar.trim_column_names(frame)` |
+=======
+| Primitive                    | What it does                                                                  | Example                                                                                         |
+| :--------------------------- | :---------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| `drop_nulls`                 | Remove rows with null/empty values                                            | `ar.drop_nulls(frame, subset=["age"])`                                                          |
+| `keep_rows_with_nulls`       | Keep only rows that contain at least one null                                 | `ar.keep_rows_with_nulls(frame, subset=["age"])`                                                |
+| `validate_columns_exist`     | Fail early when required columns are missing                                  | `ar.validate_columns_exist(frame, ["age"])`                                                     |
+| `filter_rows`                | Filter rows using comparison operators                                        | `ar.filter_rows(frame, column="age", op=">", value=18)`                                         |
+| `fill_nulls`                 | Replace nulls with a scalar                                                   | `ar.fill_nulls(frame, 0, subset=["revenue"])`                                                   |
+| `drop_duplicates`            | Deduplicate rows (first/last/none)                                            | `ar.drop_duplicates(frame, keep="first")`                                                       |
+| `drop_constant_columns`      | Remove columns with only one unique value                                     | `ar.drop_constant_columns(frame)`                                                               |
+| `clip_numeric`               | Clip numeric values to lower and/or upper bounds                              | `ar.clip_numeric(frame, lower=0, upper=100)`                                                    |
+| `strip_whitespace`           | Trim leading/trailing spaces from strings                                     | `ar.strip_whitespace(frame)`                                                                    |
+| `standardize_missing_tokens` | Replace common missing-value strings with NaN                                 | `ar.standardize_missing_tokens(frame)`                                                          |
+| `normalize_case`             | Force lower/upper/title case                                                  | `ar.normalize_case(frame, case_type="title")`                                                   |
+| `rename_columns`             | Rename columns via mapping                                                    | `ar.rename_columns(frame, {"old": "new"})`                                                      |
+| `cast_types`                 | Cast column types                                                             | `ar.cast_types(frame, {"age": "int64"})`                                                        |
+| `round_numeric_columns`      | Round numeric columns (non-numeric columns in subset ignored safely)          | `ar.round_numeric_columns(frame, decimals=2)`                                                   |
+| `replace_values`             | Replace values using a mapping (column or whole-frame). Handles `None`/`NaN`. | `ar.replace_values(frame, {"active": "A", "inactive": "I"}, column="status")`                   |
+| `clean`                      | Convenience shorthand                                                         | `ar.clean(frame, drop_nulls=True)`                                                              |
+| `safe_divide_columns`        | Divide one column by another, handling zero/null denominators                 | `ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")` |
+| `trim_column_names`          | Strip leading/trailing whitespace from column names                           | `ar.trim_column_names(frame)`                                                                   |
+>>>>>>> 63e1ff3 (Added numeric string compatibility and updated tests and README)
 
 #### `ArFrame.select_dtypes` — type-based column selection
 
@@ -783,17 +815,17 @@ This table helps users understand which pandas dtypes and workflows are fully su
 
 If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
 
-| Pandas Dtype | Support Status | Notes |
-|---|---|---|
-| `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
-| `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
-| `bool` | ✅ Supported | Native supported boolean type |
-| `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
-| `datetime64[ns]` | ❌ Unsupported for native storage | No native datetime parsing or conversion support yet. Use `ar.DateTime()` for schema validation of string timestamp columns. |
-| `category` | ⚠️ Limited | Converted to string/object during processing |
-| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may coerce to string and reduce type inference reliability |
-| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited | Supported through pandas extension dtypes with null-mask handling |
-| `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
+| Pandas Dtype                                | Support Status                    | Notes                                                                                                                        |
+| ------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `int64`                                     | ✅ Supported                      | Fully supported with native C++ columnar storage                                                                             |
+| `float64`                                   | ✅ Supported                      | Fully supported with zero-copy conversion where possible                                                                     |
+| `bool`                                      | ✅ Supported                      | Native supported boolean type                                                                                                |
+| `string`                                    | ✅ Supported                      | Recommended over `object` dtype for text workflows                                                                           |
+| `datetime64[ns]`                            | ❌ Unsupported for native storage | No native datetime parsing or conversion support yet. Use `ar.DateTime()` for schema validation of string timestamp columns. |
+| `category`                                  | ⚠️ Limited                        | Converted to string/object during processing                                                                                 |
+| `object` (mixed columns)                    | ⚠️ Limited                        | Mixed object columns may coerce to string and reduce type inference reliability                                              |
+| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited                        | Supported through pandas extension dtypes with null-mask handling                                                            |
+| `timedelta64[ns]`                           | ❌ Unsupported                    | Not currently supported                                                                                                      |
 
 ### Notes
 
@@ -805,7 +837,7 @@ If a dtype is partially supported, users may need conversion before processing. 
 - `ar.DateTime()` validates string timestamp columns with optional `format`, `min`, and `max`; it does not add native `datetime64[ns]` storage or automatic datetime conversion.
 - Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
 - Unsupported dtypes should raise clear user-facing errors instead of silent failures.
-> **Note:** pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion. Converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
+  > **Note:** pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion. Converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
 
 <br>
 
@@ -861,6 +893,25 @@ if not result.passed:
     print(summary["issues_by_column_and_rule"])
     print(result.to_pandas())
     print(result.to_markdown(max_issues=10))
+```
+
+Validation messages also indicate when string values appear safely convertible to numeric dtypes.
+
+```python
+frame = ar.from_pandas(pd.DataFrame({
+    "age": ["1", "2", "3"]
+}))
+
+schema = ar.Schema({
+    "age": ar.Int64()
+})
+
+result = ar.validate(frame, schema)
+
+print(result.issues[0].message)
+
+# Column 'age' has dtype 'string'; expected 'int64'.
+# Values appear safely convertible to 'int64'
 ```
 
 In this example, `country` becomes required only when
@@ -919,6 +970,10 @@ schema = ar.Schema({
 result = ar.validate(frame, schema)
 ```
 
+<<<<<<< HEAD
+=======
+Severity counts are not included in `summary()` yet because `ValidationIssue` does not currently carry severity information.
+>>>>>>> 63e1ff3 (Added numeric string compatibility and updated tests and README)
 
 For low-risk automatic cleanup:
 
@@ -962,22 +1017,22 @@ strict = ar.auto_clean(frame, mode="strict")
 
 Messy input:
 
-| order_id | customer | city |
-|:--|:--|:--|
-| 1001 | ` Ishan ` | ` Paris ` |
-| 1002 | ` Prasoon ` | `London` |
-| 1002 | ` Prasoon ` | `London` |
-| 1003 | ` Pranay ` | ` New York ` |
-| 1004 | ` Dhruv ` | ` Tokyo ` |
+| order_id | customer  | city       |
+| :------- | :-------- | :--------- |
+| 1001     | `Ishan`   | `Paris`    |
+| 1002     | `Prasoon` | `London`   |
+| 1002     | `Prasoon` | `London`   |
+| 1003     | `Pranay`  | `New York` |
+| 1004     | `Dhruv`   | `Tokyo`    |
 
 Expected cleaned output with `mode="strict"`:
 
-| order_id | customer | city |
-|:--|:--|:--|
-| 1001 | Ishan | Paris |
-| 1002 | Prasoon | London |
-| 1003 | Pranay | New York |
-| 1004 | Dhruv | Tokyo |
+| order_id | customer | city     |
+| :------- | :------- | :------- |
+| 1001     | Ishan    | Paris    |
+| 1002     | Prasoon  | London   |
+| 1003     | Pranay   | New York |
+| 1004     | Dhruv    | Tokyo    |
 
 `mode="safe"` only trims whitespace. Use `mode="strict"` when you also want deterministic built-in cleanup such as exact duplicate removal.
 
@@ -1089,7 +1144,8 @@ if not result.passed:
 > **Scoring Contract:** The `quality_score` starts at 100.0 and subtracts capped penalties for duplicates, nulls, and suggested dtype mismatches. The `score_components` field exposes these penalties as negative values. (Note: Semantic-validity penalties are intentionally out of scope for the current implementation.)
 
 ### 1. Terminal Representation (Simplified Example)
-*A simplified view of the standard string representation of the report object:*
+
+_A simplified view of the standard string representation of the report object:_
 
 ```text
 DataQualityReport(
@@ -1108,7 +1164,8 @@ DataQualityReport(
 ```
 
 ### 2. JSON Format (Excerpts from .to_dict())
-*Key fields from the structured JSON export for integration with APIs or dashboards:*
+
+_Key fields from the structured JSON export for integration with APIs or dashboards:_
 
 ```json
 {
@@ -1150,15 +1207,15 @@ DataQualityReport(
       "semantic_type": "categorical",
       "null_count": 0,
       "top_values": [
-        {"value": "London", "count": 3, "ratio": 0.5},
-        {"value": "Paris", "count": 2, "ratio": 0.333}
+        { "value": "London", "count": 3, "ratio": 0.5 },
+        { "value": "Paris", "count": 2, "ratio": 0.333 }
       ]
     }
   },
   "suggestions": [
     {
       "step": "cast_types",
-      "kwargs": {"score": "float64"},
+      "kwargs": { "score": "float64" },
       "confidence_score": 0.95,
       "confidence_reason": "Column 'score' conforms perfectly to float64 structure."
     }
@@ -1167,15 +1224,17 @@ DataQualityReport(
 ```
 
 ### 3. Example Summary Table
-*A manually formatted Markdown table representing the core metrics:*
 
-| Metric | Value |
-| :--- | :--- |
-| **Row Count** | 4 |
-| **Column Count** | 3 |
-| **Memory Usage** | 733 bytes |
-| **Duplicates** | 0 (0.0%) |
-| **Quality Score** | 100.0 |
+_A manually formatted Markdown table representing the core metrics:_
+
+| Metric            | Value     |
+| :---------------- | :-------- |
+| **Row Count**     | 4         |
+| **Column Count**  | 3         |
+| **Memory Usage**  | 733 bytes |
+| **Duplicates**    | 0 (0.0%)  |
+| **Quality Score** | 100.0     |
+
 <br>
 
 ### Bootstrapping a Schema from a Quality Report
@@ -1202,13 +1261,13 @@ null values were observed during profiling.
 
 ## 🗺️ Roadmap
 
-| Version | Focus | Status |
-|:---:|:---|:---:|
-| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
-| **v1.1** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
-| **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
-| **v1.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
-| **v1.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
+| Version  | Focus                                                                                   |    Status    |
+| :------: | :-------------------------------------------------------------------------------------- | :----------: |
+| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support |  ✅ Shipped  |
+| **v1.1** | Production readiness · release hardening · docs/tooling                                 |  ✅ Shipped  |
+| **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication         |  🔨 Active   |
+| **v1.3** | Chunked / streaming processing · Parquet & JSON readers                                 |  📋 Planned  |
+| **v1.4** | Parallel column processing · SIMD string operations                                     | 💭 Exploring |
 
 > For CLI command reference and examples, see [CLI_REFERENCE.md](CLI_REFERENCE.md).
 <br>
@@ -1258,6 +1317,7 @@ ar.register_step("remove_special_chars", remove_special_chars)
 ### If you do know C++
 
 The biggest performance wins are in:
+
 - **`drop_duplicates`** — replacing `std::ostringstream` row serialization with proper hash-based comparisons
 - **`strip_whitespace`** — converting from copy-on-write to in-place mutation
 - **Parallel column processing** — `std::thread` across independent columns

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable
 
+import numpy as np
 import pandas as pd
 
 from .convert import to_pandas
@@ -911,7 +912,12 @@ def _is_safely_convertible_to_dtype(
             if not values.str.match(r"^-?\d+$").all():
                 return False
 
-            pd.to_numeric(values, errors="raise")
+            parsed = pd.to_numeric(values, errors="raise")
+
+            int64_info = np.iinfo(np.int64)
+            if (parsed < int64_info.min).any() or (parsed > int64_info.max).any():
+                return False
+
             return True
 
         if expected_dtype == "float64":

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -15,6 +15,7 @@ import pandas as pd
 from .convert import to_pandas
 from .exceptions import ArnioError
 from .frame import ArFrame
+from .quality import _suggest_column_dtype
 
 ISSUE_COLUMNS = [
     "column",
@@ -887,15 +888,45 @@ def _validate_column(
 
     if field_def.dtype is not None and actual_dtype != field_def.dtype:
         if not (field_def.dtype == "datetime" and actual_dtype == "string"):
+
+            message = (
+                f"Column {name!r} has dtype {actual_dtype!r}; "
+                f"expected {field_def.dtype!r}"
+            )
+
+            compatible_dtype = None
+
+            if actual_dtype == "string":
+                lower_name = name.lower()
+
+                is_identifier_like = (
+                    lower_name == "id"
+                    or lower_name.endswith("_id")
+                    or lower_name
+                    in {
+                        "uuid",
+                        "zip",
+                        "zipcode",
+                        "zip_code",
+                    }
+                )
+
+                if not is_identifier_like:
+                    compatible_dtype = _suggest_column_dtype(
+                        series,
+                        actual_dtype,
+                    )
+
+            if compatible_dtype == field_def.dtype:
+                message += (
+                    f". Values appear safely convertible " f"to {field_def.dtype!r}"
+                )
+
             issues.append(
                 ValidationIssue(
                     column=name,
                     rule="dtype",
-                    message=(
-                        f"Column {name!r} has dtype {actual_dtype!r}; "
-                        f"expected {field_def.dtype!r}"
-                    ),
-                    severity=field_def.severity,
+                    message=message,
                 )
             )
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -879,6 +879,7 @@ def DateTime(
 def _is_safely_convertible_to_dtype(
     series: pd.Series,
     expected_dtype: str,
+    column_name: str,
 ) -> bool:
     try:
         non_null = series.dropna()
@@ -886,12 +887,35 @@ def _is_safely_convertible_to_dtype(
         if len(non_null) == 0:
             return False
 
+        values = non_null.astype(str)
+
+        lower_name = column_name.lower()
+
+        is_identifier_like = (
+            lower_name == "id"
+            or lower_name.endswith("_id")
+            or lower_name
+            in {
+                "uuid",
+                "zip",
+                "zipcode",
+                "zip_code",
+            }
+        )
+
+        if is_identifier_like:
+            if values.str.match(r"^0\d+$").any():
+                return False
+
         if expected_dtype == "int64":
-            pd.to_numeric(non_null, errors="raise").astype("int64")
+            if not values.str.match(r"^-?\d+$").all():
+                return False
+
+            pd.to_numeric(values, errors="raise")
             return True
 
         if expected_dtype == "float64":
-            pd.to_numeric(non_null, errors="raise").astype("float64")
+            pd.to_numeric(values, errors="raise")
             return True
 
     except Exception:
@@ -922,6 +946,7 @@ def _validate_column(
                 and _is_safely_convertible_to_dtype(
                     df[name],
                     field_def.dtype,
+                    name,
                 )
             ):
                 message += (

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -15,7 +15,6 @@ import pandas as pd
 from .convert import to_pandas
 from .exceptions import ArnioError
 from .frame import ArFrame
-from .quality import _suggest_column_dtype
 
 ISSUE_COLUMNS = [
     "column",
@@ -877,6 +876,30 @@ def DateTime(
     )
 
 
+def _is_safely_convertible_to_dtype(
+    series: pd.Series,
+    expected_dtype: str,
+) -> bool:
+    try:
+        non_null = series.dropna()
+
+        if len(non_null) == 0:
+            return False
+
+        if expected_dtype == "int64":
+            pd.to_numeric(non_null, errors="raise").astype("int64")
+            return True
+
+        if expected_dtype == "float64":
+            pd.to_numeric(non_null, errors="raise").astype("float64")
+            return True
+
+    except Exception:
+        return False
+
+    return False
+
+
 def _validate_column(
     df: pd.DataFrame,
     series: pd.Series,
@@ -893,33 +916,16 @@ def _validate_column(
                 f"Column {name!r} has dtype {actual_dtype!r}; "
                 f"expected {field_def.dtype!r}"
             )
-
-            compatible_dtype = None
-
-            if actual_dtype == "string":
-                lower_name = name.lower()
-
-                is_identifier_like = (
-                    lower_name == "id"
-                    or lower_name.endswith("_id")
-                    or lower_name
-                    in {
-                        "uuid",
-                        "zip",
-                        "zipcode",
-                        "zip_code",
-                    }
+            if (
+                actual_dtype == "string"
+                and field_def.dtype in {"int64", "float64"}
+                and _is_safely_convertible_to_dtype(
+                    df[name],
+                    field_def.dtype,
                 )
-
-                if not is_identifier_like:
-                    compatible_dtype = _suggest_column_dtype(
-                        series,
-                        actual_dtype,
-                    )
-
-            if compatible_dtype == field_def.dtype:
+            ):
                 message += (
-                    f". Values appear safely convertible " f"to {field_def.dtype!r}"
+                    f". Values appear safely convertible " f"to '{field_def.dtype}'"
                 )
 
             issues.append(
@@ -927,6 +933,7 @@ def _validate_column(
                     column=name,
                     rule="dtype",
                     message=message,
+                    severity=field_def.severity,
                 )
             )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,8 +1,109 @@
 """Tests for schema validation."""
 
+import pandas as pd
 import pytest
 
 import arnio as ar
+
+
+def test_dtype_validation_reports_safe_int_conversion_for_numeric_strings():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "age": pd.Series(
+                    ["1", "2", "3"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"age": ar.Int64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible to 'int64'" in result.issues[0].message
+
+
+def test_dtype_validation_reports_safe_float_conversion_for_numeric_strings():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "score": pd.Series(
+                    ["1.5", "2.0", "3.25"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"score": ar.Float64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible to 'float64'" in result.issues[0].message
+
+
+def test_dtype_validation_does_not_report_safe_conversion_for_invalid_numeric_strings():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "age": pd.Series(
+                    ["1", "abc", "3"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"age": ar.Int64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
+
+
+def test_dtype_validation_does_not_report_safe_conversion_for_identifier_like_columns():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "user_id": pd.Series(
+                    ["001", "002", "003"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"user_id": ar.Int64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
+
+
+def test_dtype_validation_does_not_report_safe_conversion_for_empty_strings():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "age": pd.Series(
+                    [None, None],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"age": ar.Int64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
 
 
 def test_schema_validation_passes_for_valid_frame(sample_csv):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -106,6 +106,29 @@ def test_dtype_validation_does_not_report_safe_conversion_for_empty_strings():
     assert "safely convertible" not in result.issues[0].message
 
 
+def test_dtype_validation_preserves_warning_severity_for_numeric_strings():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "age": pd.Series(
+                    ["1", "2", "3"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema(
+        {
+            "age": ar.Int64(severity="warning"),
+        }
+    )
+
+    result = ar.validate(frame, schema)
+
+    assert result.issues[0].severity == "warning"
+
+
 def test_schema_validation_passes_for_valid_frame(sample_csv):
     frame = ar.read_csv(sample_csv)
     schema = ar.Schema(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -129,6 +129,46 @@ def test_dtype_validation_preserves_warning_severity_for_numeric_strings():
     assert result.issues[0].severity == "warning"
 
 
+def test_dtype_validation_does_not_report_safe_conversion_above_int64_max():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "value": pd.Series(
+                    ["9223372036854775808"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"value": ar.Int64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
+
+
+def test_dtype_validation_does_not_report_safe_conversion_below_int64_min():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "value": pd.Series(
+                    ["-9223372036854775809"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"value": ar.Int64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
+
+
 def test_schema_validation_passes_for_valid_frame(sample_csv):
     frame = ar.read_csv(sample_csv)
     schema = ar.Schema(


### PR DESCRIPTION
Summary

Improves schema validation messaging for numeric-compatible string columns.

When validation fails due to a dtype mismatch between a string column and an expected numeric dtype (`int64` or `float64`), validation messages now indicate when values appear safely convertible.

This preserves strict schema validation behavior while improving clarity for data preparation workflows.

Fixes #175

Changes

* added numeric compatibility hints to schema validation messages
* preserved strict schema validation behavior with no implicit coercion
* added focused schema validation coverage for:

  * integer-like string values
  * float-like string values
  * invalid mixed values
  * identifier-like string exclusions
  * empty/all-null string columns
* added focused README example for numeric compatibility validation messaging

Example

Before:

```text id="m4q8pk"
Column 'age' has dtype 'string'; expected 'int64'
```

After:

```text id="u7p2vn"
Column 'age' has dtype 'string'; expected 'int64'. Values appear safely convertible to 'int64'
```

Validation

* `black` passes
* `ruff` passes
* focused schema validation tests added
