### PR TITLE
perf: avoid full pandas materialization in head and tail

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -311,11 +311,9 @@ class ArFrame:
         if isinstance(n, bool) or not isinstance(n, int) or n < 0:
             raise ValueError(f"`n` must be a non-negative integer, got {n!r}")
 
-        from .convert import from_pandas, to_pandas
+        actual_n = min(n, len(self))
 
-        df = to_pandas(self)
-
-        return from_pandas(df.head(n))
+        return ArFrame(self._frame.select_rows(0, actual_n))
 
     def tail(self, n: int = 5) -> ArFrame:
         """Return the last n rows as an ArFrame.
@@ -333,11 +331,10 @@ class ArFrame:
         if isinstance(n, bool) or not isinstance(n, int) or n < 0:
             raise ValueError(f"`n` must be a non-negative integer, got {n!r}")
 
-        from .convert import from_pandas, to_pandas
+        actual_n = min(n, len(self))
+        start = max(0, len(self) - actual_n)
 
-        df = to_pandas(self)
-
-        return from_pandas(df.tail(n))
+        return ArFrame(self._frame.select_rows(start, actual_n))
 
     def to_dict(self) -> dict[str, list]:
         """Export the frame as a Python dictionary.

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -142,6 +142,7 @@ PYBIND11_MODULE(_arnio_cpp, m) {
     // --- Frame ---
     py::class_<Frame>(m, "Frame")
         .def("select_columns", &Frame::select_columns)
+        .def("select_rows", &Frame::select_rows)
         .def(py::init<>())
         .def(py::init<size_t>(), py::arg("row_count"))
         .def("shape", &Frame::shape)

--- a/cpp/include/arnio/frame.h
+++ b/cpp/include/arnio/frame.h
@@ -44,6 +44,7 @@ class Frame {
     // Clone
     Frame clone() const;
     Frame select_columns(const std::vector<std::string>& columns) const;
+    Frame select_rows(size_t start, size_t count) const;
 
    private:
     std::vector<Column> columns_;

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -135,6 +135,46 @@ Frame Frame::select_columns(const std::vector<std::string>& columns) const {
     return Frame(row_count_, std::move(selected));
 }
 
+Frame Frame::select_rows(size_t start, size_t count) const {
+    if (start > row_count_) {
+        throw std::out_of_range("Row start index out of range");
+    }
+
+    size_t actual_count = std::min(count, row_count_ - start);
+
+    std::vector<Column> selected_columns;
+    selected_columns.reserve(columns_.size());
+
+    for (const auto& col : columns_) {
+        Column new_col(col.name(), col.dtype());
+
+        for (size_t i = start; i < start + actual_count; ++i) {
+            if (col.is_null(i)) {
+                new_col.push_null();
+                continue;
+            }
+
+            auto value = col.at(i);
+
+            if (std::holds_alternative<std::string>(value)) {
+                new_col.push_back(std::get<std::string>(value));
+            } else if (std::holds_alternative<int64_t>(value)) {
+                new_col.push_back(std::get<int64_t>(value));
+            } else if (std::holds_alternative<double>(value)) {
+                new_col.push_back(std::get<double>(value));
+            } else if (std::holds_alternative<bool>(value)) {
+                new_col.push_back(std::get<bool>(value));
+            } else {
+                new_col.push_null();
+            }
+        }
+
+        selected_columns.push_back(std::move(new_col));
+    }
+
+    return Frame(actual_count, std::move(selected_columns));
+}
+
 void Frame::rebuild_index() {
     name_index_.clear();
     for (size_t i = 0; i < columns_.size(); ++i) {

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -237,6 +237,158 @@ def test_select_columns_native_path_avoids_pandas_roundtrip(monkeypatch):
     assert list(df.columns) == ["salary", "name"]
 
 
+def test_head_native_path_avoids_pandas_roundtrip(monkeypatch):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["alice", "bob", "charlie"],
+                "salary": [100, 200, 300],
+            }
+        )
+    )
+
+    from arnio import convert
+
+    def fail_to_pandas(_):
+        raise AssertionError("head() should avoid to_pandas")
+
+    monkeypatch.setattr(convert, "to_pandas", fail_to_pandas)
+
+    result = frame.head(2)
+
+    assert result.shape == (2, 2)
+    assert result.columns == ["name", "salary"]
+
+
+def test_tail_native_path_avoids_pandas_roundtrip(monkeypatch):
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "name": ["alice", "bob", "charlie"],
+                "salary": [100, 200, 300],
+            }
+        )
+    )
+
+    from arnio import convert
+
+    def fail_to_pandas(_):
+        raise AssertionError("tail() should avoid to_pandas")
+
+    monkeypatch.setattr(convert, "to_pandas", fail_to_pandas)
+
+    result = frame.tail(2)
+
+    assert result.shape == (2, 2)
+    assert result.columns == ["name", "salary"]
+
+
+def test_head_default_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6],
+            }
+        )
+    )
+
+    result = frame.head()
+
+    assert result.shape == (5, 1)
+    assert result["a"] == [1, 2, 3, 4, 5]
+
+
+def test_tail_default_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6],
+            }
+        )
+    )
+
+    result = frame.tail()
+
+    assert result.shape == (5, 1)
+    assert result["a"] == [2, 3, 4, 5, 6]
+
+
+def test_head_zero_rows():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.head(0)
+
+    assert result.shape == (0, 1)
+    assert result["a"] == []
+
+
+def test_tail_zero_rows():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.tail(0)
+
+    assert result.shape == (0, 1)
+    assert result["a"] == []
+
+
+def test_head_oversized_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.head(999)
+
+    assert result.shape == (3, 1)
+    assert result["a"] == [1, 2, 3]
+
+
+def test_tail_oversized_n():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+    )
+
+    result = frame.tail(999)
+
+    assert result.shape == (3, 1)
+    assert result["a"] == [1, 2, 3]
+
+
+@pytest.mark.parametrize("invalid_n", [-1, 1.5, "5", True, None])
+def test_head_invalid_n(invalid_n):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+
+    with pytest.raises(ValueError):
+        frame.head(invalid_n)
+
+
+@pytest.mark.parametrize("invalid_n", [-1, 1.5, "5", True, None])
+def test_tail_invalid_n(invalid_n):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+
+    with pytest.raises(ValueError):
+        frame.tail(invalid_n)
+
+
 class TestArFrame:
     """Test ArFrame properties and methods."""
 


### PR DESCRIPTION
## Summary

Avoids full pandas materialization in `ArFrame.head()` and `ArFrame.tail()` by introducing a native bounded row-selection path in the C++ core.

This PR:

* adds native `select_rows()` support to `Frame`
* exposes native row selection through pybind
* updates `ArFrame.head()` and `ArFrame.tail()` to use bounded native slicing instead of full `to_pandas()` conversion
* preserves column order, dtypes, null masks, and row-count behavior
* adds regression tests covering:

  * default `n`
  * custom `n`
  * `n=0`
  * oversized `n`
  * invalid `n`
  * native-path enforcement without pandas round-trips

This keeps small preview operations lightweight even on large datasets.

## Linked issue

Fixes #1449

## Type of change

* [ ] Bug fix
* [ ] Feature
* [x] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [x] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash id="3lf9vn"
ruff check .
black .
pytest tests/test_frame.py -q
```

Result:

* all targeted tests passing locally
* native row slicing path validated
* `head()` / `tail()` verified to avoid full `to_pandas()` materialization

## Screenshots / Media

N/A

## Performance Impact

`head()` and `tail()` now only materialize the requested bounded row slice through the native C++ path instead of converting the full frame through pandas before slicing.

This reduces unnecessary memory overhead and avoids full-frame pandas round-trips for small preview operations such as `head(5)` on large datasets.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR intentionally keeps the optimization narrowly scoped to `ArFrame.head()` and `ArFrame.tail()` and does not introduce a broader/generalized row slicing API beyond the bounded native path needed for these methods.
