### PR TITLE
feat(quality): add exclude_columns support to DataQualityReport.to_dict

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -190,8 +190,26 @@ class DataQualityReport:
     score_components: dict[str, float] = field(default_factory=dict)
     suggestions: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
 
-    def to_dict(self, *, redact_sample_values: bool = False) -> dict[str, Any]:
+    def to_dict(
+        self,
+        *,
+        redact_sample_values: bool = False,
+        exclude_columns: list[str] | set[str] | tuple[str, ...] | None = None,
+    ) -> dict[str, Any]:
         """Return a JSON-friendly dictionary representation."""
+
+        if exclude_columns is None:
+            exclude_columns = set()
+
+        elif not isinstance(exclude_columns, (list, tuple, set)):
+            raise TypeError("exclude_columns must be a list, tuple, set, or None")
+
+        else:
+            if not all(isinstance(column, str) for column in exclude_columns):
+                raise TypeError("exclude_columns must contain only string column names")
+
+            exclude_columns = set(exclude_columns)
+
         return {
             "row_count": self.row_count,
             "column_count": self.column_count,
@@ -203,6 +221,7 @@ class DataQualityReport:
             "columns": {
                 name: column.to_dict(redact_sample_values=redact_sample_values)
                 for name, column in self.columns.items()
+                if name not in exclude_columns
             },
             "suggestions": [
                 {
@@ -387,7 +406,7 @@ class DataQualityReport:
         )
         lines.append("</div>")
         lines.append(
-            f"<div class=\"pill\"><span class=\"muted\">Quality score</span> <span class=\"score {score_class(self.quality_score)}\">{e(f'{self.quality_score:.2f}')}</span></div>"
+            f'<div class="pill"><span class="muted">Quality score</span> <span class="score {score_class(self.quality_score)}">{e(f"{self.quality_score:.2f}")}</span></div>'
         )
         lines.append("</div>")
 
@@ -418,7 +437,7 @@ class DataQualityReport:
                 cls = "warn" if value < 0 else "muted"
                 lines.append("<tr>")
                 lines.append(f"<td><code>{e(key)}</code></td>")
-                lines.append(f"<td class=\"{cls}\">{e(f'{value:+.2f}')}</td>")
+                lines.append(f'<td class="{cls}">{e(f"{value:+.2f}")}</td>')
                 lines.append("</tr>")
             lines.append("</tbody>")
             lines.append("</table>")
@@ -446,7 +465,7 @@ class DataQualityReport:
                     top_bits: list[str] = []
                     for v, _c, r in col.top_values[:3]:
                         top_bits.append(
-                            f"<span class=\"chip\">{e(v)} · {e(f'{r:.0%}')}</span>"
+                            f'<span class="chip">{e(v)} · {e(f"{r:.0%}")}</span>'
                         )
                     top_html = "".join(top_bits)
                 elif col.histogram:
@@ -470,7 +489,7 @@ class DataQualityReport:
                         f'<div style="display:inline-flex;align-items:flex-end;gap:1.5px;'
                         f'height:20px;width:100px;background:#f3f4f6;border-radius:3px;padding:2px;" '
                         f'title="Numeric Distribution Histogram">'
-                        f'{"".join(bars)}'
+                        f"{''.join(bars)}"
                         f"</div>"
                     )
                 else:
@@ -482,19 +501,19 @@ class DataQualityReport:
                 lines.append(f"<td>{e(col.semantic_type)}</td>")
                 lines.append(
                     "<td>"
-                    f"{e(col.null_count)} <span class=\"muted\">({e(f'{null_pct:.1f}%')})</span>"
+                    f'{e(col.null_count)} <span class="muted">({e(f"{null_pct:.1f}%")})</span>'
                     f'<div class="bar"><span style="width:{max(0.0, min(100.0, null_pct)):.2f}%"></span></div>'
                     "</td>"
                 )
                 lines.append(
                     "<td>"
-                    f"{e(col.unique_count)} <span class=\"muted\">({e(f'{unique_pct:.1f}%')})</span>"
+                    f'{e(col.unique_count)} <span class="muted">({e(f"{unique_pct:.1f}%")})</span>'
                     f'<div class="bar"><span style="width:{max(0.0, min(100.0, unique_pct)):.2f}%"></span></div>'
                     "</td>"
                 )
                 lines.append(f"<td>{top_html}</td>")
                 lines.append(
-                    f"<td class=\"{'warn' if col.warnings else 'muted'}\">{e(warnings_str)}</td>"
+                    f'<td class="{"warn" if col.warnings else "muted"}">{e(warnings_str)}</td>'
                 )
                 lines.append(f"<td>{e(suggested)}</td>")
                 lines.append("</tr>")

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -226,7 +226,24 @@ class DataQualityReport:
             "suggestions": [
                 {
                     "step": s[0],
-                    "kwargs": dict(s[1]),
+                    "kwargs": {
+                        key: (
+                            [
+                                item
+                                for item in value
+                                if item not in exclude_columns
+                            ]
+                            if isinstance(value, list)
+                            else {
+                                k: v
+                                for k, v in value.items()
+                                if k not in exclude_columns
+                            }
+                            if isinstance(value, dict)
+                            else value
+                        )
+                        for key, value in dict(s[1]).items()
+                    },
                     "confidence_score": getattr(s, "confidence_score", None),
                     "confidence_reason": getattr(s, "confidence_reason", None),
                 }

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -229,14 +229,14 @@ class DataQualityReport:
                     "kwargs": {
                         key: (
                             [item for item in value if item not in exclude_columns]
-                            if isinstance(value, list)
+                            if key in {"subset", "columns"} and isinstance(value, list)
                             else (
                                 {
                                     k: v
                                     for k, v in value.items()
                                     if k not in exclude_columns
                                 }
-                                if isinstance(value, dict)
+                                if key == "cast_types" and isinstance(value, dict)
                                 else value
                             )
                         )
@@ -421,7 +421,7 @@ class DataQualityReport:
         )
         lines.append("</div>")
         lines.append(
-            f'<div class="pill"><span class="muted">Quality score</span> <span class="score {score_class(self.quality_score)}">{e(f"{self.quality_score:.2f}")}</span></div>'
+            f"<div class=\"pill\"><span class=\"muted\">Quality score</span> <span class=\"score {score_class(self.quality_score)}\">{e(f'{self.quality_score:.2f}')}</span></div>"
         )
         lines.append("</div>")
 
@@ -452,7 +452,7 @@ class DataQualityReport:
                 cls = "warn" if value < 0 else "muted"
                 lines.append("<tr>")
                 lines.append(f"<td><code>{e(key)}</code></td>")
-                lines.append(f'<td class="{cls}">{e(f"{value:+.2f}")}</td>')
+                lines.append(f"<td class=\"{cls}\">{e(f'{value:+.2f}')}</td>")
                 lines.append("</tr>")
             lines.append("</tbody>")
             lines.append("</table>")
@@ -480,7 +480,7 @@ class DataQualityReport:
                     top_bits: list[str] = []
                     for v, _c, r in col.top_values[:3]:
                         top_bits.append(
-                            f'<span class="chip">{e(v)} · {e(f"{r:.0%}")}</span>'
+                            f"<span class=\"chip\">{e(v)} · {e(f'{r:.0%}')}</span>"
                         )
                     top_html = "".join(top_bits)
                 elif col.histogram:
@@ -504,7 +504,7 @@ class DataQualityReport:
                         f'<div style="display:inline-flex;align-items:flex-end;gap:1.5px;'
                         f'height:20px;width:100px;background:#f3f4f6;border-radius:3px;padding:2px;" '
                         f'title="Numeric Distribution Histogram">'
-                        f"{''.join(bars)}"
+                        f'{"".join(bars)}'
                         f"</div>"
                     )
                 else:
@@ -516,19 +516,19 @@ class DataQualityReport:
                 lines.append(f"<td>{e(col.semantic_type)}</td>")
                 lines.append(
                     "<td>"
-                    f'{e(col.null_count)} <span class="muted">({e(f"{null_pct:.1f}%")})</span>'
+                    f"{e(col.null_count)} <span class=\"muted\">({e(f'{null_pct:.1f}%')})</span>"
                     f'<div class="bar"><span style="width:{max(0.0, min(100.0, null_pct)):.2f}%"></span></div>'
                     "</td>"
                 )
                 lines.append(
                     "<td>"
-                    f'{e(col.unique_count)} <span class="muted">({e(f"{unique_pct:.1f}%")})</span>'
+                    f"{e(col.unique_count)} <span class=\"muted\">({e(f'{unique_pct:.1f}%')})</span>"
                     f'<div class="bar"><span style="width:{max(0.0, min(100.0, unique_pct)):.2f}%"></span></div>'
                     "</td>"
                 )
                 lines.append(f"<td>{top_html}</td>")
                 lines.append(
-                    f'<td class="{"warn" if col.warnings else "muted"}">{e(warnings_str)}</td>'
+                    f"<td class=\"{'warn' if col.warnings else 'muted'}\">{e(warnings_str)}</td>"
                 )
                 lines.append(f"<td>{e(suggested)}</td>")
                 lines.append("</tr>")

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -228,19 +228,17 @@ class DataQualityReport:
                     "step": s[0],
                     "kwargs": {
                         key: (
-                            [
-                                item
-                                for item in value
-                                if item not in exclude_columns
-                            ]
+                            [item for item in value if item not in exclude_columns]
                             if isinstance(value, list)
-                            else {
-                                k: v
-                                for k, v in value.items()
-                                if k not in exclude_columns
-                            }
-                            if isinstance(value, dict)
-                            else value
+                            else (
+                                {
+                                    k: v
+                                    for k, v in value.items()
+                                    if k not in exclude_columns
+                                }
+                                if isinstance(value, dict)
+                                else value
+                            )
                         )
                         for key, value in dict(s[1]).items()
                     },

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1923,17 +1923,15 @@ def test_data_quality_report_to_dict_invalid_exclude_columns_type():
     with pytest.raises(TypeError):
         report.to_dict(exclude_columns="name")
 
+
 def test_data_quality_report_to_dict_invalid_exclude_columns_entries():
-    frame = ar.read_csv(
-        io.StringIO(
-            "name\nalice\nbob\n"
-        )
-    )
+    frame = ar.read_csv(io.StringIO("name\nalice\nbob\n"))
 
     report = ar.profile(frame)
 
     with pytest.raises(TypeError):
         report.to_dict(exclude_columns=["name", 123])
+
 
 def test_data_quality_report_to_dict_excludes_columns_from_suggestions():
     report = ar.DataQualityReport(
@@ -1964,6 +1962,4 @@ def test_data_quality_report_to_dict_excludes_columns_from_suggestions():
     kwargs = result["suggestions"][0]["kwargs"]
 
     assert kwargs["subset"] == ["name"]
-    assert kwargs["cast_types"] == {
-        "name": "string"
-    }        
+    assert kwargs["cast_types"] == {"name": "string"}

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1922,3 +1922,48 @@ def test_data_quality_report_to_dict_invalid_exclude_columns_type():
 
     with pytest.raises(TypeError):
         report.to_dict(exclude_columns="name")
+
+def test_data_quality_report_to_dict_invalid_exclude_columns_entries():
+    frame = ar.read_csv(
+        io.StringIO(
+            "name\nalice\nbob\n"
+        )
+    )
+
+    report = ar.profile(frame)
+
+    with pytest.raises(TypeError):
+        report.to_dict(exclude_columns=["name", 123])
+
+def test_data_quality_report_to_dict_excludes_columns_from_suggestions():
+    report = ar.DataQualityReport(
+        row_count=2,
+        column_count=2,
+        memory_usage=100,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=1.0,
+        score_components={},
+        columns={},
+        suggestions=[
+            (
+                "strip_whitespace",
+                {
+                    "subset": ["name", "age"],
+                    "cast_types": {
+                        "name": "string",
+                        "age": "int",
+                    },
+                },
+            )
+        ],
+    )
+
+    result = report.to_dict(exclude_columns=["age"])
+
+    kwargs = result["suggestions"][0]["kwargs"]
+
+    assert kwargs["subset"] == ["name"]
+    assert kwargs["cast_types"] == {
+        "name": "string"
+    }        

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1963,3 +1963,34 @@ def test_data_quality_report_to_dict_excludes_columns_from_suggestions():
 
     assert kwargs["subset"] == ["name"]
     assert kwargs["cast_types"] == {"name": "string"}
+
+
+def test_data_quality_report_to_dict_preserves_non_column_suggestion_values():
+    report = ar.DataQualityReport(
+        row_count=2,
+        column_count=1,
+        memory_usage=100,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=1.0,
+        score_components={},
+        columns={},
+        suggestions=[
+            (
+                "custom_step",
+                {
+                    "message": ["age"],
+                    "metadata": {"age": "keep"},
+                    "threshold": 5,
+                },
+            )
+        ],
+    )
+
+    result = report.to_dict(exclude_columns=["age"])
+
+    kwargs = result["suggestions"][0]["kwargs"]
+
+    assert kwargs["message"] == ["age"]
+    assert kwargs["metadata"] == {"age": "keep"}
+    assert kwargs["threshold"] == 5

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,5 +1,7 @@
 """Tests for data quality profiling and smart cleaning."""
 
+import io
+
 import pandas as pd
 import pytest
 
@@ -975,7 +977,7 @@ def test_report_to_markdown_basic(tmp_path):
 def test_report_to_markdown_includes_uniqueness_metrics(tmp_path):
     path = tmp_path / "unique_metrics.csv"
 
-    path.write_text("id,name\n" "1,Alice\n" "2,Bob\n" "2,Bob\n")
+    path.write_text("id,name\n1,Alice\n2,Bob\n2,Bob\n")
 
     report = ar.profile(ar.read_csv(path))
 
@@ -1880,3 +1882,43 @@ def test_quality_gate_markdown_escapes_pipe_characters():
     assert r"cat\|egory" in md
     assert r"pipe\|warning" in md
     assert "| col|name |" not in md
+
+
+def test_data_quality_report_to_dict_exclude_columns():
+    frame = ar.read_csv(io.StringIO("name,age\nalice,20\nbob,30\n"))
+
+    report = ar.profile(frame)
+
+    result = report.to_dict(exclude_columns=["age"])
+
+    assert "age" not in result["columns"]
+    assert "name" in result["columns"]
+
+
+def test_data_quality_report_to_dict_default_behavior():
+    frame = ar.read_csv(io.StringIO("name\nalice\nbob\n"))
+
+    report = ar.profile(frame)
+
+    result = report.to_dict()
+
+    assert "name" in result["columns"]
+
+
+def test_data_quality_report_to_dict_unknown_column():
+    frame = ar.read_csv(io.StringIO("name\nalice\nbob\n"))
+
+    report = ar.profile(frame)
+
+    result = report.to_dict(exclude_columns=["missing_column"])
+
+    assert "name" in result["columns"]
+
+
+def test_data_quality_report_to_dict_invalid_exclude_columns_type():
+    frame = ar.read_csv(io.StringIO("name\nalice\nbob\n"))
+
+    report = ar.profile(frame)
+
+    with pytest.raises(TypeError):
+        report.to_dict(exclude_columns="name")


### PR DESCRIPTION
## Summary

Adds optional keyword-only `exclude_columns` support to `DataQualityReport.to_dict()`.

### Changes

* adds optional `exclude_columns`
* validates invalid input types
* preserves existing default behavior
* filters excluded columns consistently from exported report payloads
* adds focused regression tests for:

  * default behavior
  * excluded columns
  * unknown columns
  * invalid input types

## Testing

```bash
py -3.12 -m pytest tests/test_quality.py -v
```

112 passed.

Fixes #1041
