### PR TITLE
chore: add environment doctor for native builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint format benchmark clean help
+.PHONY: install test lint format benchmark doctor clean help
 
 help:  ## Show this help message
 	@python -c "import re; [print(f'\033[36m{m[0]:<15}\033[0m {m[1]}') for m in sorted([re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line).groups() for line in open('$(MAKEFILE_LIST)') if re.match(r'^[a-zA-Z_-]+:.*?## .*$$', line)])]"
@@ -6,6 +6,9 @@ help:  ## Show this help message
 install: ## Install dependencies and pre-commit
 	pip install -e ".[dev]"
 	pre-commit install
+
+doctor: ## Check Python dependencies, native core, and local build tools
+	python examples/check_env.py
 
 test: ## Run tests with coverage
 	pytest tests/ -v --cov=arnio --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -1781,6 +1781,7 @@ make test      # pytest with coverage
 make lint      # ruff + black
 
 # Windows
+python examples/check_env.py
 pip install -e ".[dev]"
 pre-commit install
 pytest tests/ -v
@@ -1840,6 +1841,15 @@ If `pip install -e ".[dev]"` fails on Windows, work through this checklist befor
    pre-commit install
    pytest tests/ -v
    ```
+
+Before retrying, run the environment doctor:
+
+```bash
+python examples/check_env.py
+```
+
+If it reports `[BUILD BLOCKED]`, fix the missing compiler/CMake/NMake entry
+first. That is a build-toolchain problem, not a test failure.
 
 If you want a quick wheel-build smoke test before running the full suite, use:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -6,6 +6,16 @@ must build the native C++ extension before most examples and tests can run. The
 gate because import failures are usually build/setup problems, not test logic
 problems.
 
+Run the environment doctor before debugging build failures:
+
+```bash
+python examples/check_env.py
+```
+
+On Windows, `[BUILD BLOCKED]` usually means PowerShell cannot see Visual Studio
+Build Tools commands such as `cl` or `nmake`. Install the `Desktop development
+with C++` workload, then retry from an x64 Developer Command Prompt.
+
 ## MemoryError when reading large CSV files
 
 ### Problem

--- a/examples/check_env.py
+++ b/examples/check_env.py
@@ -6,7 +6,14 @@ prints a beautifully formatted status dashboard indicating which example scripts
 can be run.
 """
 
+from __future__ import annotations
+
+import platform
+import shutil
 import sys
+from dataclasses import dataclass
+from importlib.machinery import EXTENSION_SUFFIXES
+from pathlib import Path
 
 # Map import name to (install package name, description)
 DEPENDENCIES = {
@@ -30,6 +37,17 @@ DEPENDENCIES = {
 }
 
 
+@dataclass(frozen=True)
+class BuildToolCheck:
+    """Status for a local build tool required by Arnio's native extension."""
+
+    name: str
+    command: str
+    available: bool
+    detail: str
+    required: bool = True
+
+
 # Map example script name to its list of optional dependency keys
 EXAMPLES = {
     "basic_usage.py": [],
@@ -51,29 +69,128 @@ def check_dependencies():
         try:
             __import__(lib)
             results[lib] = (True, "Installed")
-        except ImportError:
-            results[lib] = (False, "Not Installed")
+        except ImportError as exc:
+            if exc.name and exc.name != lib:
+                results[lib] = (False, f"Import failed: missing {exc.name}")
+            else:
+                results[lib] = (False, f"Not Installed ({lib})")
+        except Exception as exc:  # pragma: no cover - defensive diagnostic path
+            results[lib] = (False, f"Import failed: {type(exc).__name__}: {exc}")
     return results
 
 
-def print_dashboard(results):
+def check_build_tools():
+    """Check whether source-build tools are visible in the current shell."""
+    system = platform.system()
+    checks = [
+        BuildToolCheck(
+            name="CMake",
+            command="cmake",
+            available=shutil.which("cmake") is not None,
+            detail="Required by scikit-build-core to configure the C++ extension.",
+        ),
+    ]
+
+    if system == "Windows":
+        checks.extend(
+            [
+                BuildToolCheck(
+                    name="MSVC compiler",
+                    command="cl",
+                    available=shutil.which("cl") is not None,
+                    detail=(
+                        "Install Visual Studio Build Tools with Desktop development "
+                        "with C++, then use a Developer Command Prompt."
+                    ),
+                ),
+                BuildToolCheck(
+                    name="NMake",
+                    command="nmake",
+                    available=shutil.which("nmake") is not None,
+                    detail=(
+                        "CMake may choose NMake on Windows; nmake must be on PATH "
+                        "or another generator must be configured."
+                    ),
+                ),
+            ]
+        )
+    else:
+        checks.append(
+            BuildToolCheck(
+                name="C++ compiler",
+                command="c++",
+                available=any(
+                    shutil.which(command) is not None
+                    for command in ("c++", "g++", "clang++")
+                ),
+                detail="Required to compile Arnio's native C++ extension.",
+            )
+        )
+
+    return checks
+
+
+def detect_core_status():
+    """Detect the native extension without importing the full arnio package."""
+    if "arnio._core" in sys.modules:
+        if sys.modules["arnio._core"] is None:
+            return "Not Compiled (arnio._core unavailable)", False
+        return "Available (C++ Accelerated)", True
+
+    for entry in sys.path:
+        package_dir = Path(entry or ".") / "arnio"
+        if not package_dir.is_dir():
+            continue
+
+        for suffix in EXTENSION_SUFFIXES:
+            if (package_dir / f"_arnio_cpp{suffix}").exists():
+                return "Available (C++ Accelerated)", True
+
+    return "Not Compiled (_arnio_cpp extension file not found)", False
+
+
+def print_build_tool_status(build_tools):
+    """Print build-tool checks and setup tips."""
+    print("Build Toolchain Status:")
+    blocked = False
+    for check in build_tools:
+        mark = "[OK]" if check.available else "[X]"
+        required = "required" if check.required else "optional"
+        print(f"  - {check.name:<15} {mark:<4} {check.command:<10} ({required})")
+        if check.required and not check.available:
+            blocked = True
+            print(f"    Tip: {check.detail}")
+
+    if blocked:
+        print(
+            '\n[BUILD BLOCKED] Source installs like `pip install -e ".[dev]"` '
+            "may fail until the missing build tools are available."
+        )
+        if platform.system() == "Windows":
+            print(
+                "Windows fix: install Visual Studio Build Tools 2022 with the "
+                "`Desktop development with C++` workload, then reopen an x64 "
+                "Developer Command Prompt and retry."
+            )
+    else:
+        print("\nBuild toolchain looks ready for a local native-extension build.")
+
+
+def print_dashboard(results, build_tools=None):
     """Print a clean dashboard of the check results."""
+    if build_tools is None:
+        build_tools = check_build_tools()
+
     print("=" * 70)
     print(" ARNIO DEVELOPMENT ENVIRONMENT STATUS ")
     print("=" * 70)
 
     # Check Arnio C++ Core status
-    core_available = False
-    try:
-        import arnio._core  # noqa: F401
-
-        core_status = "Available (C++ Accelerated)"
-        core_available = True
-    except ImportError:
-        core_status = "Not Compiled (Pure-Python Mode)"
+    core_status, core_available = detect_core_status()
 
     print(f"Arnio Core Module:  {core_status}")
     print(f"Python Version:     {sys.version.split()[0]}")
+    print(f"Platform:           {platform.platform()}")
     print("-" * 70)
     print(f"{'Dependency':<15} | {'Status':<15} | {'Description'}")
     print("-" * 70)
@@ -82,7 +199,11 @@ def print_dashboard(results):
         package, desc = DEPENDENCIES[lib]
         mark = "[OK]" if status else "[X]"
         print(f"{lib:<15} | {mark:<15} | {desc}")
+        if not status:
+            print(f"{'':<15} | {'':<15} | {status_str}")
 
+    print("-" * 70)
+    print_build_tool_status(build_tools)
     print("-" * 70)
 
     # Suggest runnable examples based on core status and packages found

--- a/tests/test_check_env.py
+++ b/tests/test_check_env.py
@@ -5,7 +5,17 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from examples.check_env import print_dashboard
+from examples.check_env import BuildToolCheck, check_dependencies, print_dashboard
+
+READY_BUILD_TOOLS = [
+    BuildToolCheck("CMake", "cmake", True, "ok"),
+    BuildToolCheck("MSVC compiler", "cl", True, "ok"),
+]
+
+MISSING_BUILD_TOOLS = [
+    BuildToolCheck("CMake", "cmake", True, "ok"),
+    BuildToolCheck("MSVC compiler", "cl", False, "install build tools"),
+]
 
 
 def test_check_env_core_missing(capsys: pytest.CaptureFixture[str]) -> None:
@@ -19,12 +29,14 @@ def test_check_env_core_missing(capsys: pytest.CaptureFixture[str]) -> None:
             "pytest": (True, "Installed"),
         }
 
-        print_dashboard(results)
+        print_dashboard(results, build_tools=MISSING_BUILD_TOOLS)
         captured = capsys.readouterr()
         output = captured.out
 
         # Verify core status reporting
-        assert "Not Compiled (Pure-Python Mode)" in output
+        assert "Not Compiled" in output
+        assert "Build Toolchain Status" in output
+        assert "[BUILD BLOCKED]" in output
         # Verify examples report missing core
         for line in output.splitlines():
             if "arnio_with_pandas.py" in line:
@@ -47,12 +59,13 @@ def test_check_env_core_available_some_missing(
             "pytest": (True, "Installed"),
         }
 
-        print_dashboard(results)
+        print_dashboard(results, build_tools=READY_BUILD_TOOLS)
         captured = capsys.readouterr()
         output = captured.out
 
         # Verify core status reporting
         assert "Available (C++ Accelerated)" in output
+        assert "Build toolchain looks ready" in output
 
         # Verify ready / missing optional dependencies reported correctly
         for line in output.splitlines():
@@ -76,7 +89,7 @@ def test_check_env_all_available(capsys: pytest.CaptureFixture[str]) -> None:
             "pytest": (True, "Installed"),
         }
 
-        print_dashboard(results)
+        print_dashboard(results, build_tools=READY_BUILD_TOOLS)
         captured = capsys.readouterr()
         output = captured.out
 
@@ -85,3 +98,37 @@ def test_check_env_all_available(capsys: pytest.CaptureFixture[str]) -> None:
             if "arnio_with_duckdb.py" in line:
                 assert "[Ready]" in line
         assert "All optional dependencies are successfully installed!" in output
+
+
+def test_check_dependencies_reports_broken_import() -> None:
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pandas":
+            raise RuntimeError("broken binary dependency")
+        return real_import(name, *args, **kwargs)
+
+    with (
+        patch("examples.check_env.DEPENDENCIES", {"pandas": ("pandas", "desc")}),
+        patch("builtins.__import__", side_effect=fake_import),
+    ):
+        results = check_dependencies()
+
+    assert results["pandas"][0] is False
+    assert "Import failed: RuntimeError" in results["pandas"][1]
+
+
+def test_check_dependencies_reports_transitive_import_error() -> None:
+    def fake_import(name, *args, **kwargs):
+        if name == "pandas":
+            raise ImportError("DLL load failed", name="_ctypes")
+        raise AssertionError(f"unexpected import: {name}")
+
+    with (
+        patch("examples.check_env.DEPENDENCIES", {"pandas": ("pandas", "desc")}),
+        patch("builtins.__import__", side_effect=fake_import),
+    ):
+        results = check_dependencies()
+
+    assert results["pandas"][0] is False
+    assert results["pandas"][1] == "Import failed: missing _ctypes"


### PR DESCRIPTION
## Summary
- harden xamples/check_env.py into a real environment doctor for source installs
- detect CMake, MSVC cl, and 
make availability before contributors hit CMake/NMake build failures
- avoid importing the full rnio package while checking native core status, so broken pandas/NumPy installs do not crash diagnostics
- add make doctor plus README and troubleshooting guidance

## Verification
- python examples/check_env.py reports missing _ctypes, cl, and 
make clearly on the current Windows environment
- Python 3.12 temp venv: pytest tests/test_check_env.py tests/test_metadata.py -q -> 6 passed
- Python 3.12 temp venv: uff check examples/check_env.py tests/test_check_env.py -> passed
- Python 3.12 temp venv: lack --check examples/check_env.py tests/test_check_env.py -> passed
- git diff --check -> passed

## Note
Full editable install and full test suite are still blocked locally because this shell cannot see MSVC/
make; the new doctor now reports that blocker directly.