### PR TITLE
feat: unify column selection validation across select_columns

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -329,8 +329,43 @@ def keep_rows_with_nulls(
 
 
 def select_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
-    """Return a new frame containing only the requested columns."""
-    return frame.select_columns(columns)
+    """Return a new frame containing only the requested columns.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    columns : sequence of str
+        Column names to select.
+
+    Returns
+    -------
+    ArFrame
+        New frame containing only the requested columns.
+
+    Raises
+    ------
+    TypeError
+        If columns is not a valid sequence of strings.
+    ValueError
+        If the selection is empty, contains duplicates,
+        or includes unknown columns.
+    """
+    requested_columns = _validate_existing_column_sequence(
+        columns,
+        available_columns=frame.columns,
+        argument_name="columns",
+        missing_error=ValueError,
+        missing_message=lambda missing, _available: (
+            f"Unknown columns: {missing}"
+        ),
+    )
+    if len(requested_columns) == 0:
+        raise ValueError("Column selection cannot be empty.")
+    if len(requested_columns) != len(set(requested_columns)):
+        raise ValueError("Duplicate column names are not allowed.")
+
+    return frame.select_columns(requested_columns)
 
 
 def fill_nulls(

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import copy
 import json
 import math
+from collections.abc import Sequence
 
 from ._core import _Frame
 
@@ -362,13 +363,13 @@ class ArFrame:
             for i in range(num_cols)
         }
 
-    def select_columns(self, columns: list[str]) -> ArFrame:
+    def select_columns(self, columns: Sequence[str]) -> ArFrame:
         """Return a new ArFrame with only the selected columns.
 
         Parameters
         ----------
-        columns : list[str]
-            List of column names to select.
+        columns : sequence of str
+            Sequence of column names to select.
 
         Returns
         -------
@@ -383,27 +384,29 @@ class ArFrame:
             If the selection is empty, contains duplicates,
             or includes unknown columns.
         """
-        if isinstance(columns, str):
+        if isinstance(columns, (str, bytes)):
             raise TypeError("columns must be a sequence of column names, not a string.")
 
-        if not isinstance(columns, (list, tuple)):
-            raise TypeError("columns must be a list or tuple of column names.")
+        try:
+            cols_list = list(columns)
+        except TypeError:
+            raise TypeError("columns must be a sequence of column names.")
 
-        if not columns:
+        if not cols_list:
             raise ValueError("Column selection cannot be empty.")
 
-        if any(not isinstance(col, str) for col in columns):
-            raise TypeError("All column names must be strings.")
+        if any(not isinstance(col, str) for col in cols_list):
+            raise TypeError("columns must contain only string column names")
 
-        if len(columns) != len(set(columns)):
+        if len(cols_list) != len(set(cols_list)):
             raise ValueError("Duplicate column names are not allowed.")
 
-        missing = [col for col in columns if col not in self.columns]
+        missing = [col for col in cols_list if col not in self.columns]
 
         if missing:
             raise ValueError(f"Unknown columns: {missing}")
 
-        return ArFrame(self._frame.select_columns(columns))
+        return ArFrame(self._frame.select_columns(cols_list))
 
     def drop_columns(self, cols: list[str]) -> ArFrame:
         """Return a new ArFrame with the specified columns removed.

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3208,7 +3208,7 @@ class TestSelectColumns:
     def test_select_columns_rejects_non_string_items(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(TypeError, match="All column names must be strings"):
+        with pytest.raises(TypeError, match="must contain only string column names"):
             ar.select_columns(frame, ["age", 1])
 
     def test_select_columns_rejects_empty(self):
@@ -3236,6 +3236,28 @@ class TestSelectColumns:
 
         with pytest.raises(ValueError):
             ar.select_columns(frame, ["id", "id"])
+
+    def test_select_columns_allows_tuple(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "id": [1, 2],
+                    "name": ["Alice", "Bob"],
+                }
+            )
+        )
+
+        # Standalone function with tuple
+        res_tuple = ar.select_columns(frame, ("name", "id"))
+        assert list(ar.to_pandas(res_tuple).columns) == ["name", "id"]
+
+        # Class method with tuple
+        res_tuple_method = frame.select_columns(("name", "id"))
+        assert list(ar.to_pandas(res_tuple_method).columns) == ["name", "id"]
+
+        # Verify set is rejected because it is not a sequence
+        with pytest.raises(TypeError, match="must be a sequence of column names"):
+            ar.select_columns(frame, {"id", "name"})
 
 
 class TestFilterReplaceTypeAnnotations:


### PR DESCRIPTION
### Summary
This PR unifies sequence-type validation in `select_columns` across both the standalone function `ar.select_columns` and the `ArFrame.select_columns` class method. 

### Details
- Standardized sequence/iterable checks to support custom sequence types (lists, tuples, collections) consistently using internal sequence validation helpers.
- Aligned validation exception messages to be uniformly descriptive and accurate.
- Added comprehensive unit tests in `tests/test_cleaning.py`.

Closes #1363

---
I am contributing on behalf of GSSoc’26.