### PR TITLE
test : added unit tests for _compare_column_profiles helper in quality.py

### DIFF
--- a/tests/test_compare_column_profiles.py
+++ b/tests/test_compare_column_profiles.py
@@ -1,7 +1,37 @@
 """Tests for _compare_column_profiles helper in arnio.quality."""
 
-import pytest
-from arnio.quality import _compare_column_profiles
+from arnio.quality import ColumnProfile, _compare_column_profiles
+
+
+def make_profile(
+    name="col",
+    dtype="int64",
+    semantic_type="numeric",
+    row_count=10,
+    null_count=0,
+    null_ratio=0.0,
+    unique_count=10,
+    unique_ratio=1.0,
+    min=None,
+    max=None,
+    mean=None,
+    std=None,
+):
+    """Helper to create a ColumnProfile instance with default values."""
+    return ColumnProfile(
+        name=name,
+        dtype=dtype,
+        semantic_type=semantic_type,
+        row_count=row_count,
+        null_count=null_count,
+        null_ratio=null_ratio,
+        unique_count=unique_count,
+        unique_ratio=unique_ratio,
+        min=min,
+        max=max,
+        mean=mean,
+        std=std,
+    )
 
 
 class TestCompareColumnProfiles:
@@ -9,79 +39,80 @@ class TestCompareColumnProfiles:
 
     def test_detects_dtype_change(self):
         """_compare_column_profiles reports dtype change between profiles."""
-        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10}
-        p2 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 10}
+        p1 = make_profile(dtype="int64")
+        p2 = make_profile(dtype="string")
         result = _compare_column_profiles(p1, p2)
-        assert "dtype" in result
-        assert result["dtype"]["baseline"] == "int"
-        assert result["dtype"]["comparison"] == "string"
+        assert "dtype" in result["changes"]
+        assert result["changes"]["dtype"]["baseline"] == "int64"
+        assert result["changes"]["dtype"]["comparison"] == "string"
 
     def test_detects_null_ratio_change(self):
         """_compare_column_profiles reports null_ratio changes."""
-        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10}
-        p2 = {"dtype": "int", "null_ratio": 0.5, "unique_count": 10}
+        p1 = make_profile(null_ratio=0.0)
+        p2 = make_profile(null_ratio=0.5)
         result = _compare_column_profiles(p1, p2)
-        assert "null_ratio" in result
-        assert result["null_ratio"]["baseline"] == 0.0
-        assert result["null_ratio"]["comparison"] == 0.5
+        assert "null_ratio" in result["changes"]
+        assert result["changes"]["null_ratio"]["baseline"] == 0.0
+        assert result["changes"]["null_ratio"]["comparison"] == 0.5
 
     def test_detects_unique_count_change(self):
         """_compare_column_profiles reports unique_count changes."""
-        p1 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 10}
-        p2 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 5}
+        p1 = make_profile(unique_count=10)
+        p2 = make_profile(unique_count=5)
         result = _compare_column_profiles(p1, p2)
-        assert "unique_count" in result
-        assert result["unique_count"]["baseline"] == 10
-        assert result["unique_count"]["comparison"] == 5
+        assert "unique_count" in result["changes"]
+        assert result["changes"]["unique_count"]["baseline"] == 10
+        assert result["changes"]["unique_count"]["comparison"] == 5
 
     def test_no_changes_for_identical_profiles(self):
         """_compare_column_profiles returns empty changes for identical profiles."""
-        p1 = {"dtype": "int", "null_ratio": 0.1, "unique_count": 10}
-        p2 = {"dtype": "int", "null_ratio": 0.1, "unique_count": 10}
+        p1 = make_profile(null_ratio=0.1, unique_count=10)
+        p2 = make_profile(null_ratio=0.1, unique_count=10)
         result = _compare_column_profiles(p1, p2)
-        assert len(result) == 0
+        assert len(result["changes"]) == 0
 
     def test_handles_missing_profile_keys(self):
-        """_compare_column_profiles handles missing keys in profile gracefully."""
-        p1 = {"dtype": "int"}
-        p2 = {"dtype": "int", "null_ratio": 0.0}
+        """_compare_column_profiles handles None values for stats in profile gracefully."""
+        p1 = make_profile(min=None, max=None, mean=None, std=None)
+        p2 = make_profile(min=None, max=None, mean=None, std=None)
         result = _compare_column_profiles(p1, p2)
-        # Should not raise, should handle gracefully
         assert result is not None
+        assert len(result["changes"]) == 0
 
     def test_detects_min_value_change(self):
         """_compare_column_profiles reports min_value changes."""
-        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 0}
-        p2 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 10}
+        p1 = make_profile(dtype="int64", min=0)
+        p2 = make_profile(dtype="int64", min=10)
         result = _compare_column_profiles(p1, p2)
-        assert "min_value" in result
+        assert "min" in result["changes"]
 
     def test_detects_max_value_change(self):
         """_compare_column_profiles reports max_value changes."""
-        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "max_value": 100}
-        p2 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "max_value": 200}
+        p1 = make_profile(dtype="int64", max=100)
+        p2 = make_profile(dtype="int64", max=200)
         result = _compare_column_profiles(p1, p2)
-        assert "max_value" in result
+        assert "max" in result["changes"]
 
     def test_detects_mean_value_change(self):
         """_compare_column_profiles reports mean_value changes."""
-        p1 = {"dtype": "float", "null_ratio": 0.0, "unique_count": 10, "mean_value": 50.0}
-        p2 = {"dtype": "float", "null_ratio": 0.0, "unique_count": 10, "mean_value": 75.0}
+        p1 = make_profile(dtype="float64", mean=50.0)
+        p2 = make_profile(dtype="float64", mean=75.0)
         result = _compare_column_profiles(p1, p2)
-        assert "mean_value" in result
+        assert "mean" in result["changes"]
 
     def test_calculates_delta_for_numeric_changes(self):
         """_compare_column_profiles includes delta in change records."""
-        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 0}
-        p2 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 5}
+        p1 = make_profile(dtype="int64", min=0)
+        p2 = make_profile(dtype="int64", min=5)
         result = _compare_column_profiles(p1, p2)
-        assert "min_value" in result
-        assert "delta" in result["min_value"]
+        assert "min" in result["changes"]
+        assert "delta" in result["changes"]["min"]
+        assert result["changes"]["min"]["delta"] == 5.0
 
     def test_handles_string_profiles(self):
         """_compare_column_profiles works with string-typed profiles."""
-        p1 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 10}
-        p2 = {"dtype": "string", "null_ratio": 0.1, "unique_count": 8}
+        p1 = make_profile(dtype="string", null_ratio=0.0, unique_count=10)
+        p2 = make_profile(dtype="string", null_ratio=0.1, unique_count=8)
         result = _compare_column_profiles(p1, p2)
-        assert "null_ratio" in result
-        assert "unique_count" in result
+        assert "null_ratio" in result["changes"]
+        assert "unique_count" in result["changes"]

--- a/tests/test_compare_column_profiles.py
+++ b/tests/test_compare_column_profiles.py
@@ -1,0 +1,87 @@
+"""Tests for _compare_column_profiles helper in arnio.quality."""
+
+import pytest
+from arnio.quality import _compare_column_profiles
+
+
+class TestCompareColumnProfiles:
+    """Test suite for _compare_column_profiles internal helper."""
+
+    def test_detects_dtype_change(self):
+        """_compare_column_profiles reports dtype change between profiles."""
+        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10}
+        p2 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 10}
+        result = _compare_column_profiles(p1, p2)
+        assert "dtype" in result
+        assert result["dtype"]["baseline"] == "int"
+        assert result["dtype"]["comparison"] == "string"
+
+    def test_detects_null_ratio_change(self):
+        """_compare_column_profiles reports null_ratio changes."""
+        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10}
+        p2 = {"dtype": "int", "null_ratio": 0.5, "unique_count": 10}
+        result = _compare_column_profiles(p1, p2)
+        assert "null_ratio" in result
+        assert result["null_ratio"]["baseline"] == 0.0
+        assert result["null_ratio"]["comparison"] == 0.5
+
+    def test_detects_unique_count_change(self):
+        """_compare_column_profiles reports unique_count changes."""
+        p1 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 10}
+        p2 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 5}
+        result = _compare_column_profiles(p1, p2)
+        assert "unique_count" in result
+        assert result["unique_count"]["baseline"] == 10
+        assert result["unique_count"]["comparison"] == 5
+
+    def test_no_changes_for_identical_profiles(self):
+        """_compare_column_profiles returns empty changes for identical profiles."""
+        p1 = {"dtype": "int", "null_ratio": 0.1, "unique_count": 10}
+        p2 = {"dtype": "int", "null_ratio": 0.1, "unique_count": 10}
+        result = _compare_column_profiles(p1, p2)
+        assert len(result) == 0
+
+    def test_handles_missing_profile_keys(self):
+        """_compare_column_profiles handles missing keys in profile gracefully."""
+        p1 = {"dtype": "int"}
+        p2 = {"dtype": "int", "null_ratio": 0.0}
+        result = _compare_column_profiles(p1, p2)
+        # Should not raise, should handle gracefully
+        assert result is not None
+
+    def test_detects_min_value_change(self):
+        """_compare_column_profiles reports min_value changes."""
+        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 0}
+        p2 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 10}
+        result = _compare_column_profiles(p1, p2)
+        assert "min_value" in result
+
+    def test_detects_max_value_change(self):
+        """_compare_column_profiles reports max_value changes."""
+        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "max_value": 100}
+        p2 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "max_value": 200}
+        result = _compare_column_profiles(p1, p2)
+        assert "max_value" in result
+
+    def test_detects_mean_value_change(self):
+        """_compare_column_profiles reports mean_value changes."""
+        p1 = {"dtype": "float", "null_ratio": 0.0, "unique_count": 10, "mean_value": 50.0}
+        p2 = {"dtype": "float", "null_ratio": 0.0, "unique_count": 10, "mean_value": 75.0}
+        result = _compare_column_profiles(p1, p2)
+        assert "mean_value" in result
+
+    def test_calculates_delta_for_numeric_changes(self):
+        """_compare_column_profiles includes delta in change records."""
+        p1 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 0}
+        p2 = {"dtype": "int", "null_ratio": 0.0, "unique_count": 10, "min_value": 5}
+        result = _compare_column_profiles(p1, p2)
+        assert "min_value" in result
+        assert "delta" in result["min_value"]
+
+    def test_handles_string_profiles(self):
+        """_compare_column_profiles works with string-typed profiles."""
+        p1 = {"dtype": "string", "null_ratio": 0.0, "unique_count": 10}
+        p2 = {"dtype": "string", "null_ratio": 0.1, "unique_count": 8}
+        result = _compare_column_profiles(p1, p2)
+        assert "null_ratio" in result
+        assert "unique_count" in result


### PR DESCRIPTION
Closes #1233.

Summary of What Has Been Done:
Added a new test file tests/test_compare_column_profiles.py with 10 test cases covering the _compare_column_profiles internal helper from arnio/quality.py. This function handles drift detection between column profiles.

Changes Made:
New file: tests/test_compare_column_profiles.py

The test suite covers:

Profile Comparison:
- Dtype change detection between profiles
- Null ratio change detection
- Unique count change detection
- Min value change detection
- Max value change detection
- Mean value change detection
- Delta calculation for numeric changes

Edge Cases:
- Identical profiles produce no changes
- Missing profile keys handled gracefully
- String-typed profile comparison

Impact it Made:
Direct unit tests for this internal helper ensure drift detection logic is reliable, making schema evolution tracking robust.