### PR TITLE
fix: reject non-boolean nullable and unique options

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -514,6 +514,10 @@ class Field:
     severity: str = "error"
 
     def __post_init__(self) -> None:
+        if not isinstance(self.nullable, bool):
+            raise TypeError("nullable must be a bool")
+        if not isinstance(self.unique, bool):
+            raise TypeError("unique must be a bool")
         _validate_severity(self.severity)
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1649,6 +1649,25 @@ def test_schema_unique_accepts_valid_types():
     assert schema_tuple.unique == ("user_id", "course_id")
 
 
+@pytest.mark.parametrize("value", ["false", 1, None])
+def test_field_nullable_rejects_non_bool_values(value):
+    with pytest.raises(TypeError, match="nullable must be a bool"):
+        ar.String(nullable=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", ["yes", 1, None])
+def test_field_unique_rejects_non_bool_values(value):
+    with pytest.raises(TypeError, match="unique must be a bool"):
+        ar.Int64(unique=value)  # type: ignore[arg-type]
+
+
+def test_field_nullable_and_unique_accept_valid_bools():
+    field = ar.String(nullable=False, unique=True)
+
+    assert field.nullable is False
+    assert field.unique is True
+
+
 def test_email_default_keeps_backward_compatibility(sample_csv):
     frame = ar.read_csv(sample_csv)
 


### PR DESCRIPTION
## Summary
- reject non-bool values for `nullable` and `unique` in `Field.__post_init__()`
- keep existing `True`/`False` behavior unchanged across field factories
- add focused schema tests for strings, integers, `None`, and valid booleans

## Testing
- `python -m pytest tests/test_schema.py -k "field_nullable_rejects_non_bool_values or field_unique_rejects_non_bool_values or field_nullable_and_unique_accept_valid_bools"`
- `python -m ruff check arnio/schema.py tests/test_schema.py`
- `python -m black --check arnio/schema.py tests/test_schema.py`

Fixes #1413
