### PR TITLE
fix(pipeline): correct row_counts and step_timings metadata when dry_run=True

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -382,7 +382,8 @@ def pipeline(
                 if not dry_run:
                     result = step_result
 
-            elapsed_ms = (perf_counter() - started_at) * 1000
+            elapsed_sec = perf_counter() - started_at
+            elapsed_ms = elapsed_sec * 1000
 
             if verbose:
                 execution_path = f"{fn.__module__}.{fn.__name__}"
@@ -404,13 +405,15 @@ def pipeline(
                     {
                         "step": name,
                         "before": rows_before,
-                        "after": step_result.shape[0],
+                        "after": result.shape[0] if dry_run else step_result.shape[0],
+                        "dry_run": dry_run,
                     }
                 )
                 step_timings.append(
                     {
                         "step": name,
-                        "seconds": round(perf_counter() - started_at, 9),
+                        "seconds": round(elapsed_sec, 9),
+                        "dry_run": dry_run,
                     }
                 )
         elif name in python_step_registry:
@@ -456,7 +459,8 @@ def pipeline(
             if not dry_run:
                 result = step_result
 
-            elapsed_ms = (perf_counter() - started_at) * 1000
+            elapsed_sec = perf_counter() - started_at
+            elapsed_ms = elapsed_sec * 1000
 
             if verbose:
                 step_name = getattr(fn, "__name__", name)
@@ -479,13 +483,15 @@ def pipeline(
                     {
                         "step": name,
                         "before": rows_before,
-                        "after": step_result.shape[0],
+                        "after": result.shape[0] if dry_run else step_result.shape[0],
+                        "dry_run": dry_run,
                     }
                 )
                 step_timings.append(
                     {
                         "step": name,
-                        "seconds": round(perf_counter() - started_at, 9),
+                        "seconds": round(elapsed_sec, 9),
+                        "dry_run": dry_run,
                     }
                 )
         else:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -589,6 +589,7 @@ class TestPipeline:
                 "step": "timed_python_step",
                 "before": frame.shape[0],
                 "after": result.shape[0],
+                "dry_run": False,
             }
         ]
         assert len(metadata["step_timings"]) == 1
@@ -1566,3 +1567,76 @@ def test_pipeline_verbose_logs_row_change(caplog):
     )
 
     assert any("rows: 3 -> 1" in record.message for record in caplog.records)
+
+
+def test_pipeline_dry_run_with_metadata_row_counts_unchanged():
+    """dry_run=True: row_counts.after must equal row_counts.before."""
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["Alice", None, "Bob", None],
+                "age": [25, 30, None, 40],
+            }
+        )
+    )
+    original_rows = frame.shape[0]  # 4
+
+    _, meta = ar.pipeline(
+        frame,
+        [("drop_nulls",), ("strip_whitespace",)],
+        dry_run=True,
+        return_metadata=True,
+    )
+
+    for entry in meta["row_counts"]:
+        assert entry["after"] == original_rows, (
+            f"Step '{entry['step']}': expected after={original_rows} "
+            f"in dry_run, got {entry['after']}"
+        )
+        assert entry["dry_run"] is True
+
+
+def test_pipeline_dry_run_with_metadata_step_timings_consistent():
+    """dry_run=True: step_timings.seconds must be non-negative with dry_run flag."""
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["Alice", None, "Bob", None],
+            }
+        )
+    )
+
+    _, meta = ar.pipeline(
+        frame,
+        [("drop_nulls",), ("strip_whitespace",)],
+        dry_run=True,
+        return_metadata=True,
+    )
+
+    for entry in meta["step_timings"]:
+        assert entry["seconds"] >= 0
+        assert entry["dry_run"] is True
+
+
+def test_pipeline_dry_run_false_metadata_unchanged():
+    """dry_run=False: existing metadata shape must not be affected by the fix."""
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["Alice", None, "Bob", None],
+            }
+        )
+    )
+
+    result, meta = ar.pipeline(
+        frame,
+        [("drop_nulls",)],
+        dry_run=False,
+        return_metadata=True,
+    )
+
+    assert meta["row_counts"][0]["before"] == frame.shape[0]
+    assert meta["row_counts"][0]["after"] == result.shape[0]
+    assert meta["row_counts"][0]["after"] < frame.shape[0]
+    assert meta["step_timings"][0]["seconds"] >= 0
+    assert meta["row_counts"][0].get("dry_run") is False


### PR DESCRIPTION
## Summary

Fixes two bugs in `pipeline()` metadata when `dry_run=True` is combined with `return_metadata=True`.

## Problems Fixed

**Bug 1: `row_counts["after"]` was misleading in dry_run mode**

When `dry_run=True`, `result` is never mutated but `row_counts["after"]` was 
reporting `step_result.shape[0]` (the transformed frame) instead of `result.shape[0]` 
(the unchanged frame). This made metadata appear as if rows were actually dropped.

**Bug 2: `step_timings["seconds"]` was inconsistent**

`elapsed_ms` was captured once, but `step_timings["seconds"]` was computed from a 
second `perf_counter()` call made later producing a different, larger value.

## Changes

**`arnio/pipeline.py`**
- Capture elapsed time once via `elapsed_sec = perf_counter() - started_at`
- Use `result.shape[0] if dry_run else step_result.shape[0]` for `row_counts["after"]`
- Add backward-compatible `"dry_run"` flag to both `row_counts` and `step_timings` entries
- Same fix applied to both C++ step path and Python step path

**`tests/test_pipeline.py`**
- `test_pipeline_dry_run_with_metadata_row_counts_unchanged` verifies `after == before` in dry_run
- `test_pipeline_dry_run_with_metadata_step_timings_consistent` verifies `dry_run` flag present and seconds >= 0
- `test_pipeline_dry_run_false_metadata_unchanged` regression: `dry_run=False` metadata unaffected
- Updated `test_pipeline_return_metadata_handles_python_steps` to include new `dry_run` field

## Test Results
All 95 tests passing. Black and Ruff checks clean.

Closes #1315