### PR TITLE
fix: harden file-like CSV inputs and sklearn feature names

### DIFF
--- a/arnio/integrations/sklearn.py
+++ b/arnio/integrations/sklearn.py
@@ -49,6 +49,7 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
         # Store column dtypes so transform() can warn when they change
         # between fit and transform (e.g. after a CSV round-trip).
         self.feature_dtypes_in_ = {col: str(X[col].dtype) for col in X.columns}
+        self.feature_names_out_ = self.feature_names_in_.copy()
 
         return self
 
@@ -85,6 +86,7 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
         ar_frame = from_pandas(X_in)
         cleaned_ar_frame = run_pipeline(ar_frame, self.steps)
         X_out = to_pandas(cleaned_ar_frame)
+        self.feature_names_out_ = np.array(X_out.columns, dtype=object)
 
         if len(X_out.index) != len(X.index):
             if not self.allow_row_count_change:
@@ -103,7 +105,7 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
         check_is_fitted(self, "n_features_in_")
 
         if input_features is None:
-            return self.feature_names_in_
+            return self.feature_names_out_
 
         if len(input_features) != self.n_features_in_:
             raise ValueError(
@@ -111,4 +113,9 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
                 f"({self.n_features_in_}), got {len(input_features)}"
             )
 
-        return np.asarray(input_features, dtype=object)
+        if list(input_features) != list(self.feature_names_in_):
+            raise ValueError(
+                "input_features must match the columns seen during fit, including order."
+            )
+
+        return self.feature_names_out_

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -260,6 +260,7 @@ def _validate_nrows(nrows: int) -> int:
 
 
 _PREVIEW_BAD_ROWS = 10
+_FILE_LIKE_COPY_CHUNK_SIZE = 8192
 
 
 def _warn_bad_rows(bad_rows: list) -> None:
@@ -350,11 +351,6 @@ def _materialize_csv_input(
     if isinstance(source, io.StringIO) or (
         hasattr(source, "read") and callable(source.read)
     ):
-        content = source.read()
-
-        if not isinstance(content, str):
-            raise TypeError("read_csv file-like objects must return text, not bytes")
-
         tmp = tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
@@ -363,10 +359,19 @@ def _materialize_csv_input(
         )
 
         try:
-            tmp.write(content)
+            while True:
+                chunk = source.read(_FILE_LIKE_COPY_CHUNK_SIZE)
+                if chunk == "":
+                    break
+                if not isinstance(chunk, str):
+                    raise TypeError(
+                        "read_csv file-like objects must return text, not bytes"
+                    )
+                tmp.write(chunk)
             tmp.close()
             return tmp.name, True
         except Exception:
+            tmp.close()
             os.unlink(tmp.name)
             raise
 
@@ -419,7 +424,7 @@ def _validate_encoding_errors(value: str) -> str:
 
 
 def read_csv(
-    path: str | os.PathLike[str],
+    path: str | os.PathLike[str] | io.TextIOBase,
     *,
     delimiter: str | None = None,
     has_header: bool = True,
@@ -539,46 +544,51 @@ def read_csv(
     """
     path, should_cleanup = _materialize_csv_input(path)
 
-    _validate_csv_path(path, encoding)
+    try:
+        _validate_csv_path(path, encoding)
 
-    path_lower = path.lower()
+        path_lower = path.lower()
 
-    # Resolve the sentinel: auto-detect tab for .tsv only when the caller
-    # truly omitted delimiter (None).  An explicit delimiter="," is always
-    # honoured, even for .tsv paths.
-    if delimiter is None:
-        delimiter = "\t" if path_lower.endswith(".tsv") else ","
+        # Resolve the sentinel: auto-detect tab for .tsv only when the caller
+        # truly omitted delimiter (None).  An explicit delimiter="," is always
+        # honoured, even for .tsv paths.
+        if delimiter is None:
+            delimiter = "\t" if path_lower.endswith(".tsv") else ","
 
-    decimal_separator = _validate_decimal_separator(decimal_separator)
-    _validate_thousands_separator(thousands_separator, decimal_separator)
-    delimiter = _validate_delimiter(delimiter)
-    mode = _validate_parser_mode(mode)
-    encoding_errors = _validate_encoding_errors(encoding_errors)
-    on_bad_lines = _validate_on_bad_lines(on_bad_lines)
-    config = _CsvConfig()
-    config.delimiter = delimiter
-    config.has_header = _validate_bool_option(has_header, "has_header")
-    config.encoding = encoding
-    config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
-    config.decimal_separator = decimal_separator
-    config.thousands_separator = thousands_separator
-    config.mode = mode
-    config.encoding_errors = encoding_errors
-    if null_values is not None:
-        config.null_values = _validate_null_values(null_values)
-    if dtype is not None:
-        config.dtype = _validate_dtype_mapping(dtype)
+        decimal_separator = _validate_decimal_separator(decimal_separator)
+        _validate_thousands_separator(thousands_separator, decimal_separator)
+        delimiter = _validate_delimiter(delimiter)
+        mode = _validate_parser_mode(mode)
+        encoding_errors = _validate_encoding_errors(encoding_errors)
+        on_bad_lines = _validate_on_bad_lines(on_bad_lines)
+        config = _CsvConfig()
+        config.delimiter = delimiter
+        config.has_header = _validate_bool_option(has_header, "has_header")
+        config.encoding = encoding
+        config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
+        config.decimal_separator = decimal_separator
+        config.thousands_separator = thousands_separator
+        config.mode = mode
+        config.encoding_errors = encoding_errors
+        if null_values is not None:
+            config.null_values = _validate_null_values(null_values)
+        if dtype is not None:
+            config.dtype = _validate_dtype_mapping(dtype)
 
-    if usecols is not None:
-        config.usecols = _validate_usecols(usecols)
+        if usecols is not None:
+            config.usecols = _validate_usecols(usecols)
 
-    if nrows is not None:
-        config.nrows = _validate_nrows(nrows)
+        if nrows is not None:
+            config.nrows = _validate_nrows(nrows)
 
-    if skiprows is not None:
-        config.skip_rows = _validate_skip_rows(skiprows)
+        if skiprows is not None:
+            config.skip_rows = _validate_skip_rows(skiprows)
 
-    reader = _CsvReader(config)
+        reader = _CsvReader(config)
+    except Exception:
+        if should_cleanup and os.path.exists(path):
+            os.unlink(path)
+        raise
 
     try:
         with _utf8_csv_path(
@@ -605,7 +615,7 @@ def read_csv(
 
 
 def read_csv_chunked(
-    path: str | os.PathLike[str],
+    path: str | os.PathLike[str] | io.TextIOBase,
     *,
     chunksize: int = 10_000,
     delimiter: str = ",",
@@ -628,8 +638,10 @@ def read_csv_chunked(
 
     Parameters
     ----------
-    path : str
+    path : str or file-like object
         Path to the CSV file. Supports .csv, .txt, and .tsv extensions.
+        Text file-like objects are copied to a temporary file in bounded
+        chunks before native parsing.
     chunksize : int, default 10_000
         Maximum number of data rows per yielded chunk.
     delimiter : str, default ","
@@ -687,51 +699,55 @@ def read_csv_chunked(
     ...     df = ar.to_pandas(clean)
     ...     process(df)
     """
-    path = os.fspath(path)
-    path_lower = path.lower()
-    if not (
-        path_lower.endswith(".csv")
-        or path_lower.endswith(".txt")
-        or path_lower.endswith(".tsv")
-    ):
-        raise ValueError(
-            f"Unsupported file format: {path}. Only .csv, .txt, and .tsv are supported."
-        )
-
+    is_path_input = isinstance(path, (str, os.PathLike))
+    path, should_cleanup = _materialize_csv_input(path)
     try:
-        if os.path.getsize(path) == 0:
-            raise CsvReadError(f"CSV file is empty: {path!r}")
-    except FileNotFoundError:
-        pass
+        if is_path_input:
+            path_lower = path.lower()
+            if not (
+                path_lower.endswith(".csv")
+                or path_lower.endswith(".txt")
+                or path_lower.endswith(".tsv")
+            ):
+                raise ValueError(
+                    f"Unsupported file format: {path}. "
+                    "Only .csv, .txt, and .tsv are supported."
+                )
 
-    decimal_separator = _validate_decimal_separator(decimal_separator)
-    _validate_thousands_separator(thousands_separator, decimal_separator)
-    delimiter = _validate_delimiter(delimiter)
-    mode = _validate_parser_mode(mode)
-    chunksize = _validate_chunksize(chunksize)
-    skip_rows = _validate_skip_rows(skip_rows)
-    on_bad_lines = _validate_on_bad_lines(on_bad_lines)
+        _validate_csv_path(path, encoding)
 
-    config = _CsvConfig()
-    config.delimiter = delimiter
-    config.has_header = _validate_bool_option(has_header, "has_header")
-    config.encoding = encoding
-    config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
-    config.decimal_separator = decimal_separator
-    config.thousands_separator = thousands_separator
-    config.mode = mode
-    config.skip_rows = skip_rows
+        decimal_separator = _validate_decimal_separator(decimal_separator)
+        _validate_thousands_separator(thousands_separator, decimal_separator)
+        delimiter = _validate_delimiter(delimiter)
+        mode = _validate_parser_mode(mode)
+        chunksize = _validate_chunksize(chunksize)
+        skip_rows = _validate_skip_rows(skip_rows)
+        on_bad_lines = _validate_on_bad_lines(on_bad_lines)
 
-    if null_values is not None:
-        config.null_values = _validate_null_values(null_values)
+        config = _CsvConfig()
+        config.delimiter = delimiter
+        config.has_header = _validate_bool_option(has_header, "has_header")
+        config.encoding = encoding
+        config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
+        config.decimal_separator = decimal_separator
+        config.thousands_separator = thousands_separator
+        config.mode = mode
+        config.skip_rows = skip_rows
 
-    if usecols is not None:
-        config.usecols = _validate_usecols(usecols)
+        if null_values is not None:
+            config.null_values = _validate_null_values(null_values)
 
-    if nrows is not None:
-        config.nrows = _validate_nrows(nrows)
+        if usecols is not None:
+            config.usecols = _validate_usecols(usecols)
 
-    reader = _CsvChunkReader(config)
+        if nrows is not None:
+            config.nrows = _validate_nrows(nrows)
+
+        reader = _CsvChunkReader(config)
+    except Exception:
+        if should_cleanup and os.path.exists(path):
+            os.unlink(path)
+        raise
     try:
         with _utf8_csv_path(path, encoding, delimiter=delimiter) as native_path:
             reader.open(native_path)
@@ -753,6 +769,8 @@ def read_csv_chunked(
         raise CsvReadError(str(e)) from e
     finally:
         reader.close()
+        if should_cleanup and os.path.exists(path):
+            os.unlink(path)
 
 
 def write_csv(

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -15,6 +15,16 @@ from arnio.io import _utf8_csv_path
 MESSY_CSV = str(Path(__file__).parent / "fixtures" / "messy_sales_data.csv")
 
 
+class ChunkTrackingTextStream:
+    def __init__(self, chunks):
+        self._chunks = iter(chunks)
+        self.read_sizes = []
+
+    def read(self, size=-1):
+        self.read_sizes.append(size)
+        return next(self._chunks, "")
+
+
 class TestReadCsv:
     def test_read_csv_dtype_override_string(self, tmp_path):
         path = tmp_path / "zip_codes.csv"
@@ -759,6 +769,32 @@ class TestReadCsv:
     def test_pathlike_input(self, sample_csv):
         frame = ar.read_csv(Path(sample_csv))
         assert frame.shape == (3, 4)
+
+    def test_read_csv_file_like_input_is_copied_in_bounded_chunks(self):
+        stream = ChunkTrackingTextStream(["name,age\n", "Alice,30\n", "Bob,25\n"])
+
+        frame = ar.read_csv(stream)
+        df = ar.to_pandas(frame)
+
+        assert df["name"].tolist() == ["Alice", "Bob"]
+        assert stream.read_sizes
+        assert -1 not in stream.read_sizes
+
+    def test_read_csv_chunked_file_like_input_is_copied_in_bounded_chunks(self):
+        stream = ChunkTrackingTextStream(["name,age\nAlice,30\n", "Bob,25\n"])
+
+        chunks = list(ar.read_csv_chunked(stream, chunksize=1))
+
+        assert [ar.to_pandas(chunk)["name"].iloc[0] for chunk in chunks] == [
+            "Alice",
+            "Bob",
+        ]
+        assert stream.read_sizes
+        assert -1 not in stream.read_sizes
+
+    def test_file_like_input_rejects_bytes(self):
+        with pytest.raises(TypeError, match="file-like objects must return text"):
+            ar.read_csv(io.BytesIO(b"name,age\nAlice,30\n"))
 
     def test_read_csv_encoding_errors_strict(self, tmp_path):
         csv_file = tmp_path / "invalid_utf8.csv"

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -54,6 +54,37 @@ def test_arniocleaner_in_pipeline():
     assert list(result.columns) == ["A", "B"]
 
 
+def test_arniocleaner_feature_names_out_tracks_dropped_columns():
+    df = pd.DataFrame({"A": ["x", "y"], "B": [1, 2]})
+
+    cleaner = ArnioCleaner(steps=[("drop_columns", {"columns": ["B"]})])
+    cleaner.fit(df)
+    result = cleaner.transform(df)
+
+    assert list(result.columns) == ["A"]
+    assert cleaner.get_feature_names_out().tolist() == ["A"]
+
+
+def test_arniocleaner_feature_names_out_tracks_renamed_columns():
+    df = pd.DataFrame({"A": ["x", "y"], "B": [1, 2]})
+
+    cleaner = ArnioCleaner(steps=[("rename_columns", {"mapping": {"A": "name"}})])
+    cleaner.fit(df)
+    result = cleaner.transform(df)
+
+    assert list(result.columns) == ["name", "B"]
+    assert cleaner.get_feature_names_out(["A", "B"]).tolist() == ["name", "B"]
+
+
+def test_arniocleaner_feature_names_out_rejects_wrong_input_features():
+    df = pd.DataFrame({"A": ["x", "y"], "B": [1, 2]})
+
+    cleaner = ArnioCleaner().fit(df)
+
+    with pytest.raises(ValueError, match="input_features must match"):
+        cleaner.get_feature_names_out(["B", "A"])
+
+
 def test_arniocleaner_rejects_row_dropping_by_default():
     df = pd.DataFrame({"name": ["Alice", None], "age": [30, 40]})
 


### PR DESCRIPTION
## Summary
- copy text file-like CSV inputs to temporary files in bounded chunks instead of one unbounded `read()` call
- allow `read_csv_chunked()` to accept text file-like inputs with the same bounded-copy path
- cache ArnioCleaner output feature names after transform so sklearn pipelines see dropped/renamed columns correctly
- add regression coverage for bounded file-like reads and sklearn `get_feature_names_out()` behavior

## Linked issues
Closes #1332
Closes #1335

Note: #1337 is intentionally not closed here. Duplicate CSV header auto-mangling is a maintainer/API decision because Arnio currently rejects duplicate headers by design.

## Local verification
- `ruff check arnio/io.py arnio/integrations/sklearn.py tests/test_csv.py tests/test_sklearn.py`
- `black --check arnio/io.py arnio/integrations/sklearn.py tests/test_csv.py tests/test_sklearn.py`
- `python -m py_compile arnio/io.py arnio/integrations/sklearn.py tests/test_csv.py tests/test_sklearn.py`
- `git diff --check`

Full native pytest is blocked in this local shell because `_arnio_cpp` is not compiled and MSVC `cl`/`nmake` are not on PATH. GitHub Actions should provide the native matrix verification.