### PR TITLE
fix(schema): Schema.to_json() emits UserWarning and includes rules_omitted marker instead of raising ValueError when cross-field rules are present

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import re
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable
@@ -380,11 +381,23 @@ class Schema:
         return validate(frame, self, max_errors=max_errors)
 
     def to_json(self) -> str:
-        """Serialize the schema to a stable JSON string."""
-        if self.rules:
-            raise ValueError(
-                "Schema rules are not JSON serializable. "
-                "Serialize only fields/strict/unique for now."
+        """Serialize the schema to a stable JSON string.
+
+        Cross-field ``rules`` cannot be serialized. When rules are present
+        they are silently omitted and a ``UserWarning`` is emitted. The
+        returned payload includes ``"rules_omitted": true`` so downstream
+        consumers can detect the gap. Call ``from_json()`` to restore the
+        field-only schema; rules must be re-attached manually afterward.
+        """
+        rules_omitted = bool(self.rules)
+        if rules_omitted:
+            warnings.warn(
+                "Schema.to_json(): cross-field rules cannot be serialized "
+                "and have been omitted. The JSON payload includes "
+                '"rules_omitted": true. Restore rules manually after '
+                "from_json().",
+                UserWarning,
+                stacklevel=2,
             )
 
         payload = {
@@ -395,6 +408,8 @@ class Schema:
             "strict": self.strict,
             "unique": list(self.unique) if self.unique is not None else None,
         }
+        if rules_omitted:
+            payload["rules_omitted"] = True
         return json.dumps(payload, sort_keys=True)
 
     @classmethod
@@ -429,6 +444,9 @@ class Schema:
         if unique is not None and not isinstance(unique, list):
             raise TypeError("Schema JSON 'unique' must be a list of strings or null.")
 
+        # rules_omitted marker is accepted and silently ignored — rules
+        # cannot be round-tripped through JSON and must be re-attached
+        # manually by the caller if needed.
         return cls(fields=fields, strict=strict, unique=unique)
 
     @classmethod

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,8 @@
 """Tests for schema validation."""
 
 import io
+import json
+import warnings
 
 import pandas as pd
 import pytest
@@ -2465,14 +2467,18 @@ def test_schema_from_json_rejects_invalid_json():
         ar.Schema.from_json("{bad json}")
 
 
-def test_schema_to_json_rejects_rules():
+def test_schema_to_json_warns_and_omits_rules():
     schema = ar.Schema(
         {"id": ar.String()},
         rules=[lambda df: []],
     )
 
-    with pytest.raises(ValueError, match="not JSON serializable"):
-        schema.to_json()
+    with pytest.warns(UserWarning, match="rules_omitted"):
+        payload_str = schema.to_json()
+
+    payload = json.loads(payload_str)
+    assert payload["rules_omitted"] is True
+    assert "id" in payload["fields"]
 
 
 def test_schema_from_json_rejects_non_object_field_definition():
@@ -2588,3 +2594,95 @@ def test_url_allowed_schemes_non_string_raises():
 def test_url_allowed_schemes_whitespace_string_raises():
     with pytest.raises(ValueError, match="non-empty strings"):
         ar.URL(allowed_schemes=["   "])
+
+
+# --- Issue #1279: Schema.to_json() rules_omitted contract ---
+
+
+def test_schema_to_json_with_rules_emits_warning():
+    """to_json() emits UserWarning when rules are present."""
+    schema = ar.Schema(
+        {"start_date": ar.String(), "end_date": ar.String()},
+        rules=[lambda df: []],
+    )
+    with pytest.warns(UserWarning, match="rules_omitted"):
+        schema.to_json()
+
+
+def test_schema_to_json_with_rules_includes_marker():
+    """to_json() payload contains rules_omitted: true when rules are present."""
+    schema = ar.Schema(
+        {"id": ar.String()},
+        rules=[lambda df: []],
+    )
+    with pytest.warns(UserWarning):
+        payload = json.loads(schema.to_json())
+    assert payload["rules_omitted"] is True
+
+
+def test_schema_to_json_without_rules_no_marker():
+    """to_json() payload does not include rules_omitted when no rules are present."""
+    schema = ar.Schema({"id": ar.String()})
+    payload = json.loads(schema.to_json())
+    assert "rules_omitted" not in payload
+
+
+def test_schema_to_json_without_rules_no_warning():
+    """to_json() emits no warning when no rules are present."""
+    schema = ar.Schema({"id": ar.String()})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        schema.to_json()  # must not raise
+
+
+def test_schema_to_json_with_rules_fields_are_preserved():
+    """Field definitions are fully serialized even when rules are omitted."""
+    schema = ar.Schema(
+        {
+            "start_date": ar.String(nullable=False),
+            "end_date": ar.String(nullable=True),
+        },
+        rules=[lambda df: []],
+    )
+    with pytest.warns(UserWarning):
+        payload = json.loads(schema.to_json())
+    assert set(payload["fields"].keys()) == {"start_date", "end_date"}
+
+
+def test_schema_from_json_tolerates_rules_omitted_marker():
+    """from_json() accepts a payload with rules_omitted: true without error or warning."""
+    schema = ar.Schema(
+        {"id": ar.String(nullable=False)},
+        rules=[lambda df: []],
+    )
+    with pytest.warns(UserWarning):
+        json_str = schema.to_json()
+
+    # Must not raise or warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        restored = ar.Schema.from_json(json_str)
+
+    assert "id" in restored.fields
+    assert not restored.rules
+
+
+def test_schema_field_only_roundtrip_with_rules_present():
+    """Fields, strict, and unique survive a to_json/from_json round-trip even when rules exist."""
+    schema = ar.Schema(
+        {
+            "id": ar.String(nullable=False),
+            "score": ar.Int64(nullable=True),
+        },
+        strict=True,
+        unique=["id"],
+        rules=[lambda df: []],
+    )
+    with pytest.warns(UserWarning):
+        restored = ar.Schema.from_json(schema.to_json())
+
+    assert restored.fields["id"] == schema.fields["id"]
+    assert restored.fields["score"] == schema.fields["score"]
+    assert restored.strict is True
+    assert list(restored.unique) == ["id"]
+    assert not restored.rules


### PR DESCRIPTION
## Summary

Closes #1279.

`Schema.to_json()` previously raised `ValueError` unconditionally when cross-field `rules` were present, blocking CI data-contract serialization workflows even though all field definitions were fully serializable.

## Changes

**`arnio/schema.py`**
- `to_json()` now serializes `fields`, `strict`, and `unique` even when `rules` are present
- Emits `UserWarning` with message referencing `rules_omitted` when rules are dropped
- Includes `"rules_omitted": true` in the JSON payload so downstream consumers can detect the gap
- `from_json()` silently tolerates a payload containing `"rules_omitted": true` — no warning, no error, rules must be re-attached manually by the caller

**`tests/test_schema.py`**
- Updated `test_schema_to_json_warns_and_omits_rules` (was `test_schema_to_json_rejects_rules`) to assert warning instead of ValueError
- Added 7 new focused tests covering: warning emission, marker presence, no marker when no rules, no warning when no rules, field preservation, `from_json` tolerance, and full field-only round-trip

## Contract (agreed in #1279)

| Behaviour | Before | After |
|---|---|---|
| `to_json()` with rules | raises `ValueError` | emits `UserWarning`, serializes fields |
| JSON payload with rules | — | includes `"rules_omitted": true` |
| `to_json()` without rules | no warning | no warning, no marker (unchanged) |
| `from_json()` with marker | — | accepts silently, returns field-only schema |

## Testing