### PR TITLE
feat(quality): add high-cardinality profile warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1542,6 +1542,7 @@ DataQualityReport(
 }
 ```
 Columns where a single non-null value represents at least 95% of rows are reported with a `near_constant` warning.
+Columns with a very high ratio of unique values are reported with a `high_cardinality` warning because they may represent identifiers, leakage risk, or modeling hazards.
 
 Example near-constant distribution:
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1758,6 +1758,8 @@ def _profile_column(
         null_count=null_count,
         row_count=row_count,
         unique_count=unique_count,
+        unique_ratio=unique_ratio,
+        semantic_type=semantic_type,
         whitespace_count=whitespace_count,
         empty_string_count=empty_string_count,
         dominant_ratio=dominant_ratio,
@@ -1864,6 +1866,8 @@ def _column_warnings(
     null_count: int,
     row_count: int,
     unique_count: int,
+    unique_ratio: float,
+    semantic_type: str,
     whitespace_count: int,
     empty_string_count: int,
     dominant_ratio: float,
@@ -1877,6 +1881,14 @@ def _column_warnings(
         warnings.append("constant")
     if row_count and unique_count > 1 and dominant_ratio >= _NEAR_CONSTANT_THRESHOLD:
         warnings.append("near_constant")
+    non_null_count = row_count - null_count
+    if (
+        non_null_count > 0
+        and unique_count >= _HIGH_CARDINALITY_MIN_UNIQUE
+        and unique_ratio >= _HIGH_CARDINALITY_RATIO_THRESHOLD
+        and semantic_type in {"identifier", "text"}
+    ):
+        warnings.append("high_cardinality")
     if whitespace_count:
         warnings.append("leading_or_trailing_whitespace")
     if empty_string_count:
@@ -1919,6 +1931,8 @@ def _clean_scalar(value: Any) -> Any:
 
 _APPROX_TOP_VALUES_SEED = 0
 _NEAR_CONSTANT_THRESHOLD = 0.95
+_HIGH_CARDINALITY_RATIO_THRESHOLD = 0.9
+_HIGH_CARDINALITY_MIN_UNIQUE = 100
 
 
 def _top_values(

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -857,6 +857,51 @@ def test_profile_near_constant_threshold_boundary():
     assert "near_constant" in report.columns["status"].warnings
 
 
+def test_profile_detects_high_cardinality_identifier_column(tmp_path):
+    path = tmp_path / "ids.csv"
+    path.write_text(
+        "user_id\n" + "\n".join(f"id_{i}" for i in range(200)),
+        encoding="utf-8",
+    )
+
+    frame = ar.read_csv(path)
+    report = ar.profile(frame)
+
+    assert "high_cardinality" in report.columns["user_id"].warnings
+
+
+def test_profile_low_cardinality_column_not_marked_high_cardinality(tmp_path):
+    path = tmp_path / "status.csv"
+    values = ["active", "inactive"] * 100
+    path.write_text("status\n" + "\n".join(values), encoding="utf-8")
+
+    frame = ar.read_csv(path)
+    report = ar.profile(frame)
+
+    assert "high_cardinality" not in report.columns["status"].warnings
+
+
+def test_profile_constant_column_not_marked_high_cardinality(tmp_path):
+    path = tmp_path / "constant.csv"
+    path.write_text("user_id\n" + "\n".join(["same"] * 200), encoding="utf-8")
+
+    frame = ar.read_csv(path)
+    report = ar.profile(frame)
+
+    assert "high_cardinality" not in report.columns["user_id"].warnings
+
+
+def test_profile_null_heavy_column_not_marked_high_cardinality(tmp_path):
+    path = tmp_path / "null_heavy.csv"
+    values = [f"id_{i}" for i in range(20)] + [""] * 180
+    path.write_text("user_id\n" + "\n".join(values), encoding="utf-8")
+
+    frame = ar.read_csv(path)
+    report = ar.profile(frame)
+
+    assert "high_cardinality" not in report.columns["user_id"].warnings
+
+
 # ── string length statistics tests ───────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #178

## Summary
Adds informational high-cardinality warnings to the quality/profile contract for identifier/text-like columns.

## Changes
* added `high_cardinality` warning detection in `_column_warnings(...)`
* warning is triggered only for:

  * high unique-ratio columns
  * identifier/text semantic types
  * sufficiently large unique counts
* preserved existing validation behavior (warning only; no hard validation failures)

## Regression coverage
Added focused tests for:

* ID-like/high-cardinality columns
* low-cardinality categorical columns
* constant columns
* null-heavy columns

## Validation
Ran:

* `pytest tests/test_quality.py -q`
