### PR TITLE
feat: add winsorize_outliers cleaning step

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,6 +971,22 @@ clean = ar.pipeline(frame, [
 ])
 ```
 
+### Winsorize outliers
+
+`winsorize_outliers()` clips extreme numeric values using lower and upper quantiles. Non-numeric columns are ignored unless explicitly selected in `subset`.
+
+```python
+frame = ar.read_csv("data.csv")
+
+result = ar.winsorize_outliers(
+    frame,
+    lower=0.05,
+    upper=0.95,
+)
+```
+
+It can also be used inside `ar.pipeline()` as `("winsorize_outliers", {"lower": 0.05, "upper": 0.95})`.
+
 ### 🔁 Replace values
 
 Use `replace_values` to substitute values using a mapping. It works as a pipeline step (Python backend) and can operate on a single column or the whole frame when `column` is omitted. It also understands null semantics: using `None` (or `np.nan`) as a mapping key targets existing nulls, and mapping a value to `None` creates real nulls.

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -38,6 +38,7 @@ from .cleaning import (
     strip_whitespace,
     trim_column_names,
     validate_columns_exist,
+    winsorize_outliers,
 )
 from .convert import from_pandas, to_pandas
 from .exceptions import (
@@ -133,6 +134,7 @@ __all__ = [
     "drop_constant_columns",
     "drop_empty_columns",
     "clip_numeric",
+    "winsorize_outliers",
     "coalesce_columns",
     "combine_columns",
     "drop_columns_matching",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -23,6 +23,7 @@ from ._core import (
     _safe_divide_columns,
     _strip_whitespace,
 )
+from .convert import from_pandas, to_pandas
 from .exceptions import TypeCastError
 from .frame import ArFrame
 
@@ -612,6 +613,81 @@ def clip_numeric(
         subset=subset,
     )
     return ArFrame(result)
+
+
+def winsorize_outliers(
+    frame: ArFrame,
+    *,
+    lower: float = 0.05,
+    upper: float = 0.95,
+    subset: list[str] | None = None,
+) -> ArFrame:
+    """Winsorize numeric columns using quantile-based clipping.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    lower : float, default 0.05
+        Lower quantile bound.
+    upper : float, default 0.95
+        Upper quantile bound.
+    subset : list[str], optional
+        Numeric columns to winsorize. If None, applies to all numeric columns.
+
+    Returns
+    -------
+    ArFrame
+        New frame with winsorized numeric values.
+    """
+
+    if lower < 0 or upper > 1:
+        raise ValueError("lower and upper must be between 0 and 1")
+
+    if lower >= upper:
+        raise ValueError("lower must be less than upper")
+
+    dtypes = frame.dtypes
+
+    numeric_columns = [
+        col for col, dtype in dtypes.items() if dtype in ("int64", "float64")
+    ]
+
+    if subset is not None:
+        unknown_columns = [col for col in subset if col not in dtypes]
+        if unknown_columns:
+            raise ValueError(f"Unknown columns in subset: {unknown_columns}")
+
+        non_numeric_columns = [
+            col for col in subset if dtypes.get(col) not in ("int64", "float64")
+        ]
+        if non_numeric_columns:
+            raise ValueError(
+                "winsorize_outliers only supports numeric columns: "
+                f"{non_numeric_columns}"
+            )
+
+        target_columns = subset
+    else:
+        target_columns = numeric_columns
+
+    if not target_columns:
+        return frame
+
+    df = to_pandas(frame).copy()
+
+    for column in target_columns:
+        lower_bound = df[column].quantile(lower)
+        upper_bound = df[column].quantile(upper)
+
+        series = df[column].astype("float64")
+
+        df[column] = series.clip(
+            lower=lower_bound,
+            upper=upper_bound,
+        )
+
+    return from_pandas(df)
 
 
 def strip_whitespace(

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -36,6 +36,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "drop_constant_columns": cleaning.drop_constant_columns,
     "drop_empty_columns": cleaning.drop_empty_columns,
     "clip_numeric": cleaning.clip_numeric,
+    "winsorize_outliers": cleaning.winsorize_outliers,
     "strip_whitespace": cleaning.strip_whitespace,
     "parse_bool_strings": cleaning.parse_bool_strings,
     "normalize_case": cleaning.normalize_case,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -124,6 +124,109 @@ class TestFillNulls:
             ar.fill_nulls(frame, "bad", subset=["x"])
 
 
+class TestWinsorizeOutliers:
+    def test_winsorize_outliers_clips_numeric_values(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [1, 2, 3, 4, 100],
+                }
+            )
+        )
+
+        result = ar.winsorize_outliers(frame, lower=0.2, upper=0.8)
+        df = ar.to_pandas(result)
+
+        assert df["value"].tolist() == pytest.approx([1.8, 2.0, 3.0, 4.0, 23.2])
+
+    def test_winsorize_outliers_subset(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 100],
+                    "b": [10, 20, 30, 40, 500],
+                }
+            )
+        )
+
+        result = ar.winsorize_outliers(
+            frame,
+            lower=0.2,
+            upper=0.8,
+            subset=["a"],
+        )
+        df = ar.to_pandas(result)
+
+        assert df["a"].tolist() == pytest.approx([1.8, 2.0, 3.0, 4.0, 23.2])
+        assert list(df["b"]) == [10, 20, 30, 40, 500]
+
+    def test_winsorize_outliers_ignores_non_numeric_without_subset(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [1, 2, 3, 4, 100],
+                    "label": ["a", "b", "c", "d", "e"],
+                }
+            )
+        )
+
+        result = ar.winsorize_outliers(frame, lower=0.2, upper=0.8)
+        df = ar.to_pandas(result)
+
+        assert df["value"].tolist() == pytest.approx([1.8, 2.0, 3.0, 4.0, 23.2])
+        assert list(df["label"]) == ["a", "b", "c", "d", "e"]
+
+    def test_winsorize_outliers_rejects_non_numeric_subset(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [1, 2, 3],
+                    "label": ["a", "b", "c"],
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="only supports numeric columns"):
+            ar.winsorize_outliers(frame, subset=["label"])
+
+    def test_winsorize_outliers_rejects_unknown_subset_column(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(ValueError, match="Unknown columns in subset"):
+            ar.winsorize_outliers(frame, subset=["missing"])
+
+    @pytest.mark.parametrize(
+        ("lower", "upper"),
+        [
+            (-0.1, 0.95),
+            (0.05, 1.1),
+            (0.8, 0.2),
+            (0.5, 0.5),
+        ],
+    )
+    def test_winsorize_outliers_rejects_invalid_bounds(self, lower, upper):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(ValueError):
+            ar.winsorize_outliers(frame, lower=lower, upper=upper)
+
+    def test_winsorize_outliers_identical_values_noop(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [5, 5, 5]}))
+
+        result = ar.winsorize_outliers(frame)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [5, 5, 5]
+
+    def test_winsorize_outliers_single_row_noop(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [10]}))
+
+        result = ar.winsorize_outliers(frame)
+        df = ar.to_pandas(result)
+
+        assert list(df["value"]) == [10]
+
+
 class TestValidateColumnsExist:
     def test_returns_original_frame_when_columns_exist(self, sample_csv):
         frame = ar.read_csv(sample_csv)
@@ -2636,6 +2739,27 @@ class TestClipNumericNativeRegression:
         frame = ar.from_pandas(pd.DataFrame({"score": [-10, 50, 200]}))
         result = ar.pipeline(frame, [("clip_numeric", {"lower": 0, "upper": 100})])
         assert ar.to_pandas(result)["score"].tolist() == [0, 50, 100]
+
+    def test_pipeline_winsorize_outliers(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "value": [1, 2, 3, 4, 100],
+                    "label": ["a", "b", "c", "d", "e"],
+                }
+            )
+        )
+
+        result = ar.pipeline(
+            frame,
+            [
+                ("winsorize_outliers", {"lower": 0.2, "upper": 0.8}),
+            ],
+        )
+        df = ar.to_pandas(result)
+
+        assert df["value"].tolist() == pytest.approx([1.8, 2.0, 3.0, 4.0, 23.2])
+        assert list(df["label"]) == ["a", "b", "c", "d", "e"]
 
     # ------------------------------------------------------------------
     # Large-frame determinism: result must be identical to the old


### PR DESCRIPTION
## Summary
Adds a new `winsorize_outliers` cleaning utility for quantile-based outlier clipping on numeric columns.

Fixes #144

## Features
* Supports configurable lower/upper quantile bounds
* Supports subset selection
* Ignores non-numeric columns unless explicitly selected
* Validates invalid bounds and unknown columns
* Pipeline integration support
* Added unit and pipeline tests

## Notes
* Uses pandas quantile computation for percentile-based clipping
* Preserves non-target columns unchanged
* Added edge-case coverage for invalid bounds, unknown columns, non-numeric subsets, identical values, and single-row frames


