### PR TITLE
feat: improve __str__ to show data preview in ArFrame

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -604,12 +604,12 @@ class ArFrame:
         """Return a detailed string summary of the ArFrame with data preview."""
         rows, cols = self.shape
         header = f"ArFrame: {rows} rows × {cols} columns"
+        truncated_names = self._truncate_column_names()
 
         if rows == 0:
-            return f"{header}\nColumns: {self.columns}\n(empty frame)"
+            return f"{header}\nColumns: {truncated_names}\n(empty frame)"
 
         actual_n = min(5, rows)
-        col_names = self.columns
         col_data = [
             [self._frame.column_by_index(i).at(r) for r in range(actual_n)]
             for i in range(cols)
@@ -617,13 +617,15 @@ class ArFrame:
 
         col_widths = [
             max(
-                len(col_names[i]),
+                len(truncated_names[i]),
                 max((len(str(col_data[i][r])) for r in range(actual_n)), default=0),
             )
             for i in range(cols)
         ]
 
-        col_header = "  ".join(col_names[i].ljust(col_widths[i]) for i in range(cols))
+        col_header = "  ".join(
+            truncated_names[i].ljust(col_widths[i]) for i in range(cols)
+        )
         separator = "  ".join("-" * col_widths[i] for i in range(cols))
         data_rows = [
             "  ".join(str(col_data[i][r]).ljust(col_widths[i]) for i in range(cols))
@@ -631,15 +633,20 @@ class ArFrame:
         ]
 
         suffix = f"\n... ({rows - actual_n} more rows)" if rows > actual_n else ""
+        columns_line = f"Columns: {truncated_names}"
         dtypes_line = f"DTypes: {self.dtypes}"
         memory_line = f"Memory: {self.memory_usage()} bytes"
 
-        return (
-            "\n".join(
-                [header, dtypes_line, memory_line, col_header, separator] + data_rows
-            )
-            + suffix
-        )
+        parts = [
+            header,
+            columns_line,
+            dtypes_line,
+            memory_line,
+            col_header,
+            separator,
+        ] + data_rows
+
+        return "\n".join(parts) + suffix
 
     def __contains__(self, item: object) -> bool:
         return isinstance(item, str) and item in self.columns

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -601,12 +601,45 @@ class ArFrame:
         return f"ArFrame({rows} rows × {cols} cols)"
 
     def __str__(self) -> str:
-        """Return a detailed string summary of the ArFrame."""
-        lines = [f"ArFrame: {self.shape[0]} rows × {self.shape[1]} columns"]
-        lines.append(f"Columns: {self._truncate_column_names()}")
-        lines.append(f"DTypes:  {self.dtypes}")
-        lines.append(f"Memory:  {self.memory_usage()} bytes")
-        return "\n".join(lines)
+        """Return a detailed string summary of the ArFrame with data preview."""
+        rows, cols = self.shape
+        header = f"ArFrame: {rows} rows × {cols} columns"
+
+        if rows == 0:
+            return f"{header}\nColumns: {self.columns}\n(empty frame)"
+
+        actual_n = min(5, rows)
+        col_names = self.columns
+        col_data = [
+            [self._frame.column_by_index(i).at(r) for r in range(actual_n)]
+            for i in range(cols)
+        ]
+
+        col_widths = [
+            max(
+                len(col_names[i]),
+                max((len(str(col_data[i][r])) for r in range(actual_n)), default=0),
+            )
+            for i in range(cols)
+        ]
+
+        col_header = "  ".join(col_names[i].ljust(col_widths[i]) for i in range(cols))
+        separator = "  ".join("-" * col_widths[i] for i in range(cols))
+        data_rows = [
+            "  ".join(str(col_data[i][r]).ljust(col_widths[i]) for i in range(cols))
+            for r in range(actual_n)
+        ]
+
+        suffix = f"\n... ({rows - actual_n} more rows)" if rows > actual_n else ""
+        dtypes_line = f"DTypes: {self.dtypes}"
+        memory_line = f"Memory: {self.memory_usage()} bytes"
+
+        return (
+            "\n".join(
+                [header, dtypes_line, memory_line, col_header, separator] + data_rows
+            )
+            + suffix
+        )
 
     def __contains__(self, item: object) -> bool:
         return isinstance(item, str) and item in self.columns

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -2503,3 +2503,43 @@ class TestArFrameToDict:
         result = frame.to_dict()
         for col in frame.columns:
             assert result[col] == frame[col]
+
+
+class TestArFrameStr:
+    def test_str_contains_shape(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = str(frame)
+        assert "3" in result
+        assert "4" in result
+
+    def test_str_contains_column_names(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = str(frame)
+        assert "name" in result
+        assert "age" in result
+
+    def test_str_contains_data_values(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = str(frame)
+        assert "Alice" in result
+
+    def test_str_contains_dtypes(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        result = str(frame)
+        assert "string" in result or "int64" in result
+
+    def test_str_empty_frame(self, tmp_path):
+        csv_path = tmp_path / "empty_rows.csv"
+        csv_path.write_text("name,age\n")
+        frame = ar.read_csv(csv_path)
+        result = str(frame)
+        assert "empty" in result.lower() or "0" in result
+
+    def test_str_large_frame_shows_truncation(self, large_csv):
+        frame = ar.read_csv(large_csv)
+        result = str(frame)
+        assert "more rows" in result
+
+    def test_str_returns_string(self, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        assert isinstance(str(frame), str)


### PR DESCRIPTION
## Summary
Improves __str__ on ArFrame to display an actual data preview instead of only metadata. Calling print(frame) now renders a formatted table showing the first 5 rows, along with shape, column dtypes, memory usage, and a truncation indicator for larger frames.

## Linked issue
Refs #35

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
python -m pytest tests/test_csv.py::TestArFrameStr -v
7/7 passed.

python -m pytest tests/test_csv.py -v
Full suite passed with no new failures.

python -m ruff check .
python -m black .
No lint or formatting issues.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
