### PR TITLE
feat: add ArFrame.schema_summary property

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -47,7 +47,7 @@ from .exceptions import (
     TypeCastError,
     UnknownStepError,
 )
-from .frame import ArFrame
+from .frame import ArFrame, ColumnSummary
 from .integrations import ArnioPandasAccessor, register_duckdb
 from .io import (
     read_csv,
@@ -108,6 +108,7 @@ from .schema import (
 __all__ = [
     # Core class
     "ArFrame",
+    "ColumnSummary",
     # I/O
     "read_csv",
     "read_csv_chunked",

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -13,6 +13,42 @@ _VALID_DTYPES: frozenset[str] = frozenset(
 )
 
 
+class ColumnSummary:
+    """Schema summary for a single column.
+
+    Attributes
+    ----------
+    name : str
+        Column name.
+    dtype : str
+        Inferred dtype string (e.g. ``"int64"``, ``"string"``).
+    nullable : bool
+        True if the column contains at least one null value, False otherwise.
+    """
+
+    __slots__ = ("name", "dtype", "nullable")
+
+    def __init__(self, name: str, dtype: str, nullable: bool) -> None:
+        self.name = name
+        self.dtype = dtype
+        self.nullable = nullable
+
+    def __repr__(self) -> str:
+        return (
+            f"ColumnSummary(name={self.name!r}, dtype={self.dtype!r},"
+            f" nullable={self.nullable})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ColumnSummary):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.dtype == other.dtype
+            and self.nullable == other.nullable
+        )
+
+
 class ArFrame:
     """Lightweight columnar data container backed by C++."""
 
@@ -56,6 +92,42 @@ class ArFrame:
             Mapping of column names to their data types.
         """
         return self._frame.dtypes()
+
+    @property
+    def schema_summary(self) -> list[ColumnSummary]:
+        """Column names, dtypes, and nullability in one place.
+
+        Inspects the C++ frame directly — no pandas conversion triggered.
+
+        Returns
+        -------
+        list[ColumnSummary]
+            One :class:`ColumnSummary` per column, in original column order.
+            Each entry has three attributes:
+
+            * ``name`` – column name (``str``)
+            * ``dtype`` – inferred dtype string, e.g. ``"int64"`` (``str``)
+            * ``nullable`` – ``True`` if the column contains at least one null
+              value, ``False`` otherwise (``bool``)
+
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> for col in frame.schema_summary:
+        ...     print(col.name, col.dtype, col.nullable)
+        id int64 False
+        email string True
+        score float64 True
+        """
+        col_dtypes = self.dtypes
+        result: list[ColumnSummary] = []
+        for i, name in enumerate(self.columns):
+            mask = self._frame.column_by_index(i).get_null_mask()
+            nullable = bool(mask.any())
+            result.append(
+                ColumnSummary(name=name, dtype=col_dtypes[name], nullable=nullable)
+            )
+        return result
 
     @property
     def is_empty(self) -> bool:

--- a/tests/test_schema_summary.py
+++ b/tests/test_schema_summary.py
@@ -1,0 +1,228 @@
+"""
+Tests for ArFrame.schema_summary property.
+"""
+
+import pandas as pd
+
+import arnio as ar
+from arnio.frame import ColumnSummary
+
+# ---------------------------------------------------------------------------
+# ColumnSummary dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestColumnSummary:
+    def test_attributes(self):
+        entry = ColumnSummary(name="age", dtype="int64", nullable=False)
+        assert entry.name == "age"
+        assert entry.dtype == "int64"
+        assert entry.nullable is False
+
+    def test_repr(self):
+        entry = ColumnSummary(name="score", dtype="float64", nullable=True)
+        r = repr(entry)
+        assert "score" in r
+        assert "float64" in r
+        assert "True" in r
+
+    def test_equality(self):
+        a = ColumnSummary("x", "int64", False)
+        b = ColumnSummary("x", "int64", False)
+        assert a == b
+
+    def test_inequality_name(self):
+        assert ColumnSummary("x", "int64", False) != ColumnSummary("y", "int64", False)
+
+    def test_inequality_dtype(self):
+        assert ColumnSummary("x", "int64", False) != ColumnSummary(
+            "x", "float64", False
+        )
+
+    def test_inequality_nullable(self):
+        assert ColumnSummary("x", "int64", False) != ColumnSummary("x", "int64", True)
+
+    def test_not_equal_to_non_column_summary(self):
+        entry = ColumnSummary("x", "int64", False)
+        assert entry.__eq__("x") is NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# Normal behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaSummaryNormal:
+    def test_returns_list(self):
+        df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        frame = ar.from_pandas(df)
+        result = frame.schema_summary
+        assert isinstance(result, list)
+
+    def test_length_matches_column_count(self):
+        df = pd.DataFrame({"a": [1], "b": [2.0], "c": ["z"]})
+        frame = ar.from_pandas(df)
+        assert len(frame.schema_summary) == 3
+
+    def test_each_entry_is_column_summary(self):
+        df = pd.DataFrame({"a": [1]})
+        frame = ar.from_pandas(df)
+        for entry in frame.schema_summary:
+            assert isinstance(entry, ColumnSummary)
+
+    def test_column_order_preserved(self):
+        df = pd.DataFrame({"z": [1], "a": [2], "m": [3]})
+        frame = ar.from_pandas(df)
+        names = [e.name for e in frame.schema_summary]
+        assert names == ["z", "a", "m"]
+
+    def test_names_match_frame_columns(self):
+        df = pd.DataFrame({"id": [1, 2], "email": ["a@b.com", "c@d.com"]})
+        frame = ar.from_pandas(df)
+        assert [e.name for e in frame.schema_summary] == frame.columns
+
+    def test_dtypes_match_frame_dtypes(self):
+        df = pd.DataFrame({"id": [1, 2], "score": [1.5, 2.5], "label": ["a", "b"]})
+        frame = ar.from_pandas(df)
+        summary_dtypes = {e.name: e.dtype for e in frame.schema_summary}
+        assert summary_dtypes == frame.dtypes
+
+    def test_non_nullable_column(self):
+        df = pd.DataFrame({"age": [10, 20, 30]})
+        frame = ar.from_pandas(df)
+        entry = frame.schema_summary[0]
+        assert entry.nullable is False
+
+    def test_nullable_column_from_null_values(self):
+        df = pd.DataFrame({"score": [1.0, None, 3.0]})
+        frame = ar.from_pandas(df)
+        entry = frame.schema_summary[0]
+        assert entry.nullable is True
+
+    def test_nullable_string_column(self):
+        df = pd.DataFrame({"name": ["Alice", None, "Charlie"]})
+        frame = ar.from_pandas(df)
+        entry = frame.schema_summary[0]
+        assert entry.nullable is True
+
+    def test_mixed_nullable_and_non_nullable(self):
+        df = pd.DataFrame(
+            {
+                "id": [1, 2, 3],
+                "name": ["a", None, "c"],
+                "score": [1.0, 2.0, None],
+            }
+        )
+        frame = ar.from_pandas(df)
+        summary = {e.name: e.nullable for e in frame.schema_summary}
+        assert summary["id"] is False
+        assert summary["name"] is True
+        assert summary["score"] is True
+
+    def test_all_dtypes_covered(self):
+        df = pd.DataFrame(
+            {
+                "i": [1, 2],
+                "f": [1.1, 2.2],
+                "s": ["a", "b"],
+                "b": [True, False],
+            }
+        )
+        frame = ar.from_pandas(df)
+        dtype_map = {e.name: e.dtype for e in frame.schema_summary}
+        assert dtype_map["i"] == "int64"
+        assert dtype_map["f"] == "float64"
+        assert dtype_map["s"] == "string"
+        assert dtype_map["b"] == "bool"
+
+    def test_csv_based_frame(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = frame.schema_summary
+        assert len(result) == len(frame.columns)
+        for entry in result:
+            assert entry.name in frame.columns
+            assert entry.dtype in ("int64", "float64", "string", "bool", "null")
+
+    def test_csv_with_nulls_marks_nullable(self, csv_with_nulls):
+        frame = ar.read_csv(csv_with_nulls)
+        assert any(e.nullable for e in frame.schema_summary)
+
+    def test_does_not_trigger_pandas_roundtrip(self, monkeypatch):
+        """schema_summary must read directly from the C++ frame."""
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        frame = ar.from_pandas(df)
+
+        from arnio import convert
+
+        def fail_to_pandas(_frame, **_kwargs):
+            raise AssertionError("schema_summary must not call to_pandas()")
+
+        monkeypatch.setattr(convert, "to_pandas", fail_to_pandas)
+
+        result = frame.schema_summary
+        assert len(result) == 2
+
+    def test_stable_across_calls(self):
+        df = pd.DataFrame({"a": [1, None], "b": ["x", "y"]})
+        frame = ar.from_pandas(df)
+        assert frame.schema_summary == frame.schema_summary
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaSummaryEdgeCases:
+    def test_single_column_frame(self):
+        df = pd.DataFrame({"only": [42]})
+        frame = ar.from_pandas(df)
+        result = frame.schema_summary
+        assert len(result) == 1
+        assert result[0].name == "only"
+        assert result[0].dtype == "int64"
+        assert result[0].nullable is False
+
+    def test_empty_frame_no_rows(self):
+        df = pd.DataFrame(columns=["name", "age"])
+        frame = ar.from_pandas(df)
+        result = frame.schema_summary
+        assert [e.name for e in result] == ["name", "age"]
+        for entry in result:
+            assert entry.nullable is False
+
+    def test_single_row_no_nulls(self):
+        df = pd.DataFrame({"x": [1], "y": ["hello"]})
+        frame = ar.from_pandas(df)
+        assert all(not e.nullable for e in frame.schema_summary)
+
+    def test_all_values_null_marks_nullable(self):
+        df = pd.DataFrame({"x": [None, None, None]})
+        frame = ar.from_pandas(df)
+        assert frame.schema_summary[0].nullable is True
+
+    def test_only_last_row_null(self):
+        df = pd.DataFrame({"v": [1, 2, None]})
+        frame = ar.from_pandas(df)
+        assert frame.schema_summary[0].nullable is True
+
+    def test_only_first_row_null(self):
+        df = pd.DataFrame({"v": [None, 2, 3]})
+        frame = ar.from_pandas(df)
+        assert frame.schema_summary[0].nullable is True
+
+    def test_wide_frame(self):
+        cols = {f"col_{i}": list(range(5)) for i in range(50)}
+        df = pd.DataFrame(cols)
+        frame = ar.from_pandas(df)
+        result = frame.schema_summary
+        assert len(result) == 50
+        assert [e.name for e in result] == list(cols.keys())
+
+    def test_publicly_accessible_from_arnio_namespace(self):
+        from arnio import ColumnSummary as CS  # noqa: F401
+
+        df = pd.DataFrame({"a": [1]})
+        frame = ar.from_pandas(df)
+        for entry in frame.schema_summary:
+            assert isinstance(entry, CS)


### PR DESCRIPTION
Fixes #224

## Summary

Adds `ArFrame.schema_summary`, a property that returns column names, dtypes,
and nullability in one place, without triggering a pandas round-trip.

```python
frame = ar.read_csv("data.csv")
for col in frame.schema_summary:
    print(col.name, col.dtype, col.nullable)
# id      int64   False
# email   string  True
# score   float64 True
```

## 

- Added `ColumnSummary` (a `__slots__` class with `name`, `dtype`, `nullable`)
  to `arnio/frame.py`, above `ArFrame`.
- `schema_summary` reads nullability via `column_by_index(i).get_null_mask()`
  directly on the C++ frame, same path used by `preview()`. No pandas
  conversion is triggered.
- `ColumnSummary` is exported from `arnio/__init__.py` and added to `__all__`
  so users can type-annotate against it.

## Files changed

- `arnio/frame.py` - `ColumnSummary` class + `schema_summary` property
- `arnio/__init__.py` - export `ColumnSummary`
- `tests/test_schema_summary.py` - 30 new tests (new file)

## Tests

30 new tests across three groups:
- `TestColumnSummary` - attributes, `__repr__`, `__eq__`, inequality
- `TestSchemaSummaryNormal` - return type, order, dtype accuracy, nullability
  detection, all four dtypes, CSV-sourced frames, no pandas round-trip guarantee
- `TestSchemaSummaryEdgeCases` - single column, zero-row frame, all-null column,
  null at boundary positions, 50-column frame, public namespace import

All 30 new tests pass. Full suite: 1255 passed, 31 skipped, 0 failures.