### PR TITLE
fix: warn instead of crash in Schema.to_json() with cross-field rules

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import re
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable
@@ -382,9 +383,10 @@ class Schema:
     def to_json(self) -> str:
         """Serialize the schema to a stable JSON string."""
         if self.rules:
-            raise ValueError(
-                "Schema rules are not JSON serializable. "
-                "Serialize only fields/strict/unique for now."
+            warnings.warn(
+                "Schema rules are not JSON serializable and will be excluded from the JSON output. "
+                "Serializing only fields/strict/unique.",
+                UserWarning,
             )
 
         payload = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2588,3 +2588,28 @@ def test_url_allowed_schemes_non_string_raises():
 def test_url_allowed_schemes_whitespace_string_raises():
     with pytest.raises(ValueError, match="non-empty strings"):
         ar.URL(allowed_schemes=["   "])
+
+def test_schema_to_json_with_rules_warns():
+    import arnio as ar
+    import warnings
+    
+    def my_rule(frame):
+        return []
+        
+    schema = ar.Schema(
+        fields={'a': ar.Int64()},
+        rules=[my_rule]
+    )
+    
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        json_str = schema.to_json()
+        
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert 'Schema rules are not JSON serializable' in str(w[-1].message)
+        
+    import json
+    parsed = json.loads(json_str)
+    assert 'fields' in parsed
+    assert 'a' in parsed['fields']


### PR DESCRIPTION
## Summary
Currently, `Schema.to_json()` raises a `ValueError` if `self.rules` are present because Python functions cannot be serialized. This crashes CI pipelines trying to export data contracts. 

This PR:
- Replaces the `ValueError` with `warnings.warn(..., UserWarning)` to gracefully ignore `rules` during serialization while allowing the rest of the schema (`fields`, `strict`, `unique`) to serialize properly.
- Adds a unit test in `test_schema.py` to ensure a warning is raised and the JSON is returned correctly.

## Linked issue
Fixes #1279

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other: Added `test_schema_to_json_with_rules_warns` test case. Relying on CI to run the full test suite since local C++ compilers were unavailable.

## Screenshots / Media
N/A

## Performance Impact
N/A

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).