### PR TITLE
feat: add pandas DataFrame support to drop_constant_columns

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -426,7 +426,9 @@ def drop_duplicates(
     return ArFrame(result)
 
 
-def drop_constant_columns(frame: ArFrame) -> ArFrame:
+def drop_constant_columns(
+    frame: ArFrame | pd.DataFrame,
+) -> ArFrame | pd.DataFrame:
     """Remove columns with exactly one unique value.
 
     Nulls are counted as values when determining whether a column is constant.
@@ -439,12 +441,12 @@ def drop_constant_columns(frame: ArFrame) -> ArFrame:
 
     Parameters
     ----------
-    frame : ArFrame
+    frame : ArFrame or pd.DataFrame
         Input data frame.
 
     Returns
     -------
-    ArFrame
+    ArFrame or pd.DataFrame
         New frame without constant columns.
 
     Examples
@@ -452,16 +454,24 @@ def drop_constant_columns(frame: ArFrame) -> ArFrame:
     >>> frame = ar.read_csv("data.csv")
     >>> reduced = ar.drop_constant_columns(frame)
     """
-    from .convert import from_pandas, to_pandas
+    import pandas as pd
 
-    df = to_pandas(frame)
+    from .convert import from_pandas, to_pandas
+    from .frame import ArFrame
+
+    is_arframe = isinstance(frame, ArFrame)
+    if not is_arframe and not isinstance(frame, pd.DataFrame):
+        raise TypeError("frame must be an ArFrame or a pandas DataFrame")
+
+    df = to_pandas(frame) if is_arframe else frame.copy()
     if len(df.index) == 0:
         return frame
 
     constant_columns = [
         column for column in df.columns if df[column].nunique(dropna=False) == 1
     ]
-    return from_pandas(df.drop(columns=constant_columns))
+    result_df = df.drop(columns=constant_columns)
+    return from_pandas(result_df) if is_arframe else result_df
 
 
 def drop_empty_columns(frame: ArFrame) -> ArFrame:

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -463,13 +463,12 @@ def drop_constant_columns(
     if not is_arframe and not isinstance(frame, pd.DataFrame):
         raise TypeError("frame must be an ArFrame or a pandas DataFrame")
 
-    df = to_pandas(frame) if is_arframe else frame.copy()
+    df = to_pandas(frame) if is_arframe else frame
     if len(df.index) == 0:
         return frame
 
-    constant_columns = [
-        column for column in df.columns if df[column].nunique(dropna=False) == 1
-    ]
+    nunique_counts = df.nunique(dropna=False)
+    constant_columns = nunique_counts[nunique_counts == 1].index.tolist()
     result_df = df.drop(columns=constant_columns)
     return from_pandas(result_df) if is_arframe else result_df
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -767,6 +767,24 @@ class TestDropConstantColumns:
         assert cloned.num_rows() == 4
         assert cloned.num_cols() == 0
 
+    def test_drop_constant_columns_pandas_input(self):
+        df = pd.DataFrame(
+            {
+                "value": [1, 2, 3],
+                "constant_num": [7, 7, 7],
+                "constant_text": ["x", "x", "x"],
+            }
+        )
+
+        result = ar.drop_constant_columns(df)
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == ["value"]
+        assert list(result["value"]) == [1, 2, 3]
+
+    def test_drop_constant_columns_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="frame must be an ArFrame or a pandas DataFrame"):
+            ar.drop_constant_columns([1, 2, 3])
+
 
 class TestDropEmptyColumns:
     def test_drop_empty_columns_removes_fully_empty_columns(self, tmp_path):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -780,9 +780,13 @@ class TestDropConstantColumns:
         assert isinstance(result, pd.DataFrame)
         assert list(result.columns) == ["value"]
         assert list(result["value"]) == [1, 2, 3]
+        # Assert that the input DataFrame was not mutated
+        assert list(df.columns) == ["value", "constant_num", "constant_text"]
 
     def test_drop_constant_columns_invalid_type_raises(self):
-        with pytest.raises(TypeError, match="frame must be an ArFrame or a pandas DataFrame"):
+        with pytest.raises(
+            TypeError, match="frame must be an ArFrame or a pandas DataFrame"
+        ):
             ar.drop_constant_columns([1, 2, 3])
 
 


### PR DESCRIPTION
### Summary
This PR adds support for pandas `DataFrame` input and output to `drop_constant_columns`, matching all other cleaning primitives in the `arnio` library.

### Details
- Checked type of the `frame` parameter using type checking to support both `ArFrame` and `pd.DataFrame`.
- Operates directly on the input `pd.DataFrame` without triggering unnecessary `to_pandas` and `from_pandas` round-trips.
- Aligned validation checks and types to ensure consistent API experience.
- Added comprehensive unit tests in `tests/test_cleaning.py`.

Closes #1365

---
I am contributing on behalf of GSSoc’26.