### PR TITLE
test: Expand smoke tests and coverage for pyarrow dependency (issue #1282)

### DIFF
--- a/examples/check_env.py
+++ b/examples/check_env.py
@@ -66,7 +66,6 @@ EXAMPLES = {
     "arnio_with_arrow.py": ["pandas", "pyarrow"],
     "arnio_chunk_reading.py": ["pandas"],
     "schema_validation.py": ["pandas"],
-    "check_env.py": [],
     "sales/recipe.py": ["pandas"],
     "customers/recipe.py": ["pandas"],
     "survey/recipe.py": ["pandas"],

--- a/examples/check_env.py
+++ b/examples/check_env.py
@@ -33,6 +33,10 @@ DEPENDENCIES = {
         "scikit-learn",
         "Required for scikit-learn pipeline integration examples.",
     ),
+    "pyarrow": (
+        "pyarrow",
+        "Required for Arrow export examples (pip install arnio[arrow]).",
+    ),
     "pytest": ("pytest", "Required for running the integration and unit test suites."),
 }
 
@@ -59,6 +63,15 @@ EXAMPLES = {
     "sklearn_pipeline.py": ["sklearn", "pandas"],
     "auto_clean_tutorial.py": ["pandas"],
     "arnio_with_jsonl.py": ["pandas"],
+    "arnio_with_arrow.py": ["pandas", "pyarrow"],
+    "arnio_chunk_reading.py": ["pandas"],
+    "schema_validation.py": ["pandas"],
+    "check_env.py": [],
+    "sales/recipe.py": ["pandas"],
+    "customers/recipe.py": ["pandas"],
+    "survey/recipe.py": ["pandas"],
+    "logs/recipe.py": ["pandas"],
+    "finance/recipe.py": ["pandas"],
 }
 
 

--- a/tests/test_check_env.py
+++ b/tests/test_check_env.py
@@ -26,6 +26,7 @@ def test_check_env_core_missing(capsys: pytest.CaptureFixture[str]) -> None:
             "pandas": (True, "Installed"),
             "duckdb": (True, "Installed"),
             "sklearn": (True, "Installed"),
+            "pyarrow": (True, "Installed"),
             "pytest": (True, "Installed"),
         }
 
@@ -56,6 +57,7 @@ def test_check_env_core_available_some_missing(
             "pandas": (True, "Installed"),
             "duckdb": (False, "Not Installed"),
             "sklearn": (True, "Installed"),
+            "pyarrow": (True, "Installed"),
             "pytest": (True, "Installed"),
         }
 
@@ -86,6 +88,7 @@ def test_check_env_all_available(capsys: pytest.CaptureFixture[str]) -> None:
             "pandas": (True, "Installed"),
             "duckdb": (True, "Installed"),
             "sklearn": (True, "Installed"),
+            "pyarrow": (True, "Installed"),
             "pytest": (True, "Installed"),
         }
 

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -56,9 +56,7 @@ EXAMPLE_SPECS: tuple[ExampleSpec, ...] = (
 
 # Scripts intentionally excluded from subprocess smoke (with reason for maintainers).
 EXCLUDED_EXAMPLES: dict[str, str] = {
-    "check_env.py": (
-        "Dashboard utility; behavior covered by tests/test_check_env.py."
-    ),
+    "check_env.py": ("Dashboard utility; behavior covered by tests/test_check_env.py."),
 }
 
 
@@ -67,8 +65,7 @@ def _discover_example_scripts() -> set[str]:
     if not EXAMPLES_DIR.exists():
         return set()
     return {
-        path.relative_to(EXAMPLES_DIR).as_posix()
-        for path in EXAMPLES_DIR.rglob("*.py")
+        path.relative_to(EXAMPLES_DIR).as_posix() for path in EXAMPLES_DIR.rglob("*.py")
     }
 
 

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -101,6 +101,9 @@ def has_dependencies(deps: tuple[str, ...]) -> bool:
 
 def test_all_example_scripts_are_accounted_for() -> None:
     """Fail when a new examples/**/*.py is not allowlisted or explicitly excluded."""
+    if not EXAMPLES_DIR.exists():
+        pytest.skip("examples/ directory is not present in this test environment.")
+
     discovered = _discover_example_scripts()
     allowlisted = {spec.path for spec in EXAMPLE_SPECS}
     excluded = set(EXCLUDED_EXAMPLES)

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -1,8 +1,12 @@
 """Integration tests to ensure all Python example scripts run successfully."""
 
+from __future__ import annotations
+
 import importlib.util
+import os
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -15,36 +19,79 @@ try:
 except ImportError:
     HAS_CORE = False
 
-EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+REPO_ROOT = Path(__file__).parent.parent
+EXAMPLES_DIR = REPO_ROOT / "examples"
 
-# Explicit allowlist of CI-safe examples and their optional dependencies
-CI_SAFE_EXAMPLES = {
-    "basic_usage.py": ["pandas"],
-    "custom_step.py": ["pandas"],
-    "auto_clean_tutorial.py": ["pandas"],
-    "arnio_with_pandas.py": ["pandas"],
-    "arnio_with_numpy.py": ["numpy", "pandas"],
-    "arnio_with_duckdb.py": ["duckdb", "pandas"],
-    "arnio_with_sklearn.py": ["sklearn", "pandas"],
-    "sklearn_pipeline.py": ["sklearn", "pandas"],
-    "arnio_with_jsonl.py": ["pandas"],
+
+@dataclass(frozen=True)
+class ExampleSpec:
+    """Runnable example under examples/ with optional deps and working directory."""
+
+    path: str
+    deps: tuple[str, ...] = ()
+    cwd: str = "."
+
+
+# Explicit allowlist of CI-safe examples, optional dependencies, and run directory.
+# cwd is relative to REPO_ROOT (repo root for top-level scripts; subdirs for recipes).
+EXAMPLE_SPECS: tuple[ExampleSpec, ...] = (
+    ExampleSpec("basic_usage.py", deps=("pandas",)),
+    ExampleSpec("custom_step.py", deps=("pandas",)),
+    ExampleSpec("auto_clean_tutorial.py", deps=("pandas",)),
+    ExampleSpec("arnio_with_pandas.py", deps=("pandas",)),
+    ExampleSpec("arnio_with_numpy.py", deps=("numpy", "pandas")),
+    ExampleSpec("arnio_with_duckdb.py", deps=("duckdb", "pandas")),
+    ExampleSpec("arnio_with_sklearn.py", deps=("sklearn", "pandas")),
+    ExampleSpec("sklearn_pipeline.py", deps=("sklearn", "pandas")),
+    ExampleSpec("arnio_with_jsonl.py", deps=("pandas",)),
+    ExampleSpec("arnio_with_arrow.py", deps=("pandas", "pyarrow")),
+    ExampleSpec("arnio_chunk_reading.py", deps=("pandas",)),
+    ExampleSpec("schema_validation.py", deps=("pandas",)),
+    ExampleSpec("sales/recipe.py", deps=("pandas",), cwd="examples/sales"),
+    ExampleSpec("customers/recipe.py", deps=("pandas",), cwd="examples/customers"),
+    ExampleSpec("survey/recipe.py", deps=("pandas",), cwd="examples/survey"),
+    ExampleSpec("logs/recipe.py", deps=("pandas",), cwd="examples/logs"),
+    ExampleSpec("finance/recipe.py", deps=("pandas",), cwd="examples/finance"),
+)
+
+# Scripts intentionally excluded from subprocess smoke (with reason for maintainers).
+EXCLUDED_EXAMPLES: dict[str, str] = {
+    "check_env.py": (
+        "Dashboard utility; behavior covered by tests/test_check_env.py."
+    ),
 }
 
 
-def get_example_scripts():
-    """Locate all runnable python files in the examples directory that are CI-safe."""
+def _discover_example_scripts() -> set[str]:
+    """Return relative paths of all .py files under examples/."""
     if not EXAMPLES_DIR.exists():
-        return []
-
-    scripts = []
-    for name in sorted(CI_SAFE_EXAMPLES.keys()):
-        script_path = EXAMPLES_DIR / name
-        if script_path.exists():
-            scripts.append(script_path)
-    return scripts
+        return set()
+    return {
+        path.relative_to(EXAMPLES_DIR).as_posix()
+        for path in EXAMPLES_DIR.rglob("*.py")
+    }
 
 
-def has_dependencies(deps):
+def get_example_specs() -> list[ExampleSpec]:
+    """Return allowlisted specs whose script files exist."""
+    specs: list[ExampleSpec] = []
+    for spec in EXAMPLE_SPECS:
+        if (EXAMPLES_DIR / spec.path).exists():
+            specs.append(spec)
+    return specs
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Ensure subprocesses can import the in-tree arnio package (editable or not)."""
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        str(REPO_ROOT) if not existing else f"{REPO_ROOT}{os.pathsep}{existing}"
+    )
+    return env
+
+
+def has_dependencies(deps: tuple[str, ...]) -> bool:
     """Check if all required dependencies are installed."""
     for dep in deps:
         try:
@@ -55,33 +102,49 @@ def has_dependencies(deps):
     return True
 
 
+def test_all_example_scripts_are_accounted_for() -> None:
+    """Fail when a new examples/**/*.py is not allowlisted or explicitly excluded."""
+    discovered = _discover_example_scripts()
+    allowlisted = {spec.path for spec in EXAMPLE_SPECS}
+    excluded = set(EXCLUDED_EXAMPLES)
+    missing = discovered - allowlisted - excluded
+    extra = allowlisted - discovered
+    assert not missing, (
+        "New example script(s) missing from EXAMPLE_SPECS or EXCLUDED_EXAMPLES: "
+        f"{sorted(missing)}"
+    )
+    assert not extra, (
+        "EXAMPLE_SPECS lists script(s) that do not exist: " f"{sorted(extra)}"
+    )
+
+
 @pytest.mark.skipif(not HAS_CORE, reason="Arnio C++ extension is not compiled.")
-@pytest.mark.parametrize("script_path", get_example_scripts(), ids=lambda p: p.name)
-def test_example_script_runs_successfully(script_path):
+@pytest.mark.parametrize("spec", get_example_specs(), ids=lambda s: s.path)
+def test_example_script_runs_successfully(spec: ExampleSpec) -> None:
     """Run an example python script and verify that it exits with code 0."""
-    # Check if optional dependencies are missing
-    required_deps = CI_SAFE_EXAMPLES.get(script_path.name, [])
-    if not has_dependencies(required_deps):
+    script_path = EXAMPLES_DIR / spec.path
+    if not has_dependencies(spec.deps):
         pytest.skip(
-            f"Skipping {script_path.name} due to missing optional dependencies: {required_deps}"
+            f"Skipping {spec.path} due to missing optional dependencies: {list(spec.deps)}"
         )
 
-    # Run the script in a subprocess using the same python interpreter with a timeout
+    run_cwd = REPO_ROOT / spec.cwd
     try:
         result = subprocess.run(
             [sys.executable, str(script_path)],
             capture_output=True,
             text=True,
-            cwd=str(EXAMPLES_DIR.parent),
-            timeout=30,  # Keep smoke tests bounded while allowing slow imports on Windows.
+            cwd=str(run_cwd),
+            env=_subprocess_env(),
+            timeout=30,
         )
     except subprocess.TimeoutExpired as e:
         pytest.fail(
-            f"Example {script_path.name} timed out after 30 seconds.\nOutput so far:\n{e.stdout}"
+            f"Example {spec.path} timed out after 30 seconds.\nOutput so far:\n{e.stdout}"
         )
 
     assert result.returncode == 0, (
-        f"Example {script_path.name} failed with return code {result.returncode}.\n"
+        f"Example {spec.path} failed with return code {result.returncode}.\n"
         f"Stdout:\n{result.stdout}\n"
         f"Stderr:\n{result.stderr}"
     )


### PR DESCRIPTION
## Summary

- Extended `tests/test_examples_smoke.py` to smoke-test all runnable examples/**/*.py scripts.
- Added per-example optional dependencies and working directory (required for domain recipe.py files).
- Added guard test so new example scripts cannot be added without updating the allowlist.

## Linked issue
Fixes #1282

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
```
pytest tests/test_examples_smoke.py -v
pytest tests/test_check_env.py -v
pytest tests/ -v
```

## Performance Impact
No performance impact — test-only changes, no changes to the arnio library.

## Contributor checklist
- [x] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behaviour changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that the generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
- Scripts with missing optional deps (pyarrow, duckdb, sklearn) skip via existing pattern — no hard fails.
- No runtime behaviour changes to the arnio library.
- `check_env.py` excluded from subprocess smoke as it is already covered by `tests/test_check_env.py`.