### PR TITLE
fix(csv_reader): include line number in unterminated quoted field error

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -79,15 +79,17 @@ static bool getline_universal(std::istream& stream, std::string& line, std::stri
     return true;
 }
 
-bool read_record(std::istream& file, std::string& record) {
+bool read_record(std::istream& file, std::string& record, size_t& line_number) {
     record.clear();
 
     std::string line;
     std::string line_ending;
     std::string prev_line_ending;
     bool first = true;
+    size_t record_start_line = line_number + 1;
 
     while (getline_universal(file, line, line_ending)) {
+        ++line_number;
         if (!first) {
             record += prev_line_ending;  //  use PREVIOUS ending as separator
         }
@@ -101,10 +103,17 @@ bool read_record(std::istream& file, std::string& record) {
     }
 
     if (!record.empty() && !record_complete(record)) {
-        throw std::runtime_error("Unterminated quoted CSV record");
+        throw std::runtime_error("Unterminated quoted field starting at line " +
+                                 std::to_string(record_start_line));
     }
 
     return !record.empty();
+}
+
+// Overload without line tracking — used by callers that do not need location.
+bool read_record(std::istream& file, std::string& record) {
+    size_t dummy = 0;
+    return read_record(file, record, dummy);
 }
 
 void validate_header(const std::vector<std::string>& header) {
@@ -524,18 +533,19 @@ Frame CsvReader::read(const std::string& path) const {
     std::vector<std::vector<std::string>> raw_data;
 
     size_t record_number = 0;
+    size_t line_number = 0;
 
     if (config.skip_rows.has_value()) {
         size_t to_skip = config.skip_rows.value();
         size_t skipped = 0;
-        while (skipped < to_skip && read_record(file, line)) {
+        while (skipped < to_skip && read_record(file, line, line_number)) {
             ++record_number;
             ++skipped;
         }
     }
 
     // Read header
-    if (config.has_header && read_record(file, line)) {
+    if (config.has_header && read_record(file, line, line_number)) {
         ++record_number;
         strip_utf8_bom(line);
         header = parser_.parse_line(line);
@@ -552,7 +562,7 @@ Frame CsvReader::read(const std::string& path) const {
     size_t row_count = 0;
     std::optional<size_t> expected_cols =
         config.has_header ? std::optional<size_t>{header.size()} : std::nullopt;
-    while (read_record(file, line)) {
+    while (read_record(file, line, line_number)) {
         ++record_number;
 
         if (config.nrows.has_value() && row_count >= config.nrows.value()) {

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -705,7 +705,9 @@ class TestReadCsv:
         csv_path = tmp_path / "unterminated.csv"
         csv_path.write_text('id,text\n1,"hello\n')
 
-        with pytest.raises(ar.CsvReadError, match="Unterminated quoted CSV record"):
+        with pytest.raises(
+            ar.CsvReadError, match="Unterminated quoted field starting at line 2"
+        ):
             ar.read_csv(csv_path)
 
     def test_duplicate_headers_rejected(self, tmp_path):
@@ -2134,3 +2136,58 @@ class TestUnicodeFilePath:
 
         total_rows = sum(chunk.shape[0] for chunk in chunks)
         assert total_rows == 2
+
+
+# --- Issue #113: unterminated quoted field errors must include line number ---
+
+
+class TestUnterminatedQuoteLocation:
+    """Regression tests for #113 — CsvReadError must include the line number
+    where an unterminated quoted field begins so users can locate the problem
+    in their input file quickly."""
+
+    def test_error_message_includes_line_number(self, tmp_path):
+        # Unterminated quote starts on line 2 (after the header).
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_text('name,note\nAlice,"unterminated\n')
+        with pytest.raises(ar.CsvReadError, match="line 2"):
+            ar.read_csv(csv_path)
+
+    def test_error_message_includes_correct_line_for_later_row(self, tmp_path):
+        # Two valid rows, then an unterminated quote on line 4.
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_text('a,b\n1,ok\n2,fine\n3,"oops\n')
+        with pytest.raises(ar.CsvReadError, match="line 4"):
+            ar.read_csv(csv_path)
+
+    def test_error_message_includes_line_for_multiline_field_start(self, tmp_path):
+        # A valid multiline field followed by an unterminated one.
+        # Valid: rows 1-3 (header + "hello\nworld" spanning lines 2-3).
+        # Invalid: unterminated quote starts on line 4.
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_bytes(b'id,text\n1,"hello\nworld"\n2,"oops\n')
+        with pytest.raises(ar.CsvReadError, match="line 4"):
+            ar.read_csv(csv_path)
+
+    def test_error_message_says_unterminated_quoted_field(self, tmp_path):
+        # The error message must mention "Unterminated quoted field".
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_text('x\n"no close\n')
+        with pytest.raises(ar.CsvReadError, match="Unterminated quoted field"):
+            ar.read_csv(csv_path)
+
+    def test_valid_multiline_field_still_parses(self, tmp_path):
+        # A properly closed multiline field must NOT raise.
+        csv_path = tmp_path / "ok.csv"
+        csv_path.write_bytes(b'id,text\n1,"hello\nworld"\n')
+        frame = ar.read_csv(csv_path)
+        assert frame.shape == (1, 2)
+        df = ar.to_pandas(frame)
+        assert df["text"].iloc[0] == "hello\nworld"
+
+    def test_no_header_unterminated_quote_line_number(self, tmp_path):
+        # Without a header, the unterminated quote is on line 1.
+        csv_path = tmp_path / "bad.csv"
+        csv_path.write_text('"oops\n')
+        with pytest.raises(ar.CsvReadError, match="line 1"):
+            ar.read_csv(csv_path, has_header=False)


### PR DESCRIPTION
## Summary

Fixes #113

Previously, the parser error:

```text id="7v4o3k"
Unterminated quoted CSV record
```

did not include any row or line information, which made debugging malformed CSV files difficult.

## Change

The CSV reader now tracks the physical line number while parsing records and includes it in unterminated quoted-field errors.

**Before**

```text id="g0kj8l"
CsvReadError: Unterminated quoted CSV record
```

**After**

```text id="x4p8tf"
CsvReadError: Unterminated quoted field starting at line 4
```

## Implementation

* Added a `size_t& line_number` parameter to the tracking version of `read_record()`
* Kept a compatibility overload (`read_record(file, record)`) so existing call sites continue to work unchanged
* Updated `CsvReader::read()` to use the tracking overload for accurate line reporting

## Tests

Added `TestUnterminatedQuoteLocation` with 6 focused regression tests covering:

* unterminated quotes on different rows
* multiline quoted fields
* no-header CSVs
* error message wording
* valid multiline records still parsing correctly
