### PR TITLE
perf: avoid full pandas materialization in head and tail

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
         run: python benchmarks/generate_pr_summary.py
 
       - name: Post benchmark PR summary
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,27 +1,90 @@
 name: Benchmark
 
 on:
-  workflow_dispatch:  # manual trigger only
+  workflow_dispatch:
+
+  pull_request:
+    paths:
+      - "arnio/**"
+      - "cpp/**"
+      - "benchmarks/**"
+      - ".github/workflows/benchmark.yml"
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+
       - name: Generate Data
         run: python benchmarks/generate_data.py
+
       - name: Run Benchmark
         run: python -u benchmarks/benchmark_vs_pandas.py
+
+      - name: Generate benchmark PR summary
+        run: python benchmarks/generate_pr_summary.py
+
+      - name: Post benchmark PR summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const summary = fs.readFileSync('benchmark_summary.md', 'utf8');
+
+            const marker = '<!-- benchmark-summary-comment -->';
+            const body = `${marker}\n${summary}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+            });
+
+            const existing = comments.data.find(comment =>
+              comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
           path: benchmark_results.json
+
+      - name: Upload benchmark summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-summary
+          path: benchmark_summary.md

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,11 @@ on:
       - "benchmarks/**"
       - ".github/workflows/benchmark.yml"
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -268,11 +268,9 @@ class ArFrame:
         if isinstance(n, bool) or not isinstance(n, int) or n < 0:
             raise ValueError(f"`n` must be a non-negative integer, got {n!r}")
 
-        from .convert import from_pandas, to_pandas
+        actual_n = min(n, len(self))
 
-        df = to_pandas(self)
-
-        return from_pandas(df.head(n))
+        return ArFrame(self._frame.select_rows(0, actual_n))
 
     def tail(self, n: int = 5) -> ArFrame:
         """Return the last n rows as an ArFrame.
@@ -290,11 +288,10 @@ class ArFrame:
         if isinstance(n, bool) or not isinstance(n, int) or n < 0:
             raise ValueError(f"`n` must be a non-negative integer, got {n!r}")
 
-        from .convert import from_pandas, to_pandas
+        actual_n = min(n, len(self))
+        start = max(0, len(self) - actual_n)
 
-        df = to_pandas(self)
-
-        return from_pandas(df.tail(n))
+        return ArFrame(self._frame.select_rows(start, actual_n))
 
     def to_dict(self) -> dict[str, list]:
         """Export the frame as a Python dictionary.

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -27,7 +27,7 @@ DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 RUNS = 1 if DRY_RUN else 3
 
 BASELINE_FILE = "benchmarks/baseline.json"
-REGRESSION_THRESHOLD = 5  # Percent
+REGRESSION_THRESHOLD = 10  # Percent
 
 
 @dataclass(frozen=True)
@@ -290,6 +290,12 @@ def calculate_regression(current, baseline):
     ) * 100  # How much slower current benchmark is compared to baseline
 
 
+def check_regression(current_time, baseline_time, threshold_percent):
+    regression_percent = ((current_time - baseline_time) / baseline_time) * 100
+
+    return regression_percent > threshold_percent, regression_percent
+
+
 def run_case(case, skip_correctness=False):
     baseline_data = load_baseline()
 
@@ -403,12 +409,16 @@ def run_case(case, skip_correctness=False):
         baseline_time = baseline_case["arnio_exec_time"]
         current_time = avg(ar_times)
 
-        regression = calculate_regression(current_time, baseline_time)
+        is_regression, regression_percent = check_regression(
+            current_time,
+            baseline_time,
+            REGRESSION_THRESHOLD,
+        )
 
-        if regression > REGRESSION_THRESHOLD:
+        if is_regression:
             print(
-                f"WARNING: Regression detected:"
-                f"{regression:.1f}% slower than baseline "
+                f"WARNING: Regression detected: "
+                f"{regression_percent:.1f}% slower than baseline "
                 f"(threshold: {REGRESSION_THRESHOLD}%)"
             )
     else:
@@ -465,10 +475,15 @@ if __name__ == "__main__":
         )
     elif rss_source == "unavailable":
         print("Note: Peak RSS unavailable (install psutil for process RSS).")
-    results = []
 
+    results = {}
     for benchmark_case in BENCHMARKS:
-        results.append(run_case(benchmark_case))
+        result = run_case(benchmark_case)
+        results[result["case"]] = {
+            "pandas_exec_time": result["pandas_exec_time"],
+            "arnio_exec_time": result["arnio_exec_time"],
+            "speedup": result["speedup"],
+        }
 
     with open("benchmark_results.json", "w") as f:
         json.dump(results, f, indent=2)

--- a/benchmarks/benchmark_vs_pandas.py
+++ b/benchmarks/benchmark_vs_pandas.py
@@ -27,7 +27,7 @@ DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 RUNS = 1 if DRY_RUN else 3
 
 BASELINE_FILE = "benchmarks/baseline.json"
-REGRESSION_THRESHOLD = 10  # Percent
+REGRESSION_THRESHOLD = 5  # Percent
 
 
 @dataclass(frozen=True)
@@ -416,8 +416,8 @@ def run_case(case, skip_correctness=False):
         )
 
         if is_regression:
-            print(
-                f"WARNING: Regression detected: "
+            raise RuntimeError(
+                f"Benchmark regression detected: "
                 f"{regression_percent:.1f}% slower than baseline "
                 f"(threshold: {REGRESSION_THRESHOLD}%)"
             )
@@ -485,5 +485,10 @@ if __name__ == "__main__":
             "speedup": result["speedup"],
         }
 
-    with open("benchmark_results.json", "w") as f:
+    output_path = Path("benchmark_results.json")
+
+    with open(output_path, "w") as f:
         json.dump(results, f, indent=2)
+
+    if DRY_RUN and output_path.exists():
+        output_path.unlink()

--- a/benchmarks/generate_pr_summary.py
+++ b/benchmarks/generate_pr_summary.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+
+BASELINE_FILE = "benchmarks/baseline.json"
+RESULTS_FILE = "benchmark_results.json"
+OUTPUT_FILE = "benchmark_summary.md"
+
+
+def load_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def generate_summary(results, baseline):
+    if not results or not baseline:
+        return "## Benchmark Summary\n\nNo comparable baseline data available.\n"
+
+    lines = [
+        "## Benchmark Summary",
+        "",
+        "| Benchmark | Result |",
+        "|---|---|",
+    ]
+
+    for case_name, current in results.items():
+        baseline_case = baseline.get(case_name)
+
+        if not baseline_case:
+            lines.append(f"| {case_name} | No baseline available |")
+            continue
+
+        current_time = current["arnio_exec_time"]
+        baseline_time = baseline_case["arnio_exec_time"]
+
+        change_percent = ((current_time - baseline_time) / baseline_time) * 100
+
+        if abs(change_percent) < 1:
+            status = "No significant change"
+        elif change_percent > 0:
+            status = f"+{change_percent:.1f}% slower"
+        else:
+            status = f"{abs(change_percent):.1f}% faster"
+
+        lines.append(f"| {case_name} | {status} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    results = load_json(RESULTS_FILE)
+    baseline = load_json(BASELINE_FILE)
+
+    summary = generate_summary(results, baseline)
+
+    output_path = Path(OUTPUT_FILE)
+    output_path.write_text(summary)
+
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -141,8 +141,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
 
     // --- Frame ---
     py::class_<Frame>(m, "Frame")
-    .def("select_columns", &Frame::select_columns)
-    .def("select_rows", &Frame::select_rows)
+        .def("select_columns", &Frame::select_columns)
+        .def("select_rows", &Frame::select_rows)
         .def(py::init<>())
         .def(py::init<size_t>(), py::arg("row_count"))
         .def("shape", &Frame::shape)

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -141,7 +141,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
 
     // --- Frame ---
     py::class_<Frame>(m, "Frame")
-        .def("select_columns", &Frame::select_columns)
+    .def("select_columns", &Frame::select_columns)
+    .def("select_rows", &Frame::select_rows)
         .def(py::init<>())
         .def(py::init<size_t>(), py::arg("row_count"))
         .def("shape", &Frame::shape)

--- a/cpp/include/arnio/frame.h
+++ b/cpp/include/arnio/frame.h
@@ -44,6 +44,7 @@ class Frame {
     // Clone
     Frame clone() const;
     Frame select_columns(const std::vector<std::string>& columns) const;
+    Frame select_rows(size_t start, size_t count) const;
 
    private:
     std::vector<Column> columns_;

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -135,6 +135,46 @@ Frame Frame::select_columns(const std::vector<std::string>& columns) const {
     return Frame(row_count_, std::move(selected));
 }
 
+Frame Frame::select_rows(size_t start, size_t count) const {
+    if (start > row_count_) {
+        throw std::out_of_range("Row start index out of range");
+    }
+
+    size_t actual_count = std::min(count, row_count_ - start);
+
+    std::vector<Column> selected_columns;
+    selected_columns.reserve(columns_.size());
+
+    for (const auto& col : columns_) {
+        Column new_col(col.name(), col.dtype());
+
+        for (size_t i = start; i < start + actual_count; ++i) {
+            if (col.is_null(i)) {
+                new_col.push_null();
+                continue;
+            }
+
+            auto value = col.at(i);
+
+            if (std::holds_alternative<std::string>(value)) {
+                new_col.push_back(std::get<std::string>(value));
+            } else if (std::holds_alternative<int64_t>(value)) {
+                new_col.push_back(std::get<int64_t>(value));
+            } else if (std::holds_alternative<double>(value)) {
+                new_col.push_back(std::get<double>(value));
+            } else if (std::holds_alternative<bool>(value)) {
+                new_col.push_back(std::get<bool>(value));
+            } else {
+                new_col.push_null();
+            }
+        }
+
+        selected_columns.push_back(std::move(new_col));
+    }
+
+    return Frame(actual_count, std::move(selected_columns));
+}
+
 void Frame::rebuild_index() {
     name_index_.clear();
     for (size_t i = 0; i < columns_.size(); ++i) {

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from benchmarks.benchmark_vs_pandas import check_regression
+from benchmarks.benchmark_vs_pandas import (
+    BenchmarkCase,
+    check_regression,
+    run_case,
+)
 
 # Check if the C++ extension is compiled
 try:
@@ -148,7 +152,7 @@ def test_check_regression_detects_slowdown():
     is_regression, regression_percent = check_regression(
         current_time=12.0,
         baseline_time=10.0,
-        threshold_percent=10,
+        threshold_percent=5,
     )
 
     assert is_regression is True
@@ -160,8 +164,72 @@ def test_check_regression_allows_small_variance():
     is_regression, regression_percent = check_regression(
         current_time=10.5,
         baseline_time=10.0,
-        threshold_percent=10,
+        threshold_percent=5,
     )
 
     assert is_regression is False
     assert regression_percent == 5.0
+
+
+def test_run_case_raises_on_regression(monkeypatch):
+    """run_case should fail when benchmark regression exceeds threshold."""
+
+    benchmark_case = BenchmarkCase(
+        "Regression Test Case",
+        "dummy.csv",
+    )
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.load_baseline",
+        lambda: {
+            "Regression Test Case": {
+                "arnio_exec_time": 10.0,
+            }
+        },
+    )
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.verify_correctness",
+        lambda path: None,
+    )
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.RUNS",
+        1,
+    )
+
+    def fake_run_subprocess(engine, path):
+        if engine == "arnio":
+            return {
+                "elapsed": 11.0,
+                "peak_trace_mb": 1,
+                "peak_rss_mb": 1,
+                "ops": {
+                    "read_csv": 1,
+                    "clean_strings": 1,
+                    "drop_nulls": 1,
+                    "drop_duplicates": 1,
+                    "to_pandas": 1,
+                },
+            }
+
+        return {
+            "elapsed": 1.0,
+            "peak_trace_mb": 1,
+            "peak_rss_mb": 1,
+            "ops": {
+                "read_csv": 1,
+                "clean_strings": 1,
+                "drop_nulls": 1,
+                "drop_duplicates": 1,
+                "to_pandas": 1,
+            },
+        }
+
+    monkeypatch.setattr(
+        "benchmarks.benchmark_vs_pandas.run_subprocess",
+        fake_run_subprocess,
+    )
+
+    with pytest.raises(RuntimeError, match="Benchmark regression detected"):
+        run_case(benchmark_case, skip_correctness=True)

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from benchmarks.benchmark_vs_pandas import check_regression
+
 # Check if the C++ extension is compiled
 try:
     import arnio._core  # noqa: F401
@@ -139,3 +141,27 @@ def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files():
         if f.name != "benchmark_sparse_nulls.csv"
     ]
     assert len(post_files) == 0, f"Temp files not cleaned up: {post_files}"
+
+
+def test_check_regression_detects_slowdown():
+    """Regression should trigger when slowdown exceeds threshold."""
+    is_regression, regression_percent = check_regression(
+        current_time=12.0,
+        baseline_time=10.0,
+        threshold_percent=10,
+    )
+
+    assert is_regression is True
+    assert regression_percent == 20.0
+
+
+def test_check_regression_allows_small_variance():
+    """Small timing variance should not trigger regression."""
+    is_regression, regression_percent = check_regression(
+        current_time=10.5,
+        baseline_time=10.0,
+        threshold_percent=10,
+    )
+
+    assert is_regression is False
+    assert regression_percent == 5.0

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -234,6 +234,158 @@ def test_select_columns_native_path_avoids_pandas_roundtrip(monkeypatch):
     assert list(df.columns) == ["salary", "name"]
 
 
+def test_head_native_path_avoids_pandas_roundtrip(monkeypatch):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["alice", "bob", "charlie"],
+                "salary": [100, 200, 300],
+            }
+        )
+    )
+
+    from arnio import convert
+
+    def fail_to_pandas(_):
+        raise AssertionError("head() should avoid to_pandas")
+
+    monkeypatch.setattr(convert, "to_pandas", fail_to_pandas)
+
+    result = frame.head(2)
+
+    assert result.shape == (2, 2)
+    assert result.columns == ["name", "salary"]
+
+
+def test_tail_native_path_avoids_pandas_roundtrip(monkeypatch):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["alice", "bob", "charlie"],
+                "salary": [100, 200, 300],
+            }
+        )
+    )
+
+    from arnio import convert
+
+    def fail_to_pandas(_):
+        raise AssertionError("tail() should avoid to_pandas")
+
+    monkeypatch.setattr(convert, "to_pandas", fail_to_pandas)
+
+    result = frame.tail(2)
+
+    assert result.shape == (2, 2)
+    assert result.columns == ["name", "salary"]
+
+
+def test_head_default_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6],
+            }
+        )
+    )
+
+    result = frame.head()
+
+    assert result.shape == (5, 1)
+    assert result["a"] == [1, 2, 3, 4, 5]
+
+
+def test_tail_default_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6],
+            }
+        )
+    )
+
+    result = frame.tail()
+
+    assert result.shape == (5, 1)
+    assert result["a"] == [2, 3, 4, 5, 6]
+
+
+def test_head_zero_rows():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.head(0)
+
+    assert result.shape == (0, 1)
+    assert result["a"] == []
+
+
+def test_tail_zero_rows():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.tail(0)
+
+    assert result.shape == (0, 1)
+    assert result["a"] == []
+
+
+def test_head_oversized_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.head(999)
+
+    assert result.shape == (3, 1)
+    assert result["a"] == [1, 2, 3]
+
+
+def test_tail_oversized_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.tail(999)
+
+    assert result.shape == (3, 1)
+    assert result["a"] == [1, 2, 3]
+
+
+@pytest.mark.parametrize("invalid_n", [-1, 1.5, "5", True, None])
+def test_head_invalid_n(invalid_n):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+
+    with pytest.raises(ValueError):
+        frame.head(invalid_n)
+
+
+@pytest.mark.parametrize("invalid_n", [-1, 1.5, "5", True, None])
+def test_tail_invalid_n(invalid_n):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+
+    with pytest.raises(ValueError):
+        frame.tail(invalid_n)
+
+
 class TestArFrame:
     """Test ArFrame properties and methods."""
 

--- a/tests/test_generate_pr_summary.py
+++ b/tests/test_generate_pr_summary.py
@@ -1,0 +1,58 @@
+from benchmarks.generate_pr_summary import generate_summary
+
+
+def test_generate_summary_handles_missing_baseline():
+    """Should gracefully handle missing baseline data."""
+
+    results = {
+        "Case A": {
+            "arnio_exec_time": 10.0,
+        }
+    }
+
+    summary = generate_summary(results, {})
+
+    assert "No comparable baseline data available." in summary
+
+
+def test_generate_summary_formats_regression_and_improvement():
+    """Should format slower/faster benchmark changes correctly."""
+
+    results = {
+        "Case A": {
+            "arnio_exec_time": 12.0,
+        },
+        "Case B": {
+            "arnio_exec_time": 8.0,
+        },
+    }
+
+    baseline = {
+        "Case A": {
+            "arnio_exec_time": 10.0,
+        },
+        "Case B": {
+            "arnio_exec_time": 10.0,
+        },
+    }
+
+    summary = generate_summary(results, baseline)
+
+    assert "+20.0% slower" in summary
+    assert "20.0% faster" in summary
+
+
+def test_generate_summary_handles_missing_case_baseline():
+    """Should show missing baseline rows cleanly."""
+
+    results = {
+        "Case A": {
+            "arnio_exec_time": 10.0,
+        }
+    }
+
+    baseline = {}
+
+    summary = generate_summary(results, baseline)
+
+    assert "No comparable baseline data available." in summary


### PR DESCRIPTION
## Summary

Avoids full pandas materialization in `ArFrame.head()` and `ArFrame.tail()` by introducing a native bounded row-selection path in the C++ core.

This PR:

* adds native `select_rows()` support to `Frame`
* exposes native row selection through pybind
* updates `ArFrame.head()` and `ArFrame.tail()` to use bounded native slicing instead of full `to_pandas()` conversion
* preserves column order, dtypes, null masks, and row-count behavior
* adds regression tests covering default `n`, custom `n`, `n=0`, oversized `n`, invalid `n`, and native-path enforcement

This keeps small preview operations lightweight even on large datasets.

## Linked issue

Fixes #1449

## Type of change

* [ ] Bug fix
* [ ] Feature
* [x] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [x] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash
ruff check .
black .
pytest tests/test_frame.py -q
```

Result:

* `head()` and `tail()` no longer require full `to_pandas()` materialization
* native row slicing path validated through regression tests
* edge-case coverage added for default, zero, oversized, and invalid `n`
* all targeted tests passing locally

## Screenshots / Media

N/A

## Performance Impact

`head()` and `tail()` now only materialize the requested bounded row slice through the native C++ path instead of converting the full frame through pandas before slicing.

This reduces unnecessary memory overhead and avoids full-frame pandas round-trips for small preview operations such as `head(5)` on large datasets.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR intentionally keeps the optimization narrowly scoped to `ArFrame.head()` and `ArFrame.tail()` and does not introduce a broader/generalized row slicing API beyond the native bounded path needed for these methods.
