### PR TITLE
docs: add missing NumPy-style docstrings to public and private functions

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -331,7 +331,7 @@ def keep_rows_with_nulls(
 def select_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
     """Return a new frame containing only the requested columns.
 
-     Parameters
+    Parameters
     ----------
     frame : ArFrame
         Input data frame.
@@ -1380,7 +1380,6 @@ def combine_columns(
     ArFrame or pd.DataFrame
         Frame with the combined output column appended.
 
-
     Raises
     ------
     TypeError
@@ -1836,7 +1835,7 @@ def coalesce_columns(
     ArFrame or pd.DataFrame
         New frame with coalesced column.
 
-     Raises
+    Raises
     ------
     TypeError
         If subset is not a list, or frame is not an ArFrame or DataFrame.

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -329,7 +329,32 @@ def keep_rows_with_nulls(
 
 
 def select_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
-    """Return a new frame containing only the requested columns."""
+    """Return a new frame containing only the requested columns.
+
+     Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    columns : sequence of str
+        Column names to keep.
+
+    Returns
+    -------
+    ArFrame
+        New frame containing only the specified columns, in the order given.
+
+    Raises
+    ------
+    TypeError
+        If columns is a string/bytes value or contains non-string items.
+    KeyError
+        If any requested column does not exist in the frame.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> subset = ar.select_columns(frame, ["name", "revenue"])
+    """
     return frame.select_columns(columns)
 
 
@@ -935,6 +960,32 @@ def normalize_unicode(
     This implementation operates natively on the ArFrame's internal columnar
     representation, avoiding a full pandas roundtrip. Only STRING columns are
     processed; all other column types are cloned unchanged.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    subset : list[str], optional
+        Column names to normalize. If None, applies to all string columns.
+    form : str, default "NFC"
+        Unicode normalization form. One of "NFC", "NFD", "NFKC", "NFKD".
+
+    Returns
+    -------
+    ArFrame
+        New frame with Unicode-normalized string columns.
+
+    Raises
+    ------
+    ValueError
+        If form is not one of the supported normalization forms.
+    KeyError
+        If any column in subset does not exist in the frame.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> normalized = ar.normalize_unicode(frame, form="NFC")
     """
     valid_forms = {"NFC", "NFD", "NFKC", "NFKD"}
     if form not in valid_forms:
@@ -1328,6 +1379,23 @@ def combine_columns(
     -------
     ArFrame or pd.DataFrame
         Frame with the combined output column appended.
+
+
+    Raises
+    ------
+    TypeError
+        If separator is not a string, or frame is not an ArFrame or DataFrame.
+    ValueError
+        If output_column is empty, output_column already exists in the frame,
+        or subset is provided but empty.
+    KeyError
+        If any column in subset does not exist in the frame.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> result = ar.combine_columns(frame, subset=["first_name", "last_name"],
+    ...                             separator=" ", output_column="full_name")
     """
     import pandas as pd
 
@@ -1767,6 +1835,22 @@ def coalesce_columns(
     -------
     ArFrame or pd.DataFrame
         New frame with coalesced column.
+
+     Raises
+    ------
+    TypeError
+        If subset is not a list, or frame is not an ArFrame or DataFrame.
+    ValueError
+        If subset is empty, output_column is empty, or output_column already
+        exists in the frame.
+    KeyError
+        If any column in subset does not exist in the frame.
+
+    Examples
+    --------
+    >>> frame = ar.read_csv("data.csv")
+    >>> result = ar.coalesce_columns(frame, subset=["col_a", "col_b"],
+    ...                              output_column="first_non_null")
     """
     import pandas as pd
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1264,6 +1264,7 @@ def _calculate_quality_score(
     duplicate_ratio: float,
     columns: dict[str, ColumnProfile],
 ) -> tuple[float, dict[str, float]]:
+    """Compute an overall quality score and per-penalty breakdown from profile data."""
     if row_count == 0 or not columns:
         return 100.0, {}
 
@@ -1293,17 +1294,20 @@ def _calculate_quality_score(
 
 
 def _merge_status(current: str, new_status: str) -> str:
+    """Return the higher-severity status between current and new_status."""
     order = {"ok": 0, "warning": 1, "changed": 2}
     return new_status if order[new_status] > order[current] else current
 
 
 def _numeric_delta(value_a: Any, value_b: Any) -> float | None:
+    """Return the absolute numeric difference between two values, or None if non-numeric."""
     if isinstance(value_a, (int, float)) and isinstance(value_b, (int, float)):
         return abs(float(value_a) - float(value_b))
     return None
 
 
 def _clean_drift_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a raw drift entry dict into a clean serializable structure."""
     return {
         "status": entry["status"],
         "changes": {
@@ -1315,6 +1319,7 @@ def _clean_drift_entry(entry: dict[str, Any]) -> dict[str, Any]:
 
 
 def _validate_gate_threshold(value: float | None, name: str) -> float | None:
+    """Validate that a quality gate threshold is a finite non-negative number or None."""
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -1326,12 +1331,14 @@ def _validate_gate_threshold(value: float | None, name: str) -> float | None:
 
 
 def _validate_gate_bool(value: bool, name: str) -> bool:
+    """Validate that a quality gate flag is a bool and return it."""
     if not isinstance(value, bool):
         raise TypeError(f"{name} must be a bool")
     return value
 
 
 def _relative_delta(baseline: Any, current: Any) -> float | None:
+    """Return the relative change between baseline and current, or None if not computable."""
     if baseline is None or current is None:
         return None
     if not isinstance(baseline, (int, float)) or not isinstance(current, (int, float)):
@@ -1344,6 +1351,7 @@ def _relative_delta(baseline: Any, current: Any) -> float | None:
 
 
 def _absolute_delta(baseline: Any, current: Any) -> float | None:
+    """Return the absolute numeric change between baseline and current, or None if not computable."""
     if baseline is None or current is None:
         return None
     if not isinstance(baseline, (int, float)) or not isinstance(current, (int, float)):
@@ -1365,6 +1373,7 @@ def _add_ratio_issue(
     message: str,
     column: str | None = None,
 ) -> None:
+    """Append a QualityGateIssue if the relative delta between baseline and current exceeds threshold."""
     if threshold is None:
         return
     delta = _relative_delta(baseline, current)
@@ -1392,6 +1401,7 @@ def _add_absolute_issue(
     message: str,
     column: str | None = None,
 ) -> None:
+    """Append a QualityGateIssue if the absolute delta between baseline and current exceeds threshold."""
     if threshold is None:
         return
     delta = _absolute_delta(baseline, current)
@@ -1410,6 +1420,7 @@ def _add_absolute_issue(
 
 
 def _markdown_cell(value: Any) -> str:
+    """Escape a value for safe rendering inside a Markdown table cell."""
     if value is None:
         return "-"
     text = str(_clean_scalar(value))
@@ -1426,6 +1437,7 @@ def _compare_column_profiles(
     column_a: ColumnProfile,
     column_b: ColumnProfile,
 ) -> dict[str, Any]:
+    """Compare two ColumnProfile objects and return a drift entry with status, changes, and reasons."""
     changes: dict[str, dict[str, Any]] = {}
     reasons: list[str] = []
     status = "ok"
@@ -1835,6 +1847,7 @@ def _profile_column(
     approx_top_values_min_ratio: float,
     approx_top_values_sample_size: int,
 ) -> ColumnProfile:
+    """Compute a full ColumnProfile for a single column series."""
     null_count = int(series.isna().sum())
     non_null = series.dropna()
     unique_count = int(non_null.nunique(dropna=True))
@@ -1972,6 +1985,7 @@ def _profile_column(
 
 
 def _detect_semantic_type(name: str, series: pd.Series, dtype: str) -> str:
+    """Infer the semantic type of a column from its name, dtype, and value patterns."""
     lower_name = name.lower()
     values = series.dropna().astype("string").str.strip()
     if len(values) == 0:
@@ -2003,6 +2017,7 @@ def _detect_semantic_type(name: str, series: pd.Series, dtype: str) -> str:
 
 
 def _suggest_casts(report: DataQualityReport) -> dict[str, str]:
+    """Return a mapping of column names to suggested dtype casts based on the profile report."""
     mapping: dict[str, str] = {}
     for name, column in report.columns.items():
         if column.suggested_dtype is not None:
@@ -2017,6 +2032,7 @@ def _suggest_casts(report: DataQualityReport) -> dict[str, str]:
 
 
 def _suggest_column_dtype(series: pd.Series, dtype: str) -> str | None:
+    """Return a suggested target dtype if a string column appears safely castable, else None."""
     if dtype != "string":
         return None
     values = series.dropna().astype("string").str.strip()
@@ -2046,6 +2062,7 @@ def _column_warnings(
     empty_string_count: int,
     dominant_ratio: float,
 ) -> list[str]:
+    """Build a list of warning flag strings for a column based on its profile statistics."""
     warnings: list[str] = []
     if null_count:
         warnings.append("contains_nulls")
@@ -2071,10 +2088,12 @@ def _column_warnings(
 
 
 def _match_ratio(values: pd.Series, pattern: str) -> float:
+    """Return the fraction of values in a series that fully match a regex pattern."""
     return _ratio(int(values.str.fullmatch(pattern, na=False).sum()), len(values))
 
 
 def _looks_like_datetime(values: pd.Series) -> bool:
+    """Return True if the majority of values look like parseable date strings."""
     date_like = values.str.fullmatch(
         r"(\d{4}-\d{1,2}-\d{1,2})|(\d{1,2}/\d{1,2}/\d{2,4})",
         na=False,
@@ -2086,16 +2105,19 @@ def _looks_like_datetime(values: pd.Series) -> bool:
 
 
 def _is_numeric_dtype(dtype: str) -> bool:
+    """Return True if dtype is int64 or float64."""
     return dtype in {"int64", "float64"}
 
 
 def _ratio(part: int, total: int) -> float:
+    """Return part/total rounded to 6 decimal places, or 0.0 if total is zero."""
     if total == 0:
         return 0.0
     return round(part / total, 6)
 
 
 def _clean_scalar(value: Any) -> Any:
+    """Convert NaN and numpy scalar values to JSON-safe Python types."""
     if pd.isna(value):
         return None
     if hasattr(value, "item"):

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -35,6 +35,7 @@ _VALID_SEVERITIES = {"error", "warning"}
 
 
 def _validate_severity(severity: str) -> None:
+    """Raise ValueError if severity is not 'error' or 'warning'."""
     if severity not in _VALID_SEVERITIES:
         raise ValueError("severity must be 'error' or 'warning'")
 
@@ -1807,6 +1808,7 @@ def _is_safely_convertible_to_dtype(
     expected_dtype: str,
     column_name: str,
 ) -> bool:
+    """Return True if series values can be safely cast to expected_dtype without data loss."""
     try:
         non_null = series.dropna()
 
@@ -1862,6 +1864,7 @@ def _validate_column(
     name: str,
     field_def: Field,
 ) -> list[ValidationIssue]:
+    """Validate a single column against its Field definition and return all issues found."""
     issues: list[ValidationIssue] = []
 
     if field_def.dtype is not None and actual_dtype != field_def.dtype:
@@ -2118,6 +2121,7 @@ def _validate_datetime(
     name: str,
     field_def: Field,
 ) -> list[ValidationIssue]:
+    """Validate non-null datetime values against the format and min/max bounds in field_def."""
     issues: list[ValidationIssue] = []
     parsed = pd.to_datetime(non_null, format=field_def.format, errors="coerce")
 
@@ -2161,6 +2165,7 @@ def _validate_datetime(
 
 
 def _parse_datetime_bound(value: Any, name: str) -> pd.Timestamp | None:
+    """Parse a datetime bound value into a pd.Timestamp, raising ValueError on failure."""
     if value is None:
         return None
     try:
@@ -2183,6 +2188,7 @@ def _row_issues(
     message: str,
     severity: str = "error",
 ) -> list[ValidationIssue]:
+    """Convert a series of invalid rows into a list of ValidationIssue objects."""
     return [
         ValidationIssue(
             column=column,
@@ -2197,6 +2203,7 @@ def _row_issues(
 
 
 def _field_to_dict(field_def: Field) -> dict[str, Any]:
+    """Serialize a Field definition to a plain dict suitable for in-memory use."""
     return {
         "dtype": field_def.dtype,
         "nullable": field_def.nullable,
@@ -2216,6 +2223,7 @@ def _field_to_dict(field_def: Field) -> dict[str, Any]:
 
 
 def _field_to_json_dict(field_def: Field) -> dict[str, Any]:
+    """Serialize a Field definition to a JSON-safe dict, converting timestamps to ISO strings."""
     data = _field_to_dict(field_def)
     data["severity"] = field_def.severity
     data["datetime_min"] = (
@@ -2232,6 +2240,7 @@ def _field_to_json_dict(field_def: Field) -> dict[str, Any]:
 
 
 def _field_from_json_dict(name: str, payload: Any) -> Field:
+    """Deserialize a JSON dict payload into a Field definition for the given column name."""
     if not isinstance(payload, dict):
         raise TypeError(
             f"Schema JSON field for column {name!r} must be an object, got {type(payload).__name__}."
@@ -2279,12 +2288,14 @@ def _field_from_json_dict(name: str, payload: Any) -> Field:
 def _normalize_unique(
     value: list[str] | tuple[str, ...] | None,
 ) -> tuple[str, ...] | None:
+    """Normalize a unique-constraint value into a sorted tuple, or None if not set."""
     if value is None:
         return None
     return tuple(sorted(value))
 
 
 def _normalize_sequence(value: Any) -> Any:
+    """Convert sets and tuples to lists for JSON-serializable output."""
     if isinstance(value, set):
         return sorted(value)
     if isinstance(value, tuple):
@@ -2293,6 +2304,7 @@ def _normalize_sequence(value: Any) -> Any:
 
 
 def _clean_scalar(value: Any) -> Any:
+    """Recursively convert numpy scalars and NaN values to JSON-safe Python types."""
     if isinstance(value, dict):
         return {key: _clean_scalar(val) for key, val in value.items()}
     if isinstance(value, (list, tuple, set)):
@@ -2305,6 +2317,7 @@ def _clean_scalar(value: Any) -> Any:
 
 
 def _markdown_cell(value: Any) -> str:
+    """Escape a value for safe rendering inside a Markdown table cell."""
     if value is None:
         return ""
     text = str(value).replace("\n", "<br>").replace("|", "\\|")


### PR DESCRIPTION
## Summary
Added missing NumPy-style docstrings to public functions in `cleaning.py` and brief description docstrings to private helper functions in `schema.py` and `quality.py`, as requested in issue #1018.

## Linked issue
Refs #1018 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other: Documentation-only change, no logic modified.

## Performance Impact
None. Documentation-only change.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
- `select_columns` and `normalize_unicode` in `cleaning.py` received full NumPy-style docstrings (Parameters, Returns, Raises, Examples).
- `combine_columns` and `coalesce_columns` in `cleaning.py` received Raises and Examples sections.
- 13 private helpers in `schema.py` received brief one-line docstrings.
- 22 private helpers in `quality.py` received brief one-line docstrings.
- No logic was modified in any file.