### PR TITLE
feat: add skiprows parameter to scan_csv for API consistency (Fixes #…

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -937,8 +937,7 @@ def scan_csv(
     config.encoding_errors = encoding_errors
 
     if skiprows is not None:
-        config.skip_rows = _validate_skip_rows(skiprows)
-
+      config.skip_rows = _validate_skip_rows(skiprows)
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)
 
@@ -950,13 +949,13 @@ def scan_csv(
         config.sample_size = sample_size
 
     reader = _CsvReader(config)
-    
+
     # Calculate the total rows needed from the file to satisfy the sample
     # request, ensuring skipped rows don't reduce the effective sample size.
     effective_sample_rows = 100 if sample_size is None else sample_size
     if skiprows is not None:
         effective_sample_rows += skiprows
-        
+
     try:
         # Schema inference only needs a sample, avoiding full-file transcode.
         # sample_rows is passed so _utf8_csv_path uses record-aware sampling
@@ -971,6 +970,8 @@ def scan_csv(
             return cast(dict[str, str], reader.scan_schema(native_path))
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e
+
+
 def read_jsonl(
     path: str | os.PathLike[str],
     *,

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -831,6 +831,7 @@ def scan_csv(
     *,
     delimiter: str | None = None,
     encoding: str = "utf-8",
+    skiprows: int | None = None,
     trim_headers: bool = True,
     decimal_separator: str = ".",
     thousands_separator: str | None = None,
@@ -855,6 +856,9 @@ def scan_csv(
     encoding : str, default "utf-8"
         File encoding. For non-UTF-8 inputs, a sample of the file is
         transcoded to infer the schema.
+    skiprows : int or None, default None
+        Number of lines to skip at the beginning of the file before reading the
+        header or data. Useful for bypassing unstructured metadata.
     trim_headers : bool, default True
         Strip leading/trailing whitespace from column names.  Regardless
         of this setting, headers that differ only by leading or trailing
@@ -888,11 +892,11 @@ def scan_csv(
     Raises
     ------
     ValueError
-        If thousands_separator is invalid.
+        If thousands_separator or skiprows is invalid.
 
     TypeError
         If delimiter is not a string or None, or thousands_separator is
-        not a string or None.
+        not a string or None, or skiprows is not an integer.
 
     CsvReadError
         If CSV input contains NUL bytes and appears binary or corrupted.
@@ -932,6 +936,9 @@ def scan_csv(
     config.has_header = has_header
     config.encoding_errors = encoding_errors
 
+    if skiprows is not None:
+        config.skip_rows = _validate_skip_rows(skiprows)
+
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)
 
@@ -943,6 +950,13 @@ def scan_csv(
         config.sample_size = sample_size
 
     reader = _CsvReader(config)
+    
+    # Calculate the total rows needed from the file to satisfy the sample
+    # request, ensuring skipped rows don't reduce the effective sample size.
+    effective_sample_rows = 100 if sample_size is None else sample_size
+    if skiprows is not None:
+        effective_sample_rows += skiprows
+        
     try:
         # Schema inference only needs a sample, avoiding full-file transcode.
         # sample_rows is passed so _utf8_csv_path uses record-aware sampling
@@ -952,13 +966,11 @@ def scan_csv(
             encoding,
             encoding_errors=encoding_errors,
             delimiter=delimiter,
-            sample_rows=100 if sample_size is None else sample_size,
+            sample_rows=effective_sample_rows,
         ) as native_path:
             return cast(dict[str, str], reader.scan_schema(native_path))
     except RuntimeError as e:
         raise CsvReadError(str(e)) from e
-
-
 def read_jsonl(
     path: str | os.PathLike[str],
     *,

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -937,7 +937,7 @@ def scan_csv(
     config.encoding_errors = encoding_errors
 
     if skiprows is not None:
-      config.skip_rows = _validate_skip_rows(skiprows)
+        config.skip_rows = _validate_skip_rows(skiprows)
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)
 

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -872,8 +872,8 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     std::vector<std::string> header;
 
     std::vector<std::string> first_row;
-    
-// --- NEW LOGIC: Advance the reader past the skipped rows ---
+
+// Advance the reader past the skipped rows
     if (config.skip_rows.has_value()) {
         size_t to_skip = config.skip_rows.value();
         size_t skipped = 0;
@@ -881,7 +881,6 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
             ++skipped;
         }
     }
-    // -----------------------------------------------------------
 
     if (record_reader.read(line)) {
         strip_utf8_bom(line);

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -872,6 +872,16 @@ std::vector<std::pair<std::string, std::string>> CsvReader::scan_schema(
     std::vector<std::string> header;
 
     std::vector<std::string> first_row;
+    
+// --- NEW LOGIC: Advance the reader past the skipped rows ---
+    if (config.skip_rows.has_value()) {
+        size_t to_skip = config.skip_rows.value();
+        size_t skipped = 0;
+        while (skipped < to_skip && record_reader.read(line)) {
+            ++skipped;
+        }
+    }
+    // -----------------------------------------------------------
 
     if (record_reader.read(line)) {
         strip_utf8_bom(line);

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1100,6 +1100,44 @@ class TestReadCsv:
 
 
 class TestScanCsv:
+    # --- scan_csv skiprows regression tests ---
+
+    def test_scan_csv_skiprows_default_behavior(self, tmp_path):
+        """Default behavior remains unchanged when skiprows is not provided."""
+        csv_path = tmp_path / "default.csv"
+        csv_path.write_text("id,name\n1,Alice\n2,Bob\n")
+        schema = ar.scan_csv(csv_path)
+        assert schema == {"id": "int64", "name": "string"}
+
+    def test_scan_csv_skiprows_zero(self, tmp_path):
+        """skiprows=0 behaves identically to default behavior."""
+        csv_path = tmp_path / "zero.csv"
+        csv_path.write_text("id,name\n1,Alice\n2,Bob\n")
+        schema = ar.scan_csv(csv_path, skiprows=0)
+        assert schema == {"id": "int64", "name": "string"}
+
+    @pytest.mark.xfail(reason="C++ engine scan_schema currently ignores skip_rows config")
+    def test_scan_csv_skiprows_positive_with_metadata(self, tmp_path):
+        """Positive skiprows correctly skips metadata rows before the header."""
+        csv_path = tmp_path / "meta.csv"
+        csv_path.write_text("System Report\nGenerated 2026-05-25\nid,name\n1,Alice\n2,Bob\n")
+        schema = ar.scan_csv(csv_path, skiprows=2)
+        assert schema == {"id": "int64", "name": "string"}
+
+    def test_scan_csv_skiprows_invalid_values(self, tmp_path):
+        """Invalid skiprows values (negative, float, bool) raise appropriate errors."""
+        csv_path = tmp_path / "invalid.csv"
+        csv_path.write_text("id,name\n1,Alice\n")
+        
+        with pytest.raises(ValueError, match="non-negative"):
+            ar.scan_csv(csv_path, skiprows=-1)
+            
+        with pytest.raises(TypeError, match="integer"):
+            ar.scan_csv(csv_path, skiprows=1.5)
+            
+        with pytest.raises(TypeError, match="integer"):
+            ar.scan_csv(csv_path, skiprows=True)
+
     def test_scan_schema(self, sample_csv):
         schema = ar.scan_csv(sample_csv)
         assert isinstance(schema, dict)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1119,7 +1119,9 @@ class TestScanCsv:
     def test_scan_csv_skiprows_positive_with_metadata(self, tmp_path):
         """Positive skiprows correctly skips metadata rows before the header."""
         csv_path = tmp_path / "meta.csv"
-        csv_path.write_text("System Report\nGenerated 2026-05-25\nid,name\n1,Alice\n2,Bob\n")
+        csv_path.write_text(
+            "System Report\nGenerated 2026-05-25\nid,name\n1,Alice\n2,Bob\n"
+        )
         schema = ar.scan_csv(csv_path, skiprows=2)
         assert schema == {"id": "int64", "name": "string"}
 
@@ -1127,13 +1129,13 @@ class TestScanCsv:
         """Invalid skiprows values (negative, float, bool) raise appropriate errors."""
         csv_path = tmp_path / "invalid.csv"
         csv_path.write_text("id,name\n1,Alice\n")
-        
+
         with pytest.raises(ValueError, match="non-negative"):
             ar.scan_csv(csv_path, skiprows=-1)
-            
+
         with pytest.raises(TypeError, match="integer"):
             ar.scan_csv(csv_path, skiprows=1.5)
-            
+
         with pytest.raises(TypeError, match="integer"):
             ar.scan_csv(csv_path, skiprows=True)
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1116,7 +1116,6 @@ class TestScanCsv:
         schema = ar.scan_csv(csv_path, skiprows=0)
         assert schema == {"id": "int64", "name": "string"}
 
-    @pytest.mark.xfail(reason="C++ engine scan_schema currently ignores skip_rows config")
     def test_scan_csv_skiprows_positive_with_metadata(self, tmp_path):
         """Positive skiprows correctly skips metadata rows before the header."""
         csv_path = tmp_path / "meta.csv"


### PR DESCRIPTION
# Description

This PR introduces the `skiprows` parameter to `scan_csv`, bringing it into API parity with `read_csv`. 

Previously, `scan_csv` would fail on files with unstructured metadata at the top because it lacked the ability to bypass those lines before inferring the schema. This update allows the schema inference engine to cleanly skip `n` rows, while safely adjusting the effective sample window so that skipped rows do not diminish the number of actual data rows used for type inference.

Fixes #1299

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement / New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code structure)
- [ ] Documentation (non-breaking change which improves documentation)

# How Has This Been Tested?

- [x] Validated that `skiprows` properly passes through the configuration to the C++ core.
- [x] Ensured default behavior (`skiprows=None`) remains completely unchanged.
- [x] Verified that the `sample_rows` calculation dynamically expands to offset the skipped rows.

## Checklist
- [x] My PR references the issue number.
- [x] I placed files in the correct location.
- [x] I have updated the docstrings to reflect the new parameter.