### PR TITLE
fix: validate profile exclude_columns before len checks

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -932,23 +932,25 @@ def profile(
     if approx_top_values_sample_size <= 0:
         raise ValueError("approx_top_values_sample_size must be positive")
 
-    has_exclusions = exclude_columns is not None and len(exclude_columns) > 0
+    normalized_exclude_columns: list[str] = []
 
     if exclude_columns is not None:
-        exclude_columns = _validate_column_sequence(
+        normalized_exclude_columns = _validate_column_sequence(
             exclude_columns,
             argument_name="exclude_columns",
         )
         validate_columns_exist(
             frame,
-            exclude_columns,
+            normalized_exclude_columns,
             operation="profile",
         )
+
+    has_exclusions = len(normalized_exclude_columns) > 0
 
     df = to_pandas(frame)
 
     if has_exclusions:
-        df = df.drop(columns=list(exclude_columns))
+        df = df.drop(columns=normalized_exclude_columns)
 
     row_count = len(df)
     column_count = len(df.columns)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -976,6 +976,20 @@ def test_profile_exclude_columns_rejects_missing_column(sample_csv):
         ar.profile(frame, exclude_columns=["missing"])
 
 
+@pytest.mark.parametrize(
+    "exclude_columns",
+    [
+        123,
+        (name for name in ["name"]),
+    ],
+)
+def test_profile_exclude_columns_rejects_non_sequences(sample_csv, exclude_columns):
+    frame = ar.read_csv(sample_csv)
+
+    with pytest.raises(TypeError, match="exclude_columns must be a sequence"):
+        ar.profile(frame, exclude_columns=exclude_columns)
+
+
 def test_profile_exclude_columns_rejects_bare_string(sample_csv):
     frame = ar.read_csv(sample_csv)
 
@@ -988,6 +1002,16 @@ def test_profile_exclude_columns_rejects_non_string_items(sample_csv):
 
     with pytest.raises(TypeError, match="exclude_columns must contain only string"):
         ar.profile(frame, exclude_columns=["name", 123])
+
+
+def test_profile_exclude_columns_accepts_empty_list(sample_csv):
+    frame = ar.read_csv(sample_csv)
+
+    full_report = ar.profile(frame)
+    report = ar.profile(frame, exclude_columns=[])
+
+    assert list(report.columns) == list(full_report.columns)
+    assert report.column_count == full_report.column_count
 
 
 def test_profile_exclude_columns_scopes_report_metrics_and_suggestions(tmp_path):


### PR DESCRIPTION
## Summary
Restore Arnio-style validation for `profile(exclude_columns=...)` by validating and normalizing `exclude_columns` before any `len()` check.

This change:
- normalizes `exclude_columns` before computing `has_exclusions`
- keeps `validate_columns_exist(...)` on the normalized list
- adds regression coverage for integer input, generator/non-sequence input, and valid empty lists

## Linked issue
Fixes #1436

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `python3 -m pytest tests/test_quality.py -v`
  - `python3 -m pytest tests/test_quality.py -k "exclude_columns"`
  - `ruff check arnio/quality.py tests/test_quality.py`
  - `black --check arnio/quality.py tests/test_quality.py`

## Screenshots / Media
Not applicable.

## Performance Impact
No expected performance impact. This only changes validation ordering for `exclude_columns` before profiling work begins.

## GSSoC labels
Maintainers only. Existing issue labels already mark this as a bug and claimed GSSoC task.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
No docs update is included because the public API signature and documented `exclude_columns` behavior stay the same; this PR restores the intended validation/error path for invalid inputs.
