### PR TITLE
fix: move Counter import to top-level in io.py

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import tempfile
 import warnings
+from collections import Counter
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from typing import cast
@@ -1162,8 +1163,6 @@ def sniff_delimiter(
     # 5. Score Candidates and Detect Ties/Ambiguity
     best_candidates = []
     best_score = -1.0
-
-    from collections import Counter
 
     for delimiter in candidates:
         line_counts = counts[delimiter]


### PR DESCRIPTION
Closes #1158

Moves the deferred  import to the top-level imports in  for consistency.