### PR TITLE
fix: validate encoding type before UTF-8 checks in read_csv and scan_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -27,6 +27,8 @@ from .frame import ArFrame
 
 def _is_utf8_encoding(encoding: str) -> bool:
     """Return whether the encoding should be treated as raw UTF-8 input."""
+    if not isinstance(encoding, str):
+        raise TypeError(f"encoding must be a string, got {type(encoding).__name__!r}")
     return encoding.lower().replace("_", "-") in {"utf-8", "utf8"}
 
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -2608,3 +2608,38 @@ class TestArFrameStr:
     def test_str_returns_string(self, sample_csv):
         frame = ar.read_csv(sample_csv)
         assert isinstance(str(frame), str)
+
+
+def test_read_csv_encoding_non_string_raises_type_error(tmp_path):
+    path = tmp_path / "test.csv"
+    path.write_text("a,b\n1,2\n")
+    with pytest.raises(TypeError, match="encoding must be a string"):
+        ar.read_csv(path, encoding=123)
+
+
+def test_read_csv_encoding_none_raises_type_error(tmp_path):
+    path = tmp_path / "test.csv"
+    path.write_text("a,b\n1,2\n")
+    with pytest.raises(TypeError, match="encoding must be a string"):
+        ar.read_csv(path, encoding=None)
+
+
+def test_read_csv_encoding_list_raises_type_error(tmp_path):
+    path = tmp_path / "test.csv"
+    path.write_text("a,b\n1,2\n")
+    with pytest.raises(TypeError, match="encoding must be a string"):
+        ar.read_csv(path, encoding=["utf-8"])
+
+
+def test_scan_csv_encoding_non_string_raises_type_error(tmp_path):
+    path = tmp_path / "test.csv"
+    path.write_text("a,b\n1,2\n")
+    with pytest.raises(TypeError, match="encoding must be a string"):
+        ar.scan_csv(path, encoding=123)
+
+
+def test_scan_csv_encoding_none_raises_type_error(tmp_path):
+    path = tmp_path / "test.csv"
+    path.write_text("a,b\n1,2\n")
+    with pytest.raises(TypeError, match="encoding must be a string"):
+        ar.scan_csv(path, encoding=None)


### PR DESCRIPTION
Fixes #1440

## What changed
- Added `isinstance(encoding, str)` check in `_is_utf8_encoding()` before calling `encoding.lower()`
- Non-string encodings now raise a clear `TypeError` instead of `AttributeError`

## Tests
- Added 5 regression tests in `tests/test_csv.py` for `read_csv()` and `scan_csv()` with `encoding=123`, `encoding=None`, and `encoding=["utf-8"]`