### PR TITLE
tests: add dry_run coverage for auto_clean pandas accessor

### DIFF
--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -111,6 +111,7 @@ def test_pandas_accessor_validates_dataframe():
 # --- Issue: dry_run mode for auto_clean missing edge cases ---
 # Tests added to cover dry_run=True with return_report=True and safe mode
 
+
 def test_auto_clean_dry_run_with_return_report():
     # dry_run=True with return_report=True should return (frame, report)
     frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
@@ -133,4 +134,3 @@ def test_auto_clean_dry_run_safe_mode_does_not_mutate():
     assert isinstance(result, ar.DataQualityReport)
     # Frame must not be mutated — score stays as string
     assert frame.dtypes["score"] == "string"
-    

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -63,6 +63,7 @@ def test_pandas_accessor_auto_clean_returns_dataframe_and_report():
 # --- Issue: dry_run mode for auto_clean via pandas accessor ---
 # Tests added to verify dry_run=True returns report without mutating the frame
 
+
 def test_pandas_accessor_auto_clean_dry_run_returns_report():
     # dry_run=True should return a DataQualityReport without mutating the frame
     df = pd.DataFrame({"name": [" Alice ", " Bob "]})

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -60,6 +60,44 @@ def test_pandas_accessor_auto_clean_returns_dataframe_and_report():
     assert isinstance(report, ar.DataQualityReport)
 
 
+# --- Issue: dry_run mode for auto_clean via pandas accessor ---
+# Tests added to verify dry_run=True returns report without mutating the frame
+
+def test_pandas_accessor_auto_clean_dry_run_returns_report():
+    # dry_run=True should return a DataQualityReport without mutating the frame
+    df = pd.DataFrame({"name": [" Alice ", " Bob "]})
+
+    result = df.arnio.auto_clean(dry_run=True)
+
+    assert isinstance(result, ar.DataQualityReport)
+    # Original frame must not be mutated
+    assert list(df["name"]) == [" Alice ", " Bob "]
+
+
+def test_pandas_accessor_auto_clean_dry_run_with_return_report():
+    # dry_run=True with return_report=True should return (frame, report)
+    df = pd.DataFrame({"name": [" Alice ", " Bob "]})
+
+    result = df.arnio.auto_clean(dry_run=True, return_report=True)
+
+    assert isinstance(result, tuple)
+    frame, report = result
+    assert isinstance(report, ar.DataQualityReport)
+    # Original frame must not be mutated
+    assert list(df["name"]) == [" Alice ", " Bob "]
+
+
+def test_pandas_accessor_auto_clean_dry_run_safe_mode():
+    # dry_run=True in safe mode should also return report without mutating
+    df = pd.DataFrame({"score": ["10", "20", "30"]})
+
+    result = df.arnio.auto_clean(mode="safe", dry_run=True)
+
+    assert isinstance(result, ar.DataQualityReport)
+    # Original frame must not be mutated
+    assert list(df["score"]) == ["10", "20", "30"]
+
+
 def test_pandas_accessor_validates_dataframe():
     df = pd.DataFrame({"email": ["alice@example.com", "bad"]})
 
@@ -68,3 +106,31 @@ def test_pandas_accessor_validates_dataframe():
     assert isinstance(result, ar.ValidationResult)
     assert not result.passed
     assert result.issues[0].rule == "email"
+
+
+# --- Issue: dry_run mode for auto_clean missing edge cases ---
+# Tests added to cover dry_run=True with return_report=True and safe mode
+
+def test_auto_clean_dry_run_with_return_report():
+    # dry_run=True with return_report=True should return (frame, report)
+    frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
+
+    result = ar.auto_clean(frame, dry_run=True, return_report=True)
+
+    assert isinstance(result, tuple)
+    original_frame, report = result
+    assert isinstance(report, ar.DataQualityReport)
+    # Frame must not be mutated
+    assert frame.dtypes["name"] == "string"
+
+
+def test_auto_clean_dry_run_safe_mode_does_not_mutate():
+    # dry_run=True in safe mode should return report without mutating
+    frame = ar.from_pandas(pd.DataFrame({"score": ["10", "20", "30"]}))
+
+    result = ar.auto_clean(frame, mode="safe", dry_run=True)
+
+    assert isinstance(result, ar.DataQualityReport)
+    # Frame must not be mutated — score stays as string
+    assert frame.dtypes["score"] == "string"
+    


### PR DESCRIPTION
Fixes #650

## Problem
`auto_clean(dry_run=True)` was missing test coverage for the pandas accessor path and edge cases like `dry_run=True` with `return_report=True` and `mode="safe"`.

## Changes
Added focused regression tests to `tests/test_pandas_accessor.py`:

- `test_pandas_accessor_auto_clean_dry_run_returns_report` — verifies dry_run=True returns DataQualityReport without mutating the frame
- `test_pandas_accessor_auto_clean_dry_run_with_return_report` — verifies dry_run=True with return_report=True returns (frame, report) tuple
- `test_pandas_accessor_auto_clean_dry_run_safe_mode` — verifies dry_run=True in safe mode returns report without mutating

## Validation
- No runtime behavior changes
- All existing tests continue to pass
- Tests are deterministic and have clear contracts