### PR TITLE
fix: validate file_path type in DataQualityReport.to_html

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import html
 import json
 import math
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -24,8 +25,6 @@ from .cleaning import (
 )
 from .convert import to_pandas
 from .frame import ArFrame
-
-import os
 
 
 class CleaningSuggestion(tuple):

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -406,9 +406,13 @@ class DataQualityReport:
         automatically via ``_repr_html_``.
         """
         if file_path is not None:
-            if isinstance(file_path, bool) or not isinstance(file_path, (str, bytes, os.PathLike)):
-                raise TypeError(f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}")
-        
+            if isinstance(file_path, bool) or not isinstance(
+                file_path, (str, bytes, os.PathLike)
+            ):
+                raise TypeError(
+                    f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
+                )
+
         max_suggestions = self._validate_max_suggestions(max_suggestions)
         html_out = self._to_html_dashboard(
             full_document=True,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -25,6 +25,8 @@ from .cleaning import (
 from .convert import to_pandas
 from .frame import ArFrame
 
+import os
+
 
 class CleaningSuggestion(tuple):
     """A data quality cleaning suggestion that is backwards-compatible with tuples.
@@ -403,6 +405,10 @@ class DataQualityReport:
         In notebook environments, ``DataQualityReport`` will render a compact dashboard
         automatically via ``_repr_html_``.
         """
+        if file_path is not None:
+            if isinstance(file_path, bool) or not isinstance(file_path, (str, bytes, os.PathLike)):
+                raise TypeError(f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}")
+        
         max_suggestions = self._validate_max_suggestions(max_suggestions)
         html_out = self._to_html_dashboard(
             full_document=True,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1506,6 +1506,7 @@ def test_data_quality_report_to_html(tmp_path):
     assert out_path.exists()
     assert out_path.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
+
 def test_report_to_html_rejects_invalid_filepath_types():
     report = ar.DataQualityReport(
         row_count=0,
@@ -1518,10 +1519,11 @@ def test_report_to_html_rejects_invalid_filepath_types():
     )
 
     invalid_paths = [True, False, 123, object()]
-    
+
     for invalid_path in invalid_paths:
         with pytest.raises(TypeError, match="must be a string, bytes, or os.PathLike"):
             report.to_html(file_path=invalid_path)
+
 
 def test_report_to_html_limits_suggestions():
     report = ar.DataQualityReport(

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1506,6 +1506,22 @@ def test_data_quality_report_to_html(tmp_path):
     assert out_path.exists()
     assert out_path.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
+def test_report_to_html_rejects_invalid_filepath_types():
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[],
+    )
+
+    invalid_paths = [True, False, 123, object()]
+    
+    for invalid_path in invalid_paths:
+        with pytest.raises(TypeError, match="must be a string, bytes, or os.PathLike"):
+            report.to_html(file_path=invalid_path)
 
 def test_report_to_html_limits_suggestions():
     report = ar.DataQualityReport(


### PR DESCRIPTION
**Description:**

This adds a strict type guard to `DataQualityReport.to_html` to explicitly reject bool and other non-path values, preventing them from being passed to `open()`. Valid `str`, `bytes`, and `os.PathLike` behavior is preserved.

Added regression tests for `True`, `False`, `123`, and `object()`.

Fixes #1460