### PR TITLE
perf: bulk-append fast path for CsvParser::parse_line

### DIFF
--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <fstream>
 #include <memory>
 #include <optional>
@@ -56,6 +57,9 @@ class CsvParser {
 
    private:
     CsvConfig config_;
+    // 256-byte lookup table: non-zero for chars that stop the unquoted
+    // bulk-scan (delimiter, '"', '\r'). Initialised once in the constructor.
+    std::array<uint8_t, 256> stop_unquoted_{};
 };
 
 class CsvReader {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -495,8 +495,8 @@ static std::string handle_utf8_errors(const std::string& input, const std::strin
 CsvParser::CsvParser(const CsvConfig& config) : config_(config) {
     // Build stop-character table for the unquoted bulk-scan fast path.
     stop_unquoted_.fill(0);
-    stop_unquoted_[static_cast<unsigned char>('"')]            = 1;
-    stop_unquoted_[static_cast<unsigned char>('\r')]           = 1;
+    stop_unquoted_[static_cast<unsigned char>('"')] = 1;
+    stop_unquoted_[static_cast<unsigned char>('\r')] = 1;
     stop_unquoted_[static_cast<unsigned char>(config.delimiter)] = 1;
 }
 
@@ -549,11 +549,10 @@ void CsvParser::parse_line(const std::string& line, std::vector<std::string>& fi
                 // (delimiter, '"', '\r') using a precomputed 256-byte lookup
                 // table, then append the whole plain-text run in one call
                 // instead of N individual field += c assignments.
-                const char* ptr     = line.data() + i;
+                const char* ptr = line.data() + i;
                 const char* end_ptr = line.data() + line.size();
-                const char* scan    = ptr;
-                while (scan < end_ptr &&
-                       !stop_unquoted_[static_cast<unsigned char>(*scan)]) {
+                const char* scan = ptr;
+                while (scan < end_ptr && !stop_unquoted_[static_cast<unsigned char>(*scan)]) {
                     ++scan;
                 }
                 field.append(ptr, scan - ptr);

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -492,7 +492,13 @@ static std::string handle_utf8_errors(const std::string& input, const std::strin
 
     return output;
 }
-CsvParser::CsvParser(const CsvConfig& config) : config_(config) {}
+CsvParser::CsvParser(const CsvConfig& config) : config_(config) {
+    // Build stop-character table for the unquoted bulk-scan fast path.
+    stop_unquoted_.fill(0);
+    stop_unquoted_[static_cast<unsigned char>('"')]            = 1;
+    stop_unquoted_[static_cast<unsigned char>('\r')]           = 1;
+    stop_unquoted_[static_cast<unsigned char>(config.delimiter)] = 1;
+}
 
 CsvReader::CsvReader(const CsvConfig& config) : parser_(config) {}
 
@@ -536,10 +542,24 @@ void CsvParser::parse_line(const std::string& line, std::vector<std::string>& fi
             } else if (c == config_.delimiter) {
                 add_field(field);
                 field.clear();
-            } else if (c == '\r' && !in_quotes) {
+            } else if (c == '\r') {
                 continue;
             } else {
-                field += c;
+                // Bulk-append fast path: scan ahead to the next stop character
+                // (delimiter, '"', '\r') using a precomputed 256-byte lookup
+                // table, then append the whole plain-text run in one call
+                // instead of N individual field += c assignments.
+                const char* ptr     = line.data() + i;
+                const char* end_ptr = line.data() + line.size();
+                const char* scan    = ptr;
+                while (scan < end_ptr &&
+                       !stop_unquoted_[static_cast<unsigned char>(*scan)]) {
+                    ++scan;
+                }
+                field.append(ptr, scan - ptr);
+                // After loop's ++i, i will point at the first stop char (or
+                // one past end), so subtract 1 to compensate.
+                i = static_cast<size_t>(scan - line.data()) - 1;
             }
         }
     }

--- a/cpp/tests/test_csv_parser.cpp
+++ b/cpp/tests/test_csv_parser.cpp
@@ -121,7 +121,8 @@ TEST_CASE("parse_line bulk fast path handles long unquoted field", "[csv_parser]
     REQUIRE(fields[2] == "end");
 }
 
-TEST_CASE("parse_line bulk fast path preserves quoted fields alongside long unquoted", "[csv_parser]") {
+TEST_CASE("parse_line bulk fast path preserves quoted fields alongside long unquoted",
+          "[csv_parser]") {
     CsvParser parser;
     std::string long_field(200, 'a');
     std::string line = long_field + ",\"quoted, value\",end";

--- a/cpp/tests/test_csv_parser.cpp
+++ b/cpp/tests/test_csv_parser.cpp
@@ -108,3 +108,62 @@ TEST_CASE("is_null_sentinel respects custom null_values config", "[csv_parser]")
     REQUIRE(parser.is_null_sentinel("NULL") == true);
     REQUIRE(parser.is_null_sentinel("alice") == false);
 }
+TEST_CASE("parse_line bulk fast path handles long unquoted field", "[csv_parser]") {
+    CsvParser parser;
+    std::string long_field(200, 'x');
+    std::string line = long_field + ",short,end";
+
+    auto fields = parser.parse_line(line);
+
+    REQUIRE(fields.size() == 3);
+    REQUIRE(fields[0] == long_field);
+    REQUIRE(fields[1] == "short");
+    REQUIRE(fields[2] == "end");
+}
+
+TEST_CASE("parse_line bulk fast path preserves quoted fields alongside long unquoted", "[csv_parser]") {
+    CsvParser parser;
+    std::string long_field(200, 'a');
+    std::string line = long_field + ",\"quoted, value\",end";
+
+    auto fields = parser.parse_line(line);
+
+    REQUIRE(fields.size() == 3);
+    REQUIRE(fields[0] == long_field);
+    REQUIRE(fields[1] == "quoted, value");
+    REQUIRE(fields[2] == "end");
+}
+
+TEST_CASE("parse_line bulk fast path works with custom delimiter", "[csv_parser]") {
+    CsvConfig cfg;
+    cfg.delimiter = ';';
+    CsvParser parser(cfg);
+    std::string long_field(200, 'z');
+    std::string line = long_field + ";col2;col3";
+
+    auto fields = parser.parse_line(line);
+
+    REQUIRE(fields.size() == 3);
+    REQUIRE(fields[0] == long_field);
+    REQUIRE(fields[1] == "col2");
+}
+TEST_CASE("parse_line handles \\r correctly in unquoted field", "[csv_parser]") {
+    CsvParser parser;
+    auto fields = parser.parse_line("alice\r");
+    REQUIRE(fields.size() == 1);
+    REQUIRE(fields[0] == "alice");
+}
+
+TEST_CASE("parse_line row width — more fields than expected does not crash", "[csv_parser]") {
+    CsvParser parser;
+    auto fields = parser.parse_line("a,b,c,d,e");
+    REQUIRE(fields.size() == 5);
+    REQUIRE(fields[4] == "e");
+}
+
+TEST_CASE("parse_line row width — single field no delimiter", "[csv_parser]") {
+    CsvParser parser;
+    auto fields = parser.parse_line("onlyfield");
+    REQUIRE(fields.size() == 1);
+    REQUIRE(fields[0] == "onlyfield");
+}


### PR DESCRIPTION
## Title

perf: bulk-append fast path for CsvParser::parse_line

---

## What this PR does

Replaces the per-character `field += c` loop in
`CsvParser::parse_line` with a bulk append fast path for unquoted
fields.

### Changes

- Adds `std::array<uint8_t, 256> stop_unquoted_` to `CsvParser`
- Lookup table is initialized once in the constructor
- Marks delimiter, `"`, and `\r` as stop characters
- Unquoted parsing now scans forward until the next stop character
- Appends contiguous plain-text runs using:

```cpp
field.append(ptr, count);
```

instead of repeated:

```cpp
field += c;
```

This reduces:
- per-character append overhead
- repeated capacity checks
- branch pressure in the parser hot path

---

## Files changed

- `cpp/src/csv_reader.cpp`
- `cpp/include/arnio/csv_reader.h`
- `cpp/tests/test_csv_parser.cpp`

No Python API, pybind11 binding, or data model changes.

---

## Benchmark

### Reproducible command

```bash
python benchmarks/benchmark_vs_pandas.py
```

Observed improvements are concentrated in `read_csv`, which is the
code path modified by this PR.

### read_csv performance

| Dataset | Before | After | Improvement |
|---|---:|---:|---:|
| Tall CSV (1M × 12) | 5.95s | 5.67s | ~5% |
| Wide CSV (5k × 256) | 0.79s | 0.74s | ~6% |
| Sparse-null (1M × 6) | 3.18s | 2.91s | ~8% |
| Dense-null (1M × 6) | 2.69s | 2.46s | ~9% |
| Multiline (100k × 4) | 0.29s | 0.28s | ~3% |

<img width="832" height="837" alt="Screenshot 2026-05-23 201445" src="https://github.com/user-attachments/assets/79b489b8-a28d-4f47-9784-9ee2d7654652" />
<img width="909" height="810" alt="Screenshot 2026-05-23 201500" src="https://github.com/user-attachments/assets/1f72186e-fc9c-405f-af68-0776a922e743" />
<img width="977" height="412" alt="image" src="https://github.com/user-attachments/assets/91090197-3dd3-4053-842d-6827ce65bb88" />


Correctness verification passed on all benchmark datasets.

Memory usage remained stable across benchmark runs.

---

## Tests added

Added targeted C++ parser tests in:

```text
cpp/tests/test_csv_parser.cpp
```

Coverage of new tests added in this PR:
- long unquoted fields (bulk fast path)
- quoted field alongside long unquoted field
- custom delimiter with bulk fast path
- \r stripping in unquoted field
- row width: more fields than expected
- row width: single field with no delimiter

Existing tests (already passing, unchanged):
- escaped quotes
- multiline quoted records
- empty fields

---

## Checklist

- [x] All existing tests pass (`1576 passed, 0 failed`)
- [x] New parser correctness tests added
- [x] Before/after benchmark numbers included
- [x] Reproducible benchmark command included
- [x] No behavior change for quoted fields, escaped quotes, multiline records, custom delimiters, or empty fields
- [x] No Python API or binding changes

---

Closes  #1263 