### PR TITLE
fix: add missing json import to io.py

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -6,6 +6,7 @@ CSV reading and writing functions.
 from __future__ import annotations
 
 import io
+import json
 import os
 import shutil
 import tempfile


### PR DESCRIPTION
Closes #1156

Adds the missing  import to .