### PR TITLE
Make duckdb smoke test blocking

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -58,7 +58,9 @@ jobs:
   examples-duckdb:
     name: Smoke – duckdb example
     runs-on: ubuntu-latest
-    continue-on-error: true
+
+    # Required smoke test: duckdb is explicitly installed here, so failures
+    # in examples/arnio_with_duckdb.py must block the workflow visibly.
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Removed continue-on-error: true from the examples-duckdb job in .github/workflows/examples-smoke.yml and added a comment clarifying that this is a required smoke test. Since duckdb is explicitly installed as a dependency before the example runs, a failure in examples/arnio_with_duckdb.py should block the workflow visibly rather than being silently ignored.

## Linked issue
Fixes #1399 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [X] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [X] Developer tooling

## Testing
No code logic was changed — only CI configuration. Verified by reviewing the workflow file directly.
- [ ] `make test`
- [ ] `make lint`
- [X] Other: Manual review of .github/workflows/examples-smoke.yml to confirm continue-on-error: true is removed only from examples-duckdb and no other jobs are affected.

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
This is a low-risk, one-line CI change. The only behavioral difference is that a broken examples/arnio_with_duckdb.py will now correctly fail the Examples Smoke workflow instead of producing a green check with a hidden failure. No follow-up work required unless maintainers want to add an explicit dependency-install guard for genuinely optional scenarios.