### PR TITLE
feat(pipeline): add verbose diagnostics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,8 +548,8 @@ Enable lightweight pipeline diagnostics with `verbose=True`:
 result = ar.pipeline(
     frame,
     [
-        ar.trim_strings,
-        ar.drop_nulls,
+        ("strip_whitespace",),
+        ("drop_nulls",),
     ],
     verbose=True,
 )

--- a/README.md
+++ b/README.md
@@ -540,6 +540,24 @@ frame.head(0)
 Raises `ValueError` for negative or boolean `n`.
 </details>
 
+### Pipeline verbose diagnostics
+
+Enable lightweight pipeline diagnostics with `verbose=True`:
+
+```python
+result = ar.pipeline(
+    frame,
+    [
+        ar.trim_strings,
+        ar.drop_nulls,
+    ],
+    verbose=True,
+)
+```
+
+This logs step execution order, execution path, elapsed time,
+and row-count changes through the `arnio` logger.
+
 <br>
 
 ---

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -6,6 +6,7 @@ Chained cleaning pipeline.
 from __future__ import annotations
 
 import inspect
+import logging
 import warnings
 from dataclasses import dataclass
 from threading import Lock
@@ -19,6 +20,7 @@ from .convert import from_pandas, to_pandas
 from .exceptions import PipelineStepError, UnknownStepError
 from .frame import ArFrame
 
+logger = logging.getLogger("arnio")
 _BUILTIN_STEP_NAMESPACE = "builtin"
 _STEP_NAMESPACE_SEPARATOR = ":"
 
@@ -266,6 +268,7 @@ def pipeline(
     *,
     return_metadata: bool = False,
     dry_run: bool = False,
+    verbose: bool = False,
 ) -> ArFrame | tuple[ArFrame, dict[str, Any]]:
     """Apply a list of cleaning steps sequentially.
 
@@ -373,6 +376,22 @@ def pipeline(
                 if not dry_run:
                     result = step_result
 
+            elapsed_ms = (perf_counter() - started_at) * 1000
+
+            if verbose:
+                execution_path = f"{fn.__module__}.{fn.__name__}"
+
+                logger.info(
+                    "[%s/%s] %s | path=%s | rows: %s -> %s | %.2fms",
+                    step_index + 1,
+                    total_steps,
+                    name,
+                    execution_path,
+                    rows_before,
+                    step_result.shape[0],
+                    elapsed_ms,
+                )
+
             if return_metadata:
                 applied_steps.append(name)
                 row_counts.append(
@@ -430,6 +449,23 @@ def pipeline(
             step_result = from_pandas(returned)
             if not dry_run:
                 result = step_result
+
+            elapsed_ms = (perf_counter() - started_at) * 1000
+
+            if verbose:
+                step_name = getattr(fn, "__name__", name)
+                execution_path = f"{fn.__module__}.{step_name}"
+
+                logger.info(
+                    "[%s/%s] %s | path=%s | rows: %s -> %s | %.2fms",
+                    step_index + 1,
+                    total_steps,
+                    name,
+                    execution_path,
+                    rows_before,
+                    step_result.shape[0],
+                    elapsed_ms,
+                )
 
             if return_metadata:
                 applied_steps.append(name)

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -286,6 +286,11 @@ def pipeline(
         When True, also return a metadata dictionary with per-step timing
         information in execution order.
 
+    verbose : bool, default False
+        Enable lightweight diagnostic logging through the ``arnio`` logger.
+        Logs step index, step name, execution path, elapsed execution
+        time, and row-count changes for each pipeline step.
+
     dry_run : bool, default False
         Validates pipeline structure and step execution without
         returning transformed output.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1461,3 +1461,108 @@ def test_reset_steps_removes_overwritten_custom_steps():
                 ("temp_step",),
             ],
         )
+
+
+def test_pipeline_verbose_disabled_by_default(caplog):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["A", "B"],
+            }
+        )
+    )
+
+    ar.pipeline(
+        frame,
+        [
+            ("drop_nulls",),
+        ],
+    )
+
+    assert len(caplog.records) == 0
+
+
+def test_pipeline_verbose_logs_builtin_step(caplog):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": [" A ", " B "],
+            }
+        )
+    )
+
+    caplog.set_level("INFO", logger="arnio")
+
+    ar.pipeline(
+        frame,
+        [
+            ("strip_whitespace",),
+        ],
+        verbose=True,
+    )
+
+    assert any("strip_whitespace" in record.message for record in caplog.records)
+
+
+def custom_step(df):
+    return df
+
+
+def test_pipeline_verbose_logs_custom_step(caplog):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "x": [1, 2],
+            }
+        )
+    )
+
+    ar.register_step(
+        "custom_step",
+        custom_step,
+        overwrite=True,
+    )
+
+    caplog.set_level("INFO", logger="arnio")
+
+    ar.pipeline(
+        frame,
+        [
+            ("custom_step",),
+        ],
+        verbose=True,
+    )
+
+    assert any("custom_step" in record.message for record in caplog.records)
+
+
+def drop_first_row(df):
+    return df.head(1)
+
+
+def test_pipeline_verbose_logs_row_change(caplog):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "x": [1, 2, 3],
+            }
+        )
+    )
+
+    ar.register_step(
+        "drop_first_row",
+        drop_first_row,
+        overwrite=True,
+    )
+
+    caplog.set_level("INFO", logger="arnio")
+
+    ar.pipeline(
+        frame,
+        [
+            ("drop_first_row",),
+        ],
+        verbose=True,
+    )
+
+    assert any("rows: 3 -> 1" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

Adds optional verbose diagnostics support to `pipeline()`.

### Changes

* add `verbose` parameter to `pipeline()`
* keep default behavior silent/unchanged
* log step index/name
* log execution path
* log elapsed execution time
* log row-count changes
* use the `arnio` logger instead of print
* add focused tests for:

  * disabled-by-default behavior
  * built-in steps
  * custom Python-backed steps
  * row-count change logging
* add a short README usage example

Fixes #102
