### PR TITLE
fix: implement fail-fast boundary validation in register_step

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -130,6 +130,15 @@ def register_step(name: str, fn: Callable, overwrite: bool = False):
     ...     return df
     >>> ar.register_step("custom_clean", new_custom_clean, overwrite=True)
     """
+    # === ADDED FAIL-FAST VALIDATIONS ===
+    if not isinstance(name, str) or name.strip() == "":
+        raise ValueError("Step name must be a non-empty string.")
+    if not callable(fn):
+        raise TypeError(
+            f"Step function or class must be a callable object. Got {type(fn).__name__} instead."
+        )
+    # ===================================
+
     with _REGISTRY_LOCK:
         if name.startswith(f"{_BUILTIN_STEP_NAMESPACE}{_STEP_NAMESPACE_SEPARATOR}"):
             raise ValueError(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1895,3 +1895,76 @@ def test_pipeline_bool_flags_valid():
         verbose=True,
     )
     assert isinstance(result, tuple)
+
+
+class TestRegisterStepValidation:
+    @pytest.fixture(autouse=True)
+    def cleanup_registry(self):
+        """Ensure the global custom step registry resets after every single test in this class."""
+        yield
+        from arnio.pipeline import reset_steps
+
+        reset_steps()
+
+    # --- Happy Path ---
+    def test_registers_valid_callable(self):
+        from arnio.pipeline import list_steps, register_step
+
+        def dummy_clean(df):
+            return df
+
+        register_step("custom_dummy_step", dummy_clean)
+        assert "custom_dummy_step" in list_steps()
+
+    def test_allows_intentional_overwrite(self):
+        from arnio.pipeline import register_step
+
+        def first_step(df):
+            return df
+
+        def second_step(df):
+            return df
+
+        register_step("overwrite_step", first_step)
+        register_step("overwrite_step", second_step, overwrite=True)
+
+    # --- Edge Cases & Parameter Boundaries ---
+    def test_rejects_non_callable_objects(self):
+        from arnio.pipeline import register_step
+
+        """Verify TypeError is raised immediately for numbers, strings, and instances."""
+        with pytest.raises(TypeError, match="must be a callable object"):
+            register_step("bad_int", 123)
+        with pytest.raises(TypeError, match="must be a callable object"):
+            register_step("bad_str", "not_a_callable_function")
+        with pytest.raises(TypeError, match="must be a callable object"):
+            register_step("bad_dict", {"a": 1})
+
+    def test_rejects_empty_string_names(self):
+        from arnio.pipeline import register_step
+
+        def dummy_clean(df):
+            return df
+
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            register_step("", dummy_clean)
+
+    def test_rejects_whitespace_only_names(self):
+        from arnio.pipeline import register_step
+
+        def dummy_clean(df):
+            return df
+
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            register_step("    ", dummy_clean)
+
+    def test_rejects_invalid_name_types(self):
+        from arnio.pipeline import register_step
+
+        def dummy_clean(df):
+            return df
+
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            register_step(None, dummy_clean)  # type: ignore
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            register_step(42, dummy_clean)  # type: ignore


### PR DESCRIPTION
### Description
This PR addresses robustness issues in `register_step` by enforcing fail-fast validation on its inputs. It prevents invalid data types or malformed strings from causing silent pipeline errors down the stack.

### Changes Introduced
* Added explicit type validation to ensure `name` is a non-empty, non-whitespace string.
* Added explicit validation to ensure the step handler `fn` is a callable object.
* Implemented a comprehensive boundary test suite (`TestRegisterStepValidation`) covering edge cases like empty strings, whitespace strings, invalid types (`None`, `int`), and non-callable arguments.

### Verification
* All 102 test items passed locally and across the Ubuntu/Windows/macOS CI matrices.
* Formatting and style verified with `black` and `ruff`.

Fixes #721