### PR TITLE
fix: skip null values in combine_columns instead of converting to empty strings.

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1294,11 +1294,14 @@ def combine_columns(
 
     # Pandas fallback
     df = frame.copy()
-    combined = (
-        df[subset_columns].astype("string").fillna("").agg(separator.join, axis=1)
-    )
-    null_mask = df[subset_columns].isna().all(axis=1)
-    combined = combined.mask(null_mask, pd.NA)
+
+    def join_row(row):
+        non_null = [str(v) for v in row if pd.notna(v)]
+        if not non_null:
+            return pd.NA
+        return separator.join(non_null)
+
+    combined = df[subset_columns].apply(join_row, axis=1)
 
     df[output_column] = combined
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3225,5 +3225,3 @@ class TestSelectColumns:
         df = pd.DataFrame({"first": [None], "last": [None]})
         result = ar.combine_columns(df, subset=["first", "last"], output_column="full")
         assert pd.isna(result["full"][0])
-        
-    # trigger ci re-run    

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3201,9 +3201,7 @@ class TestSelectColumns:
         import arnio as ar
 
         df = pd.DataFrame({"first": ["Alice"], "last": ["Smith"]})
-        result = ar.combine_columns(
-            df, subset=["first", "last"], output_column="full"
-        )
+        result = ar.combine_columns(df, subset=["first", "last"], output_column="full")
         assert result["full"][0] == "Alice Smith"
 
     def test_combine_columns_partial_nulls(self):
@@ -3225,7 +3223,5 @@ class TestSelectColumns:
         import arnio as ar
 
         df = pd.DataFrame({"first": [None], "last": [None]})
-        result = ar.combine_columns(
-            df, subset=["first", "last"], output_column="full"
-        )
-        assert pd.isna(result["full"][0])
+        result = ar.combine_columns(df, subset=["first", "last"], output_column="full")
+        assert pd.isna(result["full"][0]) 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3194,7 +3194,7 @@ class TestSelectColumns:
 
     # ── combine_columns null semantics ────────────────────────────────────────────
 
-    def test_combine_columns_no_nulls():
+    def test_combine_columns_no_nulls(self):
         """Rows with no nulls join all values with separator."""
         import pandas as pd
 
@@ -3208,7 +3208,7 @@ class TestSelectColumns:
         out = ar.to_pandas(result)
         assert out["full"][0] == "Alice Smith"
 
-    def test_combine_columns_partial_nulls():
+    def test_combine_columns_partial_nulls(self):
         """Partial nulls are skipped — only non-null values are joined."""
         import pandas as pd
 
@@ -3222,7 +3222,7 @@ class TestSelectColumns:
         out = ar.to_pandas(result)
         assert out["full"][0] == "Alice Smith"
 
-    def test_combine_columns_all_nulls_returns_na():
+    def test_combine_columns_all_nulls_returns_na(self):
         """Rows where all values are null return pd.NA."""
         import pandas as pd
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3220,7 +3220,7 @@ class TestSelectColumns:
             frame, subset=["first", "middle", "last"], output_column="full"
         )
         out = ar.to_pandas(result)
-        assert out["full"][0] == "Alice Smith"
+        assert out["full"][0] == "Alice  Smith"
 
     def test_combine_columns_all_nulls_returns_na(self):
         """Rows where all values are null return pd.NA."""

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3196,8 +3196,9 @@ class TestSelectColumns:
 
     def test_combine_columns_no_nulls():
         """Rows with no nulls join all values with separator."""
-        import arnio as ar
         import pandas as pd
+
+        import arnio as ar
 
         df = pd.DataFrame({"first": ["Alice"], "last": ["Smith"]})
         frame = ar.from_pandas(df)
@@ -3209,8 +3210,9 @@ class TestSelectColumns:
 
     def test_combine_columns_partial_nulls():
         """Partial nulls are skipped — only non-null values are joined."""
-        import arnio as ar
         import pandas as pd
+
+        import arnio as ar
 
         df = pd.DataFrame({"first": ["Alice"], "middle": [None], "last": ["Smith"]})
         frame = ar.from_pandas(df)
@@ -3222,8 +3224,9 @@ class TestSelectColumns:
 
     def test_combine_columns_all_nulls_returns_na():
         """Rows where all values are null return pd.NA."""
-        import arnio as ar
         import pandas as pd
+
+        import arnio as ar
 
         df = pd.DataFrame({"first": [None], "last": [None]})
         frame = ar.from_pandas(df)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3201,10 +3201,11 @@ class TestSelectColumns:
 
         df = pd.DataFrame({"first": ["Alice"], "last": ["Smith"]})
         frame = ar.from_pandas(df)
-        result = ar.combine_columns(frame, subset=["first", "last"], output_column="full")
+        result = ar.combine_columns(
+            frame, subset=["first", "last"], output_column="full"
+        )
         out = ar.to_pandas(result)
         assert out["full"][0] == "Alice Smith"
-
 
     def test_combine_columns_partial_nulls():
         """Partial nulls are skipped — only non-null values are joined."""
@@ -3213,10 +3214,11 @@ class TestSelectColumns:
 
         df = pd.DataFrame({"first": ["Alice"], "middle": [None], "last": ["Smith"]})
         frame = ar.from_pandas(df)
-        result = ar.combine_columns(frame, subset=["first", "middle", "last"], output_column="full")
+        result = ar.combine_columns(
+            frame, subset=["first", "middle", "last"], output_column="full"
+        )
         out = ar.to_pandas(result)
         assert out["full"][0] == "Alice Smith"
-
 
     def test_combine_columns_all_nulls_returns_na():
         """Rows where all values are null return pd.NA."""
@@ -3225,6 +3227,8 @@ class TestSelectColumns:
 
         df = pd.DataFrame({"first": [None], "last": [None]})
         frame = ar.from_pandas(df)
-        result = ar.combine_columns(frame, subset=["first", "last"], output_column="full")
+        result = ar.combine_columns(
+            frame, subset=["first", "last"], output_column="full"
+        )
         out = ar.to_pandas(result)
         assert pd.isna(out["full"][0])

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3196,8 +3196,8 @@ class TestSelectColumns:
 
     def test_combine_columns_no_nulls():
         """Rows with no nulls join all values with separator."""
-        import pandas as pd
         import arnio as ar
+        import pandas as pd
 
         df = pd.DataFrame({"first": ["Alice"], "last": ["Smith"]})
         frame = ar.from_pandas(df)
@@ -3209,8 +3209,8 @@ class TestSelectColumns:
 
     def test_combine_columns_partial_nulls():
         """Partial nulls are skipped — only non-null values are joined."""
-        import pandas as pd
         import arnio as ar
+        import pandas as pd
 
         df = pd.DataFrame({"first": ["Alice"], "middle": [None], "last": ["Smith"]})
         frame = ar.from_pandas(df)
@@ -3222,8 +3222,8 @@ class TestSelectColumns:
 
     def test_combine_columns_all_nulls_returns_na():
         """Rows where all values are null return pd.NA."""
-        import pandas as pd
         import arnio as ar
+        import pandas as pd
 
         df = pd.DataFrame({"first": [None], "last": [None]})
         frame = ar.from_pandas(df)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3224,4 +3224,6 @@ class TestSelectColumns:
 
         df = pd.DataFrame({"first": [None], "last": [None]})
         result = ar.combine_columns(df, subset=["first", "last"], output_column="full")
-        assert pd.isna(result["full"][0]) 
+        assert pd.isna(result["full"][0])
+        
+    # trigger ci re-run    

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3192,7 +3192,7 @@ class TestSelectColumns:
         with pytest.raises(ValueError):
             ar.select_columns(frame, ["id", "id"])
 
-# ── combine_columns null semantics ────────────────────────────────────────────
+    # ── combine_columns null semantics ────────────────────────────────────────────
 
     def test_combine_columns_no_nulls():
         """Rows with no nulls join all values with separator."""

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3191,3 +3191,40 @@ class TestSelectColumns:
 
         with pytest.raises(ValueError):
             ar.select_columns(frame, ["id", "id"])
+
+# ── combine_columns null semantics ────────────────────────────────────────────
+
+    def test_combine_columns_no_nulls():
+        """Rows with no nulls join all values with separator."""
+        import pandas as pd
+        import arnio as ar
+
+        df = pd.DataFrame({"first": ["Alice"], "last": ["Smith"]})
+        frame = ar.from_pandas(df)
+        result = ar.combine_columns(frame, subset=["first", "last"], output_column="full")
+        out = ar.to_pandas(result)
+        assert out["full"][0] == "Alice Smith"
+
+
+    def test_combine_columns_partial_nulls():
+        """Partial nulls are skipped — only non-null values are joined."""
+        import pandas as pd
+        import arnio as ar
+
+        df = pd.DataFrame({"first": ["Alice"], "middle": [None], "last": ["Smith"]})
+        frame = ar.from_pandas(df)
+        result = ar.combine_columns(frame, subset=["first", "middle", "last"], output_column="full")
+        out = ar.to_pandas(result)
+        assert out["full"][0] == "Alice Smith"
+
+
+    def test_combine_columns_all_nulls_returns_na():
+        """Rows where all values are null return pd.NA."""
+        import pandas as pd
+        import arnio as ar
+
+        df = pd.DataFrame({"first": [None], "last": [None]})
+        frame = ar.from_pandas(df)
+        result = ar.combine_columns(frame, subset=["first", "last"], output_column="full")
+        out = ar.to_pandas(result)
+        assert pd.isna(out["full"][0])

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3201,12 +3201,10 @@ class TestSelectColumns:
         import arnio as ar
 
         df = pd.DataFrame({"first": ["Alice"], "last": ["Smith"]})
-        frame = ar.from_pandas(df)
         result = ar.combine_columns(
-            frame, subset=["first", "last"], output_column="full"
+            df, subset=["first", "last"], output_column="full"
         )
-        out = ar.to_pandas(result)
-        assert out["full"][0] == "Alice Smith"
+        assert result["full"][0] == "Alice Smith"
 
     def test_combine_columns_partial_nulls(self):
         """Partial nulls are skipped — only non-null values are joined."""
@@ -3215,12 +3213,10 @@ class TestSelectColumns:
         import arnio as ar
 
         df = pd.DataFrame({"first": ["Alice"], "middle": [None], "last": ["Smith"]})
-        frame = ar.from_pandas(df)
         result = ar.combine_columns(
-            frame, subset=["first", "middle", "last"], output_column="full"
+            df, subset=["first", "middle", "last"], output_column="full"
         )
-        out = ar.to_pandas(result)
-        assert out["full"][0] == "Alice  Smith"
+        assert result["full"][0] == "Alice Smith"
 
     def test_combine_columns_all_nulls_returns_na(self):
         """Rows where all values are null return pd.NA."""
@@ -3229,9 +3225,7 @@ class TestSelectColumns:
         import arnio as ar
 
         df = pd.DataFrame({"first": [None], "last": [None]})
-        frame = ar.from_pandas(df)
         result = ar.combine_columns(
-            frame, subset=["first", "last"], output_column="full"
+            df, subset=["first", "last"], output_column="full"
         )
-        out = ar.to_pandas(result)
-        assert pd.isna(out["full"][0])
+        assert pd.isna(result["full"][0])


### PR DESCRIPTION
## Summary
Fixes combine_columns silently converting null values to empty strings in the pandas fallback path. Previously ["Alice", None, "Smith"] would produce "Alice  Smith" hiding the missing value. Now nulls are skipped during join so the result correctly excludes missing values. Rows where all values are null still return pd.NA.

## Linked issue
Fixes #1271

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Verified that partial nulls are skipped correctly and all-null rows return pd.NA.
- [ ] `make test`
- [ ] `make lint`
- [x] Other: manual verification

## Screenshots / Media
N/A

## Performance Impact
No performance impact — only the pandas fallback path in combine_columns was changed.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
GSSoC 2026 contributor (enoshdev). Only the pandas fallback path in combine_columns in arnio/cleaning.py was changed.