### PR TITLE
fix: improve CSV permission error messages (#118)

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -29,6 +29,12 @@ def _is_utf8_encoding(encoding: str) -> bool:
     return encoding.lower().replace("_", "-") in {"utf-8", "utf8"}
 
 
+def _raise_csv_path_os_error(path: str, error: OSError) -> None:
+    """Raise a path-aware CsvReadError for filesystem access failures."""
+    reason = error.strerror or str(error)
+    raise CsvReadError(f"Could not access CSV file {path!r}: {reason}") from error
+
+
 @contextmanager
 def _utf8_csv_path(
     path: str,
@@ -140,7 +146,7 @@ def _utf8_csv_path(
             f"Could not decode {path!r} using encoding {encoding!r}"
         ) from e
     except OSError as e:
-        raise CsvReadError(str(e)) from e
+        _raise_csv_path_os_error(path, e)
     finally:
         if tmp_name is not None:
             try:
@@ -306,6 +312,8 @@ def _reject_utf8_nul_bytes(path: str) -> None:
                     )
     except FileNotFoundError:
         pass  # Let C++ backend handle or raise standard error
+    except OSError as e:
+        _raise_csv_path_os_error(path, e)
 
 
 def _validate_csv_path(path: str, encoding: str) -> None:
@@ -319,6 +327,8 @@ def _validate_csv_path(path: str, encoding: str) -> None:
             raise CsvReadError(f"CSV file is empty: {path!r}")
     except FileNotFoundError:
         pass
+    except OSError as e:
+        _raise_csv_path_os_error(path, e)
 
 
 def read_csv(

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,5 +1,6 @@
 """Tests for CSV reading functionality."""
 
+import builtins
 import io
 import re
 from pathlib import Path
@@ -497,6 +498,50 @@ class TestReadCsv:
         with pytest.raises(ar.CsvReadError):
             ar.read_csv(str(tmp_path / "nonexistent.csv"))
 
+    def test_read_csv_permission_error_includes_path_and_os_reason(
+        self, tmp_path, monkeypatch
+    ):
+        csv_path = tmp_path / "permission.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        csv_path_str = str(csv_path)
+        real_open = builtins.open
+
+        def blocked_open(*args, **kwargs):
+            if args[0] == csv_path_str and args[1] == "rb":
+                raise PermissionError(13, "Access is denied")
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", blocked_open)
+
+        with pytest.raises(
+            CsvReadError,
+            match="Could not access CSV file .+: Access is denied",
+        ) as exc_info:
+            ar.read_csv(csv_path)
+        assert repr(str(csv_path)) in str(exc_info.value)
+
+    def test_read_csv_non_utf8_permission_error_includes_path_and_os_reason(
+        self, tmp_path, monkeypatch
+    ):
+        csv_path = tmp_path / "permission-latin1.csv"
+        csv_path.write_bytes("name\nAndr\xe9\n".encode("latin-1"))
+        csv_path_str = str(csv_path)
+        real_open = builtins.open
+
+        def blocked_open(*args, **kwargs):
+            if args[0] == csv_path_str and kwargs.get("encoding") == "latin-1":
+                raise PermissionError(13, "Access is denied")
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", blocked_open)
+
+        with pytest.raises(
+            CsvReadError,
+            match="Could not access CSV file .+: Access is denied",
+        ) as exc_info:
+            ar.read_csv(csv_path, encoding="latin-1")
+        assert repr(str(csv_path)) in str(exc_info.value)
+
     def test_null_values_default_preserves_empty_only_behavior(self, tmp_path):
         csv_path = tmp_path / "default_nulls.csv"
         csv_path.write_text("a,b\n,1\nNA,2\n")
@@ -781,6 +826,28 @@ class TestScanCsv:
     def test_scan_missing_file_passthrough(self, tmp_path):
         with pytest.raises(ar.CsvReadError):
             ar.scan_csv(str(tmp_path / "nonexistent.csv"))
+
+    def test_scan_csv_permission_error_includes_path_and_os_reason(
+        self, tmp_path, monkeypatch
+    ):
+        csv_path = tmp_path / "scan-permission.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        csv_path_str = str(csv_path)
+        real_open = builtins.open
+
+        def blocked_open(*args, **kwargs):
+            if args[0] == csv_path_str and args[1] == "rb":
+                raise PermissionError(13, "Access is denied")
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", blocked_open)
+
+        with pytest.raises(
+            CsvReadError,
+            match="Could not access CSV file .+: Access is denied",
+        ) as exc_info:
+            ar.scan_csv(csv_path)
+        assert repr(str(csv_path)) in str(exc_info.value)
 
     def test_scan_non_standard_extension_accepted(self, tmp_path):
         """Non-standard extensions no longer raise ValueError in scan_csv (fixes #34)."""


### PR DESCRIPTION
## Summary
- raise path-aware `CsvReadError` messages for CSV filesystem access failures
- wrap UTF-8 validation and non-UTF-8 transcode permission errors with the OS reason
- add focused regression coverage for `read_csv` and `scan_csv` permission failures

## Testing
- `python -m pytest tests/test_csv.py -k "permission_error_includes_path_and_os_reason or non_utf8_permission_error_includes_path_and_os_reason"`
- `python -m ruff check arnio/io.py tests/test_csv.py`
- `python -m black --check arnio/io.py tests/test_csv.py`

Fixes #118
