### PR TITLE
fix: add max_issues parameter to DataQualityReport.to_markdown()

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -278,7 +278,7 @@ class DataQualityReport:
             indent=indent,
         )
 
-    def to_markdown(self) -> str:
+    def to_markdown(self, *, max_issues: int | None = None) -> str:
         """Return a GitHub-friendly Markdown report."""
 
         lines: list[str] = []
@@ -331,7 +331,12 @@ class DataQualityReport:
             lines.append("## Suggested Cleaning Steps")
             lines.append("")
 
-            for step in self.suggestions:
+            suggestions = (
+                self.suggestions[:max_issues]
+                if max_issues is not None
+                else self.suggestions
+            )
+            for step in suggestions:
                 kwargs_str = json.dumps(step[1], sort_keys=True, default=str)
                 conf_score = getattr(step, "confidence_score", None)
                 conf_reason = getattr(step, "confidence_reason", None)


### PR DESCRIPTION
## Summary
Adds `max_issues` parameter to `DataQualityReport.to_markdown()` so users can limit the number of cleaning suggestions shown in the output. Previously calling `to_markdown(max_issues=10)` crashed with `TypeError` even though the README documents this usage.

## Linked issue
Fixes #1269

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Verified that `to_markdown()` works correctly with and without the `max_issues` parameter — no TypeError raised.
- [ ] `make test`
- [ ] `make lint`
- [x] Other: manual verification

## Screenshots / Media
N/A

## Performance Impact
No performance impact — small parameter addition only.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
GSSoC 2026 contributor (enoshdev). Small focused fix — only `DataQualityReport.to_markdown()` in `arnio/quality.py` was changed.