### PR TITLE
fix: stop read_jsonl before parsing beyond nrows

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -929,6 +929,8 @@ def read_jsonl(
                 line = raw_line.rstrip("\r\n")
                 if not line.strip():
                     continue  # skip blank / whitespace-only lines
+                if nrows is not None and len(records) >= nrows:
+                    break
                 try:
                     obj = json.loads(line)
                 except json.JSONDecodeError as exc:
@@ -940,8 +942,6 @@ def read_jsonl(
                         f"Expected a JSON object on line {lineno} of {path!r}, "
                         f"got {type(obj).__name__}"
                     )
-                if nrows is not None and len(records) >= nrows:
-                    break
                 records.append(obj)
     except OSError as exc:
         raise JsonlReadError(str(exc)) from exc

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -128,6 +128,14 @@ class TestReadJsonlNrows:
         frame = ar.read_jsonl(path, nrows=3)
         assert frame.shape[0] == 3
 
+    def test_nrows_stops_before_malformed_record_beyond_limit(self, tmp_path):
+        path = tmp_path / "limited.jsonl"
+        path.write_text('{"a": 1}\n{"a": 2}\nnot json\n', encoding="utf-8")
+
+        frame = ar.read_jsonl(path, nrows=2)
+
+        assert frame.shape == (2, 1)
+
     def test_nrows_zero_returns_empty_frame(self, tmp_path):
         path = _write(tmp_path, "data.jsonl", [{"x": 1}, {"x": 2}])
         # nrows=0 is valid — reads 0 rows, returns empty frame


### PR DESCRIPTION
## Summary
Fixes `read_jsonl(..., nrows=N)` so it stops before parsing records beyond the requested row limit. Previously, malformed JSON after the requested `nrows` limit could still be parsed and raise `JsonlReadError`.

## Linked issue
Fixes #977

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `python -m pytest tests/test_jsonl.py -q`

Result:

```text
34 passed