### PR TITLE
fix: validate auto_clean return_report boolean

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1842,6 +1842,8 @@ def auto_clean(
     if mode not in {"safe", "strict"}:
         raise ValueError("mode must be 'safe' or 'strict'")
 
+    if not isinstance(return_report, bool):
+        raise TypeError("return_report must be a bool")
     if not isinstance(dry_run, bool):
         raise TypeError("dry_run must be a bool")
     if not isinstance(allow_lossy_casts, bool):

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -456,6 +456,38 @@ def test_auto_clean_dry_run_with_return_report_raises():
         ar.auto_clean(frame, dry_run=True, return_report=True)
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "yes",
+        1,
+        None,
+        [],
+        object(),
+    ],
+    ids=["string", "integer", "none", "list", "object"],
+)
+def test_auto_clean_rejects_non_boolean_return_report(value):
+    frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
+
+    with pytest.raises(TypeError, match="return_report must be a bool"):
+        ar.auto_clean(frame, return_report=value)
+
+
+def test_auto_clean_accepts_boolean_return_report_values():
+    frame = ar.from_pandas(pd.DataFrame({"name": [" Alice ", " Bob "]}))
+
+    clean_only = ar.auto_clean(frame, return_report=False)
+    clean_with_report = ar.auto_clean(frame, return_report=True)
+
+    assert isinstance(clean_only, ar.ArFrame)
+    assert isinstance(clean_with_report, tuple)
+    assert len(clean_with_report) == 2
+    cleaned, report = clean_with_report
+    assert isinstance(cleaned, ar.ArFrame)
+    assert isinstance(report, ar.DataQualityReport)
+
+
 def test_auto_clean_rejects_unknown_mode(sample_csv):
     frame = ar.read_csv(sample_csv)
 


### PR DESCRIPTION
## Summary
- add strict boolean validation for `auto_clean(return_report=...)` alongside the existing `dry_run`, `allow_lossy_casts`, and `explain` checks
- add regression tests for invalid string, integer, `None`, list, and object values
- preserve the existing valid `True` and `False` return shapes

## Linked issue
Fixes #1437

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [ ] `make lint`
- [x] Other:
  - `python3 -m pytest tests/test_quality.py -k 'auto_clean_rejects_non_boolean_return_report or auto_clean_accepts_boolean_return_report_values' -q`
  - `python3 -m pytest tests/test_quality.py -q`
  - `ruff check arnio/quality.py tests/test_quality.py`
  - `black --check arnio/quality.py tests/test_quality.py`

`make lint` is currently blocked by a pre-existing repo issue in `examples/ignite_arnio_cleaning.ipynb` (`ruff` import-order error) that is unrelated to this change.

## Screenshots / Media
- N/A

## Performance Impact
- None. This change only adds argument validation and tests.

## GSSoC labels
- Maintainers only.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
- Kept the PR limited to the exact maintainer-requested scope from issue #1437.
