### PR TITLE
Fix : Preserve schema in drop_empty_columns for empty frames

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -486,6 +486,9 @@ def drop_empty_columns(frame: ArFrame) -> ArFrame:
     """
     from .convert import to_pandas
 
+    if frame.shape[0] == 0:
+        return frame
+
     df = to_pandas(frame)
     empty_columns: list[str] = []
     for column in df.columns:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -809,6 +809,16 @@ class TestDropEmptyColumns:
         assert result.shape[0] in {0, 2}
         assert ar.to_pandas(result).shape[1] == 0
 
+    def test_drop_empty_columns_preserves_schema_on_empty_frame(self):
+        df = pd.DataFrame(columns=["a", "b", "c"])
+        frame = ar.from_pandas(df)
+        
+        result = ar.drop_empty_columns(frame)
+        
+        assert result.columns == ["a", "b", "c"]
+        assert result.shape[0] == 0
+        assert result.shape[1] == 3
+
 
 class TestClipNumeric:
     def test_clip_numeric_lower_only(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -812,9 +812,9 @@ class TestDropEmptyColumns:
     def test_drop_empty_columns_preserves_schema_on_empty_frame(self):
         df = pd.DataFrame(columns=["a", "b", "c"])
         frame = ar.from_pandas(df)
-        
+
         result = ar.drop_empty_columns(frame)
-        
+
         assert result.columns == ["a", "b", "c"]
         assert result.shape[0] == 0
         assert result.shape[1] == 3


### PR DESCRIPTION
This pull request improves the behavior of the `drop_empty_columns` function to handle empty data frames more gracefully and adds a corresponding test to ensure this case is covered.

Functionality improvements:

* Updated `drop_empty_columns` in `arnio/cleaning.py` to immediately return the input frame if it has zero rows, preventing unnecessary processing and preserving the schema.

Testing enhancements:

* Added a new test `test_drop_empty_columns_preserves_schema_on_empty_frame` in `tests/test_cleaning.py` to verify that the schema (column names) is preserved when the input frame is empty.

Closes #1265