### PR TITLE
feat: support generic sequence for subset in coalesce_columns

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -82,7 +82,7 @@ def _validate_column_sequence(
         raise TypeError(
             f"{argument_name} must be a sequence of column names, not a string"
         )
-    if not isinstance(columns, Sequence):
+    if not isinstance(columns, Sequence) and not isinstance(columns, pd.Index):
         raise TypeError(f"{argument_name} must be a sequence of column names")
 
     normalized = list(columns)

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1749,7 +1749,7 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
 def coalesce_columns(
     frame,
     *,
-    subset: list[str],
+    subset: Sequence[str],
     output_column: str = "coalesced",
 ):
     """Select the first non-null value from a list of columns.
@@ -1758,8 +1758,8 @@ def coalesce_columns(
     ----------
     frame : ArFrame or pd.DataFrame
         Input data frame.
-    subset : list[str]
-        List of columns to check in order.
+    subset : sequence of str
+        Sequence of columns to check in order.
     output_column : str, default "coalesced"
         Name of the new column to store coalesced values.
 
@@ -1773,16 +1773,12 @@ def coalesce_columns(
     from .convert import from_pandas, to_pandas
     from .frame import ArFrame
 
-    if not isinstance(subset, list):
-        raise TypeError("subset must be a list of column names")
-    if not subset:
-        raise ValueError("subset must contain at least one column")
-    if not isinstance(output_column, str) or not output_column.strip():
-        raise ValueError("output_column must be a non-empty string")
-
     is_arframe = isinstance(frame, ArFrame)
     if not is_arframe and not isinstance(frame, pd.DataFrame):
         raise TypeError("frame must be an ArFrame or a pandas DataFrame")
+
+    if not isinstance(output_column, str) or not output_column.strip():
+        raise ValueError("output_column must be a non-empty string")
 
     column_names = list(frame.columns)
     subset_columns = _validate_existing_column_sequence(
@@ -1794,6 +1790,9 @@ def coalesce_columns(
             f"Available columns: {available}"
         ),
     )
+
+    if not subset_columns:
+        raise ValueError("subset must contain at least one column")
 
     if output_column in column_names:
         raise ValueError(f"Output column '{output_column}' already exists.")

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -384,6 +384,25 @@ class TestSharedColumnSequenceValidation:
         with pytest.raises(ValueError, match="subset must contain at least one column"):
             ar.coalesce_columns(frame, subset=[])
 
+    def test_coalesce_columns_allows_tuple(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "nickname": [None, "Bee", None],
+                    "name": ["Alice", "Bob", "Cara"],
+                }
+            )
+        )
+
+        result = ar.coalesce_columns(
+            frame,
+            subset=("nickname", "name"),
+            output_column="display_name",
+        )
+        df = ar.to_pandas(result)
+
+        assert df["display_name"].tolist() == ["Alice", "Bee", "Cara"]
+
     @pytest.mark.parametrize(
         ("func", "kwargs", "message"),
         [
@@ -413,7 +432,7 @@ class TestSharedColumnSequenceValidation:
             (
                 "coalesce_columns",
                 {"subset": 123, "output_column": "combined"},
-                "must be a list of column names",
+                "must be a sequence of column names",
             ),
         ],
     )

--- a/tests/test_coalesce_columns.py
+++ b/tests/test_coalesce_columns.py
@@ -86,10 +86,34 @@ def test_coalesce_columns_validation() -> None:
     with pytest.raises(ValueError, match="already exists"):
         ar.coalesce_columns(frame, subset=["a"], output_column="b")
 
-    # Invalid subset type
-    with pytest.raises(TypeError, match="subset must be a list"):
+    # Invalid subset type (string)
+    with pytest.raises(
+        TypeError, match="subset must be a sequence of column names, not a string"
+    ):
         ar.coalesce_columns(frame, subset="not_a_list")  # type: ignore
+
+    # Invalid subset type (unordered set)
+    with pytest.raises(TypeError, match="subset must be a sequence of column names"):
+        ar.coalesce_columns(frame, subset={"a", "b"})  # type: ignore
 
     # Invalid output_column type
     with pytest.raises(ValueError, match="must be a non-empty string"):
         ar.coalesce_columns(frame, subset=["a"], output_column="")
+
+
+def test_coalesce_columns_pandas_index() -> None:
+    # Test coalesce on pandas DataFrame with pandas Index for subset
+    df = pd.DataFrame(
+        {
+            "a": [None, 2.0, None],
+            "b": [10.0, None, None],
+            "c": [20.0, 30.0, 40.0],
+        }
+    )
+    subset_index = pd.Index(["a", "b", "c"])
+    res_df = ar.coalesce_columns(df, subset=subset_index, output_column="result")
+
+    expected = df.copy()
+    expected["result"] = [10.0, 2.0, 40.0]
+
+    pd.testing.assert_frame_equal(res_df, expected, check_dtype=False)


### PR DESCRIPTION
### Summary
This PR unifies the `subset` parameter validation in `coalesce_columns` with other subset-taking functions in `arnio` (like `drop_duplicates` and `combine_columns`) by supporting any python `Sequence[str]` (such as lists or tuples) instead of strictly checking for a `list` type.

### Details
- Updated type hints and relaxed type validation of the `subset` parameter in `coalesce_columns`.
- Utilized the standard `_validate_existing_column_sequence` helper to normalize subset inputs.
- Aligned validation exception messages and tests to be consistent with all other subset operations.
- Added comprehensive unit tests in `tests/test_cleaning.py`.

Closes #1364

---
I am contributing on behalf of GSSoc’26.