### PR TITLE
fix(cleaning): add strict boolean validation for clean() parameters

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1154,6 +1154,13 @@ def clean(
     >>> frame = ar.read_csv("data.csv")
     >>> cleaned = ar.clean(frame, strip_whitespace=True, drop_nulls=True)
     """
+    if not isinstance(strip_whitespace, bool):
+        raise TypeError("strip_whitespace must be a bool")
+    if not isinstance(drop_nulls, bool):
+        raise TypeError("drop_nulls must be a bool")
+    if not isinstance(drop_duplicates, bool):
+        raise TypeError("drop_duplicates must be a bool")
+
     from .pipeline import pipeline
 
     steps = []

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2030,6 +2030,35 @@ class TestCleanAPI:
         result = ar.clean(frame, strip_whitespace=False, drop_nulls=True)
         assert len(result) < len(frame)
 
+    @pytest.mark.parametrize("invalid_val", ["yes", 1, None, []])
+    def test_clean_invalid_strip_whitespace(self, csv_with_whitespace, invalid_val):
+        frame = ar.read_csv(csv_with_whitespace)
+        with pytest.raises(TypeError, match="strip_whitespace must be a bool"):
+            ar.clean(frame, strip_whitespace=invalid_val)
+
+    @pytest.mark.parametrize("invalid_val", ["yes", 1, None, []])
+    def test_clean_invalid_drop_nulls(self, csv_with_whitespace, invalid_val):
+        frame = ar.read_csv(csv_with_whitespace)
+        with pytest.raises(TypeError, match="drop_nulls must be a bool"):
+            ar.clean(frame, drop_nulls=invalid_val)
+
+    @pytest.mark.parametrize("invalid_val", ["yes", 1, None, []])
+    def test_clean_invalid_drop_duplicates(self, csv_with_whitespace, invalid_val):
+        frame = ar.read_csv(csv_with_whitespace)
+        with pytest.raises(TypeError, match="drop_duplicates must be a bool"):
+            ar.clean(frame, drop_duplicates=invalid_val)
+
+    def test_clean_valid_booleans(self, csv_with_whitespace):
+        frame = ar.read_csv(csv_with_whitespace)
+        # Should not raise
+        result = ar.clean(
+            frame,
+            strip_whitespace=True,
+            drop_nulls=False,
+            drop_duplicates=True,
+        )
+        assert len(ar.to_pandas(result)) > 0
+
 
 class TestFilterRows:
     def test_filter_rows_missing_column_raises_clear_error(self):


### PR DESCRIPTION
## Summary
The `clean()` function is a convenience API that acts as a pipeline for several data manipulation steps (e.g., `strip_whitespace`, `drop_nulls`, `drop_duplicates`). Previously, the parameters controlling these steps relied on Python's implicit truthiness rather than explicit type checking. 

This allowed non-boolean truthy values (such as strings, integers, or lists) to be silently accepted, triggering cleaning steps that the user might not have intended. For example, passing `strip_whitespace="no"` would paradoxically enable whitespace stripping because `"no"` is a truthy string.

Closes #1433


## Why it matters
Since `clean()` can drastically mutate the data shape and content (such as dropping rows), silently interpreting configuration errors or typos as truthy values can lead to unexpected data loss or modification. Enforcing strict boolean types ensures the API behaves predictably and fails fast when misconfigured (e.g., when passing values from a CLI or an unparsed config file).

## Changes Implemented
* **Strict Type Validation:** Added `isinstance(value, bool)` checks at the beginning of the `clean()` function in `arnio/cleaning.py`.
* **Fail-Fast Behavior:** The function now immediately raises a `TypeError` with a descriptive message if `strip_whitespace`, `drop_nulls`, or `drop_duplicates` are not strictly `bool`.
* **Testing Coverage:** Added parametrized tests in `tests/test_cleaning.py` to assert that:
  * Passing invalid values like `"yes"`, `1`, `None`, and `[]` raises the expected `TypeError`.
  * Passing valid boolean configurations (`True` or `False`) continues to operate normally.

## Steps to Reproduce the Previous Issue (Now Fixed)
```python
import pandas as pd
import arnio as ar

frame = ar.from_pandas(pd.DataFrame({"x": [" a ", None, " a "]}))

# These previously executed the cleaning steps due to truthiness.
# They will now properly raise a TypeError.
ar.clean(frame, strip_whitespace="no")
ar.clean(frame, drop_nulls="yes")
ar.clean(frame, drop_duplicates=1)






---
