### PR TITLE
fix : validate duckdb connection before registration

### DIFF
--- a/arnio/integrations/duckdb.py
+++ b/arnio/integrations/duckdb.py
@@ -53,8 +53,12 @@ def register_duckdb(
     if not name:
         raise ValueError("name must not be empty")
 
-    if not hasattr(conn, "register"):
-        raise TypeError("conn must be a DuckDB connection with a register() method")
+    register = getattr(conn, "register", None)
+
+    if not callable(register):
+        raise TypeError(
+            "conn must be a DuckDB connection with a callable register() method"
+        )
 
     df = to_pandas(frame)
     conn.register(name, df)

--- a/arnio/integrations/duckdb.py
+++ b/arnio/integrations/duckdb.py
@@ -53,5 +53,8 @@ def register_duckdb(
     if not name:
         raise ValueError("name must not be empty")
 
+    if not hasattr(conn, "register"):
+        raise TypeError("conn must be a DuckDB connection with a register() method")
+
     df = to_pandas(frame)
     conn.register(name, df)

--- a/examples/ignite_arnio_cleaning.ipynb
+++ b/examples/ignite_arnio_cleaning.ipynb
@@ -18,7 +18,6 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "\n",
     "import arnio as ar\n",
     "\n",
     "# 1. Setup sample messy dataset with generic tracking tokens\n",

--- a/examples/ignite_arnio_cleaning.ipynb
+++ b/examples/ignite_arnio_cleaning.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "\n",
     "import arnio as ar\n",
     "\n",
     "# 1. Setup sample messy dataset with generic tracking tokens\n",

--- a/tests/test_integrations_duckdb.py
+++ b/tests/test_integrations_duckdb.py
@@ -46,7 +46,7 @@ def test_register_duckdb_invalid_connection_object():
 
     with pytest.raises(
         TypeError,
-        match="conn must be a DuckDB connection with a register\\(\\) method",
+        match="conn must be a DuckDB connection with a callable register\\(\\) method",
     ):
         ar.register_duckdb(frame, object(), "tbl")
 
@@ -58,6 +58,21 @@ def test_register_duckdb_none_connection():
 
     with pytest.raises(
         TypeError,
-        match="conn must be a DuckDB connection with a register\\(\\) method",
+        match="conn must be a DuckDB connection with a callable register\\(\\) method",
     ):
         ar.register_duckdb(frame, None, "tbl")
+
+
+def test_register_duckdb_noncallable_register_attribute():
+    import pandas as pd
+
+    class FakeConnection:
+        register = 123
+
+    frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+    with pytest.raises(
+        TypeError,
+        match="conn must be a DuckDB connection with a callable register\\(\\) method",
+    ):
+        ar.register_duckdb(frame, FakeConnection(), "tbl")

--- a/tests/test_integrations_duckdb.py
+++ b/tests/test_integrations_duckdb.py
@@ -37,3 +37,27 @@ def test_register_duckdb_empty_name():
 
     with pytest.raises(ValueError):
         ar.register_duckdb(frame, conn, "")
+
+
+def test_register_duckdb_invalid_connection_object():
+    import pandas as pd
+
+    frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+    with pytest.raises(
+        TypeError,
+        match="conn must be a DuckDB connection with a register\\(\\) method",
+    ):
+        ar.register_duckdb(frame, object(), "tbl")
+
+
+def test_register_duckdb_none_connection():
+    import pandas as pd
+
+    frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+    with pytest.raises(
+        TypeError,
+        match="conn must be a DuckDB connection with a register\\(\\) method",
+    ):
+        ar.register_duckdb(frame, None, "tbl")


### PR DESCRIPTION
## Summary

Adds explicit validation for the DuckDB connection object in `register_duckdb()` before calling `conn.register(...)`.

This PR:

* validates that `conn` exposes the expected DuckDB registration API
* raises a clear `TypeError` for invalid connection objects instead of exposing a raw `AttributeError`
* preserves existing behavior for valid DuckDB connections
* adds focused tests for:

  * `None`
  * `object()`
  * valid DuckDB connections when the dependency is available

## Linked issue

Fixes #1404

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

```bash id="3lf9vn"
ruff check .
black .
pytest tests/test_integrations_duckdb.py -q
```

Result:

* validation tests pass locally
* valid DuckDB registration behavior preserved
* invalid connection objects now raise clear `TypeError`s

## Screenshots / Media

N/A

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR intentionally keeps the change narrowly scoped to connection validation in `register_duckdb()` and related integration tests only.
