### PR TITLE
feat: add verbose progress mode for read_csv and read_csv_chunked

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -406,6 +406,7 @@ def read_csv(
     dtype: dict[str, str] | None = None,
     mode: str = "strict",
     encoding_errors: str = "strict",
+    verbose: bool = False,
 ) -> ArFrame:
     """Read a CSV file into an ArFrame via C++ backend.
 
@@ -469,6 +470,10 @@ def read_csv(
         - permissive: fills missing trailing fields with nulls.
         - both modes reject extra fields because they would otherwise be
           silently dropped.
+
+    verbose : bool, default False
+        If True, prints progress information during CSV reading,
+        including the file path and number of rows loaded.
 
     Returns
     -------
@@ -542,6 +547,11 @@ def read_csv(
         ) as native_path:
             cpp_frame = reader.read(native_path)
 
+        if verbose:
+            print(f"[arnio] Reading: {path}")
+            frame = ArFrame(cpp_frame)
+            print(f"[arnio] Done! {len(frame)} rows loaded.")
+            return frame
         return ArFrame(cpp_frame)
 
     except ValueError:
@@ -571,6 +581,7 @@ def read_csv_chunked(
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
     mode: str = "strict",
+    verbose: bool = False,
 ) -> Iterator[ArFrame]:
     """Read a CSV file in chunks, yielding ArFrame objects.
 
@@ -676,7 +687,10 @@ def read_csv_chunked(
                 cpp_frame = reader.next_chunk(chunksize)
                 if cpp_frame is None:
                     break
-                yield ArFrame(cpp_frame)
+                chunk = ArFrame(cpp_frame)
+                if verbose:
+                    print(f"[arnio] Chunk loaded: {len(chunk)} rows")
+                yield chunk
     except ValueError:
         raise
     except CsvReadError:


### PR DESCRIPTION
## Summary
Added optional `verbose=True` parameter to `read_csv` and `read_csv_chunked` functions. When enabled, prints real-time progress info (file path + row count) during long-running CSV operations. Defaults to `False` so existing code is fully backward compatible.

## Linked issue
Fixes #1026

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: Tested locally with StringIO input and verbose=True

Output observed:
<img width="601" height="73" alt="Screenshot 2026-05-22 at 9 24 59 AM" src="https://github.com/user-attachments/assets/89e3b2f7-508a-480f-856c-1e14ed6e4881" />

## Screenshots / Media
<img width="1202" height="146" alt="image" src="https://github.com/user-attachments/assets/37906d28-37a0-44db-9d44-b48709c65114" />

## Performance Impact
No performance impact when `verbose=False` (default). Minimal overhead when `verbose=True` — only two print statements added.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
This is a non-breaking additive change. The `verbose` parameter defaults to `False`, so no existing code is affected.