### PR TITLE
fix(quality): filter cast_types in exclude_columns to prevent suggestion leakage

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -218,6 +218,13 @@ class DataQualityReport:
 
             exclude_columns = set(exclude_columns)
 
+        def _redact_reason(reason: str | None) -> str | None:
+            if not reason or not exclude_columns:
+                return reason
+            for col in exclude_columns:
+                reason = reason.replace(f"'{col}'", "'[REDACTED]'")
+            return reason
+
         return {
             "row_count": self.row_count,
             "column_count": self.column_count,
@@ -247,7 +254,7 @@ class DataQualityReport:
                         }
                     ),
                     "confidence_score": getattr(s, "confidence_score", None),
-                    "confidence_reason": getattr(s, "confidence_reason", None),
+                    "confidence_reason": _redact_reason(getattr(s, "confidence_reason", None)),
                 }
                 for s in self.suggestions
             ],

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -242,19 +242,26 @@ class DataQualityReport:
                 {
                     "step": s[0],
                     "kwargs": (
-                        {k: v for k, v in dict(s[1]).items() if k not in exclude_columns}
+                        {
+                            k: v
+                            for k, v in dict(s[1]).items()
+                            if k not in exclude_columns
+                        }
                         if s[0] == "cast_types"
                         else {
                             key: (
                                 [item for item in value if item not in exclude_columns]
-                                if key in {"subset", "columns"} and isinstance(value, list)
+                                if key in {"subset", "columns"}
+                                and isinstance(value, list)
                                 else value
                             )
                             for key, value in dict(s[1]).items()
                         }
                     ),
                     "confidence_score": getattr(s, "confidence_score", None),
-                    "confidence_reason": _redact_reason(getattr(s, "confidence_reason", None)),
+                    "confidence_reason": _redact_reason(
+                        getattr(s, "confidence_reason", None)
+                    ),
                 }
                 for s in self.suggestions
             ],

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -234,22 +234,18 @@ class DataQualityReport:
             "suggestions": [
                 {
                     "step": s[0],
-                    "kwargs": {
-                        key: (
-                            [item for item in value if item not in exclude_columns]
-                            if key in {"subset", "columns"} and isinstance(value, list)
-                            else (
-                                {
-                                    k: v
-                                    for k, v in value.items()
-                                    if k not in exclude_columns
-                                }
-                                if key == "cast_types" and isinstance(value, dict)
+                    "kwargs": (
+                        {k: v for k, v in dict(s[1]).items() if k not in exclude_columns}
+                        if s[0] == "cast_types"
+                        else {
+                            key: (
+                                [item for item in value if item not in exclude_columns]
+                                if key in {"subset", "columns"} and isinstance(value, list)
                                 else value
                             )
-                        )
-                        for key, value in dict(s[1]).items()
-                    },
+                            for key, value in dict(s[1]).items()
+                        }
+                    ),
                     "confidence_score": getattr(s, "confidence_score", None),
                     "confidence_reason": getattr(s, "confidence_reason", None),
                 }

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -437,6 +437,17 @@ def test_auto_clean_strict_casts_require_explicit_opt_in():
         ar.auto_clean(frame, mode="strict")
 
 
+def test_exclude_columns_prevents_leakage_in_json():
+    import json
+    frame = ar.from_pandas(pd.DataFrame({"secret_token": ["true", "false"]}))
+    report = ar.profile(frame)
+    
+    report_dict = report.to_dict(exclude_columns=["secret_token"])
+    json_str = json.dumps(report_dict)
+    
+    assert "secret_token" not in json_str
+
+
 def test_auto_clean_dry_run_returns_report_without_mutating():
     frame = ar.from_pandas(pd.DataFrame({"active": ["true", "false"]}))
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -439,12 +439,13 @@ def test_auto_clean_strict_casts_require_explicit_opt_in():
 
 def test_exclude_columns_prevents_leakage_in_json():
     import json
+
     frame = ar.from_pandas(pd.DataFrame({"secret_token": ["true", "false"]}))
     report = ar.profile(frame)
-    
+
     report_dict = report.to_dict(exclude_columns=["secret_token"])
     json_str = json.dumps(report_dict)
-    
+
     assert "secret_token" not in json_str
 
 


### PR DESCRIPTION
## Summary
Fixed a logic error in `DataQualityReport.to_dict()` where `cast_types` suggestions bypassed the `exclude_columns` filter. Changed the dictionary comprehension to correctly evaluate `s[0] == "cast_types"` (the step name) rather than mistakenly checking the nested key, which previously allowed excluded columns to leak into the final suggestions output.

## Linked issue
Fixes #1466

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [x] `make lint`
- [ ] Other:

## Screenshots / Media
*N/A - Data dictionary JSON structure fixed behind the scenes.*

## Performance Impact
*N/A - Standard dictionary comprehension fix, no performance penalty.*

## GSSoC labels

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
N/A