### PR TITLE
docs: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1956,3 +1956,7 @@ arnio/
 <sub>Built with C++ and pybind11 · Licensed under MIT · Maintained by <a href="https://github.com/im-anishraj">@im-anishraj</a></sub>
 
 </div>
+
+## Security
+
+Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Arnio, please report it responsibly by emailing:
+
+**anishrajyadav97@gmail.com**
+
+Subject line:
+
+```text
+ARNIO SECURITY
+```
+
+Please include:
+- Description of the issue
+- Steps to reproduce
+- Potential impact
+- Affected files/components
+- Proof of concept (if available)
+
+Please do not publicly disclose security vulnerabilities until they have been reviewed and addressed.
+
+---
+
+## Scope
+
+The following security-related issues are considered in scope for Arnio:
+
+- CSV parsing crashes or malformed CSV handling
+- File path traversal vulnerabilities in `read_csv` or `scan_csv`
+- Memory exhaustion or denial-of-service through crafted inputs
+- Unsafe file handling or unintended file access
+- Crashes caused by malformed datasets
+- Security issues affecting CLI/API behavior
+
+---
+
+## Out of Scope
+
+The following are generally considered out of scope:
+
+- Feature requests
+- Performance optimizations without security impact
+- Style or formatting issues
+- Documentation typos
+- Non-security-related crashes
+- Third-party dependency vulnerabilities without direct exploitability in Arnio
+
+---
+
+## Responsible Disclosure
+
+We appreciate responsible disclosure and will review all valid reports as quickly as possible.


### PR DESCRIPTION
# 🚀 GSSoC '26 Pull Request Contribution

**Program:** GirlScript Summer of Code 2026 (GSSoC '26)  
**Associated Issue:** Fixes #1334  
**Type of Change:** 📝 Documentation / Docs / website

---

## 📝 Summary

Added a dedicated `SECURITY.md` file with a vulnerability reporting policy for Arnio.

This improves security policy visibility, contributor guidance, and repository discoverability while preserving the existing reporting workflow.

Also added a README reference link to the security policy.

---

## 🔗 Linked issue

Fixes #1334

---

## 🛠️ Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

---

## 📂 Area

- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

---

## 🧪 Testing

- [ ] `make test`
- [ ] `make lint`
- [x] Other:

Verified markdown rendering locally and confirmed README link correctness.

---

## 🖼️ Screenshots / Media

N/A — documentation-only update.

---

## ⚡ Performance Impact

No performance impact. Documentation-only changes.

---

## 📋 Contributor checklist (GSSoC '26)

- [x] I am assigned to this issue and contributing under GSSoC '26.
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

---

## 🗒️ Maintainer notes

Added:
- Root-level `SECURITY.md`
- Scope and Out of Scope sections
- README reference link for discoverability

Preserved the existing vulnerability reporting email workflow and instructions.