### PR TITLE
test : added unit tests for _validate_column_sequence helper

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -6,6 +6,7 @@ import pytest
 
 import arnio as ar
 from arnio import from_pandas, to_pandas
+from arnio.cleaning import _validate_column_sequence
 
 
 class TestDropNulls:
@@ -3303,47 +3304,33 @@ class TestFilterReplaceTypeAnnotations:
 
 class TestValidateColumnSequence:
     def test_string_raises_type_error(self):
-        from arnio.cleaning import _validate_column_sequence
-
         with pytest.raises(
             TypeError, match="must be a sequence of column names, not a string"
         ):
             _validate_column_sequence("col1", argument_name="columns")
 
     def test_bytes_raises_type_error(self):
-        from arnio.cleaning import _validate_column_sequence
-
         with pytest.raises(
             TypeError, match="must be a sequence of column names, not a string"
         ):
             _validate_column_sequence(b"col1", argument_name="columns")
 
     def test_non_sequence_raises_type_error(self):
-        from arnio.cleaning import _validate_column_sequence
-
         with pytest.raises(TypeError, match="must be a sequence of column names"):
             _validate_column_sequence({"col1", "col2"}, argument_name="columns")
 
     def test_non_string_elements_raise_type_error(self):
-        from arnio.cleaning import _validate_column_sequence
-
         with pytest.raises(TypeError, match="must contain only string column names"):
             _validate_column_sequence(["col1", 123, "col2"], argument_name="columns")
 
     def test_valid_list_returns_normalized(self):
-        from arnio.cleaning import _validate_column_sequence
-
         result = _validate_column_sequence(["col1", "col2"], argument_name="columns")
         assert result == ["col1", "col2"]
 
     def test_valid_tuple_returns_normalized(self):
-        from arnio.cleaning import _validate_column_sequence
-
         result = _validate_column_sequence(("col1", "col2"), argument_name="columns")
         assert result == ["col1", "col2"]
 
     def test_empty_list_returns_empty(self):
-        from arnio.cleaning import _validate_column_sequence
-
         result = _validate_column_sequence([], argument_name="columns")
         assert result == []

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3299,3 +3299,47 @@ class TestFilterReplaceTypeAnnotations:
         assert isinstance(result, pd.DataFrame)
         assert result["a"].tolist() == ["X", "y"]
         assert result["b"].tolist() == ["X", "z"]
+
+
+class TestValidateColumnSequence:
+    def test_string_raises_type_error(self):
+        from arnio.cleaning import _validate_column_sequence
+
+        with pytest.raises(TypeError, match="must be a sequence of column names, not a string"):
+            _validate_column_sequence("col1", argument_name="columns")
+
+    def test_bytes_raises_type_error(self):
+        from arnio.cleaning import _validate_column_sequence
+
+        with pytest.raises(TypeError, match="must be a sequence of column names, not a string"):
+            _validate_column_sequence(b"col1", argument_name="columns")
+
+    def test_non_sequence_raises_type_error(self):
+        from arnio.cleaning import _validate_column_sequence
+
+        with pytest.raises(TypeError, match="must be a sequence of column names"):
+            _validate_column_sequence({"col1", "col2"}, argument_name="columns")
+
+    def test_non_string_elements_raise_type_error(self):
+        from arnio.cleaning import _validate_column_sequence
+
+        with pytest.raises(TypeError, match="must contain only string column names"):
+            _validate_column_sequence(["col1", 123, "col2"], argument_name="columns")
+
+    def test_valid_list_returns_normalized(self):
+        from arnio.cleaning import _validate_column_sequence
+
+        result = _validate_column_sequence(["col1", "col2"], argument_name="columns")
+        assert result == ["col1", "col2"]
+
+    def test_valid_tuple_returns_normalized(self):
+        from arnio.cleaning import _validate_column_sequence
+
+        result = _validate_column_sequence(("col1", "col2"), argument_name="columns")
+        assert result == ["col1", "col2"]
+
+    def test_empty_list_returns_empty(self):
+        from arnio.cleaning import _validate_column_sequence
+
+        result = _validate_column_sequence([], argument_name="columns")
+        assert result == []

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3305,13 +3305,17 @@ class TestValidateColumnSequence:
     def test_string_raises_type_error(self):
         from arnio.cleaning import _validate_column_sequence
 
-        with pytest.raises(TypeError, match="must be a sequence of column names, not a string"):
+        with pytest.raises(
+            TypeError, match="must be a sequence of column names, not a string"
+        ):
             _validate_column_sequence("col1", argument_name="columns")
 
     def test_bytes_raises_type_error(self):
         from arnio.cleaning import _validate_column_sequence
 
-        with pytest.raises(TypeError, match="must be a sequence of column names, not a string"):
+        with pytest.raises(
+            TypeError, match="must be a sequence of column names, not a string"
+        ):
             _validate_column_sequence(b"col1", argument_name="columns")
 
     def test_non_sequence_raises_type_error(self):


### PR DESCRIPTION
Refs #1375, Refs #1403.

Summary of What Has Been Done:
Added comprehensive unit tests for the _validate_column_sequence helper function in arnio/cleaning.py. This function validates column name sequences.

Changes Made:
- Added TestValidateColumnSequence test class with 7 test methods covering:
  - String input raises TypeError
  - Bytes input raises TypeError
  - Non-Sequence types raise TypeError
  - Non-string elements raise TypeError
  - Valid list returns normalized list
  - Valid tuple returns normalized list
  - Empty list returns empty list

Impact it Made:
- Ensures proper input validation for column sequences
- Improves test coverage for validation helpers
- Documents edge case handling for future maintainers
- Prevents regressions in validation logic