### PR TITLE
ci: repair release wheel publish checks

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -8,7 +8,9 @@
 #include <codecvt>
 #include <cstddef>
 #include <cstdlib>
+#ifdef _WIN32
 #include <filesystem>
+#endif
 #include <fstream>
 #include <limits>
 #include <locale>
@@ -19,6 +21,14 @@
 namespace arnio {
 
 namespace {
+inline void open_binary_input(std::ifstream& file, const std::string& path) {
+#ifdef _WIN32
+    file.open(std::filesystem::u8path(path), std::ios::binary);
+#else
+    file.open(path, std::ios::binary);
+#endif
+}
+
 inline void trim_in_place(std::string& s) {
     s.erase(s.begin(),
             std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
@@ -658,7 +668,8 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype) const {
 
 CsvParseResult CsvReader::read(const std::string& path, const std::string& on_bad_lines) const {
     const CsvConfig& config = parser_.config();
-    std::ifstream file(std::filesystem::u8path(path), std::ios::binary);
+    std::ifstream file;
+    open_binary_input(file, path);
     std::vector<BadRow> bad_rows;
 
     if (!file.is_open()) {
@@ -837,7 +848,8 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
 std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     const std::string& path) const {
     const CsvConfig& config = parser_.config();
-    std::ifstream file(std::filesystem::u8path(path), std::ios::binary);
+    std::ifstream file;
+    open_binary_input(file, path);
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
     }
@@ -1009,7 +1021,7 @@ void CsvChunkReader::open(const std::string& path) {
     const CsvConfig& config = parser_.config();
     close();
 
-    file_.open(std::filesystem::u8path(path), std::ios::binary);
+    open_binary_input(file_, path);
     if (!file_.is_open()) {
         throw std::runtime_error("Cannot open file: " + path);
     }

--- a/tests/test_benchmark_from_pandas.py
+++ b/tests/test_benchmark_from_pandas.py
@@ -1,13 +1,25 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
+
+import pytest
 
 
-def test_benchmark_dry_run():
+def test_benchmark_dry_run(tmp_path):
+    benchmark_script = (
+        Path(__file__).resolve().parents[1]
+        / "benchmarks"
+        / "benchmark_from_pandas_memory.py"
+    )
+    if not benchmark_script.exists():
+        pytest.skip("benchmark script is only available in a source checkout")
+
     env = os.environ.copy()
     env["ARNIO_BENCHMARK_DRY_RUN"] = "1"
     result = subprocess.run(
-        [sys.executable, "benchmarks/benchmark_from_pandas_memory.py"],
+        [sys.executable, str(benchmark_script)],
+        cwd=tmp_path,
         env=env,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
- resolve the benchmark dry-run script from the source checkout so cibuildwheel tests pass from their isolated test cwd
- keep UTF-8 filesystem path handling on Windows while avoiding `std::filesystem::u8path` on non-Windows builds, fixing the macOS wheel compile failure

Fixes #1042.

## Validation
- Windows/MSVC editable install with Python 3.12
- `python -m pytest tests/test_benchmark_from_pandas.py -q`
- `python -m pytest tests/test_csv.py -q`
- `python -m pytest tests/ -q` (`1507 passed, 7 skipped`)
- `python -m black --check .`
- `python -m ruff check .`
- `python -m mypy arnio`
- pre-commit hooks: black, ruff, clang-format
- local cibuildwheel: `python -m cibuildwheel --only cp312-win_amd64 --output-dir wheelhouse` with the release `CIBW_TEST_COMMAND`

macOS wheel compilation still needs GitHub Actions confirmation because this Windows runner cannot execute macOS cibuildwheel locally.