### PR TITLE
feat(csv): add encoding_errors support

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,34 @@ frame = ar.read_csv("data.csv", null_values=["", "MISSING", "UNKNOWN"])
 # Disable null sentinel handling completely
 frame = ar.read_csv("data.csv", null_values=[])
 ```
+### Handling invalid UTF-8 bytes
 
+Use `encoding_errors` to control how invalid UTF-8 bytes are handled during CSV parsing.
+
+```python
+# Raise an error on invalid UTF-8 bytes (default)
+frame = ar.read_csv(
+    "data.csv",
+    encoding_errors="strict",
+)
+
+# Replace invalid bytes with the Unicode replacement character (�)
+frame = ar.read_csv(
+    "data.csv",
+    encoding_errors="replace",
+)
+
+# Ignore invalid bytes completely
+frame = ar.read_csv(
+    "data.csv",
+    encoding_errors="ignore",
+)
+```
+Supported values:
+
+- `"strict"` (default)
+- `"replace"`
+- `"ignore"`
 > Every step above executes in C++. Your Python code is a _configuration_ — not the execution engine.
 
 > Explore more in the **[examples/](./examples/)** folder — ready-to-run recipes for sales, customers, survey, logs, and finance datasets.

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -35,6 +35,7 @@ def _utf8_csv_path(
     encoding: str,
     delimiter: str = ",",
     sample_rows: int | None = None,
+    encoding_errors: str = "strict",
 ) -> Iterator[str]:
     """Return a UTF-8 file path for the C++ reader.
 
@@ -48,7 +49,7 @@ def _utf8_csv_path(
 
     tmp_name: str | None = None
     try:
-        with open(path, encoding=encoding, newline="") as src:
+        with open(path, encoding=encoding, errors=encoding_errors, newline="") as src:
             with tempfile.NamedTemporaryFile(
                 "w", encoding="utf-8", newline="", suffix=".csv", delete=False
             ) as tmp:
@@ -321,6 +322,21 @@ def _validate_csv_path(path: str, encoding: str) -> None:
         pass
 
 
+_VALID_ENCODING_ERRORS = {"strict", "replace", "ignore"}
+
+
+def _validate_encoding_errors(value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError("encoding_errors must be a string")
+
+    if value not in _VALID_ENCODING_ERRORS:
+        raise ValueError(
+            "encoding_errors must be one of " "'strict', 'replace', or 'ignore'"
+        )
+
+    return value
+
+
 def read_csv(
     path: str | os.PathLike[str],
     *,
@@ -334,6 +350,7 @@ def read_csv(
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
     mode: str = "strict",
+    encoding_errors: str = "strict",
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -420,6 +437,7 @@ def read_csv(
     _validate_thousands_separator(thousands_separator)
     delimiter = _validate_delimiter(delimiter)
     mode = _validate_parser_mode(mode)
+    encoding_errors = _validate_encoding_errors(encoding_errors)
     config = _CsvConfig()
     config.delimiter = delimiter
     config.has_header = _validate_bool_option(has_header, "has_header")
@@ -427,7 +445,7 @@ def read_csv(
     config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
     config.thousands_separator = thousands_separator
     config.mode = mode
-
+    config.encoding_errors = encoding_errors
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)
 
@@ -443,7 +461,9 @@ def read_csv(
     reader = _CsvReader(config)
 
     try:
-        with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
+        with _utf8_csv_path(
+            path, encoding, encoding_errors=encoding_errors, delimiter=delimiter
+        ) as native_path:
             cpp_frame = reader.read(native_path)
 
         return ArFrame(cpp_frame)
@@ -663,6 +683,7 @@ def scan_csv(
     sample_size: int | None = None,
     null_values: list[str] | None = None,
     has_header: bool = True,
+    encoding_errors: str = "strict",
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
 
@@ -740,13 +761,14 @@ def scan_csv(
 
     _validate_thousands_separator(thousands_separator)
     delimiter = _validate_delimiter(delimiter)
-
+    encoding_errors = _validate_encoding_errors(encoding_errors)
     config = _CsvConfig()
     config.delimiter = delimiter
     config.encoding = encoding
     config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
     config.thousands_separator = thousands_separator
     config.has_header = has_header
+    config.encoding_errors = encoding_errors
 
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)
@@ -766,6 +788,7 @@ def scan_csv(
         with _utf8_csv_path(
             path,
             encoding,
+            encoding_errors=encoding_errors,
             delimiter=delimiter,
             sample_rows=100 if sample_size is None else sample_size,
         ) as native_path:

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -233,6 +233,7 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("thousands_separator", &CsvConfig::thousands_separator)
         .def_readwrite("sample_size", &CsvConfig::sample_size)
         .def_readwrite("mode", &CsvConfig::mode)
+        .def_readwrite("encoding_errors", &CsvConfig::encoding_errors)
         .def_readwrite("null_values", &CsvConfig::null_values);
 
     py::class_<CsvReader>(m, "CsvReader")

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -22,6 +22,7 @@ struct CsvConfig {
     std::optional<size_t> sample_size = std::nullopt;
     std::optional<std::vector<std::string>> null_values = std::nullopt;
     std::string mode = "strict";
+    std::string encoding_errors = "strict";
 };
 
 // Shared CSV field parsing and type inference used by CsvReader and CsvChunkReader.

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -5,6 +5,7 @@
 #include <cerrno>
 #include <charconv>
 #include <cmath>
+#include <codecvt>
 #include <cstddef>
 #include <cstdlib>
 #include <fstream>
@@ -14,7 +15,6 @@
 #include <stdexcept>
 #include <system_error>
 #include <unordered_set>
-
 namespace arnio {
 
 namespace {
@@ -274,6 +274,82 @@ inline bool try_parse_float64(const std::string& cleaned, double& out) {
 }
 }  // namespace
 
+static std::string handle_utf8_errors(const std::string& input, const std::string& mode) {
+    std::string output;
+
+    size_t i = 0;
+
+    while (i < input.size()) {
+        unsigned char c = static_cast<unsigned char>(input[i]);
+
+        size_t char_len = 0;
+
+        if (c <= 0x7F) {
+            char_len = 1;
+        } else if (c >= 0xC2 && c <= 0xDF) {
+            char_len = 2;
+        } else if (c >= 0xE0 && c <= 0xEF) {
+            char_len = 3;
+        } else if (c >= 0xF0 && c <= 0xF4) {
+            char_len = 4;
+        } else {
+            char_len = 0;
+        }
+
+        bool valid = true;
+
+        if (char_len == 0 || i + char_len > input.size()) {
+            valid = false;
+        } else {
+            for (size_t j = 1; j < char_len; ++j) {
+                unsigned char cc = static_cast<unsigned char>(input[i + j]);
+
+                if ((cc & 0xC0) != 0x80) {
+                    valid = false;
+                    break;
+                }
+            }
+
+            if (valid && char_len == 2) {
+                valid = c >= 0xC2;
+            }
+
+            if (valid && char_len == 3) {
+                unsigned char c1 = static_cast<unsigned char>(input[i + 1]);
+
+                if ((c == 0xE0 && c1 < 0xA0) || (c == 0xED && c1 >= 0xA0)) {
+                    valid = false;
+                }
+            }
+
+            if (valid && char_len == 4) {
+                unsigned char c1 = static_cast<unsigned char>(input[i + 1]);
+
+                if ((c == 0xF0 && c1 < 0x90) || (c == 0xF4 && c1 >= 0x90)) {
+                    valid = false;
+                }
+            }
+        }
+
+        if (valid) {
+            output.append(input.substr(i, char_len));
+
+            i += char_len;
+        } else {
+            if (mode == "strict") {
+                throw std::runtime_error("Invalid UTF-8 sequence encountered");
+            }
+
+            if (mode == "replace") {
+                output += "\xEF\xBF\xBD";
+            }
+
+            ++i;
+        }
+    }
+
+    return output;
+}
 CsvParser::CsvParser(const CsvConfig& config) : config_(config) {}
 
 CsvReader::CsvReader(const CsvConfig& config) : parser_(config) {}
@@ -335,15 +411,16 @@ bool CsvParser::is_null_sentinel(const std::string& value) const {
 }
 
 DType CsvParser::infer_type(const std::string& value) const {
-    if (is_null_sentinel(value)) return DType::NULL_TYPE;
+    const std::string sanitized = handle_utf8_errors(value, config_.encoding_errors);
+    if (is_null_sentinel(sanitized)) return DType::NULL_TYPE;
 
     // Try bool
-    std::string trimmed = value;
+    std::string trimmed = sanitized;
     trim_in_place(trimmed);
     std::string lower = to_lower_copy(trimmed);
     if (lower == "true" || lower == "false") return DType::BOOL;
 
-    std::string cleaned = normalize_numeric(value, config_);
+    std::string cleaned = normalize_numeric(sanitized, config_);
 
     if (is_special_float_token(to_lower_copy(cleaned))) {
         return DType::FLOAT64;
@@ -371,8 +448,9 @@ DType CsvParser::infer_type(const std::string& value) const {
     // so it doesn't poison the whole column's dtype to STRING.
     if (config_.thousands_separator.has_value()) {
         char sep = config_.thousands_separator.value();
-        if (value.find(sep) != std::string::npos && !has_valid_thousands_grouping(value, sep)) {
-            std::string check = value;
+        if (sanitized.find(sep) != std::string::npos &&
+            !has_valid_thousands_grouping(sanitized, sep)) {
+            std::string check = sanitized;
             trim_in_place(check);
             if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
             bool looks_numeric =
@@ -402,30 +480,31 @@ DType CsvParser::promote_type(DType current, DType incoming) {
 }
 
 CellValue CsvParser::parse_value(const std::string& raw, DType dtype) const {
-    if (is_null_sentinel(raw)) return std::monostate{};
+    const std::string sanitized = handle_utf8_errors(raw, config_.encoding_errors);
+    if (is_null_sentinel(sanitized)) return std::monostate{};
 
     switch (dtype) {
         case DType::BOOL: {
-            std::string trimmed = raw;
+            std::string trimmed = sanitized;
             trim_in_place(trimmed);
             std::string lower = to_lower_copy(trimmed);
             return (lower == "true");
         }
         case DType::INT64: {
-            std::string cleaned = normalize_numeric(raw, config_);
+            std::string cleaned = normalize_numeric(sanitized, config_);
             int64_t value = 0;
             if (!try_parse_int64(cleaned, value)) return std::monostate{};
             return value;
         }
         case DType::FLOAT64: {
-            std::string cleaned = normalize_numeric(raw, config_);
+            std::string cleaned = normalize_numeric(sanitized, config_);
             double value = 0.0;
             if (!try_parse_float64(cleaned, value)) return std::monostate{};
             return value;
         }
         case DType::STRING: {
             // Keep raw string values exactly as they appear in the CSV
-            return raw;
+            return sanitized;
         }
         default:
             return std::monostate{};
@@ -459,6 +538,9 @@ Frame CsvReader::read(const std::string& path) const {
         ++record_number;
         strip_utf8_bom(line);
         header = parser_.parse_line(line);
+        for (auto& h : header) {
+            h = handle_utf8_errors(h, config.encoding_errors);
+        }
         for (auto& h : header) {
             if (config.trim_headers) trim_in_place(h);
         }
@@ -582,6 +664,10 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
 
         if (config.has_header) {
             header = parser_.parse_line(line);
+
+            for (auto& h : header) {
+                h = handle_utf8_errors(h, config.encoding_errors);
+            }
 
             for (auto& h : header) {
                 if (config.trim_headers) trim_in_place(h);

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -441,6 +441,101 @@ class TestReadCsv:
         frame = ar.read_csv(Path(sample_csv))
         assert frame.shape == (3, 4)
 
+    def test_read_csv_encoding_errors_strict(self, tmp_path):
+        csv_file = tmp_path / "invalid_utf8.csv"
+
+        csv_file.write_bytes(b"name\nabc\xffdef\n")
+
+        with pytest.raises(ar.CsvReadError):
+            ar.read_csv(
+                csv_file,
+                encoding="utf-8",
+                encoding_errors="strict",
+            )
+
+    def test_read_csv_encoding_errors_replace(self, tmp_path):
+        csv_file = tmp_path / "invalid_utf8.csv"
+
+        csv_file.write_bytes(b"name\nabc\xffdef\n")
+
+        frame = ar.read_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="replace",
+        )
+
+        value = frame["name"][0]
+
+        assert value == "abc�def"
+        assert "def" in value
+
+    def test_read_csv_encoding_errors_ignore(self, tmp_path):
+        csv_file = tmp_path / "invalid_utf8.csv"
+
+        csv_file.write_bytes(b"name\nabc\xffdef\n")
+
+        frame = ar.read_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="ignore",
+        )
+
+        value = frame["name"][0]
+
+        assert value == "abcdef"
+
+    def test_read_csv_invalid_encoding_errors_mode(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+
+        csv_file.write_text(
+            "name\nalice\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError):
+            ar.read_csv(
+                csv_file,
+                encoding_errors="bad-mode",
+            )
+
+    def test_scan_csv_encoding_errors_strict(self, tmp_path):
+        csv_file = tmp_path / "invalid_utf8.csv"
+
+        csv_file.write_bytes(b"name\nabc\xffdef\n")
+
+        with pytest.raises(ar.CsvReadError):
+            ar.scan_csv(
+                csv_file,
+                encoding="utf-8",
+                encoding_errors="strict",
+            )
+
+    def test_scan_csv_encoding_errors_replace(self, tmp_path):
+        csv_file = tmp_path / "invalid_utf8.csv"
+
+        csv_file.write_bytes(b"name\nabc\xffdef\n")
+
+        schema = ar.scan_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="replace",
+        )
+
+        assert schema["name"] == "string"
+
+    def test_scan_csv_encoding_errors_ignore(self, tmp_path):
+        csv_file = tmp_path / "invalid_utf8.csv"
+
+        csv_file.write_bytes(b"name\nabc\xffdef\n")
+
+        schema = ar.scan_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="ignore",
+        )
+
+        assert schema["name"] == "string"
+
     def test_non_utf8_encoding(self, tmp_path):
         csv_path = tmp_path / "latin.csv"
         csv_path.write_bytes("name\nAndré\n".encode("latin-1"))
@@ -595,6 +690,48 @@ class TestReadCsv:
         assert df["text"].iloc[0] == "hello"
         assert df["text"].iloc[1] == long_text
         assert df["text"].iloc[2] == "world"
+
+    def test_read_csv_encoding_errors_replace_header(self, tmp_path):
+        csv_file = tmp_path / "invalid_header.csv"
+
+        csv_file.write_bytes(b"na\xffme\nalice\n")
+
+        frame = ar.read_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="replace",
+        )
+
+        columns = frame.columns
+
+        assert columns == ["na�me"]
+
+    def test_read_csv_encoding_errors_ignore_header(self, tmp_path):
+        csv_file = tmp_path / "invalid_header.csv"
+
+        csv_file.write_bytes(b"na\xffme\nalice\n")
+
+        frame = ar.read_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="ignore",
+        )
+
+        columns = frame.columns
+
+        assert columns == ["name"]
+
+    def test_read_csv_encoding_errors_strict_header(self, tmp_path):
+        csv_file = tmp_path / "invalid_header.csv"
+
+        csv_file.write_bytes(b"na\xffme\nalice\n")
+
+        with pytest.raises(ar.CsvReadError):
+            ar.read_csv(
+                csv_file,
+                encoding="utf-8",
+                encoding_errors="strict",
+            )
 
 
 class TestScanCsv:
@@ -886,6 +1023,49 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_file, has_header=False)
 
         assert list(frame.columns) == list(schema.keys())
+
+    def test_read_csv_encoding_errors_preserve_valid_utf8(
+        self,
+        tmp_path,
+    ):
+        csv_file = tmp_path / "mixed_utf8.csv"
+
+        csv_file.write_bytes(b"name\ncaf\xc3\xa9\xff\n")
+
+        frame = ar.read_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="replace",
+        )
+
+        value = frame["name"][0]
+
+        assert value == "café�"
+
+    def test_read_csv_encoding_errors_ignore_preserves_numeric_inference(
+        self, tmp_path
+    ):
+        csv_file = tmp_path / "numeric_ignore.csv"
+
+        csv_file.write_bytes(b"value\n1\xff\n2\n")
+
+        frame = ar.read_csv(
+            csv_file,
+            encoding="utf-8",
+            encoding_errors="ignore",
+        )
+
+        values = frame["value"]
+
+        assert values == [1, 2]
+
+    def test_read_csv_encoding_errors_rejects_overlong_utf8(self, tmp_path):
+        csv_file = tmp_path / "overlong.csv"
+
+        csv_file.write_bytes(b"name\n\xc0\xaf\n")
+
+        with pytest.raises(ar.CsvReadError):
+            ar.read_csv(csv_file, encoding="utf-8", encoding_errors="strict")
 
 
 # --- Issue #115: quoted multiline round-trip across line endings ---


### PR DESCRIPTION
## Summary

Adds `encoding_errors` support to CSV APIs while preserving backward-compatible strict behavior by default.

Supported modes:

* `strict`
* `replace`
* `ignore`

## Changes

* added `encoding_errors` parameter to `read_csv()` and `scan_csv()`
* validated supported modes in the Python API layer
* threaded the option through `_CsvConfig` and bindings
* added focused UTF-8 handling for invalid byte sequences in CSV string parsing and schema inference
* added regression tests for all supported modes
* updated documentation/examples

Fixes #129
