### PR TITLE
fix: reject auto_clean dry_run return_report combo

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1578,11 +1578,14 @@ def auto_clean(
 
     if dry_run and explain:
         raise ValueError("explain=True cannot be used with dry_run=True")
+    if dry_run and return_report:
+        raise ValueError(
+            "return_report=True cannot be used with dry_run=True. "
+            "dry_run already returns the DataQualityReport directly."
+        )
 
     report = profile(frame)
     if dry_run:
-        if return_report:
-            return frame, report
         return report
 
     result = frame

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -444,6 +444,25 @@ def test_auto_clean_dry_run_returns_report_without_mutating():
     assert frame.dtypes["active"] == "string"
 
 
+def test_auto_clean_dry_run_with_return_report_raises():
+    frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
+
+    with pytest.raises(
+        ValueError,
+        match="return_report=True cannot be used with dry_run=True",
+    ):
+        ar.auto_clean(frame, dry_run=True, return_report=True)
+
+
+def test_auto_clean_dry_run_never_returns_tuple():
+    frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
+
+    result = ar.auto_clean(frame, dry_run=True)
+
+    assert isinstance(result, ar.DataQualityReport)
+    assert not isinstance(result, tuple)
+
+
 def test_auto_clean_rejects_unknown_mode(sample_csv):
     frame = ar.read_csv(sample_csv)
 


### PR DESCRIPTION
## Summary
- reject the inconsistent `dry_run=True` + `return_report=True` combination in `auto_clean()` with a clear `ValueError`
- remove the undocumented tuple return path so `dry_run` always returns a `DataQualityReport`
- add focused regression coverage for the invalid combination and the non-tuple dry-run contract

Fixes #1306

## Testing
- `python -m pytest tests/test_quality.py -k "dry_run and auto_clean"`
- `python -m ruff check arnio/quality.py tests/test_quality.py`
- `python -m black --check arnio/quality.py tests/test_quality.py`
