### PR TITLE
feat: add ArFrame._repr_html_() for notebook-friendly display

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -831,7 +831,6 @@ class ArFrame:
         """
         import html as _html
 
-        from .convert import to_pandas
 
         _REPR_HTML_MAX_ROWS = 10
 
@@ -866,11 +865,17 @@ class ArFrame:
         )
         header = f"<thead><tr>{header_cells}</tr></thead>"
 
-        # ── data rows — only convert the bounded slice, not the full frame ──
+                # Read only the rows needed for display; do not convert the full frame.
+        preview_rows = min(num_rows, _REPR_HTML_MAX_ROWS)
+
         try:
-            bounded = self.head(_REPR_HTML_MAX_ROWS)
-            df = to_pandas(bounded)
-            preview = df
+            preview_values = [
+                [
+                    self._frame.column_by_index(col_idx).at(row_idx)
+                    for col_idx in range(num_cols)
+                ]
+                for row_idx in range(preview_rows)
+            ]
         except Exception as exc:
             return (
                 summary
@@ -884,12 +889,12 @@ class ArFrame:
             "font-family:monospace;font-size:0.9em;white-space:nowrap;'"
         )
         rows_html = ""
-        for _, row in preview.iterrows():
+        for row in preview_values:
             cells = "".join(
                 f"<td {td_style}>"
-                + _html.escape("" if row[c] is None else str(row[c]))
+                + _html.escape("" if value is None else str(value))
                 + "</td>"
-                for c in col_names
+                for value in row
             )
             rows_html += f"<tr>{cells}</tr>"
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -816,3 +816,94 @@ class ArFrame:
 
         label = f"ArFrame preview (showing {actual_n} of {num_rows} rows):"
         return "\n".join([label, header, separator] + rows)
+
+    def _repr_html_(self) -> str:
+        """Return a bounded HTML table for Jupyter/IPython display.
+
+        Jupyter calls this automatically when an ArFrame is the last
+        expression in a cell. Output is always bounded to 10 rows.
+
+        Returns
+        -------
+        str
+            HTML string with shape/dtype summary, up to 10 data rows,
+            HTML-escaped content, and a truncation notice when needed.
+        """
+        import html as _html
+
+        from .convert import to_pandas
+
+        _REPR_HTML_MAX_ROWS = 10
+
+        num_rows, num_cols = self.shape
+        col_names = self.columns
+        dtypes = self.dtypes
+
+        # ── summary line ──────────────────────────────────────────────────
+        dtype_parts = ", ".join(
+            f"{_html.escape(c)}: {_html.escape(dtypes.get(c, '?'))}" for c in col_names
+        )
+        summary = (
+            '<p style="font-family:monospace;font-size:0.85em;'
+            'color:#555;margin:0 0 4px 0;">'
+            f"ArFrame [{num_rows} rows \u00d7 {num_cols} cols]"
+            + (f"&nbsp;&nbsp;|&nbsp;&nbsp;{dtype_parts}" if dtype_parts else "")
+            + "</p>"
+        )
+
+        # ── empty-frame fast path ─────────────────────────────────────────
+        if num_cols == 0 or num_rows == 0:
+            return summary + "<p><em>(empty)</em></p>"
+
+        # ── column header ─────────────────────────────────────────────────
+        th_style = (
+            "style='padding:4px 10px;text-align:left;"
+            "background:#f0f0f0;border:1px solid #ccc;"
+            "font-family:monospace;font-size:0.9em;'"
+        )
+        header_cells = "".join(
+            f"<th {th_style}>{_html.escape(c)}</th>" for c in col_names
+        )
+        header = f"<thead><tr>{header_cells}</tr></thead>"
+
+        # ── data rows via to_pandas slice ─────────────────────────────────
+        try:
+            df = to_pandas(self)
+            preview = df.iloc[:_REPR_HTML_MAX_ROWS]
+        except Exception as exc:
+            return (
+                summary
+                + "<p><em>HTML preview unavailable: "
+                + _html.escape(str(exc))
+                + "</em></p>"
+            )
+
+        td_style = (
+            "style='padding:4px 10px;border:1px solid #ddd;"
+            "font-family:monospace;font-size:0.9em;white-space:nowrap;'"
+        )
+        rows_html = ""
+        for _, row in preview.iterrows():
+            cells = "".join(
+                f"<td {td_style}>"
+                + _html.escape("" if row[c] is None else str(row[c]))
+                + "</td>"
+                for c in col_names
+            )
+            rows_html += f"<tr>{cells}</tr>"
+
+        tbody = f"<tbody>{rows_html}</tbody>"
+        table = (
+            "<table style='border-collapse:collapse;'>" f"{header}{tbody}" "</table>"
+        )
+
+        # ── truncation notice ─────────────────────────────────────────────
+        notice = ""
+        if num_rows > _REPR_HTML_MAX_ROWS:
+            notice = (
+                '<p style="font-size:0.82em;color:#888;margin:4px 0 0 0;">'
+                f"Showing {_REPR_HTML_MAX_ROWS} of {num_rows} rows"
+                "</p>"
+            )
+
+        return summary + table + notice

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -866,10 +866,11 @@ class ArFrame:
         )
         header = f"<thead><tr>{header_cells}</tr></thead>"
 
-        # ── data rows via to_pandas slice ─────────────────────────────────
+        # ── data rows — only convert the bounded slice, not the full frame ──
         try:
-            df = to_pandas(self)
-            preview = df.iloc[:_REPR_HTML_MAX_ROWS]
+            bounded = self.head(_REPR_HTML_MAX_ROWS)
+            df = to_pandas(bounded)
+            preview = df
         except Exception as exc:
             return (
                 summary

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -831,7 +831,6 @@ class ArFrame:
         """
         import html as _html
 
-
         _REPR_HTML_MAX_ROWS = 10
 
         num_rows, num_cols = self.shape
@@ -865,7 +864,7 @@ class ArFrame:
         )
         header = f"<thead><tr>{header_cells}</tr></thead>"
 
-                # Read only the rows needed for display; do not convert the full frame.
+        # Read only the rows needed for display; do not convert the full frame.
         preview_rows = min(num_rows, _REPR_HTML_MAX_ROWS)
 
         try:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -816,3 +816,24 @@ def test_repr_html_escapes_html_in_column_name(tmp_path):
     out = frame._repr_html_()
     assert "<b>bad</b>" not in out
     assert "&lt;b&gt;bad&lt;/b&gt;" in out
+
+
+def test_repr_html_does_not_convert_full_frame(large_csv, monkeypatch):
+    """_repr_html_() must not call to_pandas() on the full frame."""
+    frame = ar.read_csv(large_csv)
+
+    from arnio import convert
+
+    original_to_pandas = convert.to_pandas
+    call_sizes = []
+
+    def tracking_to_pandas(f, **kwargs):
+        call_sizes.append(len(f))
+        return original_to_pandas(f, **kwargs)
+
+    monkeypatch.setattr(convert, "to_pandas", tracking_to_pandas)
+    frame._repr_html_()
+
+    assert all(
+        size <= 10 for size in call_sizes
+    ), f"to_pandas() was called with {call_sizes} rows — full frame must not be converted"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -833,7 +833,6 @@ def test_repr_html_does_not_convert_full_frame(large_csv, monkeypatch):
     monkeypatch.setattr(convert, "to_pandas", tracking_to_pandas)
     frame._repr_html_()
 
-    assert call_sizes == [], (
-        f"_repr_html_() should not call to_pandas(), but got calls with {call_sizes} rows"
-    )
- 
+    assert (
+        call_sizes == []
+    ), f"_repr_html_() should not call to_pandas(), but got calls with {call_sizes} rows"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -819,21 +819,21 @@ def test_repr_html_escapes_html_in_column_name(tmp_path):
 
 
 def test_repr_html_does_not_convert_full_frame(large_csv, monkeypatch):
-    """_repr_html_() must not call to_pandas() on the full frame."""
+    """_repr_html_() must not call to_pandas() for automatic display."""
     frame = ar.read_csv(large_csv)
 
     from arnio import convert
 
-    original_to_pandas = convert.to_pandas
     call_sizes = []
 
     def tracking_to_pandas(f, **kwargs):
         call_sizes.append(len(f))
-        return original_to_pandas(f, **kwargs)
+        raise AssertionError("_repr_html_() must not call to_pandas()")
 
     monkeypatch.setattr(convert, "to_pandas", tracking_to_pandas)
     frame._repr_html_()
 
-    assert all(
-        size <= 10 for size in call_sizes
-    ), f"to_pandas() was called with {call_sizes} rows — full frame must not be converted"
+    assert call_sizes == [], (
+        f"_repr_html_() should not call to_pandas(), but got calls with {call_sizes} rows"
+    )
+ 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -717,3 +717,102 @@ class TestDropColumns:
         frame = ar.from_pandas(df)
         frame.drop_columns(["a"])
         assert frame.columns == ["a", "b"]
+
+
+# ── _repr_html_() ─────────────────────────────────────────────────────────────
+
+
+def test_repr_html_returns_str(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    assert isinstance(frame._repr_html_(), str)
+
+
+def test_repr_html_has_table_tag(sample_csv):
+    assert "<table" in ar.read_csv(sample_csv)._repr_html_()
+
+
+def test_repr_html_has_thead_and_tbody(sample_csv):
+    out = ar.read_csv(sample_csv)._repr_html_()
+    assert "<thead>" in out
+    assert "<tbody>" in out
+
+
+def test_repr_html_contains_column_names(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    out = frame._repr_html_()
+    for col in frame.columns:
+        assert col in out
+
+
+def test_repr_html_contains_cell_values(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    out = frame._repr_html_()
+    assert "Alice" in out
+    assert "Bob" in out
+
+
+def test_repr_html_summary_shows_shape(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    out = frame._repr_html_()
+    rows, cols = frame.shape
+    assert str(rows) in out
+    assert str(cols) in out
+
+
+def test_repr_html_summary_shows_dtypes(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    out = frame._repr_html_()
+    for dtype in frame.dtypes.values():
+        assert dtype in out
+
+
+def test_repr_html_truncation_notice_present(large_csv):
+    frame = ar.read_csv(large_csv)
+    out = frame._repr_html_()
+    assert "Showing 10 of 1000 rows" in out
+
+
+def test_repr_html_no_truncation_for_small_frame(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    assert "Showing" not in frame._repr_html_()
+
+
+def test_repr_html_body_capped_at_ten_rows(large_csv):
+    frame = ar.read_csv(large_csv)
+    out = frame._repr_html_()
+    tbody = out[out.index("<tbody>") : out.index("</tbody>") + len("</tbody>")]
+    assert tbody.count("<tr>") == 10
+
+
+def test_repr_html_empty_frame_no_crash(tmp_path):
+    csv_path = tmp_path / "empty.csv"
+    csv_path.write_text("name,age\n")
+    frame = ar.read_csv(str(csv_path))
+    out = frame._repr_html_()
+    assert isinstance(out, str)
+    assert len(out) > 0
+
+
+def test_repr_html_with_nulls_no_crash(csv_with_nulls):
+    frame = ar.read_csv(csv_with_nulls)
+    out = frame._repr_html_()
+    assert isinstance(out, str)
+    assert "<table" in out
+
+
+def test_repr_html_escapes_html_in_cell_value(tmp_path):
+    csv_path = tmp_path / "xss.csv"
+    csv_path.write_text('payload\n"<script>alert(1)</script>"\n')
+    frame = ar.read_csv(str(csv_path))
+    out = frame._repr_html_()
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_repr_html_escapes_html_in_column_name(tmp_path):
+    csv_path = tmp_path / "col_xss.csv"
+    csv_path.write_text("<b>bad</b>\n1\n")
+    frame = ar.read_csv(str(csv_path))
+    out = frame._repr_html_()
+    assert "<b>bad</b>" not in out
+    assert "&lt;b&gt;bad&lt;/b&gt;" in out


### PR DESCRIPTION
## Summary
Adds `ArFrame._repr_html_()` so Jupyter/IPython users see a readable HTML table preview instead of a plain `ArFrame(N rows × M cols)` repr.

## Changes
- `arnio/frame.py` — added `_repr_html_()` method to `ArFrame`
- `tests/test_frame.py` — added tests covering normal, edge, and HTML-escaping cases

## Behaviour
- Shows a shape + dtype summary line above the table
- Renders up to 10 data rows (bounded — no unbounded full-frame rendering)
- Shows "Showing 10 of N rows" notice when the frame is larger
- All column names and cell values are HTML-escaped to prevent markup injection
- Empty frames return a safe fallback string without crashing

## Tests added
- Return type is `str`
- Table structure (`<table>`, `<thead>`, `<tbody>`) is present
- Column names and cell values appear in output
- Shape and dtypes appear in summary line
- Truncation notice present for large frames, absent for small ones
- `<tbody>` capped at exactly 10 rows
- Empty frame and null values don't crash
- `<script>` in cell values is escaped to `&lt;script&gt;`
- HTML in column names is escaped

Fixes #221