### PR TITLE
fix(schema): normalize custom validator return values to prevent pd.N…

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1994,7 +1994,11 @@ def _validate_column(
                     )
                 )
             else:
-                invalid = non_null[~non_null.map(fn).astype(bool)]
+                invalid = non_null[
+                    ~non_null.map(
+                        lambda v: _normalize_validator_result(fn(v), validator_name)
+                    )
+                ]
                 issues.extend(
                     _row_issues(
                         invalid,
@@ -2320,6 +2324,40 @@ def register_validator(name: str, fn: callable) -> None:
     if not isinstance(name, str) or not name:
         raise ValueError("name must be a non-empty string")
     _CUSTOM_VALIDATORS[name] = fn
+
+
+def _normalize_validator_result(result: object, validator_name: str) -> bool:
+    """Normalize a custom validator return value to a strict bool.
+
+    Contract:
+    - ``True``  → passes validation
+    - ``False`` → fails validation
+    - ``None``  → fails validation
+    - ``pd.NA`` → fails validation
+    - anything else → raises TypeError naming the validator
+
+    This avoids calling bool() on pd.NA (which raises
+    "TypeError: boolean value of NA is ambiguous") and enforces a clear
+    return-value contract for custom validators.
+    """
+    if result is True:
+        return True
+    if result is False or result is None:
+        return False
+    # Check for pd.NA without importing pandas at module level
+    try:
+        import pandas as _pd
+
+        if result is _pd.NA:
+            return False
+    except ImportError:
+        pass
+    raise TypeError(
+        f"Custom validator {validator_name!r} returned "
+        f"{type(result).__name__!r} ({result!r}); "
+        "validators must return True (pass) or False (fail)."
+    )
+
 
 
 def Custom(

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2359,7 +2359,6 @@ def _normalize_validator_result(result: object, validator_name: str) -> bool:
     )
 
 
-
 def Custom(
     name: str,
     *,

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -1,7 +1,9 @@
 """Tests for register_validator and Custom validator in arnio.schema."""
 
+import pandas as pd
 import pytest
 
+import arnio as ar
 from arnio import schema
 from arnio.schema import Custom, register_validator
 
@@ -229,9 +231,6 @@ class TestCustomValidatorReturnNormalization:
 
     def test_validator_returning_true_passes(self):
         """True return value marks the row as valid."""
-        import arnio as ar
-        import pandas as pd
-
         register_validator("always_true", lambda v: True)
         frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
         result = ar.validate(frame, {"x": ar.Custom("always_true")})
@@ -240,9 +239,6 @@ class TestCustomValidatorReturnNormalization:
 
     def test_validator_returning_false_fails(self):
         """False return value marks the row as invalid with a structured issue."""
-        import arnio as ar
-        import pandas as pd
-
         register_validator("always_false", lambda v: False)
         frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
         result = ar.validate(frame, {"x": ar.Custom("always_false")})
@@ -252,9 +248,6 @@ class TestCustomValidatorReturnNormalization:
 
     def test_validator_returning_none_fails(self):
         """None return value is treated as a validation failure, not an error."""
-        import arnio as ar
-        import pandas as pd
-
         register_validator("returns_none", lambda v: None)
         frame = ar.from_pandas(pd.DataFrame({"x": [1, 2]}))
         result = ar.validate(frame, {"x": ar.Custom("returns_none")})
@@ -263,9 +256,6 @@ class TestCustomValidatorReturnNormalization:
 
     def test_validator_returning_pd_na_fails(self):
         """pd.NA return value is treated as a validation failure, not a TypeError."""
-        import arnio as ar
-        import pandas as pd
-
         register_validator(
             "nullable_bool",
             lambda v: pd.NA if v == 0 else True,
@@ -280,9 +270,6 @@ class TestCustomValidatorReturnNormalization:
 
     def test_validator_returning_non_bool_raises_type_error(self):
         """A non-bool, non-None, non-NA return value raises TypeError naming the validator."""
-        import arnio as ar
-        import pandas as pd
-
         register_validator("returns_int", lambda v: 1)
         frame = ar.from_pandas(pd.DataFrame({"x": [42]}))
         with pytest.raises(TypeError, match="returns_int"):
@@ -290,9 +277,6 @@ class TestCustomValidatorReturnNormalization:
 
     def test_validator_returning_string_raises_type_error(self):
         """A string return value raises TypeError naming the validator."""
-        import arnio as ar
-        import pandas as pd
-
         register_validator("returns_str", lambda v: "yes")
         frame = ar.from_pandas(pd.DataFrame({"x": [1]}))
         with pytest.raises(TypeError, match="returns_str"):
@@ -300,8 +284,6 @@ class TestCustomValidatorReturnNormalization:
 
     def test_mixed_true_false_none_pd_na(self):
         """Mixed True/False/None/pd.NA: only True rows pass, others fail."""
-        import arnio as ar
-        import pandas as pd
 
         def mixed_validator(v):
             if v == 1:

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -207,3 +207,117 @@ class TestCustomValidator:
 
         assert f1.semantic == "custom:positive"
         assert f2.semantic == "custom:email"
+
+
+class TestCustomValidatorReturnNormalization:
+    """Regression tests for issue #1469.
+
+    Custom validators must return a strict bool. The normalization contract:
+    - True  → passes validation
+    - False → fails validation (row reported as invalid)
+    - None  → fails validation (row reported as invalid)
+    - pd.NA → fails validation (row reported as invalid, no TypeError)
+    - any other non-bool value → raises TypeError naming the validator
+    """
+
+    def setup_method(self):
+        self._original_validators = dict(schema._CUSTOM_VALIDATORS)
+
+    def teardown_method(self):
+        schema._CUSTOM_VALIDATORS.clear()
+        schema._CUSTOM_VALIDATORS.update(self._original_validators)
+
+    def test_validator_returning_true_passes(self):
+        """True return value marks the row as valid."""
+        import arnio as ar
+        import pandas as pd
+
+        register_validator("always_true", lambda v: True)
+        frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+        result = ar.validate(frame, {"x": ar.Custom("always_true")})
+        assert result.passed
+        assert result.issue_count == 0
+
+    def test_validator_returning_false_fails(self):
+        """False return value marks the row as invalid with a structured issue."""
+        import arnio as ar
+        import pandas as pd
+
+        register_validator("always_false", lambda v: False)
+        frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3]}))
+        result = ar.validate(frame, {"x": ar.Custom("always_false")})
+        assert not result.passed
+        assert result.issue_count == 3
+        assert all(i.rule == "custom" for i in result.issues)
+
+    def test_validator_returning_none_fails(self):
+        """None return value is treated as a validation failure, not an error."""
+        import arnio as ar
+        import pandas as pd
+
+        register_validator("returns_none", lambda v: None)
+        frame = ar.from_pandas(pd.DataFrame({"x": [1, 2]}))
+        result = ar.validate(frame, {"x": ar.Custom("returns_none")})
+        assert not result.passed
+        assert all(i.rule == "custom" for i in result.issues)
+
+    def test_validator_returning_pd_na_fails(self):
+        """pd.NA return value is treated as a validation failure, not a TypeError."""
+        import arnio as ar
+        import pandas as pd
+
+        register_validator(
+            "nullable_bool",
+            lambda v: pd.NA if v == 0 else True,
+        )
+        frame = ar.from_pandas(pd.DataFrame({"x": [1, 0, -1]}))
+        # Before the fix this raised: TypeError: boolean value of NA is ambiguous
+        result = ar.validate(frame, {"x": ar.Custom("nullable_bool")})
+        assert not result.passed
+        failing = [i for i in result.issues if i.rule == "custom"]
+        assert len(failing) == 1
+        assert failing[0].row_index == 1  # the row where v == 0
+
+    def test_validator_returning_non_bool_raises_type_error(self):
+        """A non-bool, non-None, non-NA return value raises TypeError naming the validator."""
+        import arnio as ar
+        import pandas as pd
+
+        register_validator("returns_int", lambda v: 1)
+        frame = ar.from_pandas(pd.DataFrame({"x": [42]}))
+        with pytest.raises(TypeError, match="returns_int"):
+            ar.validate(frame, {"x": ar.Custom("returns_int")})
+
+    def test_validator_returning_string_raises_type_error(self):
+        """A string return value raises TypeError naming the validator."""
+        import arnio as ar
+        import pandas as pd
+
+        register_validator("returns_str", lambda v: "yes")
+        frame = ar.from_pandas(pd.DataFrame({"x": [1]}))
+        with pytest.raises(TypeError, match="returns_str"):
+            ar.validate(frame, {"x": ar.Custom("returns_str")})
+
+    def test_mixed_true_false_none_pd_na(self):
+        """Mixed True/False/None/pd.NA: only True rows pass, others fail."""
+        import arnio as ar
+        import pandas as pd
+
+        def mixed_validator(v):
+            if v == 1:
+                return True
+            if v == 2:
+                return False
+            if v == 3:
+                return None
+            if v == 4:
+                return pd.NA
+            return True
+
+        register_validator("mixed", mixed_validator)
+        frame = ar.from_pandas(pd.DataFrame({"x": [1, 2, 3, 4, 5]}))
+        result = ar.validate(frame, {"x": ar.Custom("mixed")})
+        assert not result.passed
+        failing_rows = {i.row_index for i in result.issues if i.rule == "custom"}
+        # rows at index 1 (v=2), 2 (v=3), 3 (v=4) should fail
+        assert failing_rows == {1, 2, 3}

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -266,7 +266,7 @@ class TestCustomValidatorReturnNormalization:
         assert not result.passed
         failing = [i for i in result.issues if i.rule == "custom"]
         assert len(failing) == 1
-        assert failing[0].row_index == 1  # the row where v == 0
+        assert failing[0].row_index == 2  # the row where v == 0 (1-based)
 
     def test_validator_returning_non_bool_raises_type_error(self):
         """A non-bool, non-None, non-NA return value raises TypeError naming the validator."""
@@ -301,5 +301,5 @@ class TestCustomValidatorReturnNormalization:
         result = ar.validate(frame, {"x": ar.Custom("mixed")})
         assert not result.passed
         failing_rows = {i.row_index for i in result.issues if i.rule == "custom"}
-        # rows at index 1 (v=2), 2 (v=3), 3 (v=4) should fail
-        assert failing_rows == {1, 2, 3}
+        # rows at index 2 (v=2), 3 (v=3), 4 (v=4) should fail (1-based)
+        assert failing_rows == {2, 3, 4}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Fixes #1469</p><p>Custom validators currently go through:</p><pre><code class="language-python">non_null.map(fn).astype(bool)
</code></pre><p>which causes pandas to raise:</p><pre><code class="language-text">TypeError: boolean value of NA is ambiguous
</code></pre><p>when a validator returns <code inline="">pd.NA</code>.</p><p>This prevents Arnio from producing a structured validation result.</p><h2>Fix</h2><p>Added <code inline="">_normalize_validator_result()</code> in <code inline="">schema.py</code> to normalize validator return values before pandas evaluates them as booleans.</p><p>Behavior after the fix:</p>
Return value | Behavior
-- | --
True | validation passes
False | structured ValidationIssue
None | structured ValidationIssue
pd.NA | structured ValidationIssue (no crash)
anything else | raises TypeError naming the validator

<p>This keeps validation behavior strict and predictable while preventing pandas boolean-coercion errors.</p><h2>Tests</h2><p>Added 7 regression tests in <code inline="">test_register_validator.py</code> covering:</p><ul><li><p><code inline="">pd.NA</code> returns</p></li><li><p><code inline="">None</code> returns</p></li><li><p>invalid non-bool truthy returns</p></li><li><p>existing <code inline="">True</code> / <code inline="">False</code> behavior</p></li><li><p>the exact reproduction case from the issue report</p></li></ul></body></html><!--EndFragment-->
</body>
</html>