### PR TITLE
test : added unit tests for register_validator and Custom validator in schema.py

### DIFF
--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -1,8 +1,9 @@
 """Tests for register_validator and Custom validator in arnio.schema."""
 
 import pytest
+
 from arnio import schema
-from arnio.schema import register_validator, Custom, Schema, Field
+from arnio.schema import Custom, register_validator
 
 
 class TestRegisterValidator:
@@ -19,6 +20,7 @@ class TestRegisterValidator:
 
     def test_register_custom_validator_by_name(self):
         """register_validator registers a validator function under a name."""
+
         def my_validator(value):
             return isinstance(value, int) and value > 0
 
@@ -28,6 +30,7 @@ class TestRegisterValidator:
 
     def test_register_validator_returns_none(self):
         """register_validator returns None on success."""
+
         def my_validator(value):
             return True
 
@@ -56,6 +59,7 @@ class TestRegisterValidator:
 
     def test_overwrites_existing_validator(self):
         """register_validator allows overwriting an existing validator."""
+
         def validator_a(value):
             return value > 0
 
@@ -82,72 +86,79 @@ class TestCustomValidator:
         schema._CUSTOM_VALIDATORS.update(self._original_validators)
 
     def test_custom_validator_stores_name(self):
-        """Custom stores the validator name correctly."""
+        """Custom stores the validator name correctly in semantic field."""
+
         def my_validator(value):
             return True
 
         register_validator("test_name", my_validator)
         field = Custom("test_name")
 
-        assert field.name == "test_name"
+        assert field.semantic == "custom:test_name"
 
     def test_custom_validator_default_nullable(self):
         """Custom defaults nullable to True."""
+
         def my_validator(value):
             return True
 
         register_validator("test_nullable", my_validator)
-        field = Custom("test_name")
+        field = Custom("test_nullable")
 
         assert field.nullable is True
 
     def test_custom_validator_default_unique(self):
         """Custom defaults unique to False."""
+
         def my_validator(value):
             return True
 
         register_validator("test_unique", my_validator)
-        field = Custom("test_name")
+        field = Custom("test_unique")
 
         assert field.unique is False
 
     def test_custom_validator_explicit_nullable_false(self):
         """Custom respects explicit nullable=False."""
+
         def my_validator(value):
             return True
 
         register_validator("test_nullable_false", my_validator)
-        field = Custom("test_name", nullable=False)
+        field = Custom("test_nullable_false", nullable=False)
 
         assert field.nullable is False
 
     def test_custom_validator_explicit_unique_true(self):
         """Custom respects explicit unique=True."""
+
         def my_validator(value):
             return True
 
         register_validator("test_unique_true", my_validator)
-        field = Custom("test_name", unique=True)
+        field = Custom("test_unique_true", unique=True)
 
         assert field.unique is True
 
     def test_custom_validator_default_severity(self):
         """Custom defaults severity to error."""
+
         def my_validator(value):
             return True
 
         register_validator("test_severity", my_validator)
-        field = Custom("test_name")
+        field = Custom("test_severity")
 
         assert field.severity == "error"
 
     def test_custom_validator_explicit_severity(self):
         """Custom respects explicit severity parameter."""
+
         def my_validator(value):
             return True
 
         register_validator("test_severity_warn", my_validator)
-        field = Custom("test_name", severity="warning")
+        field = Custom("test_severity_warn", severity="warning")
 
         assert field.severity == "warning"
 
@@ -158,6 +169,7 @@ class TestCustomValidator:
 
     def test_custom_repr_contains_name(self):
         """Custom repr includes the validator name."""
+
         def my_validator(value):
             return True
 
@@ -168,17 +180,19 @@ class TestCustomValidator:
 
     def test_custom_in_schema_integration(self):
         """Custom validator can be used in a Schema definition."""
+
         def is_positive(value):
             return isinstance(value, (int, float)) and value > 0
 
         register_validator("positive", is_positive)
 
         field = Custom("positive", nullable=False)
-        assert field.name == "positive"
+        assert field.semantic == "custom:positive"
         assert field.nullable is False
 
     def test_multiple_custom_validators_in_schema(self):
         """Multiple Custom validators can coexist in a schema."""
+
         def is_positive(value):
             return isinstance(value, (int, float)) and value > 0
 
@@ -191,5 +205,5 @@ class TestCustomValidator:
         f1 = Custom("positive")
         f2 = Custom("email")
 
-        assert f1.name == "positive"
-        assert f2.name == "email"
+        assert f1.semantic == "custom:positive"
+        assert f2.semantic == "custom:email"

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -1,0 +1,195 @@
+"""Tests for register_validator and Custom validator in arnio.schema."""
+
+import pytest
+from arnio import schema
+from arnio.schema import register_validator, Custom, Schema, Field
+
+
+class TestRegisterValidator:
+    """Test suite for register_validator function."""
+
+    def setup_method(self):
+        """Save original validators state before each test."""
+        self._original_validators = dict(schema._CUSTOM_VALIDATORS)
+
+    def teardown_method(self):
+        """Restore original validators state after each test."""
+        schema._CUSTOM_VALIDATORS.clear()
+        schema._CUSTOM_VALIDATORS.update(self._original_validators)
+
+    def test_register_custom_validator_by_name(self):
+        """register_validator registers a validator function under a name."""
+        def my_validator(value):
+            return isinstance(value, int) and value > 0
+
+        register_validator("positive_int", my_validator)
+        assert "positive_int" in schema._CUSTOM_VALIDATORS
+        assert schema._CUSTOM_VALIDATORS["positive_int"] is my_validator
+
+    def test_register_validator_returns_none(self):
+        """register_validator returns None on success."""
+        def my_validator(value):
+            return True
+
+        result = register_validator("test_validator", my_validator)
+        assert result is None
+
+    def test_raises_type_error_when_fn_not_callable(self):
+        """register_validator raises TypeError when fn is not callable."""
+        with pytest.raises(TypeError, match="fn must be callable"):
+            register_validator("not_callable", "not a function")
+
+    def test_raises_type_error_when_fn_is_none(self):
+        """register_validator raises TypeError when fn is None."""
+        with pytest.raises(TypeError, match="fn must be callable"):
+            register_validator("none_fn", None)
+
+    def test_raises_value_error_when_name_is_empty_string(self):
+        """register_validator raises ValueError when name is empty string."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            register_validator("", lambda x: True)
+
+    def test_raises_value_error_when_name_is_not_string(self):
+        """register_validator raises ValueError when name is not a string."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            register_validator(123, lambda x: True)
+
+    def test_overwrites_existing_validator(self):
+        """register_validator allows overwriting an existing validator."""
+        def validator_a(value):
+            return value > 0
+
+        def validator_b(value):
+            return value < 0
+
+        register_validator("my_validator", validator_a)
+        assert schema._CUSTOM_VALIDATORS["my_validator"] is validator_a
+
+        register_validator("my_validator", validator_b)
+        assert schema._CUSTOM_VALIDATORS["my_validator"] is validator_b
+
+
+class TestCustomValidator:
+    """Test suite for Custom validator field factory."""
+
+    def setup_method(self):
+        """Save original validators state before each test."""
+        self._original_validators = dict(schema._CUSTOM_VALIDATORS)
+
+    def teardown_method(self):
+        """Restore original validators state after each test."""
+        schema._CUSTOM_VALIDATORS.clear()
+        schema._CUSTOM_VALIDATORS.update(self._original_validators)
+
+    def test_custom_validator_stores_name(self):
+        """Custom stores the validator name correctly."""
+        def my_validator(value):
+            return True
+
+        register_validator("test_name", my_validator)
+        field = Custom("test_name")
+
+        assert field.name == "test_name"
+
+    def test_custom_validator_default_nullable(self):
+        """Custom defaults nullable to True."""
+        def my_validator(value):
+            return True
+
+        register_validator("test_nullable", my_validator)
+        field = Custom("test_name")
+
+        assert field.nullable is True
+
+    def test_custom_validator_default_unique(self):
+        """Custom defaults unique to False."""
+        def my_validator(value):
+            return True
+
+        register_validator("test_unique", my_validator)
+        field = Custom("test_name")
+
+        assert field.unique is False
+
+    def test_custom_validator_explicit_nullable_false(self):
+        """Custom respects explicit nullable=False."""
+        def my_validator(value):
+            return True
+
+        register_validator("test_nullable_false", my_validator)
+        field = Custom("test_name", nullable=False)
+
+        assert field.nullable is False
+
+    def test_custom_validator_explicit_unique_true(self):
+        """Custom respects explicit unique=True."""
+        def my_validator(value):
+            return True
+
+        register_validator("test_unique_true", my_validator)
+        field = Custom("test_name", unique=True)
+
+        assert field.unique is True
+
+    def test_custom_validator_default_severity(self):
+        """Custom defaults severity to error."""
+        def my_validator(value):
+            return True
+
+        register_validator("test_severity", my_validator)
+        field = Custom("test_name")
+
+        assert field.severity == "error"
+
+    def test_custom_validator_explicit_severity(self):
+        """Custom respects explicit severity parameter."""
+        def my_validator(value):
+            return True
+
+        register_validator("test_severity_warn", my_validator)
+        field = Custom("test_name", severity="warning")
+
+        assert field.severity == "warning"
+
+    def test_custom_raises_when_validator_not_registered(self):
+        """Custom raises ValueError when validator name not registered."""
+        with pytest.raises(ValueError, match="No validator registered"):
+            Custom("nonexistent_validator_name_xyz")
+
+    def test_custom_repr_contains_name(self):
+        """Custom repr includes the validator name."""
+        def my_validator(value):
+            return True
+
+        register_validator("repr_test", my_validator)
+        field = Custom("repr_test")
+
+        assert "repr_test" in repr(field)
+
+    def test_custom_in_schema_integration(self):
+        """Custom validator can be used in a Schema definition."""
+        def is_positive(value):
+            return isinstance(value, (int, float)) and value > 0
+
+        register_validator("positive", is_positive)
+
+        field = Custom("positive", nullable=False)
+        assert field.name == "positive"
+        assert field.nullable is False
+
+    def test_multiple_custom_validators_in_schema(self):
+        """Multiple Custom validators can coexist in a schema."""
+        def is_positive(value):
+            return isinstance(value, (int, float)) and value > 0
+
+        def is_email_format(value):
+            return isinstance(value, str) and "@" in value
+
+        register_validator("positive", is_positive)
+        register_validator("email", is_email_format)
+
+        f1 = Custom("positive")
+        f2 = Custom("email")
+
+        assert f1.name == "positive"
+        assert f2.name == "email"


### PR DESCRIPTION
Closes #1232.

Summary of What Has Been Done:
Added a new test file tests/test_register_validator.py with comprehensive tests for the register_validator function and Custom validator class from arnio/schema.py.

Changes Made:
New file: tests/test_register_validator.py

The test suite covers:

register_validator function:
- Successful registration of validator function under a name
- Returns None on successful registration
- TypeError when fn is not callable
- TypeError when fn is None
- ValueError when name is empty string
- ValueError when name is not a string
- Allows overwriting existing validator

Custom validator class:
- Stores validator name correctly
- Default nullable is True
- Default unique is False
- Default severity is error
- Respects explicit nullable parameter
- Respects explicit unique parameter
- Respects explicit severity parameter
- Raises ValueError when validator not registered
- Repr includes validator name
- Works in Schema integration
- Multiple Custom validators can coexist

Impact it Made:
Validates the custom validator registration system, ensuring user-defined validators can be registered, looked up, and used reliably in schema validation.