### PR TITLE
Feature/navbar hover animation 2

### DIFF
--- a/website/css/components.css
+++ b/website/css/components.css
@@ -56,6 +56,7 @@
 }
 
 .nav-links a {
+  position: relative;
   display: block;
   padding: var(--space-2) var(--space-3);
   font-size: var(--font-size-sm);
@@ -66,10 +67,29 @@
   transition: all var(--transition-fast);
 }
 
-.nav-links a:hover {
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 4px;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(to right, #ef4444, #f97316);
+  transition: width 0.3s ease, left 0.3s ease;
+  border-radius: var(--radius-full);
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
   color: var(--color-text);
   background: var(--color-surface);
   text-decoration: none;
+}
+
+.nav-links a:hover::after,
+.nav-links a:focus-visible::after {
+  width: calc(100% - var(--space-6));
+  left: var(--space-3);
 }
 
 .nav-links a.active {
@@ -178,6 +198,7 @@
 }
 
 .mobile-menu a {
+  position: relative;
   display: block;
   padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-md);
@@ -189,10 +210,29 @@
   margin-bottom: var(--space-1);
 }
 
+.mobile-menu a::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 6px;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(to right, #ef4444, #f97316);
+  transition: width 0.3s ease, left 0.3s ease;
+  border-radius: var(--radius-full);
+}
+
 .mobile-menu a:hover,
+.mobile-menu a:focus-visible,
 .mobile-menu a.active {
   color: var(--color-text);
   background: var(--color-surface);
+}
+
+.mobile-menu a:hover::after,
+.mobile-menu a:focus-visible::after {
+  width: calc(100% - var(--space-8));
+  left: var(--space-4);
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## Summary
This PR implements the requested navbar underline hover animation to improve UI feedback and visual polish, addressing #1166.

**Changes made:**
- Added a smooth gradient underline animation (`::after` pseudo-element) to desktop navbar links (`.nav-links a`).
- Applied the same hover animation logic to the mobile menu links (`.mobile-menu a`).
- Implemented both `:hover` and `:focus-visible` states together for better accessibility.
- Navigation structure and layout are strictly preserved.

## Linked issue
Fixes #1166

## Screenshots
### Desktop (Hover State)

https://github.com/user-attachments/assets/796cb1a3-bc09-4db6-bcff-853929ee6e9a


<img width="1898" height="900" alt="Screenshot 2026-05-23 080816" src="https://github.com/user-attachments/assets/1da3ed4d-cb43-4eb4-a8c2-f562aaf0d26b" />
<img width="1893" height="873" alt="Screenshot 2026-05-23 080618" src="https://github.com/user-attachments/assets/1baba5a9-1a51-48d0-aa9c-90289ec0f66a" />


## Checklist
- [x] I kept the PR focused on the existing website/navbar styles.
- [x] `:focus-visible` states match hover behavior.
- [x] Included desktop/mobile screenshots.