### PR TITLE
fix(cleaning): rename_columns raises clear TypeError with received ty…

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -140,7 +140,7 @@ def _validate_string_mapping(
 ) -> dict[str, str]:
     if not isinstance(mapping, Mapping):
         raise TypeError(
-            f"{argument_name} must be a dict mapping column names to strings, "
+            f"{argument_name} must be a mapping of string keys to strings, "
             f"got {type(mapping).__name__!r}"
         )
 

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -138,14 +138,15 @@ def _validate_string_mapping(
     argument_name: str,
     allow_empty: bool = True,
 ) -> dict[str, str]:
-    normalized = _validate_mapping(
-        mapping,
-        argument_name=argument_name,
-        allow_empty=allow_empty,
-        non_mapping_message=(
-            f"{argument_name} must be a mapping of string keys to strings"
-        ),
-    )
+    if not isinstance(mapping, Mapping):
+        raise TypeError(
+            f"{argument_name} must be a dict mapping column names to strings, "
+            f"got {type(mapping).__name__!r}"
+        )
+
+    normalized = dict(mapping)
+    if not normalized and not allow_empty:
+        raise ValueError(f"{argument_name} must not be empty")
 
     invalid_keys = [key for key in normalized if not isinstance(key, str)]
     if invalid_keys:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1674,6 +1674,34 @@ class TestRenameColumns:
         ):
             ar.rename_columns(frame, {"name": "   "})
 
+    # --- Regression tests for non-dict mapping validation (bug fix) ---
+
+    def test_rename_rejects_none_with_clear_type_error(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        with pytest.raises(TypeError, match="'NoneType'"):
+            ar.rename_columns(frame, None)
+
+    def test_rename_rejects_list_of_tuples_with_clear_type_error(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        with pytest.raises(TypeError, match="'list'"):
+            ar.rename_columns(frame, [("name", "full_name")])
+
+    def test_rename_rejects_integer_with_clear_type_error(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        with pytest.raises(TypeError, match="'int'"):
+            ar.rename_columns(frame, 42)
+
+    def test_rename_rejects_string_with_clear_type_error(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        with pytest.raises(TypeError, match="'str'"):
+            ar.rename_columns(frame, "name:full_name")
+
+    def test_rename_valid_dict_still_works(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = ar.rename_columns(frame, {"name": "full_name"})
+        assert "full_name" in result.columns
+        assert "name" not in result.columns
+
 
 class TestTrimColumnNames:
     def test_trim_column_names_basic(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1678,22 +1678,22 @@ class TestRenameColumns:
 
     def test_rename_rejects_none_with_clear_type_error(self, sample_csv):
         frame = ar.read_csv(sample_csv)
-        with pytest.raises(TypeError, match="'NoneType'"):
+        with pytest.raises(TypeError, match="must be a mapping.*'NoneType'"):
             ar.rename_columns(frame, None)
 
     def test_rename_rejects_list_of_tuples_with_clear_type_error(self, sample_csv):
         frame = ar.read_csv(sample_csv)
-        with pytest.raises(TypeError, match="'list'"):
+        with pytest.raises(TypeError, match="must be a mapping.*'list'"):
             ar.rename_columns(frame, [("name", "full_name")])
 
     def test_rename_rejects_integer_with_clear_type_error(self, sample_csv):
         frame = ar.read_csv(sample_csv)
-        with pytest.raises(TypeError, match="'int'"):
+        with pytest.raises(TypeError, match="must be a mapping.*'int'"):
             ar.rename_columns(frame, 42)
 
     def test_rename_rejects_string_with_clear_type_error(self, sample_csv):
         frame = ar.read_csv(sample_csv)
-        with pytest.raises(TypeError, match="'str'"):
+        with pytest.raises(TypeError, match="must be a mapping.*'str'"):
             ar.rename_columns(frame, "name:full_name")
 
     def test_rename_valid_dict_still_works(self, sample_csv):


### PR DESCRIPTION
Summary

Fixes #581

rename_columns() previously raised a very generic error when a non-dict value was passed as mapping:

TypeError: mapping must be a mapping of string keys to strings

The error didn’t indicate what type was actually received. This PR improves the message by including the received type name.

Example:

TypeError: mapping must be a dict mapping column names to strings, got 'list'
Change

Updated _validate_string_mapping() to include the actual received type in the validation error message.

Tests

Added 5 regression tests covering:

None → error mentions 'NoneType'
list of tuples → error mentions 'list'
integer → error mentions 'int'
string → error mentions 'str'
valid dict input still works correctly