### PR TITLE
feat: add configurable bad-line handling for malformed row widths

### DIFF
--- a/arnio/_arnio_cpp.pyi
+++ b/arnio/_arnio_cpp.pyi
@@ -6,6 +6,7 @@ from typing import Any, overload
 import numpy as np
 
 __all__ = [
+    "BadRow",
     "DType",
     "Column",
     "Frame",
@@ -25,6 +26,14 @@ __all__ = [
     "combine_columns",
     "strip_whitespace",
 ]
+
+class BadRow:
+    # File-global 1-based logical row number (excludes header).
+    row: int
+    # Expected number of fields for the row.
+    expected: int
+    # Number of fields actually parsed from the row.
+    actual: int
 
 class DType:
     STRING: DType
@@ -105,12 +114,16 @@ class CsvConfig:
 class CsvChunkReader:
     def __init__(self, config: CsvConfig | None = None) -> None: ...
     def open(self, path: str) -> None: ...
-    def next_chunk(self, chunk_size: int) -> Frame | None: ...
+    def next_chunk(
+        self, chunksize: int, on_bad_lines: str = "error"
+    ) -> tuple[Frame, list[BadRow]] | None: ...
     def close(self) -> None: ...
 
 class CsvReader:
     def __init__(self, config: CsvConfig | None = None) -> None: ...
-    def read(self, path: str) -> Frame: ...
+    def read(
+        self, path: str, on_bad_lines: str = "error"
+    ) -> tuple[Frame, list[BadRow]]: ...
     def scan_schema(self, path: str) -> Mapping[str, str]: ...
 
 class CsvWriteConfig:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -9,6 +9,7 @@ import io
 import os
 import shutil
 import tempfile
+import warnings
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from typing import cast
@@ -258,6 +259,25 @@ def _validate_nrows(nrows: int) -> int:
     return nrows
 
 
+_PREVIEW_BAD_ROWS = 10
+
+
+def _warn_bad_rows(bad_rows: list) -> None:
+    """Emit a UserWarning summarizing rows dropped by on_bad_lines='warn'."""
+    lines = [
+        f"  CSV row {br.row} has {br.actual} fields; expected {br.expected}"
+        for br in bad_rows[:_PREVIEW_BAD_ROWS]
+    ]
+    extra = len(bad_rows) - _PREVIEW_BAD_ROWS
+    if extra > 0:
+        lines.append(f"  (+{extra} more)")
+    warnings.warn(
+        f"{len(bad_rows)} malformed CSV row(s):\n" + "\n".join(lines),
+        UserWarning,
+        stacklevel=3,
+    )
+
+
 def _validate_skip_rows(skip_rows: int) -> int:
     """Validate skip_rows parameter."""
     if isinstance(skip_rows, bool) or not isinstance(skip_rows, int):
@@ -311,6 +331,14 @@ def _validate_parser_mode(mode: str) -> str:
     if mode not in {"strict", "permissive"}:
         raise ValueError("mode must be either 'strict' or 'permissive'")
     return mode
+
+
+def _validate_on_bad_lines(on_bad_lines: str) -> str:
+    if not isinstance(on_bad_lines, str):
+        raise TypeError("on_bad_lines must be a string")
+    if on_bad_lines not in {"error", "warn", "skip"}:
+        raise ValueError("on_bad_lines must be either 'error', 'warn', 'skip'")
+    return on_bad_lines
 
 
 def _materialize_csv_input(
@@ -406,6 +434,7 @@ def read_csv(
     dtype: dict[str, str] | None = None,
     mode: str = "strict",
     encoding_errors: str = "strict",
+    on_bad_lines: str = "error",
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -470,6 +499,17 @@ def read_csv(
         - both modes reject extra fields because they would otherwise be
           silently dropped.
 
+    on_bad_lines : {"error", "warn", "skip"}, default "error"
+        Action to take on rows classified as bad by ``mode``.
+
+        - error: raise CsvReadError on the first bad row.
+        - warn: drop the row and emit a UserWarning.
+        - skip: drop the row silently.
+
+        In permissive mode, narrow rows are still padded silently and do
+        not reach this dispatch; only wide rows do. Dropped rows count
+        toward ``nrows``.
+
     Returns
     -------
     ArFrame
@@ -511,6 +551,7 @@ def read_csv(
     delimiter = _validate_delimiter(delimiter)
     mode = _validate_parser_mode(mode)
     encoding_errors = _validate_encoding_errors(encoding_errors)
+    on_bad_lines = _validate_on_bad_lines(on_bad_lines)
     config = _CsvConfig()
     config.delimiter = delimiter
     config.has_header = _validate_bool_option(has_header, "has_header")
@@ -540,7 +581,11 @@ def read_csv(
         with _utf8_csv_path(
             path, encoding, encoding_errors=encoding_errors, delimiter=delimiter
         ) as native_path:
-            cpp_frame = reader.read(native_path)
+            cpp_frame, bad_rows = reader.read(native_path, on_bad_lines)
+
+        # on_bad_lines == "error" will raise RuntimeError then converted to CsvReadError as before
+        if on_bad_lines == "warn" and bad_rows:
+            _warn_bad_rows(bad_rows)
 
         return ArFrame(cpp_frame)
 
@@ -571,6 +616,7 @@ def read_csv_chunked(
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
     mode: str = "strict",
+    on_bad_lines: str = "error",
 ) -> Iterator[ArFrame]:
     """Read a CSV file in chunks, yielding ArFrame objects.
 
@@ -612,6 +658,16 @@ def read_csv_chunked(
         Controls malformed row handling.
         Both modes reject extra fields; permissive mode only allows missing
         trailing fields, which are filled with nulls.
+    on_bad_lines : {"error", "warn", "skip"}, default "error"
+        Action to take on rows classified as bad by ``mode``.
+
+        - error: raise CsvReadError on the first bad row.
+        - warn: drop the row and emit a UserWarning.
+        - skip: drop the row silently.
+
+        In permissive mode, narrow rows are still padded silently and do
+        not reach this dispatch; only wide rows do. Dropped rows count
+        toward ``nrows``.
 
     Yields
     ------
@@ -648,6 +704,7 @@ def read_csv_chunked(
     mode = _validate_parser_mode(mode)
     chunksize = _validate_chunksize(chunksize)
     skip_rows = _validate_skip_rows(skip_rows)
+    on_bad_lines = _validate_on_bad_lines(on_bad_lines)
 
     config = _CsvConfig()
     config.delimiter = delimiter
@@ -673,9 +730,14 @@ def read_csv_chunked(
         with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
             reader.open(native_path)
             while True:
-                cpp_frame = reader.next_chunk(chunksize)
-                if cpp_frame is None:
+                chunk = reader.next_chunk(chunksize, on_bad_lines)
+                if chunk is None:
                     break
+                cpp_frame, bad_rows = chunk
+
+                if on_bad_lines == "warn" and bad_rows:
+                    _warn_bad_rows(bad_rows)
+
                 yield ArFrame(cpp_frame)
     except ValueError:
         raise

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -235,6 +235,11 @@ PYBIND11_MODULE(_arnio_cpp, m) {
             py::arg("row_count") = py::none());
 
     // --- CsvReader ---
+    py::class_<BadRow>(m, "BadRow")
+        .def_readonly("row", &BadRow::row)
+        .def_readonly("expected", &BadRow::expected)
+        .def_readonly("actual", &BadRow::actual);
+
     py::class_<CsvConfig>(m, "CsvConfig")
         .def(py::init<>())
         .def_readwrite("delimiter", &CsvConfig::delimiter)
@@ -254,11 +259,18 @@ PYBIND11_MODULE(_arnio_cpp, m) {
 
     py::class_<CsvReader>(m, "CsvReader")
         .def(py::init<const CsvConfig&>(), py::arg("config") = CsvConfig{})
-        .def("read",
-             [](const CsvReader& reader, const std::string& path) {
-                 py::gil_scoped_release release;
-                 return reader.read(path);
-             })
+        .def(
+            "read",
+            [](const CsvReader& reader, const std::string& path, const std::string& on_bad_lines) {
+                CsvParseResult result;
+                {
+                    py::gil_scoped_release release;
+                    result = reader.read(path, on_bad_lines);
+                }
+
+                return py::make_tuple(std::move(result.frame), std::move(result.bad_rows));
+            },
+            py::arg("path"), py::arg("on_bad_lines") = std::string("error"))
         .def("scan_schema", [](const CsvReader& reader, const std::string& path) {
             std::vector<std::pair<std::string, std::string>> result;
             {
@@ -279,18 +291,21 @@ PYBIND11_MODULE(_arnio_cpp, m) {
                  py::gil_scoped_release release;
                  reader.open(path);
              })
-        .def("next_chunk",
-             [](CsvChunkReader& reader, size_t chunksize) -> py::object {
-                 std::optional<Frame> result;
-                 {
-                     py::gil_scoped_release release;
-                     result = reader.next_chunk(chunksize);
-                 }
-                 if (!result.has_value()) {
-                     return py::none();
-                 }
-                 return py::cast(std::move(*result));
-             })
+        .def(
+            "next_chunk",
+            [](CsvChunkReader& reader, size_t chunksize,
+               const std::string& on_bad_lines) -> py::object {
+                std::optional<CsvParseResult> result;
+                {
+                    py::gil_scoped_release release;
+                    result = reader.next_chunk(chunksize, on_bad_lines);
+                }
+                if (!result.has_value()) {
+                    return py::none();
+                }
+                return py::make_tuple(std::move(result->frame), std::move(result->bad_rows));
+            },
+            py::arg("chunksize"), py::arg("on_bad_lines") = std::string("error"))
         .def("close", &CsvChunkReader::close);
 
     // --- CsvWriter ---

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -29,6 +29,17 @@ struct CsvConfig {
     std::string encoding_errors = "strict";
 };
 
+struct BadRow {
+    size_t row;
+    size_t expected;
+    size_t actual;
+};
+
+struct CsvParseResult {
+    Frame frame;
+    std::vector<BadRow> bad_rows;
+};
+
 // Shared CSV field parsing and type inference used by CsvReader and CsvChunkReader.
 class CsvParser {
    public:
@@ -52,7 +63,7 @@ class CsvReader {
     explicit CsvReader(const CsvConfig& config = CsvConfig{});
 
     // Read full CSV into a Frame
-    Frame read(const std::string& path) const;
+    CsvParseResult read(const std::string& path, const std::string& on_bad_lines = "error") const;
 
     // Scan schema only (column names + inferred types)
     std::vector<std::pair<std::string, std::string>> scan_schema(const std::string& path) const;
@@ -68,7 +79,8 @@ class CsvChunkReader {
     ~CsvChunkReader();
 
     void open(const std::string& path);
-    std::optional<Frame> next_chunk(size_t chunksize);
+    std::optional<CsvParseResult> next_chunk(size_t chunksize,
+                                             const std::string& on_bad_lines = "error");
     void close();
 
    private:
@@ -86,7 +98,9 @@ class CsvChunkReader {
     std::unique_ptr<class RecordReader> record_reader_;
 
     void resolve_col_indices();
-    bool read_one_data_row(std::vector<std::string>& fields_out);
+    bool read_one_data_row(std::vector<std::string>& fields_out,
+                           const std::string& on_bad_lines = "error",
+                           std::vector<BadRow>* bad_rows_out = nullptr);
     Frame build_frame(const std::vector<std::vector<std::string>>& raw_data) const;
 };
 

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -656,9 +656,11 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype) const {
     }
 }
 
-Frame CsvReader::read(const std::string& path) const {
+CsvParseResult CsvReader::read(const std::string& path, const std::string& on_bad_lines) const {
     const CsvConfig& config = parser_.config();
     std::ifstream file(std::filesystem::u8path(path), std::ios::binary);
+    std::vector<BadRow> bad_rows;
+
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
     }
@@ -708,7 +710,7 @@ Frame CsvReader::read(const std::string& path) const {
     while (record_reader.read(line, line_number)) {
         ++record_number;
 
-        if (config.nrows.has_value() && row_count >= config.nrows.value()) {
+        if (config.nrows.has_value() && (row_count + bad_rows.size()) >= config.nrows.value()) {
             break;
         }
 
@@ -722,10 +724,17 @@ Frame CsvReader::read(const std::string& path) const {
             expected_cols = reusable_fields.size();
         }
 
-        if (expected_cols.has_value()) {
+        if (expected_cols.has_value() && reusable_fields.size() != expected_cols.value()) {
             const size_t expected = expected_cols.value();
-            if (reusable_fields.size() > expected || config.mode == "strict") {
-                validate_row_width(record_number, expected, reusable_fields.size());
+            const size_t actual = reusable_fields.size();
+            // The definition of "bad rows" will remain the same as before for consistency.
+            if (actual > expected || config.mode == "strict") {
+                if (on_bad_lines == "error") {
+                    validate_row_width(record_number, expected, actual);
+                }
+                // on_bad_lines='warn' also skips the row to be consistent with pandas
+                bad_rows.push_back(BadRow{record_number, expected, actual});
+                continue;
             }
         }
 
@@ -822,7 +831,7 @@ Frame CsvReader::read(const std::string& path) const {
         columns.push_back(std::move(col));
     }
 
-    return Frame(std::move(columns));
+    return CsvParseResult{Frame(std::move(columns)), std::move(bad_rows)};
 }
 
 std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
@@ -936,7 +945,9 @@ void CsvChunkReader::resolve_col_indices() {
     }
 }
 
-bool CsvChunkReader::read_one_data_row(std::vector<std::string>& fields_out) {
+bool CsvChunkReader::read_one_data_row(std::vector<std::string>& fields_out,
+                                       const std::string& on_bad_lines,
+                                       std::vector<BadRow>* bad_rows_out) {
     const CsvConfig& config = parser_.config();
     std::string line;
     while (record_reader_->read(line)) {
@@ -952,10 +963,17 @@ bool CsvChunkReader::read_one_data_row(std::vector<std::string>& fields_out) {
             expected_cols_ = fields_out.size();
         }
 
-        if (expected_cols_.has_value()) {
+        if (expected_cols_.has_value() && expected_cols_.value() != fields_out.size()) {
             const size_t expected = expected_cols_.value();
-            if (fields_out.size() > expected || config.mode == "strict") {
-                validate_row_width(record_number_, expected, fields_out.size());
+            const size_t actual = fields_out.size();
+            if (actual > expected || config.mode == "strict") {
+                if (on_bad_lines == "error") {
+                    validate_row_width(record_number_, expected, actual);
+                }
+                if (bad_rows_out != nullptr) {
+                    bad_rows_out->push_back(BadRow{record_number_, expected, actual});
+                }
+                continue;
             }
         }
 
@@ -1036,7 +1054,8 @@ void CsvChunkReader::open(const std::string& path) {
     }
 }
 
-std::optional<Frame> CsvChunkReader::next_chunk(size_t chunksize) {
+std::optional<CsvParseResult> CsvChunkReader::next_chunk(size_t chunksize,
+                                                         const std::string& on_bad_lines) {
     if (!opened_) {
         throw std::runtime_error("CsvChunkReader is not open");
     }
@@ -1056,11 +1075,12 @@ std::optional<Frame> CsvChunkReader::next_chunk(size_t chunksize) {
     }
 
     std::vector<std::vector<std::string>> raw_data;
+    std::vector<BadRow> bad_rows;
     raw_data.reserve(limit);
 
-    while (raw_data.size() < limit) {
+    while (raw_data.size() + bad_rows.size() < limit) {
         std::vector<std::string> fields;
-        if (!read_one_data_row(fields)) {
+        if (!read_one_data_row(fields, on_bad_lines, &bad_rows)) {
             break;
         }
         raw_data.push_back(std::move(fields));
@@ -1096,8 +1116,8 @@ std::optional<Frame> CsvChunkReader::next_chunk(size_t chunksize) {
         schema_locked_ = true;
     }
 
-    rows_read_total_ += raw_data.size();
-    return build_frame(raw_data);
+    rows_read_total_ += raw_data.size() + bad_rows.size();
+    return CsvParseResult{build_frame(raw_data), std::move(bad_rows)};
 }
 
 void CsvChunkReader::close() {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -1087,7 +1087,11 @@ std::optional<CsvParseResult> CsvChunkReader::next_chunk(size_t chunksize,
     }
 
     if (raw_data.empty()) {
-        return std::nullopt;
+        if (bad_rows.empty()) {
+            return std::nullopt;
+        }
+        rows_read_total_ += bad_rows.size();
+        return CsvParseResult{build_frame(raw_data), std::move(bad_rows)};
     }
 
     if (!header_finalized_) {

--- a/tests/test_csv_on_bad_lines.py
+++ b/tests/test_csv_on_bad_lines.py
@@ -353,9 +353,7 @@ class TestOnBadLinesQuotedDelimiters:
 class TestOnBadLinesMultilineRecords:
     def test_multiline_record_is_not_classified_bad(self, tmp_path):
         csv_path = tmp_path / "multiline_good.csv"
-        # The "line1\nline2" field spans two physical lines but is one logical
-        # record with 3 fields.
-        csv_path.write_text('a,b,c\n"line1\nline2",p,q\n1,2,3\n')
+        csv_path.write_bytes(b'a,b,c\n"line1\nline2",p,q\n1,2,3\n')
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             frame = ar.read_csv(csv_path, on_bad_lines="warn")

--- a/tests/test_csv_on_bad_lines.py
+++ b/tests/test_csv_on_bad_lines.py
@@ -1,0 +1,464 @@
+"""Tests for the on_bad_lines parameter on read_csv / read_csv_chunked.
+
+Covers:
+- error / warn / skip semantics for both narrow and wide width mismatches
+- interaction with the legacy `mode` parameter (strict vs permissive)
+- UserWarning content and truncation
+- chunked-reader behavior including trailing-bad-rows-at-EOF
+- nrows budgeting counts bad rows
+- argument validation
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import arnio as ar
+from arnio.io import _PREVIEW_BAD_ROWS
+
+
+class TestOnBadLinesValidation:
+    def test_invalid_value_rejected_before_read(self, tmp_path):
+        csv_path = tmp_path / "ok.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(
+            ValueError, match="on_bad_lines must be either 'error', 'warn', 'skip'"
+        ):
+            ar.read_csv(csv_path, on_bad_lines="raise")
+
+    def test_invalid_value_rejected_in_chunked(self, tmp_path):
+        csv_path = tmp_path / "ok.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(ValueError, match="on_bad_lines must be either"):
+            list(ar.read_csv_chunked(csv_path, on_bad_lines="ignore"))
+
+    def test_non_string_rejected(self, tmp_path):
+        csv_path = tmp_path / "ok.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(TypeError, match="on_bad_lines must be a string"):
+            ar.read_csv(csv_path, on_bad_lines=None)
+
+
+class TestReadCsvOnBadLinesError:
+    def test_error_is_default(self, tmp_path):
+        csv_path = tmp_path / "narrow.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n")
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 2 fields; expected 3"):
+            ar.read_csv(csv_path)
+
+    def test_explicit_error_matches_default(self, tmp_path):
+        csv_path = tmp_path / "narrow.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n")
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 2 fields; expected 3"):
+            ar.read_csv(csv_path, on_bad_lines="error")
+
+    def test_error_raises_on_wide_row(self, tmp_path):
+        csv_path = tmp_path / "wide.csv"
+        csv_path.write_text("a,b\n1,2\n3,4,5\n")
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 3 fields; expected 2"):
+            ar.read_csv(csv_path, on_bad_lines="error")
+
+    def test_error_raises_on_first_bad_row(self, tmp_path):
+        """Multiple bad rows — error stops at the first."""
+        csv_path = tmp_path / "many.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8,9\n")
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 2 fields; expected 3"):
+            ar.read_csv(csv_path, on_bad_lines="error")
+
+
+class TestReadCsvOnBadLinesWarn:
+    def test_warn_drops_bad_row_and_emits_warning(self, tmp_path):
+        csv_path = tmp_path / "warn.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (2, 3)
+        assert len(caught) == 1
+        assert caught[0].category is UserWarning
+        msg = str(caught[0].message)
+        assert "1 malformed CSV row(s)" in msg
+        assert "CSV row 3 has 2 fields; expected 3" in msg
+
+    def test_warn_collects_all_bad_rows(self, tmp_path):
+        """warn does NOT short-circuit — all bad rows surface in one warning."""
+        csv_path = tmp_path / "many_bad.csv"
+        csv_path.write_text(
+            "a,b,c\n"
+            "1,2,3\n"  # good
+            "4,5\n"  # narrow
+            "6,7,8,9\n"  # wide
+            "10,11,12\n"  # good
+            "13,14\n"  # narrow
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (2, 3)
+        assert len(caught) == 1
+        msg = str(caught[0].message)
+        assert "3 malformed CSV row(s)" in msg
+        assert "CSV row 3 has 2 fields; expected 3" in msg
+        assert "CSV row 4 has 4 fields; expected 3" in msg
+        assert "CSV row 6 has 2 fields; expected 3" in msg
+
+    def test_warn_no_warning_when_file_is_clean(self, tmp_path):
+        csv_path = tmp_path / "clean.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5,6\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (2, 3)
+        assert [w for w in caught if w.category is UserWarning] == []
+
+    def test_warn_message_uses_cpp_error_format(self, tmp_path):
+        """Per-row entries should match the C++ error message format exactly."""
+        csv_path = tmp_path / "format.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ar.read_csv(csv_path, on_bad_lines="warn")
+
+        msg = str(caught[0].message)
+        # Same shape as throw std::runtime_error("CSV row N has X fields; expected Y")
+        assert "CSV row 3 has 2 fields; expected 3" in msg
+
+    def test_warn_truncates_preview_with_more_indicator(self, tmp_path):
+        n_bad = _PREVIEW_BAD_ROWS + 3
+        rows = ["a,b,c", "1,2,3"]
+        rows.extend(f"bad_{i},only_two" for i in range(n_bad))
+        rows.append("9,9,9")
+        csv_path = tmp_path / "many.csv"
+        csv_path.write_text("\n".join(rows) + "\n")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (2, 3)
+        msg = str(caught[0].message)
+        assert f"{n_bad} malformed CSV row(s)" in msg
+        assert f"(+{n_bad - _PREVIEW_BAD_ROWS} more)" in msg
+        # First preview entry is present, last one beyond the preview is not.
+        assert "bad_0" not in msg  # field contents are not included
+        # The (PREVIEW+1)-th bad row should not appear by row-number either.
+        assert f"CSV row {_PREVIEW_BAD_ROWS + 2 + 1} has 2 fields" not in msg
+
+
+class TestReadCsvOnBadLinesSkip:
+    def test_skip_drops_bad_rows_silently(self, tmp_path):
+        csv_path = tmp_path / "skip.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8,9\n10,11,12\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="skip")
+
+        assert frame.shape == (2, 3)
+        assert [w for w in caught if w.category is UserWarning] == []
+
+
+class TestOnBadLinesModeInteraction:
+    def test_permissive_narrow_rows_do_not_reach_on_bad_lines(self, tmp_path):
+        """In permissive mode, narrow rows are padded silently regardless of
+        on_bad_lines — they never appear in bad_rows / warnings."""
+        csv_path = tmp_path / "permissive_narrow.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, mode="permissive", on_bad_lines="warn")
+
+        # Narrow row is padded and kept.
+        assert frame.shape == (3, 3)
+        # No warnings because the narrow row is not "bad" under permissive mode.
+        assert [w for w in caught if w.category is UserWarning] == []
+
+    def test_permissive_wide_rows_surface_to_on_bad_lines(self, tmp_path):
+        """Wide rows are always bad — permissive + warn drops them with a
+        UserWarning."""
+        csv_path = tmp_path / "permissive_wide.csv"
+        csv_path.write_text("a,b\n1,2\n3,4,5\n6,7\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, mode="permissive", on_bad_lines="warn")
+
+        assert frame.shape == (2, 2)
+        msg = str(caught[0].message)
+        assert "CSV row 3 has 3 fields; expected 2" in msg
+
+    def test_strict_with_warn_surfaces_both_narrow_and_wide(self, tmp_path):
+        csv_path = tmp_path / "strict_warn.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8,9\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, mode="strict", on_bad_lines="warn")
+
+        assert frame.shape == (1, 3)
+        msg = str(caught[0].message)
+        assert "CSV row 3 has 2 fields; expected 3" in msg
+        assert "CSV row 4 has 4 fields; expected 3" in msg
+
+    def test_permissive_with_default_error_preserves_legacy(self, tmp_path):
+        """mode=permissive + on_bad_lines=error: narrow rows pad silently,
+        wide rows raise. Matches pre-on_bad_lines behavior exactly."""
+        csv_path = tmp_path / "legacy.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n")
+        frame = ar.read_csv(csv_path, mode="permissive")  # default on_bad_lines
+        assert frame.shape == (2, 3)
+
+        csv_path.write_text("a,b\n1,2\n3,4,5\n")
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 3 fields; expected 2"):
+            ar.read_csv(csv_path, mode="permissive")
+
+
+class TestNrowsBudgeting:
+    def test_bad_rows_count_toward_nrows(self, tmp_path):
+        csv_path = tmp_path / "nrows.csv"
+        csv_path.write_text(
+            "a,b,c\n"
+            "1,2,3\n"  # row 2: good
+            "4,5\n"  # row 3: bad
+            "6,7,8\n"  # row 4: good
+            "9,10,11\n"  # row 5: good (should be excluded by nrows=3)
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, nrows=3, on_bad_lines="warn")
+
+        # nrows=3 covers rows 2, 3, 4 in input order; row 3 is bad and dropped,
+        # so the frame holds 2 good rows.
+        assert frame.shape == (2, 3)
+        msg = str(caught[0].message)
+        assert "CSV row 3 has 2 fields; expected 3" in msg
+
+
+class TestReadCsvChunkedOnBadLines:
+    def test_chunked_error_raises_on_first_bad_row(self, tmp_path):
+        csv_path = tmp_path / "chunked_err.csv"
+        csv_path.write_text("a,b\n1,2\n3,4,5\n6,7\n")
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 3 fields; expected 2"):
+            list(ar.read_csv_chunked(csv_path, chunksize=10, on_bad_lines="error"))
+
+    def test_chunked_warn_emits_warning(self, tmp_path):
+        csv_path = tmp_path / "chunked_warn.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frames = list(
+                ar.read_csv_chunked(csv_path, chunksize=10, on_bad_lines="warn")
+            )
+
+        assert len(frames) == 1
+        assert frames[0].shape == (2, 3)
+        assert any(w.category is UserWarning for w in caught)
+
+    def test_chunked_skip_silent(self, tmp_path):
+        csv_path = tmp_path / "chunked_skip.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frames = list(
+                ar.read_csv_chunked(csv_path, chunksize=10, on_bad_lines="skip")
+            )
+        assert sum(f.shape[0] for f in frames) == 2
+        assert [w for w in caught if w.category is UserWarning] == []
+
+    def test_chunked_trailing_bad_row_at_eof_is_surfaced(self, tmp_path):
+        """Regression: bad row at EOF used to be silently dropped because
+        next_chunk returned nullopt when raw_data was empty."""
+        csv_path = tmp_path / "trailing.csv"
+        csv_path.write_text(
+            "a,b,c\n"
+            "1,2,3\n"  # good
+            "4,5\n"  # bad
+            "6,7,8,9\n"  # bad
+            "10,11,12\n"  # good
+            "13,14\n"  # bad, trailing
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frames = list(
+                ar.read_csv_chunked(csv_path, chunksize=2, on_bad_lines="warn")
+            )
+
+        # All three bad rows must appear in the aggregated warnings.
+        joined = "\n".join(str(w.message) for w in caught)
+        assert "CSV row 3 has 2 fields; expected 3" in joined
+        assert "CSV row 4 has 4 fields; expected 3" in joined
+        assert "CSV row 6 has 2 fields; expected 3" in joined
+        # And both good rows must be kept across the yielded chunks.
+        assert sum(f.shape[0] for f in frames) == 2
+
+    def test_chunked_all_bad_after_header_yields_empty_frame_with_warning(
+        self, tmp_path
+    ):
+        """Header sets expected_cols but every data row is malformed. The
+        reader must still surface the bad rows via a final empty-frame chunk."""
+        csv_path = tmp_path / "all_bad.csv"
+        csv_path.write_text("a,b,c\nx,y\np,q,r,s\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frames = list(
+                ar.read_csv_chunked(csv_path, chunksize=10, on_bad_lines="warn")
+            )
+
+        assert len(frames) == 1
+        assert frames[0].shape == (0, 3)
+        assert frames[0].columns == ["a", "b", "c"]
+        msg = "\n".join(str(w.message) for w in caught)
+        assert "CSV row 2 has 2 fields; expected 3" in msg
+
+
+class TestOnBadLinesQuotedDelimiters:
+    def test_quoted_delimiter_is_not_classified_bad(self, tmp_path):
+        csv_path = tmp_path / "quoted.csv"
+        # The first data row contains a comma *inside* a quoted field — it must
+        # parse as 3 fields, not 4.
+        csv_path.write_text('a,b,c\n"x,y",p,q\n1,2,3\n')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (2, 3)
+        assert [w for w in caught if w.category is UserWarning] == []
+        import arnio as _ar  # noqa: F401  (frame ops happen via ar.to_pandas)
+
+        df = ar.to_pandas(frame)
+        assert df["a"].iloc[0] == "x,y"
+
+    def test_bad_row_among_quoted_rows_still_caught(self, tmp_path):
+        """Mix quoted-delimiter rows (good) with a genuinely malformed row;
+        only the malformed row should appear in the warning."""
+        csv_path = tmp_path / "mixed_quoted.csv"
+        csv_path.write_text(
+            "a,b,c\n"
+            '"x,y",p,q\n'  # row 2: good (quoted comma)
+            "1,2\n"  # row 3: bad narrow
+            '"w",e,r\n'  # row 4: good (lone-quoted field)
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (2, 3)
+        msg = str(caught[0].message)
+        assert "1 malformed CSV row(s)" in msg
+        assert "CSV row 3 has 2 fields; expected 3" in msg
+
+
+class TestOnBadLinesMultilineRecords:
+    def test_multiline_record_is_not_classified_bad(self, tmp_path):
+        csv_path = tmp_path / "multiline_good.csv"
+        # The "line1\nline2" field spans two physical lines but is one logical
+        # record with 3 fields.
+        csv_path.write_text('a,b,c\n"line1\nline2",p,q\n1,2,3\n')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (2, 3)
+        assert [w for w in caught if w.category is UserWarning] == []
+        df = ar.to_pandas(frame)
+        assert df["a"].iloc[0] == "line1\nline2"
+
+    def test_bad_row_after_multiline_uses_logical_row_number(self, tmp_path):
+        """Row-number accounting must increment by logical records, not by
+        physical lines. A bad row after a 3-line multiline record at the top
+        is still 'row 3' in 1-based logical numbering (header is row 1)."""
+        csv_path = tmp_path / "multiline_bad.csv"
+        csv_path.write_text(
+            "a,b,c\n"  # logical row 1 (header)
+            '"line1\nline2\nline3",p,q\n'  # logical row 2 (good, spans 3 physical lines)
+            "4,5\n"  # logical row 3 (bad narrow)
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+        assert frame.shape == (1, 3)
+        msg = str(caught[0].message)
+        # The number reported is the logical record (3), not the physical
+        # line in the file (which would be 5).
+        assert "CSV row 3 has 2 fields; expected 3" in msg
+
+    def test_multiline_record_across_chunk_boundaries(self, tmp_path):
+        """A multiline record must remain atomic — never split across chunks —
+        and any bad row that follows must still be reported with its global
+        logical row number."""
+        csv_path = tmp_path / "multiline_chunked.csv"
+        csv_path.write_text(
+            "a,b,c\n"  # logical row 1
+            "1,2,3\n"  # logical row 2 (good)
+            '"x\ny\nz",p,q\n'  # logical row 3 (good, multiline)
+            "4,5\n"  # logical row 4 (bad narrow)
+            "6,7,8\n"  # logical row 5 (good)
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frames = list(
+                ar.read_csv_chunked(csv_path, chunksize=2, on_bad_lines="warn")
+            )
+
+        # 3 good logical rows preserved across chunks.
+        assert sum(f.shape[0] for f in frames) == 3
+        joined = "\n".join(str(w.message) for w in caught)
+        # Bad row reports its file-global logical row number.
+        assert "CSV row 4 has 2 fields; expected 3" in joined
+
+
+class TestOnBadLinesUsecols:
+    def test_bad_row_detected_before_usecols_projection(self, tmp_path):
+        """Header has 4 columns; user selects 2 via usecols. A row with 3
+        fields is still bad (expected=4), even though both selected columns
+        happen to be present in the truncated row."""
+        csv_path = tmp_path / "usecols_bad.csv"
+        csv_path.write_text(
+            "a,b,c,d\n"
+            "1,2,3,4\n"  # row 2: good (4 fields)
+            "5,6,7\n"  # row 3: bad (3 fields; even though usecols=[a,b]
+            #          would only see 'a','b', expected is 4)
+            "8,9,10,11\n"  # row 4: good
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frame = ar.read_csv(csv_path, usecols=["a", "b"], on_bad_lines="warn")
+
+        # Projection happens AFTER bad-row dispatch — frame has the requested
+        # 2 columns, with the 2 good rows kept.
+        assert frame.shape == (2, 2)
+        assert frame.columns == ["a", "b"]
+        msg = str(caught[0].message)
+        # The expected count reflects the full header width (4), not the
+        # usecols subset (2).
+        assert "CSV row 3 has 3 fields; expected 4" in msg
+
+    def test_usecols_error_mode_uses_full_width(self, tmp_path):
+        """In error mode, the raise message must report the full expected
+        width, not the usecols-projected width."""
+        csv_path = tmp_path / "usecols_err.csv"
+        csv_path.write_text("a,b,c,d\n1,2,3,4\n5,6,7\n")
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 3 fields; expected 4"):
+            ar.read_csv(csv_path, usecols=["a", "b"])
+
+    def test_usecols_with_chunked_warn(self, tmp_path):
+        csv_path = tmp_path / "usecols_chunked.csv"
+        csv_path.write_text("a,b,c,d\n" "1,2,3,4\n" "5,6,7\n" "8,9,10,11\n")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            frames = list(
+                ar.read_csv_chunked(
+                    csv_path,
+                    usecols=["a", "d"],
+                    chunksize=10,
+                    on_bad_lines="warn",
+                )
+            )
+
+        assert sum(f.shape[0] for f in frames) == 2
+        assert frames[0].columns == ["a", "d"]
+        joined = "\n".join(str(w.message) for w in caught)
+        assert "CSV row 3 has 3 fields; expected 4" in joined


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->
Add an `on_bad_lines` option to `read_csv()` and `next_chunk()`.
```
ar.read_csv(path, on_bad_lines="error")  # default
ar.read_csv(path, on_bad_lines="warn")
ar.read_csv(path, on_bad_lines="skip")
```

Behavior:
```
error: raise CsvReadError with row number and field counts.
warn: keep best-effort parsing and emit UserWarning with row details.
skip: skip malformed rows silently.
```
<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
Fixes #945 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [x] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test`
- [x] `make lint`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
