### PR TITLE
fix: normalize whitespace-wrapped null tokens

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1682,7 +1682,7 @@ def replace_values(
 
 
 def standardize_missing_tokens(frame, tokens=None, subset=None):
-    """Converting missing tokens in the DataFrame to the standard form NaN
+    """Convert null-like string tokens in the frame to the standard NaN form.
 
     Parameters
     ----------
@@ -1692,6 +1692,12 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
         List of strings to treat as missing. If None, then a built-in default tokens list is used
     subset : list[str], optional
         Column names to replace missing tokens in. If None, applies to all columns.
+
+    Notes
+    -----
+    Matching is case-insensitive and trims surrounding whitespace before checking
+    token membership. Values that do not match a missing token preserve their
+    original whitespace.
 
     Returns
     -------

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1708,6 +1708,8 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
     --------
     >>> frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, "N/A"]}))
     >>> result = ar.standardize_missing_tokens(frame)
+    >>> frame = ar.from_pandas(pd.DataFrame({"value": [" NULL ", "\\tNaN\\t", "kept"]}))
+    >>> result = ar.standardize_missing_tokens(frame)
     """
 
     import pandas as pd

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1718,13 +1718,38 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
             f"Did you mean subset=['{subset}']?"
         )
 
-    default_tokens = ["N/A", "NA", "n/a", "na", "-", "none", "nil", "null", "", "?"]
+    default_tokens = [
+        "N/A",
+        "NA",
+        "n/a",
+        "na",
+        "nan",
+        "-",
+        "none",
+        "nil",
+        "null",
+        "",
+        "?",
+    ]
+
+    token_values = default_tokens if tokens is None else list(tokens)
+    normalized_tokens = {
+        token.strip().lower() for token in token_values if isinstance(token, str)
+    }
+
+    def _normalize_missing_value(value):
+        if not isinstance(value, str):
+            return value
+        if value.strip().lower() in normalized_tokens:
+            return float("nan")
+        return value
+
+    def _normalize_columns(columns):
+        for column in columns:
+            df[column] = df[column].map(_normalize_missing_value)
 
     if subset is None:
-        if tokens is None:
-            df = df.replace(default_tokens, float("nan"))
-        else:
-            df = df.replace(tokens, float("nan"))
+        _normalize_columns(df.columns)
 
     else:
         subset_columns = _validate_existing_column_sequence(
@@ -1736,12 +1761,7 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
                 f"Unknown columns in subset: {missing}"
             ),
         )
-        if tokens is None:
-            df[subset_columns] = df[subset_columns].replace(
-                default_tokens, float("nan")
-            )
-        else:
-            df[subset_columns] = df[subset_columns].replace(tokens, float("nan"))
+        _normalize_columns(subset_columns)
 
     return from_pandas(df) if is_arframe else df
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1106,6 +1106,17 @@ class TestStandardizeMissingTokens:
         assert result["status"].iloc[1] == "kept"
         assert result["note"].tolist() == ["UNKNOWN", "still here"]
 
+    def test_standardize_missing_tokens_normalizes_tab_and_newline_wrapped_tokens(
+        self,
+    ):
+        df = pd.DataFrame({"value": ["\tNULL\t", "\n NaN\n", "\t kept \n"]})
+
+        result = ar.standardize_missing_tokens(df)
+
+        assert pd.isna(result["value"].iloc[0])
+        assert pd.isna(result["value"].iloc[1])
+        assert result["value"].iloc[2] == "\t kept \n"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1185,6 +1185,18 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["value"].iloc[2])
         assert result["value"].iloc[3] == "kept"
 
+    def test_standardize_missing_tokens_preserves_existing_nulls_while_normalizing_wrapped_tokens(
+        self,
+    ):
+        df = pd.DataFrame({"value": [None, pd.NA, " NULL ", "kept"]})
+
+        result = ar.standardize_missing_tokens(df)
+
+        assert pd.isna(result["value"].iloc[0])
+        assert pd.isna(result["value"].iloc[1])
+        assert pd.isna(result["value"].iloc[2])
+        assert result["value"].iloc[3] == "kept"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1173,6 +1173,18 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["value"].iloc[1])
         assert result["value"].iloc[2] == "kept"
 
+    def test_standardize_missing_tokens_whitespace_only_custom_tokens_match_blank_values(
+        self,
+    ):
+        df = pd.DataFrame({"value": ["  ", "\t", "\n", "kept"]})
+
+        result = ar.standardize_missing_tokens(df, tokens=["   "])
+
+        assert pd.isna(result["value"].iloc[0])
+        assert pd.isna(result["value"].iloc[1])
+        assert pd.isna(result["value"].iloc[2])
+        assert result["value"].iloc[3] == "kept"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1034,6 +1034,13 @@ class TestStandardizeMissingTokens:
         result = ar.standardize_missing_tokens(df, tokens=[])
         assert result["value"].iloc[2] == "-"
 
+    def test_whitespace_only_values_remain_when_tokens_disabled(self):
+        df = pd.DataFrame({"value": ["  ", "\t", "\n"]})
+
+        result = ar.standardize_missing_tokens(df, tokens=[])
+
+        assert result["value"].tolist() == ["  ", "\t", "\n"]
+
     def test_standardize_missing_tokens_unknown_subset_column_raises(self):
         frame = pd.DataFrame({"value": [1, 2, 3]})
         with pytest.raises(ValueError, match="Unknown columns in subset"):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1079,6 +1079,15 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["status"].iloc[2])
         assert result["note"].tolist() == [" untouched ", "unknown", "kept"]
 
+    def test_standardize_missing_tokens_normalizes_custom_token_list_entries(self):
+        df = pd.DataFrame({"value": ["unknown", " Unknown ", "kept"]})
+
+        result = ar.standardize_missing_tokens(df, tokens=["  UNKNOWN  "])
+
+        assert pd.isna(result["value"].iloc[0])
+        assert pd.isna(result["value"].iloc[1])
+        assert result["value"].iloc[2] == "kept"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1035,7 +1035,7 @@ class TestStandardizeMissingTokens:
         assert result["value"].iloc[2] == "-"
 
     def test_standardize_missing_tokens_unknown_subset_column_raises(self):
-        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+        frame = pd.DataFrame({"value": [1, 2, 3]})
         with pytest.raises(ValueError, match="Unknown columns in subset"):
             ar.standardize_missing_tokens(frame, subset=["missing"])
 
@@ -1048,6 +1048,36 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result.loc[0, "name"])
         assert result.loc[1, "name"] == "Alice"
         assert result["city"].tolist() == ["-", "Paris"]
+
+    def test_standardize_missing_tokens_normalizes_whitespace_wrapped_defaults(self):
+        df = pd.DataFrame({"value": ["NULL ", " NaN", "  ", "", "Alice "]})
+
+        result = ar.standardize_missing_tokens(df)
+
+        assert pd.isna(result["value"].iloc[0])
+        assert pd.isna(result["value"].iloc[1])
+        assert pd.isna(result["value"].iloc[2])
+        assert pd.isna(result["value"].iloc[3])
+        assert result["value"].iloc[4] == "Alice "
+
+    def test_standardize_missing_tokens_normalizes_whitespace_wrapped_custom_tokens(
+        self,
+    ):
+        df = pd.DataFrame(
+            {
+                "status": [" unknown ", "pending", " custom-null "],
+                "note": [" untouched ", "unknown", "kept"],
+            }
+        )
+
+        result = ar.standardize_missing_tokens(
+            df, tokens=["unknown", "custom-null"], subset=["status"]
+        )
+
+        assert pd.isna(result["status"].iloc[0])
+        assert result["status"].iloc[1] == "pending"
+        assert pd.isna(result["status"].iloc[2])
+        assert result["note"].tolist() == [" untouched ", "unknown", "kept"]
 
 
 class TestStripWhitespace:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1133,6 +1133,17 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["status"].iloc[1])
         assert result["note"].tolist() == ["  ", "NULL "]
 
+    def test_standardize_missing_tokens_normalizes_carriage_return_wrapped_tokens(
+        self,
+    ):
+        df = pd.DataFrame({"value": ["\r\nNULL\r", "\r\n nAn \r\n", "\r kept \r"]})
+
+        result = ar.standardize_missing_tokens(df)
+
+        assert pd.isna(result["value"].iloc[0])
+        assert pd.isna(result["value"].iloc[1])
+        assert result["value"].iloc[2] == "\r kept \r"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1117,6 +1117,22 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["value"].iloc[1])
         assert result["value"].iloc[2] == "\t kept \n"
 
+    def test_standardize_missing_tokens_subset_does_not_normalize_excluded_whitespace(
+        self,
+    ):
+        df = pd.DataFrame(
+            {
+                "status": ["  ", "NULL "],
+                "note": ["  ", "NULL "],
+            }
+        )
+
+        result = ar.standardize_missing_tokens(df, subset=["status"])
+
+        assert pd.isna(result["status"].iloc[0])
+        assert pd.isna(result["status"].iloc[1])
+        assert result["note"].tolist() == ["  ", "NULL "]
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1162,6 +1162,17 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["value"].iloc[0])
         assert result["value"].iloc[1] == f"{nbsp} kept {nbsp}"
 
+    def test_standardize_missing_tokens_custom_tokens_do_not_fall_back_to_defaults(
+        self,
+    ):
+        df = pd.DataFrame({"value": [" NULL ", " custom-null ", "kept"]})
+
+        result = ar.standardize_missing_tokens(df, tokens=["custom-null"])
+
+        assert result["value"].iloc[0] == " NULL "
+        assert pd.isna(result["value"].iloc[1])
+        assert result["value"].iloc[2] == "kept"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1197,6 +1197,16 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["value"].iloc[2])
         assert result["value"].iloc[3] == "kept"
 
+    def test_standardize_missing_tokens_normalizes_wrapped_punctuation_defaults(self):
+        df = pd.DataFrame({"value": [" ? ", "\t-\t", "--", "kept"]})
+
+        result = ar.standardize_missing_tokens(df)
+
+        assert pd.isna(result["value"].iloc[0])
+        assert pd.isna(result["value"].iloc[1])
+        assert result["value"].iloc[2] == "--"
+        assert result["value"].iloc[3] == "kept"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1151,6 +1151,17 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["value"].iloc[1])
         assert result["value"].iloc[2] == "\r kept \r"
 
+    def test_standardize_missing_tokens_normalizes_nonbreaking_space_wrapped_tokens(
+        self,
+    ):
+        nbsp = "\u00a0"
+        df = pd.DataFrame({"value": [f"{nbsp}NULL{nbsp}", f"{nbsp} kept {nbsp}"]})
+
+        result = ar.standardize_missing_tokens(df)
+
+        assert pd.isna(result["value"].iloc[0])
+        assert result["value"].iloc[1] == f"{nbsp} kept {nbsp}"
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1088,6 +1088,24 @@ class TestStandardizeMissingTokens:
         assert pd.isna(result["value"].iloc[1])
         assert result["value"].iloc[2] == "kept"
 
+    def test_standardize_missing_tokens_normalizes_custom_token_list_entries_in_subset(
+        self,
+    ):
+        df = pd.DataFrame(
+            {
+                "status": [" unknown ", "kept"],
+                "note": ["UNKNOWN", "still here"],
+            }
+        )
+
+        result = ar.standardize_missing_tokens(
+            df, tokens=["  UNKNOWN  "], subset=["status"]
+        )
+
+        assert pd.isna(result["status"].iloc[0])
+        assert result["status"].iloc[1] == "kept"
+        assert result["note"].tolist() == ["UNKNOWN", "still here"]
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):


### PR DESCRIPTION
## Summary
- normalize whitespace-wrapped null-like strings in `standardize_missing_tokens()`
- treat default and custom missing tokens consistently after trimming surrounding whitespace without turning the helper into a general strip pass
- add focused regression coverage for default tokens, custom tokens, and subset behavior

Fixes #1304

## Testing
- `python -m pytest tests/test_cleaning.py -k "standardize_missing_tokens"`
- `python -m ruff check arnio/cleaning.py tests/test_cleaning.py`
- `python -m black --check arnio/cleaning.py tests/test_cleaning.py`
