### PR TITLE
Add writable output support to DataQualityReport.to_json()

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -263,20 +263,30 @@ class DataQualityReport:
         indent: int | None = None,
         redact_sample_values: bool = False,
         exclude_columns: list[str] | set[str] | tuple[str, ...] | None = None,
-    ) -> str:
+        output: Any | None = None,
+    ) -> str | None:
         """Return the report as a JSON string.
 
         Example:
         report.to_json(indent=2)
         """
 
-        return json.dumps(
+        json_out = json.dumps(
             self.to_dict(
                 redact_sample_values=redact_sample_values,
                 exclude_columns=exclude_columns,
             ),
             indent=indent,
         )
+
+        if output is None:
+            return json_out
+
+        if not hasattr(output, "write"):
+            raise TypeError("output must be a writable text stream")
+
+        output.write(json_out)
+        return None
 
     def to_markdown(self, output: Any | None = None) -> str | None:
         """Return a GitHub-friendly Markdown report."""

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2239,6 +2239,93 @@ def test_data_quality_report_to_json_returns_valid_json():
     assert parsed["column_count"] == 1
 
 
+def test_data_quality_report_to_json_writes_to_stringio():
+    import io
+
+    report = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", "Bob"],
+                    "age": [30, 40],
+                }
+            )
+        )
+    )
+    buffer = io.StringIO()
+
+    result = report.to_json(output=buffer)
+
+    assert result is None
+    assert buffer.getvalue() == report.to_json()
+
+
+def test_data_quality_report_to_json_writes_to_text_file_handle(tmp_path):
+    report = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", "Bob"],
+                    "age": [30, 40],
+                }
+            )
+        )
+    )
+    out_path = tmp_path / "report.json"
+
+    with out_path.open("w", encoding="utf-8") as f:
+        result = report.to_json(output=f, indent=2)
+
+    assert result is None
+    assert out_path.read_text(encoding="utf-8") == report.to_json(indent=2)
+
+
+def test_data_quality_report_to_json_rejects_invalid_output():
+    report = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", "Bob"],
+                    "age": [30, 40],
+                }
+            )
+        )
+    )
+
+    with pytest.raises(TypeError, match="output must be a writable text stream"):
+        report.to_json(output=object())
+
+
+def test_data_quality_report_to_json_output_preserves_options():
+    import io
+
+    report = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", "Bob"],
+                    "age": [30, 40],
+                }
+            )
+        )
+    )
+    buffer = io.StringIO()
+
+    result = report.to_json(
+        output=buffer,
+        indent=2,
+        redact_sample_values=True,
+        exclude_columns=["age"],
+    )
+
+    assert result is None
+    assert buffer.getvalue() == report.to_json(
+        indent=2,
+        redact_sample_values=True,
+        exclude_columns=["age"],
+    )
+
+
 def test_data_quality_report_to_json_indent():
     report = ar.DataQualityReport(
         row_count=10,


### PR DESCRIPTION
## Summary
Adds optional writable-output support to `DataQualityReport.to_json(...)` while preserving the existing backward-compatible return-string behavior.

This mirrors the writable-output support already available for:
- `DataQualityReport.to_markdown(...)`
- `DataQualityReport.to_html(...)`

and improves export API consistency for notebook, CI, logging, and reporting workflows.

Closes #1323

---
## Behavior
Existing behavior remains unchanged when `output=None`:

```python
json_text = report.to_json(indent=2)
```

Additional supported behavior:

```python
buffer = io.StringIO()
report.to_json(output=buffer, indent=2)

with open("report.json", "w", encoding="utf-8") as f:
    report.to_json(output=f, indent=2)
```

---

## Implementation
Changes are intentionally scoped only to JSON export handling in `DataQualityReport.to_json(...)`.

Added:
- optional `output` parameter
- `.write(str)` writable-output support
- deterministic `TypeError` validation for invalid outputs

Preserved:
- existing return-string behavior
- `indent`
- `redact_sample_values`
- `exclude_columns`

No profiling, parser, markdown/html export, or runtime behavior changes were made.
---

## Tests
Added focused regression coverage for:
- `io.StringIO`
- writable text file handles
- invalid output objects
- preservation of existing export options
- unchanged return-string behavior

Local validation:
```bash
ruff check arnio/quality.py tests/test_quality.py
pytest tests/test_quality.py -k "to_json" -q
pytest tests/test_quality.py -q
```

Results:
- `8 passed` (`to_json` focused tests)
- `142 passed` (full quality test suite)