### PR TITLE
Clarify unsupported chunked schema validation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ export policy should stay explicit in the application that writes the file.
 
 `ar.validate()` returns a `ValidationResult`; it does not raise for validation failures. Check `result.passed` and `result.issues` for `dtype` or `required_column` rule violations.
 
+`validate()` currently operates on a single in-memory `ArFrame`. Chunked validation via `read_csv_chunked()` iterators is not yet supported directly. Validate each chunk individually or materialize the data before validation when working with streamed/chunked inputs.
+
 ### Pipeline Step Errors
 
 Unknown step names raise `UnknownStepError` before execution begins.

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -819,7 +819,8 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
     Parameters
     ----------
     frame : ArFrame
-        Input frame.
+        Input frame. Must be a single in-memory ArFrame. Chunked validation
+        is not currently supported by this function.
     schema : Schema or dict[str, Field]
         Validation contract.
 
@@ -839,6 +840,13 @@ def validate(frame: ArFrame, schema: Schema | dict[str, Field]) -> ValidationRes
     >>> result = ar.validate(frame, schema)
     >>> result.passed
     """
+    if not isinstance(frame, ArFrame):
+        raise TypeError(
+            "validate() expects a single ArFrame. Chunked validation is not "
+            "currently supported; validate each chunk explicitly or materialize "
+            "the data before validation."
+        )
+
     schema = schema if isinstance(schema, Schema) else Schema(schema)
     df = to_pandas(frame)
     dtypes = frame.dtypes

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -66,6 +66,18 @@ def test_dtype_validation_does_not_report_safe_conversion_for_invalid_numeric_st
     assert "safely convertible" not in result.issues[0].message
 
 
+def test_validate_rejects_chunked_iterators(tmp_path):
+    path = tmp_path / "data.csv"
+    path.write_text("email\n" "a@example.com\n")
+
+    chunks = ar.read_csv_chunked(path, chunksize=1)
+
+    with pytest.raises(
+        TypeError, match="Chunked validation is not currently supported"
+    ):
+        ar.validate(chunks, {"email": ar.Email(nullable=False)})
+
+
 def test_dtype_validation_does_not_report_safe_conversion_for_identifier_like_columns():
     frame = ar.from_pandas(
         pd.DataFrame(


### PR DESCRIPTION
## Summary

## Fixes Issue  #214 

This PR clarifies the current public contract for schema validation with chunked inputs.

At the moment, `ar.validate()` operates on a single in-memory `ArFrame` and internally materializes data through the existing validation flow. Direct validation of `read_csv_chunked()` iterators is not yet supported.

## Changes

- Added an explicit runtime check in `validate()` for non-`ArFrame` inputs
- Added a clear user-facing error message for chunked iterator validation attempts
- Updated the `validate()` docstring to document the current contract
- Added regression test coverage for unsupported chunked validation usage
- Updated README schema validation documentation with current chunked validation limitations and recommended usage

## Tests

```bash
python -m pytest tests/test_schema.py

