### PR TITLE
test: add focused tests for zero-column frame row count preservation

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -454,6 +454,33 @@ class TestDropConstantColumns:
         assert result.shape[1] == 0
         assert ar.to_pandas(result).shape == (1, 0)
 
+    def test_drop_constant_columns_all_columns_dropped_preserves_row_count_multiple_rows(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [7, 7, 7], "b": ["x", "x", "x"]}))
+        result = ar.drop_constant_columns(frame)
+        assert result.columns == []
+        assert result.shape == (3, 0)
+        assert ar.to_pandas(result).shape == (3, 0)
+
+    def test_zero_column_frame_shape_and_num_rows(self):
+        df = pd.DataFrame(index=range(5))
+        frame = ar.from_pandas(df)
+        assert frame.shape == (5, 0)
+        assert frame.shape[0] == 5
+        assert frame.shape[1] == 0
+
+    def test_zero_column_frame_pandas_roundtrip(self):
+        for n in [0, 1, 5, 100]:
+            df = pd.DataFrame(index=range(n))
+            frame = ar.from_pandas(df)
+            result = ar.to_pandas(frame)
+            assert result.shape == (n, 0), f"failed for n={n}"
+
+    def test_zero_column_frame_clone_preserves_row_count(self):
+        df = pd.DataFrame(index=range(4))
+        frame = ar.from_pandas(df)
+        cloned = frame._frame.clone()
+        assert cloned.num_rows() == 4
+        assert cloned.num_cols() == 0
 
 class TestClipNumeric:
     def test_clip_numeric_lower_only(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -454,7 +454,9 @@ class TestDropConstantColumns:
         assert result.shape[1] == 0
         assert ar.to_pandas(result).shape == (1, 0)
 
-    def test_drop_constant_columns_all_columns_dropped_preserves_row_count_multiple_rows(self):
+    def test_drop_constant_columns_all_columns_dropped_preserves_row_count_multiple_rows(
+        self,
+    ):
         frame = ar.from_pandas(pd.DataFrame({"a": [7, 7, 7], "b": ["x", "x", "x"]}))
         result = ar.drop_constant_columns(frame)
         assert result.columns == []
@@ -481,6 +483,7 @@ class TestDropConstantColumns:
         cloned = frame._frame.clone()
         assert cloned.num_rows() == 4
         assert cloned.num_cols() == 0
+
 
 class TestClipNumeric:
     def test_clip_numeric_lower_only(self):


### PR DESCRIPTION
Fixes #423

## Summary
The core fix for zero-column row count preservation was already in place on `main` (explicit `row_count_` in `Frame`, `clone()` carrying it through, `from_pandas` passing `len(df)`, `to_pandas` reconstructing `(n, 0)` correctly). What was missing was the focused test coverage that every review round on #450 asked for but never received.

## Linked issue
Fixes #423

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `py -3.14 -m pytest tests/ -v` → 1181 passed, 31 skipped, 6 warnings

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. --> N/A

## Performance Impact
No performance impact. Test-only change.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`test:`).

## Maintainer notes
The core fix was already present on main. This PR adds only the focused regression tests that were repeatedly requested during review of #450 but never added. No production code was changed.
