### PR TITLE
fix: add strict bool validation for return_metadata, dry_run, and verbose in pipeline()

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -318,6 +318,14 @@ def pipeline(
     ...     ("drop_duplicates", {"keep": "first"}),
     ... ])
     """
+    if not isinstance(return_metadata, bool):
+        raise TypeError(
+            f"return_metadata must be a bool, got {type(return_metadata).__name__!r}"
+        )
+    if not isinstance(dry_run, bool):
+        raise TypeError(f"dry_run must be a bool, got {type(dry_run).__name__!r}")
+    if not isinstance(verbose, bool):
+        raise TypeError(f"verbose must be a bool, got {type(verbose).__name__!r}")
     with _REGISTRY_LOCK:
         python_step_registry = dict(_PYTHON_STEP_REGISTRY)
         namespaced_builtin_steps = _get_namespaced_builtin_steps(python_step_registry)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1662,3 +1662,33 @@ def test_pipeline_dry_run_false_metadata_unchanged():
     assert meta["row_counts"][0]["after"] < frame.shape[0]
     assert meta["step_timings"][0]["seconds"] >= 0
     assert meta["row_counts"][0].get("dry_run") is False
+
+
+def test_pipeline_return_metadata_non_bool_raises():
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="return_metadata"):
+        ar.pipeline(frame, [("strip_whitespace",)], return_metadata="yes")
+
+
+def test_pipeline_dry_run_non_bool_raises():
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="dry_run"):
+        ar.pipeline(frame, [("strip_whitespace",)], dry_run=1)
+
+
+def test_pipeline_verbose_non_bool_raises():
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="verbose"):
+        ar.pipeline(frame, [("strip_whitespace",)], verbose=None)
+
+
+def test_pipeline_bool_flags_valid():
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    result = ar.pipeline(
+        frame,
+        [("strip_whitespace",)],
+        return_metadata=True,
+        dry_run=False,
+        verbose=True,
+    )
+    assert isinstance(result, tuple)


### PR DESCRIPTION
Fixes #1448

## What changed
- Added explicit `isinstance(value, bool)` validation for `return_metadata`, `dry_run`, and `verbose` at the start of `pipeline()`
- Raises a clear `TypeError` for non-boolean values, consistent with other public API validation in the codebase

## Tests
- Added tests for invalid inputs (strings, integers, `None`) in `tests/test_pipeline.py`
- Added test for valid boolean inputs