### PR TITLE
fix: validate pipeline frame input

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -318,6 +318,8 @@ def pipeline(
     ...     ("drop_duplicates", {"keep": "first"}),
     ... ])
     """
+    if not isinstance(frame, ArFrame):
+        raise TypeError("frame must be an ArFrame")
     if not isinstance(return_metadata, bool):
         raise TypeError(
             f"return_metadata must be a bool, got {type(return_metadata).__name__!r}"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -491,6 +491,15 @@ class TestPipeline:
         result = ar.pipeline(frame, [])
         assert result.shape == frame.shape
 
+    @pytest.mark.parametrize("invalid_frame", ["not-frame", None])
+    def test_pipeline_rejects_invalid_frame_with_empty_steps(self, invalid_frame):
+        with pytest.raises(TypeError, match="frame must be an ArFrame"):
+            ar.pipeline(invalid_frame, [])
+
+    def test_pipeline_rejects_invalid_frame_before_non_empty_steps(self):
+        with pytest.raises(TypeError, match="frame must be an ArFrame"):
+            ar.pipeline("not-frame", [("strip_whitespace",)])
+
     def test_pipeline_dry_run_returns_original_frame(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 


### PR DESCRIPTION
## Summary
Added early validation in `ar.pipeline()` so non-`ArFrame` inputs raise a clear `TypeError` instead of being returned unchanged when `steps=[]`.

## Linked issue
Fixes #1447

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `pytest tests/test_pipeline.py -v` — 103 passed
  - `pytest tests/ -v` — 1935 passed, 44 skipped
  - `ruff check arnio/pipeline.py tests/test_pipeline.py` — passed
  - `ruff check arnio tests` — passed
  - `black --check arnio/pipeline.py tests/test_pipeline.py` — passed

Note: `ruff check .` reports an unrelated existing import-order issue in `examples/ignite_arnio_cleaning.ipynb`, which was left untouched to keep this PR focused.

## Screenshots / Media
Not applicable.

## Performance Impact
Not applicable. This is a small input validation fix and does not change pipeline execution behavior for valid `ArFrame` inputs.

## GSSoC labels
Maintainers only.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The fix is intentionally limited to an early `isinstance(frame, ArFrame)` guard in `pipeline()` plus focused tests for invalid frame inputs with empty and non-empty step lists.