### PR TITLE
fix: resolve pipeline shorthand ambiguity for columns named mapping

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -348,13 +348,17 @@ def pipeline(
             rows_before = result.shape[0]
 
             started_at = perf_counter()
-            if name == "rename_columns" and "mapping" not in kwargs:
+            if name == "rename_columns" and (
+                "mapping" not in kwargs or not isinstance(kwargs["mapping"], dict)
+            ):
                 step_result = fn(result, mapping=kwargs)
 
                 if not dry_run:
                     result = step_result
 
-            elif name == "cast_types" and "mapping" not in kwargs:
+            elif name == "cast_types" and (
+                "mapping" not in kwargs or not isinstance(kwargs["mapping"], dict)
+            ):
                 step_result = fn(result, kwargs)
 
                 if not dry_run:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -317,6 +317,39 @@ class TestPipeline:
         assert result.dtypes["years"] == "float64"
         assert "age" not in result.columns
 
+    def test_pipeline_shorthand_with_column_named_mapping_cast_types(self):
+        import pandas as pd
+
+        import arnio as ar
+
+        frame = ar.from_pandas(pd.DataFrame({"mapping": ["1", "2"]}))
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("cast_types", {"mapping": "int64"}),
+            ],
+        )
+
+        assert result.dtypes["mapping"] == "int64"
+
+    def test_pipeline_shorthand_with_column_named_mapping_rename_columns(self):
+        import pandas as pd
+
+        import arnio as ar
+
+        frame = ar.from_pandas(pd.DataFrame({"mapping": [1, 2]}))
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("rename_columns", {"mapping": "new_mapping_col"}),
+            ],
+        )
+
+        assert "new_mapping_col" in result.columns
+        assert "mapping" not in result.columns
+
     def test_pipeline_validate_columns_exist(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(


### PR DESCRIPTION
## Summary
Resolves an ambiguity in `arnio/pipeline.py` where the shorthand syntax for `rename_columns` and `cast_types` crashed if a dataframe column was literally named `"mapping"`. The wrapper logic now explicitly checks if the `"mapping"` key in `kwargs` is a dictionary before treating it as the keyword form. If it's not a dictionary, it correctly falls back to treating the entire `kwargs` object as the column mapping. 

## Linked issue
Fixes #720

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: 
  - Ran `pytest tests/test_pipeline.py` (successfully passed after syncing the C++ binary).
  - Ran `ruff check . --fix` and `black` to ensure formatting compliance.

## Screenshots / Media
<img width="1862" height="467" alt="image" src="https://github.com/user-attachments/assets/5729e8fc-b636-48fc-a7d6-ca7371c973eb" />
<img width="570" height="97" alt="image" src="https://github.com/user-attachments/assets/43f7890f-d09b-4839-ba70-b2a6a587e6d4" />


## Performance Impact
N/A

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
N/A