### PR TITLE
fix(frame): throw std::invalid_argument on duplicate column name in add_column

### DIFF
--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -84,6 +84,10 @@ size_t Frame::column_index(const std::string& name) const {
 }
 
 void Frame::add_column(Column col) {
+    if (name_index_.find(col.name()) != name_index_.end()) {
+        throw std::invalid_argument("Column '" + col.name() +
+                                    "' already exists in Frame. Drop or rename it before adding.");
+    }
     if (!row_count_known_) {
         row_count_ = col.size();
         row_count_known_ = true;

--- a/cpp/tests/test_frame.cpp
+++ b/cpp/tests/test_frame.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <stdexcept>
 
 #include "arnio/frame.h"
 
@@ -63,4 +64,32 @@ TEST_CASE("Frame with 0 columns has 0 rows", "[frame]") {
     REQUIRE(f.num_rows() == 0);
     REQUIRE(f.num_cols() == 0);
     REQUIRE(f.column_names().empty());
+}
+
+TEST_CASE("Frame::add_column throws on duplicate column name", "[frame]") {
+    Frame f;
+    Column first("price", DType::INT64);
+    first.push_back(int64_t(10));
+    Column second("price", DType::INT64);
+    second.push_back(int64_t(20));
+
+    f.add_column(std::move(first));
+
+    REQUIRE_THROWS_AS(f.add_column(std::move(second)), std::invalid_argument);
+    REQUIRE(f.num_cols() == 1);
+    REQUIRE(f.column("price").at(0) == CellValue(int64_t(10)));
+}
+
+TEST_CASE("Frame::add_column succeeds for distinct column names", "[frame]") {
+    Frame f;
+    Column price("price", DType::INT64);
+    price.push_back(int64_t(10));
+    Column quantity("quantity", DType::INT64);
+    quantity.push_back(int64_t(2));
+
+    REQUIRE_NOTHROW(f.add_column(std::move(price)));
+    REQUIRE_NOTHROW(f.add_column(std::move(quantity)));
+    REQUIRE(f.num_cols() == 2);
+    REQUIRE(f.has_column("price") == true);
+    REQUIRE(f.has_column("quantity") == true);
 }


### PR DESCRIPTION
## Summary
`Frame::add_column` silently overwrote the name index when a duplicate column name was passed.
This PR adds a duplicate-name guard at the top of the C++ `Frame::add_column` path so it throws
`std::invalid_argument` before any row-count validation or mutation occurs.

Also adds focused Catch2 regression coverage for duplicate-name failure and normal distinct-column behavior.

## Linked issue
Refs duplicate-column-name bug report/discussion.

<!-- Replace with the correct issue number if one exists. Do not use Fixes #718 because #718 tracks drop_duplicates(subset=[]). -->

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] C++ cleaning engine

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: Not run locally; `cmake` was not available on PATH in this environment.

## Screenshots / Media
N/A

## Performance Impact
None expected. The change adds one name-index lookup before inserting a column.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix:`).

## Maintainer notes
This PR is scoped strictly to the C++ `Frame::add_column` duplicate-column-name guard.
It does not address #718, which concerns `drop_duplicates(subset=[])`.
No Python layer, CSV parser, `read_csv`, or `scan_csv` changes included.
Existing row-count validation logic in `add_column` is preserved.