### PR TITLE
fix: scan_csv accepts non-boolean has_header values

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -959,7 +959,7 @@ def scan_csv(
     config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
     config.decimal_separator = decimal_separator
     config.thousands_separator = thousands_separator
-    config.has_header = has_header
+    config.has_header = _validate_bool_option(has_header, "has_header")
     config.encoding_errors = encoding_errors
 
     if null_values is not None:

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1476,6 +1476,21 @@ class TestScanCsv:
 
         assert list(frame.columns) == list(schema.keys())
 
+    def test_scan_csv_has_header_validation(self, tmp_path):
+        csv_content = "1,Alice\n2,Bob\n"
+        csv_file = tmp_path / "validation.csv"
+        csv_file.write_text(csv_content)
+
+        # Assert that invalid truthy/falsy types raise a TypeError
+        with pytest.raises(TypeError, match="has_header must be True or False"):
+            ar.scan_csv(csv_file, has_header=1)
+
+        with pytest.raises(TypeError, match="has_header must be True or False"):
+            ar.scan_csv(csv_file, has_header=None)
+
+        with pytest.raises(TypeError, match="has_header must be True or False"):
+            ar.scan_csv(csv_file, has_header="false")
+
     def test_read_csv_encoding_errors_preserve_valid_utf8(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary
Fixed a bug in `scan_csv()` where it failed to validate the `has_header` parameter. Previously, non-boolean values (like `1`, `None`, or `"false"`) were silently accepted and caused unexpected schema inference behavior. Now, `has_header` is routed through the `_validate_bool_option()` helper function to strictly enforce boolean inputs and raise a `TypeError` on invalid types, matching the behavior of `read_csv()`. Added corresponding unit tests inside `tests/test_csv.py`.

## Linked issue
Fixes #1407

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [x] `make lint` : shows one error with a file not associated with this issue `examples/ignite_arnio_cleaning.ipynb`
- [x] Other: Ran `pytest tests/test_csv.py` locally and confirmed all validation tests pass successfully.

## Screenshots / Media
N/A 

## Performance Impact
None

## GSSoC labels
- level:beginner
- type:bug
- area:csv-parser
- area:python-api

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes