### PR TITLE
fix: remove invalid from_pandas row-count arg (#1048)

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -325,5 +325,5 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
         if dtype_hint is not None:
             dtype_hints[name] = dtype_hint
 
-    cpp_frame = _Frame.from_dict(columns, dtype_hints, len(df))
+    cpp_frame = _Frame.from_dict(columns, dtype_hints)
     return ArFrame(cpp_frame, attrs=copylib.deepcopy(df.attrs))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -149,6 +149,14 @@ class TestFromPandas:
         assert "y" in frame.columns
         assert "z" in frame.columns
 
+    def test_from_pandas_constructed_frame_no_longer_passes_row_count_arg(self):
+        df = pd.DataFrame({"name": ["Alice", "Bob"], "score": [95.5, 87.0]})
+
+        frame = ar.from_pandas(df)
+
+        assert frame.shape == (2, 2)
+        pd.testing.assert_frame_equal(ar.to_pandas(frame), df, check_dtype=False)
+
     def test_string_dtype_roundtrip_with_missing_value(self):
         df = pd.DataFrame(
             {


### PR DESCRIPTION
## Summary
- remove the invalid third positional argument from the `_Frame.from_dict(...)` call in `from_pandas()`
- add a focused regression test covering a constructed pandas DataFrame path
- restore the broken cleaning-path conversions that were crashing from this signature mismatch

## Testing
- python -m pytest tests/test_convert.py -k "from_pandas_constructed_frame_no_longer_passes_row_count_arg or test_from_constructed_df or test_basic_roundtrip"
- python -m pytest tests/test_cleaning.py
- python -m ruff check arnio/convert.py tests/test_convert.py
- python -m black --check arnio/convert.py tests/test_convert.py

Notes:
- `tests/test_cleaning.py` in this checkout now runs past the `from_pandas()` crash path and is down to 8 unrelated failures (duplicate-handling, zero-column row-count, and `select_columns` behavior), rather than the issue's reported signature-mismatch failure mode.

Fixes #1048