### PR TITLE
test : added extended unit tests for ArFrame.to_dict method

### DIFF
--- a/tests/test_to_dict.py
+++ b/tests/test_to_dict.py
@@ -1,0 +1,94 @@
+"""Tests for ArFrame.to_dict method - additional coverage."""
+
+import pytest
+from arnio import ArFrame
+
+
+class TestArFrameToDictExtended:
+    """Extended test suite for ArFrame.to_dict beyond existing coverage."""
+
+    def test_to_dict_with_single_column(self):
+        """to_dict works correctly with a single column frame."""
+        frame = ArFrame({"name": ["Alice", "Bob", "Charlie"]})
+        result = frame.to_dict()
+        assert list(result.keys()) == ["name"]
+        assert result["name"] == ["Alice", "Bob", "Charlie"]
+
+    def test_to_dict_with_multiple_columns(self):
+        """to_dict works correctly with multiple columns."""
+        frame = ArFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+        result = frame.to_dict()
+        assert len(result) == 3
+        assert result["a"] == [1, 2]
+        assert result["b"] == [3, 4]
+        assert result["c"] == [5, 6]
+
+    def test_to_dict_preserves_column_order(self):
+        """to_dict preserves the order of columns."""
+        frame = ArFrame({"z": [1], "a": [2], "m": [3]})
+        result = frame.to_dict()
+        assert list(result.keys()) == ["z", "a", "m"]
+
+    def test_to_dict_with_none_values(self):
+        """to_dict correctly handles None values in frame."""
+        frame = ArFrame({"name": ["Alice", None, "Charlie"]})
+        result = frame.to_dict()
+        assert result["name"] == ["Alice", None, "Charlie"]
+
+    def test_to_dict_with_all_none_column(self):
+        """to_dict handles column where all values are None."""
+        frame = ArFrame({"empty": [None, None, None]})
+        result = frame.to_dict()
+        assert result["empty"] == [None, None, None]
+
+    def test_to_dict_with_mixed_types(self):
+        """to_dict handles columns with mixed value types."""
+        frame = ArFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "active": [True, False, True]})
+        result = frame.to_dict()
+        assert result["id"] == [1, 2, 3]
+        assert result["name"] == ["Alice", "Bob", "Charlie"]
+        assert result["active"] == [True, False, True]
+
+    def test_to_dict_with_float_values(self):
+        """to_dict handles float values correctly."""
+        frame = ArFrame({"price": [10.5, 20.75, 30.0]})
+        result = frame.to_dict()
+        assert result["price"] == [10.5, 20.75, 30.0]
+
+    def test_to_dict_with_empty_strings(self):
+        """to_dict handles empty string values."""
+        frame = ArFrame({"name": ["Alice", "", "Charlie"]})
+        result = frame.to_dict()
+        assert result["name"] == ["Alice", "", "Charlie"]
+
+    def test_to_dict_return_type_is_dict(self):
+        """to_dict returns a Python dict type."""
+        frame = ArFrame({"a": [1, 2]})
+        result = frame.to_dict()
+        assert isinstance(result, dict)
+
+    def test_to_dict_column_values_are_lists(self):
+        """to_dict returns column values as lists."""
+        frame = ArFrame({"name": ["Alice", "Bob"]})
+        result = frame.to_dict()
+        assert isinstance(result["name"], list)
+
+    def test_to_dict_with_row_count(self):
+        """to_dict returns correct number of rows per column."""
+        frame = ArFrame({"name": ["Alice", "Bob", "Charlie", "Diana"]})
+        result = frame.to_dict()
+        assert len(result["name"]) == 4
+
+    def test_to_dict_empty_column_names_in_result(self):
+        """to_dict keys match actual column names."""
+        frame = ArFrame({"user_name": ["Alice"], "user_age": [30]})
+        result = frame.to_dict()
+        assert "user_name" in result
+        assert "user_age" in result
+
+    def test_to_dict_consistent_with_len(self):
+        """to_dict column length matches frame row count."""
+        frame = ArFrame({"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "w", "v"]})
+        result = frame.to_dict()
+        assert len(result["a"]) == len(frame)
+        assert len(result["b"]) == len(frame)

--- a/tests/test_to_dict.py
+++ b/tests/test_to_dict.py
@@ -1,7 +1,8 @@
 """Tests for ArFrame.to_dict method - additional coverage."""
 
-import pytest
-from arnio import ArFrame
+import pandas as pd
+
+import arnio as ar
 
 
 class TestArFrameToDictExtended:
@@ -9,14 +10,14 @@ class TestArFrameToDictExtended:
 
     def test_to_dict_with_single_column(self):
         """to_dict works correctly with a single column frame."""
-        frame = ArFrame({"name": ["Alice", "Bob", "Charlie"]})
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob", "Charlie"]}))
         result = frame.to_dict()
         assert list(result.keys()) == ["name"]
         assert result["name"] == ["Alice", "Bob", "Charlie"]
 
     def test_to_dict_with_multiple_columns(self):
         """to_dict works correctly with multiple columns."""
-        frame = ArFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}))
         result = frame.to_dict()
         assert len(result) == 3
         assert result["a"] == [1, 2]
@@ -25,25 +26,38 @@ class TestArFrameToDictExtended:
 
     def test_to_dict_preserves_column_order(self):
         """to_dict preserves the order of columns."""
-        frame = ArFrame({"z": [1], "a": [2], "m": [3]})
+        frame = ar.from_pandas(pd.DataFrame({"z": [1], "a": [2], "m": [3]}))
         result = frame.to_dict()
         assert list(result.keys()) == ["z", "a", "m"]
 
     def test_to_dict_with_none_values(self):
         """to_dict correctly handles None values in frame."""
-        frame = ArFrame({"name": ["Alice", None, "Charlie"]})
+        # pd.DataFrame treats None as NaN for numeric types, but objects are None.
+        frame = ar.from_pandas(
+            pd.DataFrame({"name": ["Alice", None, "Charlie"]}, dtype=object)
+        )
         result = frame.to_dict()
         assert result["name"] == ["Alice", None, "Charlie"]
 
     def test_to_dict_with_all_none_column(self):
         """to_dict handles column where all values are None."""
-        frame = ArFrame({"empty": [None, None, None]})
+        frame = ar.from_pandas(
+            pd.DataFrame({"empty": [None, None, None]}, dtype=object)
+        )
         result = frame.to_dict()
         assert result["empty"] == [None, None, None]
 
     def test_to_dict_with_mixed_types(self):
         """to_dict handles columns with mixed value types."""
-        frame = ArFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "active": [True, False, True]})
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "id": [1, 2, 3],
+                    "name": ["Alice", "Bob", "Charlie"],
+                    "active": [True, False, True],
+                }
+            )
+        )
         result = frame.to_dict()
         assert result["id"] == [1, 2, 3]
         assert result["name"] == ["Alice", "Bob", "Charlie"]
@@ -51,44 +65,48 @@ class TestArFrameToDictExtended:
 
     def test_to_dict_with_float_values(self):
         """to_dict handles float values correctly."""
-        frame = ArFrame({"price": [10.5, 20.75, 30.0]})
+        frame = ar.from_pandas(pd.DataFrame({"price": [10.5, 20.75, 30.0]}))
         result = frame.to_dict()
         assert result["price"] == [10.5, 20.75, 30.0]
 
     def test_to_dict_with_empty_strings(self):
         """to_dict handles empty string values."""
-        frame = ArFrame({"name": ["Alice", "", "Charlie"]})
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "", "Charlie"]}))
         result = frame.to_dict()
         assert result["name"] == ["Alice", "", "Charlie"]
 
     def test_to_dict_return_type_is_dict(self):
         """to_dict returns a Python dict type."""
-        frame = ArFrame({"a": [1, 2]})
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
         result = frame.to_dict()
         assert isinstance(result, dict)
 
     def test_to_dict_column_values_are_lists(self):
         """to_dict returns column values as lists."""
-        frame = ArFrame({"name": ["Alice", "Bob"]})
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob"]}))
         result = frame.to_dict()
         assert isinstance(result["name"], list)
 
     def test_to_dict_with_row_count(self):
         """to_dict returns correct number of rows per column."""
-        frame = ArFrame({"name": ["Alice", "Bob", "Charlie", "Diana"]})
+        frame = ar.from_pandas(
+            pd.DataFrame({"name": ["Alice", "Bob", "Charlie", "Diana"]})
+        )
         result = frame.to_dict()
         assert len(result["name"]) == 4
 
     def test_to_dict_empty_column_names_in_result(self):
         """to_dict keys match actual column names."""
-        frame = ArFrame({"user_name": ["Alice"], "user_age": [30]})
+        frame = ar.from_pandas(pd.DataFrame({"user_name": ["Alice"], "user_age": [30]}))
         result = frame.to_dict()
         assert "user_name" in result
         assert "user_age" in result
 
     def test_to_dict_consistent_with_len(self):
         """to_dict column length matches frame row count."""
-        frame = ArFrame({"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "w", "v"]})
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "w", "v"]})
+        )
         result = frame.to_dict()
         assert len(result["a"]) == len(frame)
         assert len(result["b"]) == len(frame)


### PR DESCRIPTION
Closes #1234.

Summary of What Has Been Done:
Added a new test file tests/test_to_dict.py with 14 test cases for ArFrame.to_dict method, extending the coverage in test_csv.py.

Changes Made:
New file: tests/test_to_dict.py

The test suite covers:

Frame Configurations:
- Single column frame handling
- Multiple columns handling
- Column order preservation

Value Handling:
- None values in frame
- All-None column handling
- Mixed types (int, string, bool) in same frame
- Float values
- Empty string values

Output Verification:
- Return type is Python dict
- Column values are lists
- Row count correctness
- Column names match actual columns
- Consistency with frame length

Impact it Made:
Ensures the to_dict method produces correct, consistent output across all frame configurations and value types.