### PR TITLE
feat: support configurable csv decimal separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,25 @@ frame = ar.read_csv("data.csv", null_values=["", "MISSING", "UNKNOWN"])
 # Disable null sentinel handling completely
 frame = ar.read_csv("data.csv", null_values=[])
 ```
+
+### Handling decimal separators
+
+Use `decimal_separator` when numeric CSV data uses a separator other than
+the default dot. This is explicit by design: Arnio does not auto-detect decimal
+formats because a comma can also be the CSV delimiter.
+
+```python
+# Semicolon-delimited CSV with unquoted European decimals
+frame = ar.read_csv("prices.csv", delimiter=";", decimal_separator=",")
+
+# Comma-delimited CSV still needs quoted comma-decimal values
+frame = ar.read_csv("prices.csv", decimal_separator=",")
+```
+
+The default remains `decimal_separator="."`, so existing dot-decimal files keep
+their current behavior. If you also use `thousands_separator`, it must differ
+from `decimal_separator`.
+
 ### Handling invalid UTF-8 bytes
 
 Use `encoding_errors` to control how invalid UTF-8 bytes are handled during CSV parsing.

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -158,6 +158,7 @@ def _utf8_csv_path(
 
 def _validate_thousands_separator(
     thousands_separator: str | None,
+    decimal_separator: str = ".",
 ) -> None:
     if thousands_separator is None:
         return
@@ -169,10 +170,24 @@ def _validate_thousands_separator(
         raise ValueError(
             "thousands_separator must be a single non-alphanumeric character"
         )
-    if thousands_separator in {".", "+", "-"}:
+    if thousands_separator in {"+", "-"}:
+        raise ValueError("Invalid thousands_separator: '+' and '-' are not allowed")
+    if thousands_separator == decimal_separator:
+        raise ValueError("thousands_separator must differ from decimal_separator")
+
+
+def _validate_decimal_separator(decimal_separator: str) -> str:
+    if not isinstance(decimal_separator, str):
+        raise TypeError("decimal_separator must be a string")
+    if len(decimal_separator) != 1:
+        raise ValueError("decimal_separator must be a single character")
+    if decimal_separator.isalnum() or decimal_separator in {'"', "\n", "\r"}:
         raise ValueError(
-            "Invalid thousands_separator: '.', '+' and '-' are not allowed"
+            "decimal_separator must be a single non-alphanumeric character"
         )
+    if decimal_separator in {"+", "-"}:
+        raise ValueError("Invalid decimal_separator: '+' and '-' are not allowed")
+    return decimal_separator
 
 
 def _validate_delimiter(delimiter: str) -> str:
@@ -385,6 +400,7 @@ def read_csv(
     skiprows: int | None = None,
     encoding: str = "utf-8",
     trim_headers: bool = True,
+    decimal_separator: str = ".",
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
     dtype: dict[str, str] | None = None,
@@ -420,6 +436,11 @@ def read_csv(
         File encoding.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.
+    decimal_separator : str, default "."
+        Single non-alphanumeric character used as the decimal separator
+        during numeric parsing. Use "," to opt in to European-style decimals
+        such as ``"12,45"``. Values containing the CSV delimiter must still
+        be quoted.
     thousands_separator : str, optional
         Single non-alphanumeric character used as a thousands separator
         during numeric parsing.
@@ -485,7 +506,8 @@ def read_csv(
     if delimiter is None:
         delimiter = "\t" if path_lower.endswith(".tsv") else ","
 
-    _validate_thousands_separator(thousands_separator)
+    decimal_separator = _validate_decimal_separator(decimal_separator)
+    _validate_thousands_separator(thousands_separator, decimal_separator)
     delimiter = _validate_delimiter(delimiter)
     mode = _validate_parser_mode(mode)
     encoding_errors = _validate_encoding_errors(encoding_errors)
@@ -494,6 +516,7 @@ def read_csv(
     config.has_header = _validate_bool_option(has_header, "has_header")
     config.encoding = encoding
     config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
+    config.decimal_separator = decimal_separator
     config.thousands_separator = thousands_separator
     config.mode = mode
     config.encoding_errors = encoding_errors
@@ -544,6 +567,7 @@ def read_csv_chunked(
     skip_rows: int = 0,
     encoding: str = "utf-8",
     trim_headers: bool = True,
+    decimal_separator: str = ".",
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
     mode: str = "strict",
@@ -573,6 +597,9 @@ def read_csv_chunked(
         File encoding.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.
+    decimal_separator : str, default "."
+        Single non-alphanumeric character used as the decimal separator
+        during numeric parsing.
     thousands_separator : str, optional
         Single non-alphanumeric character used as a thousands separator
         during numeric parsing.
@@ -615,7 +642,8 @@ def read_csv_chunked(
     except FileNotFoundError:
         pass
 
-    _validate_thousands_separator(thousands_separator)
+    decimal_separator = _validate_decimal_separator(decimal_separator)
+    _validate_thousands_separator(thousands_separator, decimal_separator)
     delimiter = _validate_delimiter(delimiter)
     mode = _validate_parser_mode(mode)
     chunksize = _validate_chunksize(chunksize)
@@ -626,6 +654,7 @@ def read_csv_chunked(
     config.has_header = _validate_bool_option(has_header, "has_header")
     config.encoding = encoding
     config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
+    config.decimal_separator = decimal_separator
     config.thousands_separator = thousands_separator
     config.mode = mode
     config.skip_rows = skip_rows
@@ -735,6 +764,7 @@ def scan_csv(
     delimiter: str | None = None,
     encoding: str = "utf-8",
     trim_headers: bool = True,
+    decimal_separator: str = ".",
     thousands_separator: str | None = None,
     sample_size: int | None = None,
     null_values: list[str] | None = None,
@@ -759,6 +789,9 @@ def scan_csv(
         transcoded to infer the schema.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.
+    decimal_separator : str, default "."
+        Single non-alphanumeric character used as the decimal separator
+        during numeric parsing.
     thousands_separator : str, optional
         Single non-alphanumeric character used as a thousands separator
         during numeric parsing.
@@ -815,13 +848,15 @@ def scan_csv(
     if delimiter is None:
         delimiter = "\t" if path_lower.endswith(".tsv") else ","
 
-    _validate_thousands_separator(thousands_separator)
+    decimal_separator = _validate_decimal_separator(decimal_separator)
+    _validate_thousands_separator(thousands_separator, decimal_separator)
     delimiter = _validate_delimiter(delimiter)
     encoding_errors = _validate_encoding_errors(encoding_errors)
     config = _CsvConfig()
     config.delimiter = delimiter
     config.encoding = encoding
     config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
+    config.decimal_separator = decimal_separator
     config.thousands_separator = thousands_separator
     config.has_header = has_header
     config.encoding_errors = encoding_errors

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -245,6 +245,7 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("skip_rows", &CsvConfig::skip_rows)
         .def_readwrite("encoding", &CsvConfig::encoding)
         .def_readwrite("trim_headers", &CsvConfig::trim_headers)
+        .def_readwrite("decimal_separator", &CsvConfig::decimal_separator)
         .def_readwrite("thousands_separator", &CsvConfig::thousands_separator)
         .def_readwrite("sample_size", &CsvConfig::sample_size)
         .def_readwrite("mode", &CsvConfig::mode)

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -20,6 +20,7 @@ struct CsvConfig {
     std::optional<size_t> skip_rows = std::nullopt;
     std::string encoding = "utf-8";  // Currently only utf-8 supported
     bool trim_headers = true;        // for implementing the trim_headers option
+    char decimal_separator = '.';
     std::optional<char> thousands_separator = std::nullopt;
     std::optional<size_t> sample_size = std::nullopt;
     std::optional<std::vector<std::string>> null_values = std::nullopt;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -128,11 +128,14 @@ void validate_header(const std::vector<std::string>& header) {
     }
 }
 
-static bool has_valid_thousands_grouping(const std::string& value, char separator) {
+constexpr const char* INVALID_NUMERIC_TOKEN = "\x1f";
+
+static bool has_valid_thousands_grouping(const std::string& value, char separator,
+                                         char decimal_separator) {
     std::string integer_part = value;
 
     // Ignore decimal portion
-    size_t decimal_pos = value.find('.');
+    size_t decimal_pos = value.find(decimal_separator);
     if (decimal_pos != std::string::npos) {
         integer_part = value.substr(0, decimal_pos);
     }
@@ -183,14 +186,58 @@ static bool has_valid_thousands_grouping(const std::string& value, char separato
     return true;
 }
 
+static bool looks_numeric_with_chars(const std::string& value, const CsvConfig& config,
+                                     bool allow_dot) {
+    std::string check = value;
+    trim_in_place(check);
+    if (check.empty()) return false;
+    if (check[0] == '-' || check[0] == '+') check = check.substr(1);
+    if (check.empty()) return false;
+
+    bool has_digit = false;
+    for (char c : check) {
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            has_digit = true;
+            continue;
+        }
+        if (c == config.decimal_separator) continue;
+        if (allow_dot && c == '.') continue;
+        if (config.thousands_separator.has_value() && c == config.thousands_separator.value()) {
+            continue;
+        }
+        return false;
+    }
+    return has_digit;
+}
+
+static bool has_invalid_decimal_format(const std::string& value, const CsvConfig& config) {
+    std::string s = value;
+    trim_in_place(s);
+    if (s.empty()) return false;
+
+    if (config.decimal_separator != '.' && s.find('.') != std::string::npos &&
+        looks_numeric_with_chars(s, config, true)) {
+        return true;
+    }
+
+    return std::count(s.begin(), s.end(), config.decimal_separator) > 1 &&
+           looks_numeric_with_chars(s, config, false);
+}
+
 std::string normalize_numeric(const std::string& value, const CsvConfig& config) {
     std::string s = value;
     trim_in_place(s);
     if (config.thousands_separator.has_value()) {
         char sep = config.thousands_separator.value();
-        if (has_valid_thousands_grouping(s, sep)) {
+        if (has_valid_thousands_grouping(s, sep, config.decimal_separator)) {
             s.erase(std::remove(s.begin(), s.end(), sep), s.end());
         }
+    }
+    if (has_invalid_decimal_format(s, config)) {
+        return INVALID_NUMERIC_TOKEN;
+    }
+    if (config.decimal_separator != '.') {
+        std::replace(s.begin(), s.end(), config.decimal_separator, '.');
     }
     return s;
 }
@@ -459,16 +506,22 @@ DType CsvParser::infer_type(const std::string& value) const {
     if (config_.thousands_separator.has_value()) {
         char sep = config_.thousands_separator.value();
         if (sanitized.find(sep) != std::string::npos &&
-            !has_valid_thousands_grouping(sanitized, sep)) {
+            !has_valid_thousands_grouping(sanitized, sep, config_.decimal_separator)) {
             std::string check = sanitized;
             trim_in_place(check);
             if (!check.empty() && (check[0] == '-' || check[0] == '+')) check = check.substr(1);
+            const char decimal_sep = config_.decimal_separator;
             bool looks_numeric =
-                !check.empty() && std::all_of(check.begin(), check.end(), [sep](char c) {
-                    return std::isdigit((unsigned char)c) || c == sep || c == '.';
+                !check.empty() &&
+                std::all_of(check.begin(), check.end(), [sep, decimal_sep](char c) {
+                    return std::isdigit((unsigned char)c) || c == sep || c == decimal_sep;
                 });
             if (looks_numeric) return DType::NULL_TYPE;
         }
+    }
+
+    if (has_invalid_decimal_format(sanitized, config_)) {
+        return DType::NULL_TYPE;
     }
 
     return DType::STRING;

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -255,6 +255,96 @@ class TestReadCsv:
         df = ar.to_pandas(frame)
         assert df["value"].iloc[0] == "1,234"
 
+    def test_decimal_separator_comma_with_semicolon_delimiter(self, tmp_path):
+        csv_path = tmp_path / "comma_decimal_semicolon.csv"
+        csv_path.write_text("value;label\n12,45;gross\n0,5;half\n")
+        frame = ar.read_csv(csv_path, delimiter=";", decimal_separator=",")
+        df = ar.to_pandas(frame)
+        assert frame.dtypes["value"] == "float64"
+        assert df["value"].tolist() == pytest.approx([12.45, 0.5])
+
+    def test_decimal_separator_comma_with_quoted_comma_delimiter(self, tmp_path):
+        csv_path = tmp_path / "quoted_comma_decimal.csv"
+        csv_path.write_text('value\n"12,45"\n"-0,5"\n')
+        frame = ar.read_csv(csv_path, decimal_separator=",")
+        df = ar.to_pandas(frame)
+        assert df["value"].tolist() == pytest.approx([12.45, -0.5])
+
+    def test_decimal_separator_default_preserves_comma_values(self, tmp_path):
+        csv_path = tmp_path / "default_comma_decimal.csv"
+        csv_path.write_text('value\n"12,45"\n')
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+        assert frame.dtypes["value"] == "string"
+        assert df["value"].iloc[0] == "12,45"
+
+    def test_decimal_separator_with_dot_thousands_separator(self, tmp_path):
+        csv_path = tmp_path / "european_number.csv"
+        csv_path.write_text('value\n"1.234,56"\n')
+        frame = ar.read_csv(
+            csv_path,
+            decimal_separator=",",
+            thousands_separator=".",
+        )
+        df = ar.to_pandas(frame)
+        assert df["value"].iloc[0] == pytest.approx(1234.56)
+
+    def test_mixed_decimal_formats_become_null(self, tmp_path):
+        csv_path = tmp_path / "mixed_decimal_formats.csv"
+        csv_path.write_text('value\n"12,45"\n"12.45"\n')
+        frame = ar.read_csv(csv_path, decimal_separator=",")
+        df = ar.to_pandas(frame)
+        assert frame.dtypes["value"] == "float64"
+        assert df["value"].iloc[0] == pytest.approx(12.45)
+        assert pd.isna(df["value"].iloc[1])
+
+    def test_scan_csv_decimal_separator_matches_read_csv(self, tmp_path):
+        csv_path = tmp_path / "scan_comma_decimal.csv"
+        csv_path.write_text('value\n"12,45"\n')
+        assert ar.scan_csv(csv_path, decimal_separator=",")["value"] == "float64"
+        assert ar.read_csv(csv_path, decimal_separator=",").dtypes["value"] == "float64"
+
+    def test_read_csv_chunked_decimal_separator(self, tmp_path):
+        csv_path = tmp_path / "chunked_comma_decimal.csv"
+        csv_path.write_text("value;label\n12,45;a\n67,89;b\n")
+        chunks = list(
+            ar.read_csv_chunked(
+                csv_path,
+                chunksize=1,
+                delimiter=";",
+                decimal_separator=",",
+            )
+        )
+        assert [
+            ar.to_pandas(chunk)["value"].iloc[0] for chunk in chunks
+        ] == pytest.approx([12.45, 67.89])
+
+    @pytest.mark.parametrize("separator", ["", "a", "3", "ab", "\n", '"', "+", "-"])
+    def test_invalid_decimal_separator(self, tmp_path, separator):
+        csv_path = tmp_path / "decimal_separator.csv"
+        csv_path.write_text("value\n1234\n")
+        with pytest.raises(ValueError):
+            ar.read_csv(csv_path, decimal_separator=separator)
+        with pytest.raises(ValueError):
+            ar.scan_csv(csv_path, decimal_separator=separator)
+
+    @pytest.mark.parametrize("separator", [1, 1.5, True, [], {}])
+    def test_invalid_non_string_decimal_separator(self, tmp_path, separator):
+        csv_path = tmp_path / "decimal_separator_type.csv"
+        csv_path.write_text("value\n1234\n")
+        with pytest.raises(TypeError):
+            ar.read_csv(csv_path, decimal_separator=separator)
+        with pytest.raises(TypeError):
+            ar.scan_csv(csv_path, decimal_separator=separator)
+
+    def test_thousands_separator_must_differ_from_decimal_separator(self, tmp_path):
+        csv_path = tmp_path / "same_separators.csv"
+        csv_path.write_text("value\n1234\n")
+        with pytest.raises(ValueError, match="must differ"):
+            ar.read_csv(csv_path, decimal_separator=",", thousands_separator=",")
+        with pytest.raises(ValueError, match="must differ"):
+            ar.scan_csv(csv_path, decimal_separator=",", thousands_separator=",")
+
     @pytest.mark.parametrize(
         "separator", ["", "a", "3", "ab", "\n", '"', ".", "+", "-"]
     )


### PR DESCRIPTION
## Summary
- add an explicit `decimal_separator` CSV option across `read_csv`, `read_csv_chunked`, `scan_csv`, pybind, and the C++ parser config
- keep default dot-decimal parsing unchanged while supporting opted-in comma decimals, including quoted comma-delimited values
- reject ambiguous separator configs where decimal and thousands separators match, and keep mixed decimal formats from silently parsing
- document the new public API behavior in the README

Fixes #134

## Validation
- `/tmp/arnio-merge-venv/bin/python -m pip install -e .`
- `/tmp/arnio-merge-venv/bin/python -m pytest tests/test_csv.py -q` -> 261 passed
- `/tmp/arnio-merge-venv/bin/python -m pytest tests -q` -> 1348 passed, 31 skipped
- `/tmp/arnio-merge-venv/bin/python -m black --check arnio/io.py tests/test_csv.py`
- `/tmp/arnio-merge-venv/bin/python -m ruff check arnio/io.py tests/test_csv.py`
- `/tmp/arnio-merge-venv/bin/clang-format --dry-run --Werror bindings/bind_arnio.cpp cpp/include/arnio/csv_reader.h cpp/src/csv_reader.cpp`
- `git diff --check`

## Suggested GSSoC labels
If accepted, please add `gssoc:approved`, `level:intermediate`, `gssoc:level-2`, `type:feature`, `area:csv-parser`, and `quality:clean` if they match the project rubric.