### PR TITLE
refactor(cleaning): add ArFrame | pd.DataFrame union type annotations to filter_rows and replace_values

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1122,11 +1122,11 @@ def clean(
 
 
 def filter_rows(
-    frame: "ArFrame | pd.DataFrame",
+    frame: ArFrame | pd.DataFrame,
     column: str,
     op: str,
     value: object,
-) -> "ArFrame | pd.DataFrame":
+) -> ArFrame | pd.DataFrame:
     """Filter rows based on a column condition.
 
     Parameters
@@ -1523,10 +1523,10 @@ def _is_null_mapping_key(value):
 
 
 def replace_values(
-    frame: "ArFrame | pd.DataFrame",
+    frame: ArFrame | pd.DataFrame,
     mapping: dict,
     column: str | None = None,
-) -> "ArFrame | pd.DataFrame":
+) -> ArFrame | pd.DataFrame:
     """Replace values based on a mapping dict.
 
     If ``column`` is ``None``, the mapping is applied to every column.
@@ -1560,7 +1560,7 @@ def replace_values(
     >>> frame = ar.read_csv("data.csv")
     >>> replaced = ar.replace_values(frame, {"old_value": "new_value"}, column="name")
     """
-    
+
     import pandas as pd
 
     from .convert import from_pandas, to_pandas

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1121,8 +1121,38 @@ def clean(
     return pipeline(frame, steps)
 
 
-def filter_rows(frame, column, op, value):
-    """Filter rows based on a column condition."""
+def filter_rows(
+    frame: "ArFrame | pd.DataFrame",
+    column: str,
+    op: str,
+    value: object,
+) -> "ArFrame | pd.DataFrame":
+    """Filter rows based on a column condition.
+
+    Parameters
+    ----------
+    frame : ArFrame or pd.DataFrame
+        Input data frame. When an ``ArFrame`` is supplied the return value
+        is also an ``ArFrame``; when a ``pd.DataFrame`` is supplied the
+        return value is a ``pd.DataFrame``.
+    column : str
+        Name of the column to filter on.
+    op : str
+        Comparison operator.  Supported values: ``">"``, ``"<"``,
+        ``">="``, ``"<="``, ``"=="``, ``"!="``.
+    value : object
+        Scalar value to compare each cell against.
+
+    Returns
+    -------
+    ArFrame or pd.DataFrame
+        Filtered frame of the same type as the input.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> filtered = ar.filter_rows(frame, column="age", op=">", value=18)
+    """
 
     import pandas as pd
 
@@ -1492,34 +1522,45 @@ def _is_null_mapping_key(value):
     return bool(pd.isna(value))
 
 
-def replace_values(frame, mapping, column=None):
+def replace_values(
+    frame: "ArFrame | pd.DataFrame",
+    mapping: dict,
+    column: str | None = None,
+) -> "ArFrame | pd.DataFrame":
     """Replace values based on a mapping dict.
 
-    If column is None, applies to all columns.
+    If ``column`` is ``None``, the mapping is applied to every column.
 
-    Handles None/NaN in mappings:
-    - If mapping has a null-like key (None / NaN / pd.NA), this replaces existing nulls via fillna.
-    - If mapping maps to a null-like value, the replacement will result in real nulls (NaN/NA).
+    Handles ``None``/``NaN`` in mappings:
+
+    - If the mapping has a null-like key (``None`` / ``NaN`` / ``pd.NA``),
+      existing nulls in the frame are replaced via ``fillna``.
+    - If the mapping maps a value *to* a null-like value, the result will
+      contain real nulls (``NaN`` / ``NA``).
 
     Parameters
     ----------
-    frame : ArFrame
-        Input data frame.
+    frame : ArFrame or pd.DataFrame
+        Input data frame. When an ``ArFrame`` is supplied the return value
+        is also an ``ArFrame``; when a ``pd.DataFrame`` is supplied the
+        return value is a ``pd.DataFrame``.
     mapping : dict
-        Mapping of values to replace.
+        Mapping of ``{old_value: new_value}`` pairs.
     column : str, optional
-        Specific column to apply replacements to. If None, applies to all columns.
+        Specific column to apply replacements to.  When ``None`` (default)
+        the mapping is applied across all columns.
 
     Returns
     -------
-    ArFrame
-        New frame with values replaced.
+    ArFrame or pd.DataFrame
+        New frame with values replaced, same type as the input.
 
     Examples
     --------
     >>> frame = ar.read_csv("data.csv")
     >>> replaced = ar.replace_values(frame, {"old_value": "new_value"}, column="name")
     """
+    
     import pandas as pd
 
     from .convert import from_pandas, to_pandas

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3191,3 +3191,58 @@ class TestSelectColumns:
 
         with pytest.raises(ValueError):
             ar.select_columns(frame, ["id", "id"])
+
+class TestFilterReplaceTypeAnnotations:
+    """Issue #1257 — filter_rows and replace_values accept and return both ArFrame and pd.DataFrame."""
+
+    def test_filter_rows_arframe_in_arframe_out(self, tmp_path):
+        """ArFrame input returns ArFrame."""
+        path = tmp_path / "data.csv"
+        path.write_text("id,score\n1,10\n2,50\n3,90\n")
+        frame = ar.read_csv(str(path))
+        result = ar.filter_rows(frame, column="score", op=">", value=20)
+        assert isinstance(result, ar.ArFrame)
+        assert ar.to_pandas(result).shape[0] == 2
+
+    def test_filter_rows_dataframe_in_dataframe_out(self):
+        """pd.DataFrame input returns pd.DataFrame."""
+        import pandas as pd
+        df = pd.DataFrame({"id": [1, 2, 3], "score": [10, 50, 90]})
+        result = ar.filter_rows(df, column="score", op=">", value=20)
+        assert isinstance(result, pd.DataFrame)
+        assert result.shape[0] == 2
+
+    def test_replace_values_arframe_in_arframe_out(self, tmp_path):
+        """ArFrame input returns ArFrame."""
+        path = tmp_path / "data.csv"
+        path.write_text("status\nactive\ninactive\nactive\n")
+        frame = ar.read_csv(str(path))
+        result = ar.replace_values(frame, {"active": "A", "inactive": "I"}, column="status")
+        assert isinstance(result, ar.ArFrame)
+        df = ar.to_pandas(result)
+        assert set(df["status"].tolist()) == {"A", "I"}
+
+    def test_replace_values_dataframe_in_dataframe_out(self):
+        """pd.DataFrame input returns pd.DataFrame."""
+        import pandas as pd
+        df = pd.DataFrame({"status": ["active", "inactive", "active"]})
+        result = ar.replace_values(df, {"active": "A", "inactive": "I"}, column="status")
+        assert isinstance(result, pd.DataFrame)
+        assert set(result["status"].tolist()) == {"A", "I"}
+
+    def test_filter_rows_preserves_index_for_dataframe(self):
+        """pd.DataFrame return preserves the original index."""
+        import pandas as pd
+        df = pd.DataFrame({"score": [10, 50, 90]}, index=[100, 200, 300])
+        result = ar.filter_rows(df, column="score", op=">=", value=50)
+        assert list(result.index) == [200, 300]
+
+    def test_replace_values_whole_frame_dataframe(self):
+        """replace_values with no column applies across all columns for pd.DataFrame."""
+        import pandas as pd
+        df = pd.DataFrame({"a": ["x", "y"], "b": ["x", "z"]})
+        result = ar.replace_values(df, {"x": "X"})
+        assert isinstance(result, pd.DataFrame)
+        assert result["a"].tolist() == ["X", "y"]
+        assert result["b"].tolist() == ["X", "z"]
+        

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3192,6 +3192,7 @@ class TestSelectColumns:
         with pytest.raises(ValueError):
             ar.select_columns(frame, ["id", "id"])
 
+
 class TestFilterReplaceTypeAnnotations:
     """Issue #1257 — filter_rows and replace_values accept and return both ArFrame and pd.DataFrame."""
 
@@ -3207,6 +3208,7 @@ class TestFilterReplaceTypeAnnotations:
     def test_filter_rows_dataframe_in_dataframe_out(self):
         """pd.DataFrame input returns pd.DataFrame."""
         import pandas as pd
+
         df = pd.DataFrame({"id": [1, 2, 3], "score": [10, 50, 90]})
         result = ar.filter_rows(df, column="score", op=">", value=20)
         assert isinstance(result, pd.DataFrame)
@@ -3217,7 +3219,9 @@ class TestFilterReplaceTypeAnnotations:
         path = tmp_path / "data.csv"
         path.write_text("status\nactive\ninactive\nactive\n")
         frame = ar.read_csv(str(path))
-        result = ar.replace_values(frame, {"active": "A", "inactive": "I"}, column="status")
+        result = ar.replace_values(
+            frame, {"active": "A", "inactive": "I"}, column="status"
+        )
         assert isinstance(result, ar.ArFrame)
         df = ar.to_pandas(result)
         assert set(df["status"].tolist()) == {"A", "I"}
@@ -3225,14 +3229,18 @@ class TestFilterReplaceTypeAnnotations:
     def test_replace_values_dataframe_in_dataframe_out(self):
         """pd.DataFrame input returns pd.DataFrame."""
         import pandas as pd
+
         df = pd.DataFrame({"status": ["active", "inactive", "active"]})
-        result = ar.replace_values(df, {"active": "A", "inactive": "I"}, column="status")
+        result = ar.replace_values(
+            df, {"active": "A", "inactive": "I"}, column="status"
+        )
         assert isinstance(result, pd.DataFrame)
         assert set(result["status"].tolist()) == {"A", "I"}
 
     def test_filter_rows_preserves_index_for_dataframe(self):
         """pd.DataFrame return preserves the original index."""
         import pandas as pd
+
         df = pd.DataFrame({"score": [10, 50, 90]}, index=[100, 200, 300])
         result = ar.filter_rows(df, column="score", op=">=", value=50)
         assert list(result.index) == [200, 300]
@@ -3240,9 +3248,9 @@ class TestFilterReplaceTypeAnnotations:
     def test_replace_values_whole_frame_dataframe(self):
         """replace_values with no column applies across all columns for pd.DataFrame."""
         import pandas as pd
+
         df = pd.DataFrame({"a": ["x", "y"], "b": ["x", "z"]})
         result = ar.replace_values(df, {"x": "X"})
         assert isinstance(result, pd.DataFrame)
         assert result["a"].tolist() == ["X", "y"]
         assert result["b"].tolist() == ["X", "z"]
-        


### PR DESCRIPTION
Closes #1257

## Changes
- Added `frame: ArFrame | pd.DataFrame` input annotation and `-> ArFrame | pd.DataFrame` return annotation to `filter_rows` and `replace_values` in `arnio/cleaning.py`.
- Updated both docstrings to explicitly state the dual-input behaviour: ArFrame in → ArFrame out, pd.DataFrame in → pd.DataFrame out.
- No behaviour changes. No edits to `_arnio_cpp.pyi` as instructed — these functions are pure Python, not C++ binding surface.

## Tests
New `TestFilterReplaceTypeAnnotations` class added to `tests/test_cleaning.py` covering ArFrame round-trip, DataFrame round-trip, index preservation, and whole-frame replace for both functions.