### PR TITLE
ci: add lightweight benchmark regression checks

### DIFF
--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -27,7 +27,7 @@ DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 RUNS = 1 if DRY_RUN else 3
 
 BASELINE_FILE = "benchmarks/baseline.json"
-REGRESSION_THRESHOLD = 5  # Percent
+REGRESSION_THRESHOLD = 10  # Percent
 
 
 @dataclass(frozen=True)
@@ -290,6 +290,12 @@ def calculate_regression(current, baseline):
     ) * 100  # How much slower current benchmark is compared to baseline
 
 
+def check_regression(current_time, baseline_time, threshold_percent):
+    regression_percent = ((current_time - baseline_time) / baseline_time) * 100
+
+    return regression_percent > threshold_percent, regression_percent
+
+
 def run_case(case, skip_correctness=False):
     baseline_data = load_baseline()
 
@@ -403,12 +409,16 @@ def run_case(case, skip_correctness=False):
         baseline_time = baseline_case["arnio_exec_time"]
         current_time = avg(ar_times)
 
-        regression = calculate_regression(current_time, baseline_time)
+        is_regression, regression_percent = check_regression(
+            current_time,
+            baseline_time,
+            REGRESSION_THRESHOLD,
+        )
 
-        if regression > REGRESSION_THRESHOLD:
+        if is_regression:
             print(
-                f"WARNING: Regression detected:"
-                f"{regression:.1f}% slower than baseline "
+                f"WARNING: Regression detected: "
+                f"{regression_percent:.1f}% slower than baseline "
                 f"(threshold: {REGRESSION_THRESHOLD}%)"
             )
     else:
@@ -465,10 +475,15 @@ if __name__ == "__main__":
         )
     elif rss_source == "unavailable":
         print("Note: Peak RSS unavailable (install psutil for process RSS).")
-    results = []
 
+    results = {}
     for benchmark_case in BENCHMARKS:
-        results.append(run_case(benchmark_case))
+        result = run_case(benchmark_case)
+        results[result["case"]] = {
+            "pandas_exec_time": result["pandas_exec_time"],
+            "arnio_exec_time": result["arnio_exec_time"],
+            "speedup": result["speedup"],
+        }
 
     with open("benchmark_results.json", "w") as f:
         json.dump(results, f, indent=2)

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -27,7 +27,7 @@ DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 RUNS = 1 if DRY_RUN else 3
 
 BASELINE_FILE = "benchmarks/baseline.json"
-REGRESSION_THRESHOLD = 10  # Percent
+REGRESSION_THRESHOLD = 5  # Percent
 
 
 @dataclass(frozen=True)
@@ -416,8 +416,8 @@ def run_case(case, skip_correctness=False):
         )
 
         if is_regression:
-            print(
-                f"WARNING: Regression detected: "
+            raise RuntimeError(
+                f"Benchmark regression detected: "
                 f"{regression_percent:.1f}% slower than baseline "
                 f"(threshold: {REGRESSION_THRESHOLD}%)"
             )
@@ -485,5 +485,10 @@ if __name__ == "__main__":
             "speedup": result["speedup"],
         }
 
-    with open("benchmark_results.json", "w") as f:
+    output_path = Path("benchmark_results.json")
+
+    with open(output_path, "w") as f:
         json.dump(results, f, indent=2)
+
+    if DRY_RUN and output_path.exists():
+        output_path.unlink()

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from benchmarks.benchmark_vs_pandas import check_regression
+from benchmarks.benchmark_vs_pandas import (
+    BenchmarkCase,
+    check_regression,
+    run_case,
+)
 
 # Check if the C++ extension is compiled
 try:
@@ -148,7 +152,7 @@ def test_check_regression_detects_slowdown():
     is_regression, regression_percent = check_regression(
         current_time=12.0,
         baseline_time=10.0,
-        threshold_percent=10,
+        threshold_percent=5,
     )
 
     assert is_regression is True
@@ -160,8 +164,72 @@ def test_check_regression_allows_small_variance():
     is_regression, regression_percent = check_regression(
         current_time=10.5,
         baseline_time=10.0,
-        threshold_percent=10,
+        threshold_percent=5,
     )
 
     assert is_regression is False
     assert regression_percent == 5.0
+
+
+def test_run_case_raises_on_regression(monkeypatch):
+    """run_case should fail when benchmark regression exceeds threshold."""
+
+    benchmark_case = BenchmarkCase(
+        "Regression Test Case",
+        "dummy.csv",
+    )
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.load_baseline",
+        lambda: {
+            "Regression Test Case": {
+                "arnio_exec_time": 10.0,
+            }
+        },
+    )
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.verify_correctness",
+        lambda path: None,
+    )
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.RUNS",
+        1,
+    )
+
+    def fake_run_subprocess(engine, path):
+        if engine == "arnio":
+            return {
+                "elapsed": 11.0,
+                "peak_trace_mb": 1,
+                "peak_rss_mb": 1,
+                "ops": {
+                    "read_csv": 1,
+                    "clean_strings": 1,
+                    "drop_nulls": 1,
+                    "drop_duplicates": 1,
+                    "to_pandas": 1,
+                },
+            }
+
+        return {
+            "elapsed": 1.0,
+            "peak_trace_mb": 1,
+            "peak_rss_mb": 1,
+            "ops": {
+                "read_csv": 1,
+                "clean_strings": 1,
+                "drop_nulls": 1,
+                "drop_duplicates": 1,
+                "to_pandas": 1,
+            },
+        }
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.run_subprocess",
+        fake_run_subprocess,
+    )
+
+    with pytest.raises(RuntimeError, match="Benchmark regression detected"):
+        run_case(benchmark_case, skip_correctness=True)

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from benchmarks.benchmark_vs_pandas import check_regression
+
 # Check if the C++ extension is compiled
 try:
     import arnio._core  # noqa: F401
@@ -139,3 +141,27 @@ def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files():
         if f.name != "benchmark_sparse_nulls.csv"
     ]
     assert len(post_files) == 0, f"Temp files not cleaned up: {post_files}"
+
+
+def test_check_regression_detects_slowdown():
+    """Regression should trigger when slowdown exceeds threshold."""
+    is_regression, regression_percent = check_regression(
+        current_time=12.0,
+        baseline_time=10.0,
+        threshold_percent=10,
+    )
+
+    assert is_regression is True
+    assert regression_percent == 20.0
+
+
+def test_check_regression_allows_small_variance():
+    """Small timing variance should not trigger regression."""
+    is_regression, regression_percent = check_regression(
+        current_time=10.5,
+        baseline_time=10.0,
+        threshold_percent=10,
+    )
+
+    assert is_regression is False
+    assert regression_percent == 5.0


### PR DESCRIPTION
## Summary

Adds lightweight benchmark regression comparison support to the benchmark workflow infrastructure.

This change extends the existing benchmark JSON persistence work by:

* comparing benchmark results against a baseline when available
* adding a lightweight regression signal using a configurable slowdown threshold
* handling missing baselines gracefully without failing benchmark runs unexpectedly
* adding focused regression helper tests for threshold behavior

The implementation keeps the benchmark workflow incremental and lightweight without introducing dashboards, historical tracking infrastructure, or broad workflow rewrites.

## Linked issue

Refs #94

## Type of change

* [ ] Bug fix
* [ ] Feature
* [x] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [x] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [x] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

Commands run locally:

```bash
ruff check .
black .
pytest
python benchmarks/generate_data.py
python benchmarks/benchmark_vs_pandas.py
```

Results:

* benchmark runs completed successfully
* regression comparison logic executed correctly
* missing baseline handling verified
* regression threshold signaling verified
* benchmark smoke tests passed
* full pytest suite passed

## Screenshots / Media

N/A

## Performance Impact

This PR does not change benchmark execution performance itself.

It adds:

* lightweight regression comparison support
* configurable slowdown threshold signaling
* structured baseline comparison flow
* focused regression helper coverage

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR intentionally keeps the regression signaling lightweight and incremental.

It avoids:

* dashboard/history infrastructure
* PR comment bots
* large benchmark workflow rewrites

Future follow-up work for #94 may still include:

* historical benchmark tracking
* PR benchmark summaries/comments
* richer regression reporting
