### PR TITLE
test: add round_numeric_columns tests with ArFrame and DataFrame input

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2206,6 +2206,26 @@ class TestRoundNumericColumns:
         assert list(result_df["a"]) == [1.1, 2.5]
         assert list(result_df["c"]) == ["str1", "str2"]
 
+    def test_round_numeric_columns_with_arframe_input(self):
+        df = pd.DataFrame({"a": [1.123, 2.456], "b": [3.789, 4.0]})
+        frame = ar.from_pandas(df)
+
+        result = ar.round_numeric_columns(frame, decimals=1)
+
+        assert isinstance(result, ar.ArFrame)
+        result_df = ar.to_pandas(result)
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["b"]) == [3.8, 4.0]
+
+    def test_round_numeric_columns_with_dataframe_input(self):
+        df = pd.DataFrame({"a": [1.123, 2.456], "b": [3.789, 4.0]})
+
+        result = ar.round_numeric_columns(df, decimals=1)
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result["a"]) == [1.1, 2.5]
+        assert list(result["b"]) == [3.8, 4.0]
+
     def test_missing_column(self):
         import pandas as pd
 


### PR DESCRIPTION
Summary:
Added unit tests for the `round_numeric_columns` function with both ArFrame and pd.DataFrame input to verify correct behavior when rounding numeric columns.

Changes Made:
- `test_round_numeric_columns_with_arframe_input`: Tests rounding with ArFrame input
- `test_round_numeric_columns_with_dataframe_input`: Tests rounding with pd.DataFrame input

Impact:
Improves test coverage for the `round_numeric_columns` function by testing it with both ArFrame and pd.DataFrame input types.