### PR TITLE
feat(quality): add DataQualityReport.to_json helper

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -6,6 +6,7 @@ Data quality profiling and safe automatic cleaning helpers.
 from __future__ import annotations
 
 import html
+import json
 import math
 from dataclasses import dataclass, field
 from typing import Any
@@ -248,6 +249,27 @@ class DataQualityReport:
                 for s in self.suggestions
             ],
         }
+
+    def to_json(
+        self,
+        *,
+        indent: int | None = None,
+        redact_sample_values: bool = False,
+        exclude_columns: list[str] | set[str] | tuple[str, ...] | None = None,
+    ) -> str:
+        """Return the report as a JSON string.
+
+        Example:
+        report.to_json(indent=2)
+        """
+
+        return json.dumps(
+            self.to_dict(
+                redact_sample_values=redact_sample_values,
+                exclude_columns=exclude_columns,
+            ),
+            indent=indent,
+        )
 
     def to_markdown(self) -> str:
         """Return a GitHub-friendly Markdown report."""

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,6 +1,7 @@
 """Tests for data quality profiling and smart cleaning."""
 
 import io
+import json
 
 import pandas as pd
 import pytest
@@ -2039,3 +2040,84 @@ def test_data_quality_report_to_dict_preserves_non_column_suggestion_values():
     assert kwargs["message"] == ["age"]
     assert kwargs["metadata"] == {"age": "keep"}
     assert kwargs["threshold"] == 5
+
+
+def test_data_quality_report_to_json_returns_valid_json():
+    report = ar.DataQualityReport(
+        row_count=10,
+        column_count=1,
+        memory_usage=100,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+    )
+
+    json_output = report.to_json()
+
+    parsed = json.loads(json_output)
+
+    assert parsed["row_count"] == 10
+    assert parsed["column_count"] == 1
+
+
+def test_data_quality_report_to_json_indent():
+    report = ar.DataQualityReport(
+        row_count=10,
+        column_count=1,
+        memory_usage=100,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+    )
+
+    json_output = report.to_json(indent=2)
+
+    assert "\n" in json_output
+    assert '  "row_count"' in json_output
+
+
+def test_data_quality_report_to_json_exclude_columns():
+    from arnio._core import _DType, _Frame
+    from arnio.frame import ArFrame
+
+    cpp_frame = _Frame.from_dict(
+        {
+            "name": ["John"],
+            "age": [21],
+        },
+        {
+            "name": _DType.STRING,
+            "age": _DType.INT64,
+        },
+    )
+
+    frame = ArFrame(cpp_frame)
+
+    report = ar.profile(frame)
+
+    json_output = report.to_json(exclude_columns=["age"])
+
+    parsed = json.loads(json_output)
+
+    assert "name" in parsed["columns"]
+    assert "age" not in parsed["columns"]
+
+
+def test_data_quality_report_to_json_redact_sample_values():
+    from arnio._core import _DType, _Frame
+    from arnio.frame import ArFrame
+
+    cpp_frame = _Frame.from_dict(
+        {"name": ["John"]},
+        {"name": _DType.STRING},
+    )
+
+    frame = ArFrame(cpp_frame)
+
+    report = ar.profile(frame)
+
+    json_output = report.to_json(redact_sample_values=True)
+
+    parsed = json.loads(json_output)
+
+    assert parsed["columns"]["name"]["sample_values"] == ["[REDACTED]"]


### PR DESCRIPTION
Fixes #1167

## Summary

Add `DataQualityReport.to_json(...)` as a thin JSON serialization helper built on top of `to_dict(...)` and `json.dumps(...)`.

## Changes

- add `DataQualityReport.to_json(...)`
- support:
  - `indent`
  - `redact_sample_values`
  - `exclude_columns`
- add focused tests for:
  - valid JSON output
  - indentation
  - excluded columns
  - redacted sample values

## Validation

```bash
py -3.12 -m black arnio/quality.py tests/test_quality.py
py -3.12 -m ruff check .
py -3.12 -m pytest tests/test_quality.py -v