### PR TITLE
fix: add ArFrame type checking to Python API methods to prevent C++ b…

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -202,7 +202,9 @@ def to_pandas(frame: ArFrame, *, copy: bool = False) -> pd.DataFrame:
         raise TypeError("copy must be a bool")
 
     if not isinstance(frame, ArFrame):
-        raise TypeError(f"to_pandas() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first.")
+        raise TypeError(
+            f"to_pandas() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first."
+        )
 
     cpp_frame = frame._frame
     data = {}

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -201,6 +201,9 @@ def to_pandas(frame: ArFrame, *, copy: bool = False) -> pd.DataFrame:
     if not isinstance(copy, bool):
         raise TypeError("copy must be a bool")
 
+    if not isinstance(frame, ArFrame):
+        raise TypeError(f"to_pandas() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first.")
+
     cpp_frame = frame._frame
     data = {}
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -827,7 +827,9 @@ def profile(
     >>> report.summary()
     """
     if not isinstance(frame, ArFrame):
-        raise TypeError(f"profile() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first.")
+        raise TypeError(
+            f"profile() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first."
+        )
 
     if not isinstance(sample_size, int) or isinstance(sample_size, bool):
         raise TypeError("sample_size must be an integer")
@@ -1659,7 +1661,9 @@ def auto_clean(
     >>> print(explanation)
     """
     if not isinstance(frame, ArFrame):
-        raise TypeError(f"auto_clean() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first.")
+        raise TypeError(
+            f"auto_clean() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first."
+        )
 
     if mode not in {"safe", "strict"}:
         raise ValueError("mode must be 'safe' or 'strict'")

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -826,6 +826,9 @@ def profile(
     >>> report = ar.profile(frame, sample_size=3)
     >>> report.summary()
     """
+    if not isinstance(frame, ArFrame):
+        raise TypeError(f"profile() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first.")
+
     if not isinstance(sample_size, int) or isinstance(sample_size, bool):
         raise TypeError("sample_size must be an integer")
     if sample_size < 0:
@@ -1655,6 +1658,9 @@ def auto_clean(
     >>> clean, explanation = ar.auto_clean(frame, explain=True)
     >>> print(explanation)
     """
+    if not isinstance(frame, ArFrame):
+        raise TypeError(f"auto_clean() expects an ArFrame, got {type(frame).__name__}. Use arnio.from_pandas() first.")
+
     if mode not in {"safe", "strict"}:
         raise ValueError("mode must be 'safe' or 'strict'")
 

--- a/tests/test_api_type_checking.py
+++ b/tests/test_api_type_checking.py
@@ -1,28 +1,32 @@
-import pytest
 import pandas as pd
+import pytest
+
 import arnio as ar
+
 
 def test_to_pandas_raises_type_error_for_non_arframe():
     # Attempting to call to_pandas with a normal pandas DataFrame or other object
     df = pd.DataFrame({"a": [1, 2, 3]})
     with pytest.raises(TypeError):
         ar.to_pandas(df)
-        
+
     with pytest.raises(TypeError):
         ar.to_pandas([1, 2, 3])
+
 
 def test_profile_raises_type_error_for_non_arframe():
     df = pd.DataFrame({"a": [1, 2, 3]})
     with pytest.raises(TypeError):
         ar.profile(df)
-        
+
     with pytest.raises(TypeError):
         ar.profile("not an arframe")
+
 
 def test_auto_clean_raises_type_error_for_non_arframe():
     df = pd.DataFrame({"a": [1, 2, 3]})
     with pytest.raises(TypeError):
         ar.auto_clean(df)
-        
+
     with pytest.raises(TypeError):
         ar.auto_clean(123)

--- a/tests/test_api_type_checking.py
+++ b/tests/test_api_type_checking.py
@@ -1,0 +1,28 @@
+import pytest
+import pandas as pd
+import arnio as ar
+
+def test_to_pandas_raises_type_error_for_non_arframe():
+    # Attempting to call to_pandas with a normal pandas DataFrame or other object
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    with pytest.raises(TypeError):
+        ar.to_pandas(df)
+        
+    with pytest.raises(TypeError):
+        ar.to_pandas([1, 2, 3])
+
+def test_profile_raises_type_error_for_non_arframe():
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    with pytest.raises(TypeError):
+        ar.profile(df)
+        
+    with pytest.raises(TypeError):
+        ar.profile("not an arframe")
+
+def test_auto_clean_raises_type_error_for_non_arframe():
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    with pytest.raises(TypeError):
+        ar.auto_clean(df)
+        
+    with pytest.raises(TypeError):
+        ar.auto_clean(123)


### PR DESCRIPTION
## Description

Currently, passing a standard `pandas.DataFrame` into `arnio.auto_clean()`, `arnio.profile()`, or `arnio.to_pandas()` causes an immediate crash with `AttributeError: 'DataFrame' object has no attribute '_frame'`.

This occurs because the methods blindly attempt to access the internal C++ `._frame` attribute without first checking if the input is actually an `ArFrame`. 

This PR adds a standard `isinstance(frame, ArFrame)` type check to the three main Python API entry points (`to_pandas`, `profile`, `auto_clean`), mirroring the existing safety check already present in `to_arrow()`. It now raises a helpful `TypeError` advising the user to use `arnio.from_pandas()` first.

This is submitted as part of GSSoC '26!

Fixes #1227