### PR TITLE
docs: add nullable pandas extension dtype round-trip compatibility se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1717,6 +1717,7 @@ Discord is for fast conversation and support. GitHub remains the source of truth
 ## 📚 Documentation
 
 - [Troubleshooting Guide](docs/TROUBLESHOOTING.md)
+- [Nullable dtype compatibility](docs/nullable_dtype_compat.md)
 
 ## 🤝 Contribute
 

--- a/docs/nullable_dtype_compat.md
+++ b/docs/nullable_dtype_compat.md
@@ -60,4 +60,4 @@ The following dtypes raise `TypeError` with a fix hint:
 ## UInt64 Boundary
 
 `UInt64` values must fit within the signed 64-bit integer range
-(`0` to `9223372036854775807`). Values exceeding this raise `ValueError`.
+(`0` to `9223372036854775807`). Values exceeding this raise `ValueError`."" 

--- a/docs/nullable_dtype_compat.md
+++ b/docs/nullable_dtype_compat.md
@@ -60,4 +60,4 @@ The following dtypes raise `TypeError` with a fix hint:
 ## UInt64 Boundary
 
 `UInt64` values must fit within the signed 64-bit integer range
-(`0` to `9223372036854775807`). Values exceeding this raise `ValueError`."" 
+(`0` to `9223372036854775807`). Values exceeding this raise `ValueError`.

--- a/docs/nullable_dtype_compat.md
+++ b/docs/nullable_dtype_compat.md
@@ -1,0 +1,63 @@
+# Nullable pandas Extension Dtype Compatibility
+
+This section documents how arnio handles pandas nullable extension dtypes
+during a `from_pandas` → arnio → `to_pandas` round-trip.
+
+## Supported Dtypes
+
+| pandas input dtype | Supported | NA sentinel | Round-trip output dtype | Notes |
+|--------------------|-----------|-------------|------------------------|-------|
+| `Int64`            | ✅        | `pd.NA`     | `Int64`                | Nullable integer preserved |
+| `UInt64`           | ✅ (bounded) | `pd.NA`  | `Int64`                | Values must fit in signed int64 |
+| `Float64`          | ✅        | `pd.NA`     | `float64`              | Upcasts to native float |
+| `boolean`          | ✅        | `pd.NA`     | `boolean`              | Nullable bool preserved |
+| `string`           | ✅        | `pd.NA`     | `string`               | Nullable string preserved |
+
+> **Note:** `Float64` (capital F) is the pandas nullable float extension dtype.
+> After a round-trip it becomes `float64` (lowercase), the standard NumPy dtype.
+> The values and null positions are preserved; only the container dtype changes.
+
+## Round-Trip Example
+
+```python
+import pandas as pd
+import arnio as ar
+
+df = pd.DataFrame({
+    "int_col":   pd.array([1, 2, None],        dtype="Int64"),
+    "float_col": pd.array([1.5, None, 3.7],    dtype="Float64"),
+    "bool_col":  pd.array([True, None, False],  dtype="boolean"),
+    "str_col":   pd.array(["a", None, "c"],     dtype="string"),
+})
+
+frame  = ar.from_pandas(df)
+result = ar.to_pandas(frame)
+
+print(result.dtypes)
+# int_col      Int64
+# float_col    float64   ← note: Float64 → float64
+# bool_col     boolean
+# str_col      string
+```
+
+## NA Handling
+
+- `pd.NA` is preserved as `pd.NA` for `Int64`, `boolean`, and `string` columns.
+- `pd.NA` in a `Float64` column becomes `float('nan')` / `pd.isna()` after
+  round-trip because the output dtype is native `float64`.
+
+## Unsupported Dtypes
+
+The following dtypes raise `TypeError` with a fix hint:
+
+| pandas dtype     | Error |
+|-----------------|-------|
+| `datetime64`    | Convert to string first: `.astype(str)` |
+| `timedelta64`   | Convert to seconds: `.dt.total_seconds()` |
+| `category`      | Convert to string first: `.astype(str)` |
+| `complex128`    | Convert to string: `.apply(str)` |
+
+## UInt64 Boundary
+
+`UInt64` values must fit within the signed 64-bit integer range
+(`0` to `9223372036854775807`). Values exceeding this raise `ValueError`.

--- a/tests/test_nullable_dtype_compat.py
+++ b/tests/test_nullable_dtype_compat.py
@@ -1,0 +1,72 @@
+"""
+Smoke tests: nullable pandas extension dtype round-trip behavior.
+Covers the compatibility contract documented in docs/nullable_dtype_compat.md.
+"""
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+class TestNullableDtypeRoundtrip:
+    """Verify from_pandas -> to_pandas preserves nullable extension dtypes."""
+
+    def test_int64_with_na_preserves_dtype(self):
+        df = pd.DataFrame({"col": pd.array([1, 2, None], dtype="Int64")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert str(result["col"].dtype) == "Int64"
+
+    def test_int64_na_values_survive(self):
+        df = pd.DataFrame({"col": pd.array([1, None, 3], dtype="Int64")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert result["col"].isna().tolist() == [False, True, False]
+        assert result["col"].iloc[0] == 1
+        assert result["col"].iloc[2] == 3
+
+    def test_boolean_with_na_preserves_dtype(self):
+        df = pd.DataFrame({"col": pd.array([True, None, False], dtype="boolean")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert str(result["col"].dtype) == "boolean"
+
+    def test_boolean_na_values_survive(self):
+        df = pd.DataFrame({"col": pd.array([True, None, False], dtype="boolean")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert result["col"].isna().tolist() == [False, True, False]
+        assert result["col"].iloc[0]
+        assert not result["col"].iloc[2]
+
+    def test_string_with_na_preserves_dtype(self):
+        df = pd.DataFrame({"col": pd.array(["a", None, "c"], dtype="string")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert str(result["col"].dtype) == "string"
+
+    def test_string_na_values_survive(self):
+        df = pd.DataFrame({"col": pd.array(["a", None, "c"], dtype="string")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert result["col"].isna().tolist() == [False, True, False]
+
+    def test_float64_extension_na_values_survive(self):
+        """Float64 -> float64 on round-trip; NA positions must be preserved."""
+        df = pd.DataFrame({"col": pd.array([1.5, None, 3.7], dtype="Float64")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert result["col"].isna().tolist() == [False, True, False]
+        assert result["col"].iloc[0] == pytest.approx(1.5)
+        assert result["col"].iloc[2] == pytest.approx(3.7)
+
+    def test_multi_column_nullable_roundtrip(self):
+        """All nullable dtypes together in one DataFrame."""
+        df = pd.DataFrame(
+            {
+                "int_col": pd.array([1, None, 3], dtype="Int64"),
+                "bool_col": pd.array([True, None, False], dtype="boolean"),
+                "str_col": pd.array(["a", None, "c"], dtype="string"),
+            }
+        )
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert str(result["int_col"].dtype) == "Int64"
+        assert str(result["bool_col"].dtype) == "boolean"
+        assert str(result["str_col"].dtype) == "string"
+        assert result["int_col"].isna().tolist() == [False, True, False]
+        assert result["bool_col"].isna().tolist() == [False, True, False]
+        assert result["str_col"].isna().tolist() == [False, True, False]


### PR DESCRIPTION
…ction

## Summary
Add a dedicated compatibility reference for pandas nullable extension dtypes
(`Int64`, `Float64`, `boolean`, `string`) covering round-trip behavior,
NA sentinel handling, and output dtype contracts. Also adds 8 focused smoke
tests that lock in the documented behavior.

## Linked issue
Fixes #666 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
- [x] Other: `python -m pytest tests/test_nullable_dtype_compat.py -v` → 8 passed

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
- `docs/nullable_dtype_compat.md` - new file with compatibility table, round-trip example, NA handling notes, and unsupported dtype list.
- `tests/test_nullable_dtype_compat.py` - 8 smoke tests covering `Int64`, `Float64`, `boolean`, `string`, mixed columns, and NA survival.
- No existing behavior changed. All new additions only.
