### PR TITLE
feat: add ArFrame.drop_columns helper (fixes #219)Feat/drop columns 219

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -420,13 +420,13 @@ class ArFrame:
         drop_set = set(unique_cols)
         remaining = [col for col in self.columns if col not in drop_set]
 
-        # Dropping all columns — return empty frame via pandas
+        # Dropping all columns — preserve row count
         if not remaining:
             import pandas as pd
 
             from .convert import from_pandas
 
-            return from_pandas(pd.DataFrame())
+            return from_pandas(pd.DataFrame(index=range(len(self))))
 
         return ArFrame(self._frame.select_columns(remaining))
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -361,34 +361,35 @@ class ArFrame:
             raise ValueError(f"Unknown columns: {missing}")
 
         return ArFrame(self._frame.select_columns(columns))
-    
+
     def drop_columns(self, cols: list[str]) -> ArFrame:
-    """Return a new ArFrame with the specified columns removed.
+        """Return a new ArFrame with the specified columns removed.
 
-    Parameters
-    ----------
-    cols : list[str]
-        Column names to drop. Duplicates are silently ignored.
-        An empty list returns a copy of the frame unchanged.
+        Parameters
+        ----------
+        cols : list[str]
+            Column names to drop. Duplicates are silently ignored.
+            An empty list returns a copy of the frame unchanged.
 
-    Returns
-    -------
-    ArFrame
-        New ArFrame without the dropped columns. Original column
-        order is preserved.
+        Returns
+        -------
+        ArFrame
+            New ArFrame without the dropped columns. Original column
+            order is preserved.
 
-    Raises
-    ------
-    TypeError
-        If cols is not a list, or contains non-string elements.
-    ValueError
-        If any name in cols does not exist in the frame.
+        Raises
+        ------
+        TypeError
+            If cols is not a list, or contains non-string elements.
+        ValueError
+            If any name in cols does not exist in the frame.
 
-    Examples
-    --------
-    >>> frame = ar.read_csv("data.csv")
-    >>> smaller = frame.drop_columns(["col1", "col2"])
-    """
+        Examples
+        --------
+        >>> frame = ar.read_csv("data.csv")
+        >>> smaller = frame.drop_columns(["col1", "col2"])
+        """
+
     if not isinstance(cols, list):
         raise TypeError(
             f"cols must be a list of column names, got {type(cols).__name__!r}"
@@ -409,8 +410,7 @@ class ArFrame:
     missing = [col for col in unique_cols if col not in self.columns]
     if missing:
         raise ValueError(
-            f"Unknown column(s): {missing}. "
-            f"Available columns: {self.columns}"
+            f"Unknown column(s): {missing}. " f"Available columns: {self.columns}"
         )
 
     # Empty input — return unchanged copy
@@ -425,6 +425,7 @@ class ArFrame:
     if not remaining:
         from .convert import from_pandas, to_pandas
         import pandas as pd
+
         return from_pandas(pd.DataFrame())
 
     return ArFrame(self._frame.select_columns(remaining))

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -389,46 +389,46 @@ class ArFrame:
         >>> frame = ar.read_csv("data.csv")
         >>> smaller = frame.drop_columns(["col1", "col2"])
         """
+        if not isinstance(cols, list):
+            raise TypeError(
+                f"cols must be a list of column names, got {type(cols).__name__!r}"
+            )
 
-    if not isinstance(cols, list):
-        raise TypeError(
-            f"cols must be a list of column names, got {type(cols).__name__!r}"
-        )
+        if any(not isinstance(col, str) for col in cols):
+            raise TypeError("All column names in cols must be strings.")
 
-    if any(not isinstance(col, str) for col in cols):
-        raise TypeError("All column names in cols must be strings.")
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        unique_cols: list[str] = []
+        for col in cols:
+            if col not in seen:
+                seen.add(col)
+                unique_cols.append(col)
 
-    # Deduplicate while preserving order
-    seen: set[str] = set()
-    unique_cols: list[str] = []
-    for col in cols:
-        if col not in seen:
-            seen.add(col)
-            unique_cols.append(col)
+        # Validate all names exist
+        missing = [col for col in unique_cols if col not in self.columns]
+        if missing:
+            raise ValueError(
+                f"Unknown column(s): {missing}. " f"Available columns: {self.columns}"
+            )
 
-    # Validate all names exist
-    missing = [col for col in unique_cols if col not in self.columns]
-    if missing:
-        raise ValueError(
-            f"Unknown column(s): {missing}. " f"Available columns: {self.columns}"
-        )
+        # Empty input — return unchanged copy
+        if not unique_cols:
+            return ArFrame(self._frame.select_columns(self.columns))
 
-    # Empty input — return unchanged copy
-    if not unique_cols:
-        return ArFrame(self._frame.select_columns(self.columns))
+        # Preserve original order of remaining columns
+        drop_set = set(unique_cols)
+        remaining = [col for col in self.columns if col not in drop_set]
 
-    # Preserve original order of remaining columns
-    drop_set = set(unique_cols)
-    remaining = [col for col in self.columns if col not in drop_set]
+        # Dropping all columns — return empty frame via pandas
+        if not remaining:
+            import pandas as pd
 
-    # Dropping all columns — return empty frame via pandas
-    if not remaining:
-        from .convert import from_pandas, to_pandas
-        import pandas as pd
+            from .convert import from_pandas
 
-        return from_pandas(pd.DataFrame())
+            return from_pandas(pd.DataFrame())
 
-    return ArFrame(self._frame.select_columns(remaining))
+        return ArFrame(self._frame.select_columns(remaining))
 
     def select_dtypes(
         self,

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -361,6 +361,73 @@ class ArFrame:
             raise ValueError(f"Unknown columns: {missing}")
 
         return ArFrame(self._frame.select_columns(columns))
+    
+    def drop_columns(self, cols: list[str]) -> ArFrame:
+    """Return a new ArFrame with the specified columns removed.
+
+    Parameters
+    ----------
+    cols : list[str]
+        Column names to drop. Duplicates are silently ignored.
+        An empty list returns a copy of the frame unchanged.
+
+    Returns
+    -------
+    ArFrame
+        New ArFrame without the dropped columns. Original column
+        order is preserved.
+
+    Raises
+    ------
+    TypeError
+        If cols is not a list, or contains non-string elements.
+    ValueError
+        If any name in cols does not exist in the frame.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> smaller = frame.drop_columns(["col1", "col2"])
+    """
+    if not isinstance(cols, list):
+        raise TypeError(
+            f"cols must be a list of column names, got {type(cols).__name__!r}"
+        )
+
+    if any(not isinstance(col, str) for col in cols):
+        raise TypeError("All column names in cols must be strings.")
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique_cols: list[str] = []
+    for col in cols:
+        if col not in seen:
+            seen.add(col)
+            unique_cols.append(col)
+
+    # Validate all names exist
+    missing = [col for col in unique_cols if col not in self.columns]
+    if missing:
+        raise ValueError(
+            f"Unknown column(s): {missing}. "
+            f"Available columns: {self.columns}"
+        )
+
+    # Empty input — return unchanged copy
+    if not unique_cols:
+        return ArFrame(self._frame.select_columns(self.columns))
+
+    # Preserve original order of remaining columns
+    drop_set = set(unique_cols)
+    remaining = [col for col in self.columns if col not in drop_set]
+
+    # Dropping all columns — return empty frame via pandas
+    if not remaining:
+        from .convert import from_pandas, to_pandas
+        import pandas as pd
+        return from_pandas(pd.DataFrame())
+
+    return ArFrame(self._frame.select_columns(remaining))
 
     def select_dtypes(
         self,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -456,3 +456,73 @@ def test_describe_all_string_columns(csv_with_whitespace):
     for col in ["name", "city"]:
         metric_keys = list(stats[col].keys())
         assert metric_keys == ["count", "nulls", "unique"]
+
+
+# ── drop_columns ──────────────────────────────────────────────────────────────
+
+
+class TestDropColumns:
+    """Tests for ArFrame.drop_columns()."""
+
+    def test_drop_single_column(self):
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+        frame = ar.from_pandas(df)
+        result = frame.drop_columns(["b"])
+        assert result.columns == ["a", "c"]
+        assert result.shape == (2, 2)
+
+    def test_drop_multiple_columns(self):
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
+        frame = ar.from_pandas(df)
+        result = frame.drop_columns(["a", "c"])
+        assert result.columns == ["b", "d"]
+
+    def test_drop_preserves_column_order(self):
+        df = pd.DataFrame({"x": [1], "y": [2], "z": [3]})
+        frame = ar.from_pandas(df)
+        result = frame.drop_columns(["y"])
+        assert result.columns == ["x", "z"]
+
+    def test_drop_empty_list_returns_copy(self):
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        frame = ar.from_pandas(df)
+        result = frame.drop_columns([])
+        assert result.columns == ["a", "b"]
+        assert result.shape == frame.shape
+
+    def test_drop_all_columns_returns_empty_frame(self):
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        frame = ar.from_pandas(df)
+        result = frame.drop_columns(["a", "b"])
+        assert result.columns == []
+        assert result.shape[1] == 0
+
+    def test_drop_duplicate_names_in_cols(self):
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+        frame = ar.from_pandas(df)
+        result = frame.drop_columns(["a", "a"])
+        assert result.columns == ["b", "c"]
+
+    def test_drop_unknown_column_raises_value_error(self):
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(ValueError, match="Unknown column"):
+            frame.drop_columns(["z"])
+
+    def test_drop_non_list_raises_type_error(self):
+        df = pd.DataFrame({"a": [1]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="cols must be a list"):
+            frame.drop_columns("a")
+
+    def test_drop_non_string_items_raises_type_error(self):
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="strings"):
+            frame.drop_columns([1, 2])
+
+    def test_drop_does_not_mutate_original(self):
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        frame = ar.from_pandas(df)
+        frame.drop_columns(["a"])
+        assert frame.columns == ["a", "b"]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -495,7 +495,7 @@ class TestDropColumns:
         frame = ar.from_pandas(df)
         result = frame.drop_columns(["a", "b"])
         assert result.columns == []
-        assert result.shape[1] == 0
+        assert result.shape == (1, 0)
 
     def test_drop_duplicate_names_in_cols(self):
         df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})


### PR DESCRIPTION
## Summary
Fixes #219

Users can now remove columns from an ArFrame without writing a custom pipeline step.

## Changes
- Added `ArFrame.drop_columns(cols: list[str])` method in `arnio/frame.py`

## Behaviour
- Returns a new ArFrame (original is not mutated)
- Preserves remaining column order
- Empty list returns a copy of the frame unchanged
- Duplicate names in cols are silently ignored
- Unknown column name raises `ValueError`
- Non-list input or non-string items raise `TypeError`
- Dropping all columns returns an empty ArFrame

## Tests added in `tests/test_frame.py`
- Drop single column
- Drop multiple columns
- Preserve column order
- Empty list returns copy
- Drop all columns
- Duplicate names in cols
- Unknown column raises ValueError
- Non-list input raises TypeError
- Non-string items raise TypeError
- Original frame not mutated

## Checklist
- [x] Behavior implemented
- [x] Tests cover normal, edge, and invalid cases
- [x] Existing tests pass
- [x] PR linked with Fixes #219