### PR TITLE
fix(cleaning): handle non-string pandas column labels in drop_columns_matching

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1549,7 +1549,7 @@ def drop_columns_matching(frame, pattern):
     is_arframe = not isinstance(frame, pd.DataFrame)
     df = to_pandas(frame) if is_arframe else frame
 
-    cols_to_drop = [col for col in df.columns if re.search(pattern, col)]
+    cols_to_drop = [col for col in df.columns if re.search(pattern, str(col))]
 
     if len(cols_to_drop) == len(df.columns):
         raise ValueError(

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3096,6 +3096,14 @@ def test_drop_columns_matching_normal():
     assert list(result.columns) == ["keep_c"]
 
 
+def test_drop_columns_matching_handles_non_string_pandas_columns():
+    df = pd.DataFrame([[1, 2, 3]], columns=[1, ("sensor", "temp"), "temp_a"])
+
+    result = ar.drop_columns_matching(df, "^temp")
+
+    assert list(result.columns) == [1, ("sensor", "temp")]
+
+
 def test_drop_columns_matching_no_match():
     df = pd.DataFrame({"a": [1], "b": [2]})
     result = ar.drop_columns_matching(df, "^temp_")


### PR DESCRIPTION
### Fixes #1472 

## Summary

Fixes a pandas interoperability issue in `drop_columns_matching()` where non-string column labels caused `re.search()` to raise a `TypeError`.

### Problem

The function previously performed regex matching directly on column labels:

```python
re.search(pattern, col)
```

This failed for valid pandas column labels such as integers or tuples.

### Fix

* Updated matching logic to use `str(col)` during regex matching
* Preserved original column labels when passing them to `df.drop(columns=...)`
* Added regression coverage for integer and tuple pandas column labels

### Example

Previously failing:

```python
df = pd.DataFrame([[1, 2, 3]], columns=[1, ("sensor", "temp"), "temp_a"])
ar.drop_columns_matching(df, r"^temp")
```

Now correctly drops only `"temp_a"` without raising errors.

### Tests

* Added focused regression test for non-string pandas column labels
* Existing `drop_columns_matching()` behavior remains unchanged
