### PR TITLE
fix: reject auto_clean dry-run report combo

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1667,11 +1667,11 @@ def auto_clean(
 
     if dry_run and explain:
         raise ValueError("explain=True cannot be used with dry_run=True")
+    if dry_run and return_report:
+        raise ValueError("return_report=True cannot be used with dry_run=True")
 
     report = profile(frame)
     if dry_run:
-        if return_report:
-            return frame, report
         return report
 
     result = frame

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -1,6 +1,7 @@
 """Tests for the pandas DataFrame accessor."""
 
 import pandas as pd
+import pytest
 
 import arnio as ar
 
@@ -76,15 +77,15 @@ def test_pandas_accessor_auto_clean_dry_run_returns_report():
 
 
 def test_pandas_accessor_auto_clean_dry_run_with_return_report():
-    # dry_run=True with return_report=True should return (frame, report)
+    # dry_run=True with return_report=True should raise because dry_run
+    # already returns the report directly.
     df = pd.DataFrame({"name": [" Alice ", " Bob "]})
 
-    result = df.arnio.auto_clean(dry_run=True, return_report=True)
+    with pytest.raises(
+        ValueError, match="return_report=True cannot be used with dry_run=True"
+    ):
+        df.arnio.auto_clean(dry_run=True, return_report=True)
 
-    assert isinstance(result, tuple)
-    frame, report = result
-    assert isinstance(report, ar.DataQualityReport)
-    # Original frame must not be mutated
     assert list(df["name"]) == [" Alice ", " Bob "]
 
 
@@ -114,16 +115,14 @@ def test_pandas_accessor_validates_dataframe():
 
 
 def test_auto_clean_dry_run_with_return_report():
-    # dry_run=True with return_report=True should return (frame, report)
+    # dry_run=True with return_report=True should raise because dry_run
+    # already returns the report directly.
     frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
 
-    result = ar.auto_clean(frame, dry_run=True, return_report=True)
-
-    assert isinstance(result, tuple)
-    original_frame, report = result
-    assert isinstance(report, ar.DataQualityReport)
-    # Frame must not be mutated
-    assert frame.dtypes["name"] == "string"
+    with pytest.raises(
+        ValueError, match="return_report=True cannot be used with dry_run=True"
+    ):
+        ar.auto_clean(frame, dry_run=True, return_report=True)
 
 
 def test_auto_clean_dry_run_safe_mode_does_not_mutate():

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -447,6 +447,15 @@ def test_auto_clean_dry_run_returns_report_without_mutating():
     assert frame.dtypes["active"] == "string"
 
 
+def test_auto_clean_dry_run_with_return_report_raises():
+    frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
+
+    with pytest.raises(
+        ValueError, match="return_report=True cannot be used with dry_run=True"
+    ):
+        ar.auto_clean(frame, dry_run=True, return_report=True)
+
+
 def test_auto_clean_rejects_unknown_mode(sample_csv):
     frame = ar.read_csv(sample_csv)
 


### PR DESCRIPTION
## Summary
- reject `auto_clean(..., dry_run=True, return_report=True)` instead of silently returning an undocumented tuple
- align this invalid flag combination with the existing dry-run/explain guard behavior
- update direct quality tests and pandas-accessor coverage to lock the contract in place

## Testing
- `python3 -m pytest tests/test_quality.py -k 'auto_clean_dry_run' -q`
- `python3 -m pytest tests/test_pandas_accessor.py -k 'auto_clean_dry_run' -q`
- `python3 -m py_compile arnio/quality.py tests/test_quality.py tests/test_pandas_accessor.py`
- `git diff --check`

Closes #1306