### PR TITLE
fix: improve compare_profiles error message when exclude_columns causes schema mismatch

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1132,7 +1132,10 @@ def compare_profiles(
         raise ValueError(
             "Profiles have incompatible schemas: "
             f"missing from profile_a={missing_from_a}, "
-            f"missing from profile_b={missing_from_b}"
+            f"missing from profile_b={missing_from_b}. "
+            "This is likely caused by calling profile() with different exclude_columns "
+            "on each dataset. Profile both datasets with the same included/excluded "
+            "columns before comparing."
         )
 
     drift_report: dict[str, dict[str, Any]] = {}

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2576,4 +2576,3 @@ def test_compare_profiles_mismatched_exclude_columns_hints_user():
 
     with pytest.raises(ValueError, match="exclude_columns"):
         ar.compare_profiles(profile_a, profile_b)
-

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2568,112 +2568,11 @@ def test_data_quality_report_to_json_redact_sample_values():
     assert parsed["columns"]["name"]["sample_values"] == ["[REDACTED]"]
 
 
-# --- Tests for ProfileComparison.to_json() ---
+def test_compare_profiles_mismatched_exclude_columns_hints_user():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    frame = ar.from_pandas(df)
+    profile_a = ar.profile(frame, exclude_columns=["c"])
+    profile_b = ar.profile(frame)
 
-
-def test_profile_comparison_to_json_returns_string():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    comparison = ar.compare_profiles(p, p)
-    result = comparison.to_json()
-    assert isinstance(result, str)
-    parsed = json.loads(result)
-    assert "drift_report" in parsed
-    assert "status_counts" in parsed
-
-
-def test_profile_comparison_to_json_indent():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    comparison = ar.compare_profiles(p, p)
-    result = comparison.to_json(indent=2)
-    assert "\n" in result
-
-
-def test_profile_comparison_to_json_output_stream():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    comparison = ar.compare_profiles(p, p)
-    buf = io.StringIO()
-    ret = comparison.to_json(output=buf)
-    assert ret is None
-    assert len(buf.getvalue()) > 0
-
-
-def test_profile_comparison_to_json_invalid_output_raises():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    comparison = ar.compare_profiles(p, p)
-    with pytest.raises(TypeError, match="writable text stream"):
-        comparison.to_json(output="not_a_stream")
-
-
-# --- ProfileComparison.to_markdown() ---
-
-
-def test_profile_comparison_to_markdown_returns_string():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    comparison = ar.compare_profiles(p, p)
-    result = comparison.to_markdown()
-    assert isinstance(result, str)
-    assert "Profile Comparison Report" in result
-    assert "Column Drift" in result
-
-
-def test_profile_comparison_to_markdown_output_stream():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    comparison = ar.compare_profiles(p, p)
-    buf = io.StringIO()
-    ret = comparison.to_markdown(output=buf)
-    assert ret is None
-    assert "Profile Comparison" in buf.getvalue()
-
-
-def test_profile_comparison_to_markdown_invalid_output_raises():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    comparison = ar.compare_profiles(p, p)
-    with pytest.raises(TypeError, match="writable text stream"):
-        comparison.to_markdown(output=42)
-
-
-# --- Tests for QualityGateResult.to_json() ---
-
-
-def test_quality_gate_result_to_json_returns_string():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    result = ar.check_quality_gates(p, p)
-    out = result.to_json()
-    assert isinstance(out, str)
-    parsed = json.loads(out)
-    assert "passed" in parsed
-    assert "issues" in parsed
-
-
-def test_quality_gate_result_to_json_indent():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    result = ar.check_quality_gates(p, p)
-    out = result.to_json(indent=2)
-    assert "\n" in out
-
-
-def test_quality_gate_result_to_json_output_stream():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    result = ar.check_quality_gates(p, p)
-    buf = io.StringIO()
-    ret = result.to_json(output=buf)
-    assert ret is None
-    assert len(buf.getvalue()) > 0
-
-
-def test_quality_gate_result_to_json_invalid_output_raises():
-    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
-    p = ar.profile(frame)
-    result = ar.check_quality_gates(p, p)
-    with pytest.raises(TypeError, match="writable text stream"):
-        result.to_json(output=123)
+    with pytest.raises(ValueError, match="exclude_columns"):
+        ar.compare_profiles(profile_a, profile_b)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2568,6 +2568,117 @@ def test_data_quality_report_to_json_redact_sample_values():
     assert parsed["columns"]["name"]["sample_values"] == ["[REDACTED]"]
 
 
+# --- Tests for ProfileComparison.to_json() ---
+
+
+def test_profile_comparison_to_json_returns_string():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    comparison = ar.compare_profiles(p, p)
+    result = comparison.to_json()
+    assert isinstance(result, str)
+    parsed = json.loads(result)
+    assert "drift_report" in parsed
+    assert "status_counts" in parsed
+
+
+def test_profile_comparison_to_json_indent():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    comparison = ar.compare_profiles(p, p)
+    result = comparison.to_json(indent=2)
+    assert "\n" in result
+
+
+def test_profile_comparison_to_json_output_stream():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    comparison = ar.compare_profiles(p, p)
+    buf = io.StringIO()
+    ret = comparison.to_json(output=buf)
+    assert ret is None
+    assert len(buf.getvalue()) > 0
+
+
+def test_profile_comparison_to_json_invalid_output_raises():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    comparison = ar.compare_profiles(p, p)
+    with pytest.raises(TypeError, match="writable text stream"):
+        comparison.to_json(output="not_a_stream")
+
+
+# --- ProfileComparison.to_markdown() ---
+
+
+def test_profile_comparison_to_markdown_returns_string():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    comparison = ar.compare_profiles(p, p)
+    result = comparison.to_markdown()
+    assert isinstance(result, str)
+    assert "Profile Comparison Report" in result
+    assert "Column Drift" in result
+
+
+def test_profile_comparison_to_markdown_output_stream():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    comparison = ar.compare_profiles(p, p)
+    buf = io.StringIO()
+    ret = comparison.to_markdown(output=buf)
+    assert ret is None
+    assert "Profile Comparison" in buf.getvalue()
+
+
+def test_profile_comparison_to_markdown_invalid_output_raises():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    comparison = ar.compare_profiles(p, p)
+    with pytest.raises(TypeError, match="writable text stream"):
+        comparison.to_markdown(output=42)
+
+
+# --- Tests for QualityGateResult.to_json() ---
+
+
+def test_quality_gate_result_to_json_returns_string():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    result = ar.check_quality_gates(p, p)
+    out = result.to_json()
+    assert isinstance(out, str)
+    parsed = json.loads(out)
+    assert "passed" in parsed
+    assert "issues" in parsed
+
+
+def test_quality_gate_result_to_json_indent():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    result = ar.check_quality_gates(p, p)
+    out = result.to_json(indent=2)
+    assert "\n" in out
+
+
+def test_quality_gate_result_to_json_output_stream():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    result = ar.check_quality_gates(p, p)
+    buf = io.StringIO()
+    ret = result.to_json(output=buf)
+    assert ret is None
+    assert len(buf.getvalue()) > 0
+
+
+def test_quality_gate_result_to_json_invalid_output_raises():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+    p = ar.profile(frame)
+    result = ar.check_quality_gates(p, p)
+    with pytest.raises(TypeError, match="writable text stream"):
+        result.to_json(output=123)
+
+
 def test_compare_profiles_mismatched_exclude_columns_hints_user():
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     frame = ar.from_pandas(df)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2576,3 +2576,4 @@ def test_compare_profiles_mismatched_exclude_columns_hints_user():
 
     with pytest.raises(ValueError, match="exclude_columns"):
         ar.compare_profiles(profile_a, profile_b)
+


### PR DESCRIPTION
Fixes #1343

## What changed
- Updated the `ValueError` in `compare_profiles()` to mention that mismatched `exclude_columns` usage in `profile()` is the likely cause of schema incompatibility
- Added actionable guidance to profile both datasets with the same included/excluded columns before comparing

## Tests
- Added regression test `test_compare_profiles_mismatched_exclude_columns_hints_user` in `tests/test_quality.py`