### PR TITLE
bench: add from_pandas memory benchmark, design doc, and dry-run smoke test

### DIFF
--- a/benchmarks/benchmark_from_pandas_memory.py
+++ b/benchmarks/benchmark_from_pandas_memory.py
@@ -1,10 +1,12 @@
 import sys
 import tracemalloc
+
 import numpy as np
 import pandas as pd
 
 try:
     import arnio as ar
+
     HAS_ARNIO_CPP = True
 except (ImportError, ModuleNotFoundError):
     HAS_ARNIO_CPP = False
@@ -13,16 +15,18 @@ except (ImportError, ModuleNotFoundError):
 def generate_large_frame(row_count: int) -> pd.DataFrame:
     np.random.seed(42)
     str_pool = ["alpha", "beta", "gamma", "delta", "epsilon"]
-    return pd.DataFrame({
-        "col_int":   np.random.randint(0, 10000, size=row_count),
-        "col_float": np.random.randn(row_count),
-        "col_bool":  np.random.choice([True, False], size=row_count),
-        "col_str":   np.random.choice(str_pool, size=row_count),
-    })
+    return pd.DataFrame(
+        {
+            "col_int": np.random.randint(0, 10000, size=row_count),
+            "col_float": np.random.randn(row_count),
+            "col_bool": np.random.choice([True, False], size=row_count),
+            "col_str": np.random.choice(str_pool, size=row_count),
+        }
+    )
 
 
 def measure_from_pandas(row_count: int):
-    df =generate_large_frame(row_count)
+    df = generate_large_frame(row_count)
 
     tracemalloc.start()
     _ = ar.from_pandas(df)
@@ -54,7 +58,12 @@ def run():
         sys.exit(0)
 
     import os
-    scales = [10] if os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1" else [10_000, 100_000, 1_000_000]
+
+    scales = (
+        [10]
+        if os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
+        else [10_000, 100_000, 1_000_000]
+    )
 
     print("=" * 60)
     print("BENCHMARK: from_pandas() peak memory")

--- a/benchmarks/benchmark_from_pandas_memory.py
+++ b/benchmarks/benchmark_from_pandas_memory.py
@@ -1,0 +1,80 @@
+import sys
+import tracemalloc
+import numpy as np
+import pandas as pd
+
+try:
+    import arnio as ar
+    HAS_ARNIO_CPP = True
+except (ImportError, ModuleNotFoundError):
+    HAS_ARNIO_CPP = False
+
+
+def generate_large_frame(row_count: int) -> pd.DataFrame:
+    np.random.seed(42)
+    str_pool = ["alpha", "beta", "gamma", "delta", "epsilon"]
+    return pd.DataFrame({
+        "col_int":   np.random.randint(0, 10000, size=row_count),
+        "col_float": np.random.randn(row_count),
+        "col_bool":  np.random.choice([True, False], size=row_count),
+        "col_str":   np.random.choice(str_pool, size=row_count),
+    })
+
+
+def measure_from_pandas(row_count: int):
+    df =generate_large_frame(row_count)
+
+    tracemalloc.start()
+    _ = ar.from_pandas(df)
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    return peak / (1024 * 1024)
+
+
+def measure_column_hotspot(row_count: int):
+    """Measure per-column allocation to identify hotspot."""
+    df = generate_large_frame(row_count)
+    results = {}
+
+    for col in df.columns:
+        single_col_df = df[[col]]
+        tracemalloc.start()
+        _ = ar.from_pandas(single_col_df)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        results[col] = peak / (1024 * 1024)
+
+    return results
+
+
+def run():
+    if not HAS_ARNIO_CPP:
+        print("Skipping: arnio C++ extension not available.")
+        sys.exit(0)
+
+    import os
+    scales = [10] if os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1" else [10_000, 100_000, 1_000_000]
+
+    print("=" * 60)
+    print("BENCHMARK: from_pandas() peak memory")
+    print("=" * 60)
+    print(f"{'Row Count':<15} | {'Peak Memory (MB)':<20}")
+    print("-" * 60)
+
+    for scale in scales:
+        peak = measure_from_pandas(scale)
+        print(f"{scale:<15,} | {peak:<20.4f}")
+
+    print()
+    print("=" * 60)
+    print("HOTSPOT: per-column peak memory at 100k rows")
+    print("=" * 60)
+    hotspot = measure_column_hotspot(100_000)
+    for col, mb in hotspot.items():
+        print(f"  {col:<15}: {mb:.4f} MB")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/benchmark_from_pandas_memory.py
+++ b/benchmarks/benchmark_from_pandas_memory.py
@@ -81,3 +81,7 @@ def run():
     for col, mb in hotspot.items():
         print(f"  {col:<15}: {mb:.4f} MB")
     print("=" * 60)
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/benchmark_from_pandas_memory.py
+++ b/benchmarks/benchmark_from_pandas_memory.py
@@ -79,7 +79,7 @@ def run():
     print("=" * 60)
     print("HOTSPOT: per-column peak memory at 100k rows")
     print("=" * 60)
-    hotspot = measure_column_hotspot(100_000)
+    hotspot = measure_column_hotspot(scales[0])
     for col, mb in hotspot.items():
         print(f"  {col:<15}: {mb:.4f} MB")
     print("=" * 60)

--- a/benchmarks/benchmark_from_pandas_memory.py
+++ b/benchmarks/benchmark_from_pandas_memory.py
@@ -59,11 +59,9 @@ def run():
 
     import os
 
-    scales = (
-        [10]
-        if os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
-        else [10_000, 100_000, 1_000_000]
-    )
+    dry_run = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
+    scales = [10] if dry_run else [10_000, 100_000, 1_000_000]
+    hotspot_rows = 10 if dry_run else 100_000
 
     print("=" * 60)
     print("BENCHMARK: from_pandas() peak memory")
@@ -77,13 +75,9 @@ def run():
 
     print()
     print("=" * 60)
-    print("HOTSPOT: per-column peak memory at 100k rows")
+    print(f"HOTSPOT: per-column peak memory at {hotspot_rows:,} rows")
     print("=" * 60)
-    hotspot = measure_column_hotspot(scales[0])
+    hotspot = measure_column_hotspot(hotspot_rows)
     for col, mb in hotspot.items():
         print(f"  {col:<15}: {mb:.4f} MB")
     print("=" * 60)
-
-
-if __name__ == "__main__":
-    run()

--- a/docs/chunked_from_pandas_design.md
+++ b/docs/chunked_from_pandas_design.md
@@ -1,0 +1,58 @@
+# Design: Chunked `from_pandas()` Conversion
+
+## Current Memory Behavior
+
+`from_pandas()` converts each column via `.tolist()`, materializing the entire
+column as a Python list before passing it to the C++ layer. This causes a peak
+allocation proportional to the full frame size.
+
+### Measured Peak Allocations (tracemalloc)
+
+| Row Count | Peak Memory (MB) |
+|-----------|-----------------|
+| 10,000    | 0.93            |
+| 100,000   | 8.71            |
+| 1,000,000 | 88.77           |
+
+### Per-Column Hotspot (100k rows)
+
+| Column    | Peak (MB) |
+|-----------|-----------|
+| col_int   | 4.13      |
+| col_float | 3.82      |
+| col_bool  | 1.53      |
+| col_str   | 1.53      |
+
+Numeric columns (int, float) are the primary allocation hotspot.
+
+## Proposed Public API
+
+```python
+ar.from_pandas(df, chunk_size=None)
+```
+
+- `chunk_size=None` current behavior, no change.
+- `chunk_size=N` splits DataFrame into row batches of N, converts each
+  independently, then concatenates.
+
+## Limitations
+
+- Index is reset and ignored per chunk.
+- Nullable dtypes (`Int64`, `Float64`, `boolean`) supported via existing routing.
+- Mixed-type columns raise the same errors as today.
+- No parallelism in v1 sequential chunk processing only.
+
+## First PR Scope
+
+Design and measurement only:
+- Benchmark script (`benchmarks/benchmark_from_pandas_memory.py`)
+- This design document
+- No public API change
+
+## Follow-up Implementation Plan
+
+1. Add `chunk_size` parameter to `from_pandas()` in `arnio/convert.py`.
+2. Implement row slicing and per-chunk conversion.
+3. Add concatenation of ArFrame chunks.
+4. Tests: normal chunked, chunk_size > frame, single-row chunks, empty frame.
+5. Benchmark comparison: chunked vs non-chunked peak memory.

--- a/tests/test_benchmark_from_pandas.py
+++ b/tests/test_benchmark_from_pandas.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 
+
 def test_benchmark_dry_run():
     env = os.environ.copy()
     env["ARNIO_BENCHMARK_DRY_RUN"] = "1"

--- a/tests/test_benchmark_from_pandas.py
+++ b/tests/test_benchmark_from_pandas.py
@@ -13,3 +13,5 @@ def test_benchmark_dry_run():
         text=True,
     )
     assert result.returncode == 0, result.stderr
+    assert "BENCHMARK: from_pandas() peak memory" in result.stdout
+    assert "HOTSPOT: per-column peak memory" in result.stdout

--- a/tests/test_benchmark_from_pandas.py
+++ b/tests/test_benchmark_from_pandas.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+import sys
+
+def test_benchmark_dry_run():
+    env = os.environ.copy()
+    env["ARNIO_BENCHMARK_DRY_RUN"] = "1"
+    result = subprocess.run(
+        [sys.executable, "benchmarks/benchmark_from_pandas_memory.py"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Refs #248

## What's changed
- Added `benchmarks/benchmark_from_pandas_memory.py` measuring peak memory per column during `from_pandas()` conversion
- Added `docs/chunked_from_pandas_design.md` covering current behavior, proposed API contract, dtype/null/index limitations, and follow-up implementation plan
- Added `tests/test_benchmark_from_pandas.py` with a dry-run smoke test (`ARNIO_BENCHMARK_DRY_RUN=1`)

## Key findings
- Numeric columns are the primary allocation hotspot (`col_int`: 4.13 MB, `col_float`: 3.82 MB at 100k rows) due to `.tolist()` materializing the full column in Python memory
- Peak memory scales linearly: 0.93 MB at 10k rows → 88.77 MB at 1M rows

## What's not in this PR
- No public API change
- Full `chunk_size` implementation deferred to follow-up PR after design is accepted