### PR TITLE
feat(io): add encoding_errors, dtype, skiprows to read_csv_chunked; deprecate skip_rows; infer delimiter from extension

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -5,7 +5,6 @@ CSV reading and writing functions.
 
 from __future__ import annotations
 
-from importlib.resources import path
 import io
 import os
 import shutil
@@ -290,8 +289,8 @@ def _validate_skip_rows(skip_rows: int) -> int:
     return skip_rows
 
 
-    def _validate_skiprows(skiprows: int | None) -> int | None:
-    """Validate skiprows parameter (alias used by read_csv_chunked)."""
+def _validate_skiprows(skiprows: int | None) -> int | None:
+    """Validate skiprows parameter."""
     if skiprows is None:
         return None
     if isinstance(skiprows, bool) or not isinstance(skiprows, int):
@@ -730,6 +729,7 @@ def read_csv_chunked(
     # Handle skip_rows → skiprows deprecation shim
     if skip_rows is not None:
         import warnings
+
         warnings.warn(
             "skip_rows is deprecated and will be removed in a future release. "
             "Use skiprows instead.",
@@ -742,7 +742,6 @@ def read_csv_chunked(
             )
         skiprows = skip_rows
 
-    
     # Delimiter auto-inference (matches read_csv behaviour)
     if delimiter is None:
         delimiter = "\t" if path.lower().endswith(".tsv") else ","
@@ -785,7 +784,7 @@ def read_csv_chunked(
         with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
             reader.open(native_path)
             while True:
-                chunk = reader.next_chunk(chunksize, on_bad_lines)
+            chunk = reader.next_chunk(chunksize, on_bad_lines)
                 if chunk is None:
                     break
                 cpp_frame, bad_rows = chunk
@@ -793,7 +792,11 @@ def read_csv_chunked(
                 if on_bad_lines == "warn" and bad_rows:
                     _warn_bad_rows(bad_rows)
 
-                yield ArFrame(cpp_frame)
+                ar_frame = ArFrame(cpp_frame)
+                if dtype is not None:
+                    from .cleaning import cast_types as _apply_dtype
+                    ar_frame = _apply_dtype(ar_frame, dtype)
+                yield ar_frame    
     except ValueError:
         raise
     except CsvReadError:
@@ -820,10 +823,8 @@ def write_csv(
         The data frame to write.
     path : str
         Destination file path. Supports .csv, .txt, and .tsv extensions.
-    delimiter : str or None, default None
-        Field delimiter character. When ``None`` (the default) the
-        delimiter is inferred from the file extension: ``'\t'`` for
-        ``.tsv`` files and ``','`` for everything else.
+    delimiter : str or default ","
+        Field delimiter character.
     write_header : bool, default True
         Whether to write the column header row.
     line_terminator : str, default "\\n"

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -5,6 +5,7 @@ CSV reading and writing functions.
 
 from __future__ import annotations
 
+from importlib.resources import path
 import io
 import os
 import shutil
@@ -287,6 +288,17 @@ def _validate_skip_rows(skip_rows: int) -> int:
         raise ValueError("skip_rows must be non-negative")
 
     return skip_rows
+
+
+    def _validate_skiprows(skiprows: int | None) -> int | None:
+    """Validate skiprows parameter (alias used by read_csv_chunked)."""
+    if skiprows is None:
+        return None
+    if isinstance(skiprows, bool) or not isinstance(skiprows, int):
+        raise TypeError("skiprows must be an integer or None")
+    if skiprows < 0:
+        raise ValueError("skiprows must be non-negative")
+    return skiprows
 
 
 def _validate_chunksize(chunksize: int) -> int:
@@ -608,17 +620,20 @@ def read_csv_chunked(
     path: str | os.PathLike[str],
     *,
     chunksize: int = 10_000,
-    delimiter: str = ",",
+    delimiter: str | None = None,
     has_header: bool = True,
     usecols: list[str] | None = None,
     nrows: int | None = None,
-    skip_rows: int = 0,
+    skiprows: int | None = None,
+    skip_rows: int | None = None,
     encoding: str = "utf-8",
     trim_headers: bool = True,
     decimal_separator: str = ".",
     thousands_separator: str | None = None,
     null_values: list[str] | None = None,
+    dtype: dict[str, str] | None = None,
     mode: str = "strict",
+    encoding_errors: str = "strict",
     on_bad_lines: str = "error",
 ) -> Iterator[ArFrame]:
     """Read a CSV file in chunks, yielding ArFrame objects.
@@ -640,8 +655,16 @@ def read_csv_chunked(
         Columns to read. If None, reads all columns.
     nrows : int, optional
         Maximum total number of data rows to read across all chunks.
-    skip_rows : int, default 0
+    skiprows : int, optional
         Number of data rows to skip after the header row.
+        Alias ``skip_rows`` is still accepted but deprecated and
+        will be removed in a future release.
+    dtype : dict[str, str], optional
+        Explicit column dtype mapping. Specified columns skip automatic
+        type inference and use the requested dtype directly.
+        Supported dtypes: ``"string"``, ``"int64"``, ``"float64"``, ``"bool"``.
+    encoding_errors : {"strict", "replace", "ignore"}, default "strict"
+        Controls how invalid UTF-8 bytes are handled during CSV parsing.
     encoding : str, default "utf-8"
         File encoding.
     trim_headers : bool, default True
@@ -704,13 +727,35 @@ def read_csv_chunked(
     except FileNotFoundError:
         pass
 
+    # Handle skip_rows → skiprows deprecation shim
+    if skip_rows is not None:
+        import warnings
+        warnings.warn(
+            "skip_rows is deprecated and will be removed in a future release. "
+            "Use skiprows instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if skiprows is not None:
+            raise TypeError(
+                "Cannot pass both skip_rows and skiprows. Use skiprows only."
+            )
+        skiprows = skip_rows
+
+    
+    # Delimiter auto-inference (matches read_csv behaviour)
+    if delimiter is None:
+        delimiter = "\t" if path.lower().endswith(".tsv") else ","
+
     decimal_separator = _validate_decimal_separator(decimal_separator)
     _validate_thousands_separator(thousands_separator, decimal_separator)
     delimiter = _validate_delimiter(delimiter)
     mode = _validate_parser_mode(mode)
     chunksize = _validate_chunksize(chunksize)
-    skip_rows = _validate_skip_rows(skip_rows)
+    encoding_errors = _validate_encoding_errors(encoding_errors)
     on_bad_lines = _validate_on_bad_lines(on_bad_lines)
+
+    resolved_skiprows = _validate_skiprows(skiprows)
 
     config = _CsvConfig()
     config.delimiter = delimiter
@@ -720,7 +765,11 @@ def read_csv_chunked(
     config.decimal_separator = decimal_separator
     config.thousands_separator = thousands_separator
     config.mode = mode
-    config.skip_rows = skip_rows
+    config.encoding_errors = encoding_errors
+    if resolved_skiprows is not None:
+        config.skip_rows = resolved_skiprows
+    if dtype is not None:
+        config.dtype = _validate_dtype_mapping(dtype)
 
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)
@@ -771,8 +820,10 @@ def write_csv(
         The data frame to write.
     path : str
         Destination file path. Supports .csv, .txt, and .tsv extensions.
-    delimiter : str, default ","
-        Field delimiter character.
+    delimiter : str or None, default None
+        Field delimiter character. When ``None`` (the default) the
+        delimiter is inferred from the file extension: ``'\t'`` for
+        ``.tsv`` files and ``','`` for everything else.
     write_header : bool, default True
         Whether to write the column header row.
     line_terminator : str, default "\\n"

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -784,7 +784,7 @@ def read_csv_chunked(
         with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
             reader.open(native_path)
             while True:
-            chunk = reader.next_chunk(chunksize, on_bad_lines)
+                chunk = reader.next_chunk(chunksize, on_bad_lines)
                 if chunk is None:
                     break
                 cpp_frame, bad_rows = chunk
@@ -795,8 +795,9 @@ def read_csv_chunked(
                 ar_frame = ArFrame(cpp_frame)
                 if dtype is not None:
                     from .cleaning import cast_types as _apply_dtype
+
                     ar_frame = _apply_dtype(ar_frame, dtype)
-                yield ar_frame    
+                yield ar_frame
     except ValueError:
         raise
     except CsvReadError:

--- a/tests/test_csv_chunked.py
+++ b/tests/test_csv_chunked.py
@@ -142,3 +142,126 @@ class TestReadCsvChunkedParity:
             _chunked_concat(str(path), chunksize=1, mode="strict")
         with pytest.raises(CsvReadError, match="expected 2"):
             ar.read_csv(str(path), mode="strict")
+
+class TestReadCsvChunkedParamParity:
+    """Issue #1256 — encoding_errors, dtype, skiprows/skip_rows parity with read_csv."""
+
+    def test_encoding_errors_replace(self, tmp_path):
+        """encoding_errors='replace' substitutes bad bytes instead of crashing."""
+        path = tmp_path / "bad_encoding.csv"
+        # Write a CSV with a valid header and one row containing an invalid UTF-8 byte
+        path.write_bytes(b"name,score\nAlice\xff,90\nBob,85\n")
+        chunks = list(ar.read_csv_chunked(str(path), encoding_errors="replace"))
+        df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert df.shape[0] == 2
+        # The replacement character should appear somewhere in the bad row's value
+        assert "\ufffd" in df["name"].iloc[0]
+
+    def test_encoding_errors_ignore(self, tmp_path):
+        """encoding_errors='ignore' drops bad bytes silently."""
+        path = tmp_path / "bad_encoding.csv"
+        path.write_bytes(b"name,score\nAli\xffce,90\nBob,85\n")
+        chunks = list(ar.read_csv_chunked(str(path), encoding_errors="ignore"))
+        df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert df.shape[0] == 2
+        assert "\ufffd" not in df["name"].iloc[0]
+
+    def test_encoding_errors_strict_raises(self, tmp_path):
+        """encoding_errors='strict' (default) raises on bad bytes."""
+        path = tmp_path / "bad_encoding.csv"
+        path.write_bytes(b"name,score\nAlice\xff,90\n")
+        with pytest.raises(Exception):
+            list(ar.read_csv_chunked(str(path), encoding_errors="strict"))
+
+    def test_dtype_overrides_inference(self, tmp_path):
+        """dtype param forces a column to the requested type in every chunk."""
+        lines = ["id,age,score"]
+        for i in range(30):
+            lines.append(f"{i},{20 + i},9{i % 10}.5")
+        path = tmp_path / "dtype_test.csv"
+        path.write_text("\n".join(lines))
+
+        chunks = list(
+            ar.read_csv_chunked(str(path), chunksize=10, dtype={"age": "string"})
+        )
+        for chunk in chunks:
+            df = ar.to_pandas(chunk)
+            # age should be string in every chunk, not int64
+            assert str(df["age"].dtype) in ("object", "string", "StringDtype")
+
+    def test_dtype_applied_consistently_across_chunks(self, tmp_path):
+        """dtype is applied the same way in every chunk, not just the first."""
+        lines = ["code,value"]
+        for i in range(50):
+            lines.append(f"C{i:03d},{i}")
+        path = tmp_path / "dtype_chunks.csv"
+        path.write_text("\n".join(lines))
+
+        chunks = list(
+            ar.read_csv_chunked(str(path), chunksize=15, dtype={"value": "string"})
+        )
+        assert len(chunks) > 1
+        dtypes_per_chunk = [ar.to_pandas(c)["value"].dtype for c in chunks]
+        assert len(set(str(d) for d in dtypes_per_chunk)) == 1
+
+    def test_skiprows_new_name(self, tmp_path):
+        """skiprows (new name) skips the requested number of rows."""
+        lines = ["id,value"]
+        for i in range(20):
+            lines.append(f"{i},{i}")
+        path = tmp_path / "skiprows.csv"
+        path.write_text("\n".join(lines))
+
+        chunks = list(ar.read_csv_chunked(str(path), chunksize=5, skiprows=10))
+        df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert df.shape[0] == 10
+        assert df["id"].tolist() == list(range(10, 20))
+
+    def test_skip_rows_old_name_still_works_with_deprecation_warning(self, tmp_path):
+        """skip_rows still works but emits DeprecationWarning."""
+        lines = ["id,value"] + [f"{i},{i}" for i in range(10)]
+        path = tmp_path / "skip_rows_compat.csv"
+        path.write_text("\n".join(lines))
+
+        with pytest.warns(DeprecationWarning, match="skip_rows is deprecated"):
+            chunks = list(ar.read_csv_chunked(str(path), skip_rows=5))
+        df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert df.shape[0] == 5
+
+    def test_skip_rows_and_skiprows_together_raises(self, tmp_path):
+        """Passing both skip_rows and skiprows is an error."""
+        lines = ["id,value"] + [f"{i},{i}" for i in range(10)]
+        path = tmp_path / "both.csv"
+        path.write_text("\n".join(lines))
+
+        with pytest.raises(TypeError, match="Cannot pass both"):
+            list(ar.read_csv_chunked(str(path), skip_rows=2, skiprows=2))
+
+    def test_delimiter_auto_inferred_for_tsv(self, tmp_path):
+        """delimiter=None auto-infers tab for .tsv files, matching read_csv."""
+        path = tmp_path / "data.tsv"
+        path.write_text("name\tage\nAlice\t30\nBob\t25\n")
+
+        chunks = list(ar.read_csv_chunked(str(path)))
+        df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert list(df.columns) == ["name", "age"]
+        assert df.shape[0] == 2
+
+    def test_delimiter_auto_inferred_for_csv(self, tmp_path):
+        """delimiter=None defaults to comma for .csv files."""
+        path = tmp_path / "data.csv"
+        path.write_text("name,age\nAlice,30\nBob,25\n")
+
+        chunks = list(ar.read_csv_chunked(str(path)))
+        df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert list(df.columns) == ["name", "age"]
+
+    def test_explicit_delimiter_overrides_extension(self, tmp_path):
+        """Explicit delimiter always takes precedence over extension inference."""
+        path = tmp_path / "data.tsv"
+        path.write_text("name,age\nAlice,30\nBob,25\n")
+
+        chunks = list(ar.read_csv_chunked(str(path), delimiter=","))
+        df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
+        assert list(df.columns) == ["name", "age"]
+        

--- a/tests/test_csv_chunked.py
+++ b/tests/test_csv_chunked.py
@@ -143,6 +143,7 @@ class TestReadCsvChunkedParity:
         with pytest.raises(CsvReadError, match="expected 2"):
             ar.read_csv(str(path), mode="strict")
 
+
 class TestReadCsvChunkedParamParity:
     """Issue #1256 — encoding_errors, dtype, skiprows/skip_rows parity with read_csv."""
 
@@ -187,7 +188,7 @@ class TestReadCsvChunkedParamParity:
         for chunk in chunks:
             df = ar.to_pandas(chunk)
             # age should be string in every chunk, not int64
-            assert str(df["age"].dtype) in ("object", "string", "StringDtype")
+            assert str(df["age"].dtype).lower().startswith("string") or str(df["age"].dtype) == "object"
 
     def test_dtype_applied_consistently_across_chunks(self, tmp_path):
         """dtype is applied the same way in every chunk, not just the first."""
@@ -264,4 +265,3 @@ class TestReadCsvChunkedParamParity:
         chunks = list(ar.read_csv_chunked(str(path), delimiter=","))
         df = pd.concat([ar.to_pandas(c) for c in chunks], ignore_index=True)
         assert list(df.columns) == ["name", "age"]
-        


### PR DESCRIPTION
Closes #1256

## Changes
- Added `encoding_errors: str = "strict"` to `read_csv_chunked`, wired through `_validate_encoding_errors` and `_CsvConfig`, matching `read_csv`.
- Added `dtype: dict[str, str] | None = None`, wired through `_validate_dtype_mapping` and `_CsvConfig`, matching `read_csv`.
- Changed `delimiter: str = ","` to `delimiter: str | None = None` with the same extension-based inference logic `read_csv` uses — tab for `.tsv`, comma for everything else.
- Added `skiprows` as the canonical parameter name. `skip_rows` still works but emits `DeprecationWarning`. Passing both at once raises `TypeError`.

## Tests
New `TestReadCsvChunkedParamParity` class added to `tests/test_csv_chunked.py` covering all acceptance criteria from the issue.