### PR TITLE
fix: add positive_int validator for --runs and --rows CLI args in benchmark scripts

### DIFF
--- a/benchmarks/benchmark_clip_numeric.py
+++ b/benchmarks/benchmark_clip_numeric.py
@@ -38,6 +38,17 @@ UPPER = 100.0
 # ---------------------------------------------------------------------------
 
 
+def _positive_int(value):
+    """Argparse type validator that requires a positive integer."""
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer")
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"{value!r} must be >= 1")
+    return ivalue
+
+
 def _make_frame(n_rows: int) -> ar.ArFrame:
     """Return an ArFrame with two numeric columns and one string column."""
     rng = np.random.default_rng(0)
@@ -153,7 +164,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Benchmark native clip_numeric vs pandas"
     )
-    parser.add_argument("--rows", type=int, default=1_000_000, help="Number of rows")
-    parser.add_argument("--runs", type=int, default=5, help="Repetitions per engine")
+    parser.add_argument(
+        "--rows", type=_positive_int, default=1_000_000, help="Number of rows"
+    )
+    parser.add_argument(
+        "--runs", type=_positive_int, default=5, help="Repetitions per engine"
+    )
     args = parser.parse_args()
     run(n_rows=args.rows, runs=args.runs)

--- a/benchmarks/benchmark_numeric_parse.py
+++ b/benchmarks/benchmark_numeric_parse.py
@@ -36,6 +36,17 @@ import arnio as ar
 DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
 
 
+def _positive_int(value):
+    """Argparse type validator that requires a positive integer."""
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer")
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"{value!r} must be >= 1")
+    return ivalue
+
+
 def _write_csv(path: Path, n_rows: int) -> None:
     """Write a CSV with int and float columns (no nulls for simplicity)."""
     rng = np.random.default_rng(42)
@@ -126,7 +137,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Benchmark arnio numeric CSV parse vs pandas"
     )
-    parser.add_argument("--rows", type=int, default=500_000, help="Number of rows")
-    parser.add_argument("--runs", type=int, default=5, help="Repetitions per engine")
+    parser.add_argument(
+        "--rows", type=_positive_int, default=500_000, help="Number of rows"
+    )
+    parser.add_argument(
+        "--runs", type=_positive_int, default=5, help="Repetitions per engine"
+    )
     args = parser.parse_args()
     run(n_rows=args.rows, runs=args.runs)

--- a/benchmarks/benchmark_pipeline_clone.py
+++ b/benchmarks/benchmark_pipeline_clone.py
@@ -40,6 +40,17 @@ STEPS = [
 ]
 
 
+def _positive_int(value):
+    """Argparse type validator that requires a positive integer."""
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer")
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"{value!r} must be >= 1")
+    return ivalue
+
+
 def _make_frame(n_rows: int) -> ar.ArFrame:
     """2 string columns + 18 int64 columns = 20 columns total."""
     rng = np.random.default_rng(42)
@@ -94,7 +105,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Benchmark pipeline clone overhead optimization"
     )
-    parser.add_argument("--rows", type=int, default=500_000, help="Number of rows")
-    parser.add_argument("--runs", type=int, default=5, help="Repetitions")
+    parser.add_argument(
+        "--rows", type=_positive_int, default=500_000, help="Number of rows"
+    )
+    parser.add_argument("--runs", type=_positive_int, default=5, help="Repetitions")
     args = parser.parse_args()
     run(n_rows=args.rows, runs=args.runs)

--- a/benchmarks/benchmark_profile_duplicate_count.py
+++ b/benchmarks/benchmark_profile_duplicate_count.py
@@ -37,6 +37,17 @@ import arnio as ar
 from arnio.convert import to_pandas
 
 
+def _positive_int(value):
+    """Argparse type validator that requires a positive integer."""
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer")
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"{value!r} must be >= 1")
+    return ivalue
+
+
 def _make_frame(n_rows: int) -> ar.ArFrame:
     """Return an ArFrame with ~10% duplicate rows and mixed dtypes."""
     rng = np.random.default_rng(42)
@@ -108,7 +119,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Benchmark hash_pandas_object vs df.duplicated() for duplicate counting"
     )
-    parser.add_argument("--rows", type=int, default=500_000, help="Number of rows")
-    parser.add_argument("--runs", type=int, default=5, help="Repetitions per approach")
+    parser.add_argument(
+        "--rows", type=_positive_int, default=500_000, help="Number of rows"
+    )
+    parser.add_argument(
+        "--runs", type=_positive_int, default=5, help="Repetitions per approach"
+    )
     args = parser.parse_args()
     run(n_rows=args.rows, runs=args.runs)

--- a/benchmarks/benchmark_sparse_nulls.py
+++ b/benchmarks/benchmark_sparse_nulls.py
@@ -47,6 +47,17 @@ import arnio as ar
 # ---------------------------------------------------------------------------
 
 
+def _positive_int(value):
+    """Argparse type validator that requires a positive integer."""
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid integer")
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"{value!r} must be >= 1")
+    return ivalue
+
+
 def _generate_csv(rows, path, null_density, seed=42):
     """Generate a deterministic CSV with controlled null density."""
     if DRY_RUN:
@@ -288,7 +299,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Benchmark sparse-null workloads: arnio vs pandas"
     )
-    parser.add_argument("--rows", type=int, default=1_000_000, help="Number of rows")
-    parser.add_argument("--runs", type=int, default=5, help="Repetitions per density")
+    parser.add_argument(
+        "--rows", type=_positive_int, default=1_000_000, help="Number of rows"
+    )
+    parser.add_argument(
+        "--runs", type=_positive_int, default=5, help="Repetitions per density"
+    )
     args = parser.parse_args()
     run(rows=args.rows, runs=args.runs)


### PR DESCRIPTION
Fixes #1445

## What changed
- Added `_positive_int` argparse validator to 5 benchmark scripts: `benchmark_numeric_parse.py`, `benchmark_clip_numeric.py`, `benchmark_pipeline_clone.py`, `benchmark_profile_duplicate_count.py`, `benchmark_sparse_nulls.py`
- `--runs 0`, `--runs -1`, `--rows 0`, `--rows -1` now fail with a clear argparse error instead of crashing with `ZeroDivisionError`

## Validation
- `python3 benchmarks/benchmark_numeric_parse.py --rows 1 --runs 0` clear argparse error
- `python3 benchmarks/benchmark_numeric_parse.py --rows -1 --runs 1` clear argparse error
- Dry run passes: `ARNIO_BENCHMARK_DRY_RUN=1 python3 benchmarks/benchmark_numeric_parse.py`