### PR TITLE
fix: add benchmark_strip_whitespace.csv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,4 @@ benchmarks/benchmark_sparse_nulls.csv
 benchmarks/benchmark_sparse_nulls_dense.csv
 benchmark_results.json
 benchmark_run_output.txt
+benchmarks/benchmark_strip_whitespace.csv


### PR DESCRIPTION
Fixes #1446

## What changed
- Added `benchmarks/benchmark_strip_whitespace.csv` to `.gitignore` to prevent generated benchmark artifact from appearing as untracked file