### PR TITLE
fix: reject bare strings in parse_bool_strings token sets

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -840,11 +840,11 @@ def parse_bool_strings(
     """
     from .convert import from_pandas, to_pandas
 
-    if isinstance(true_values, (str, bytes)):
+    if true_values is not None and isinstance(true_values, str):
         raise TypeError(
             "true_values must be a set/list/tuple of strings, not a bare string"
         )
-    if isinstance(false_values, (str, bytes)):
+    if false_values is not None and isinstance(false_values, str):
         raise TypeError(
             "false_values must be a set/list/tuple of strings, not a bare string"
         )

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -840,11 +840,11 @@ def parse_bool_strings(
     """
     from .convert import from_pandas, to_pandas
 
-    if true_values is not None and isinstance(true_values, str):
+    if true_values is not None and isinstance(true_values, (str, bytes)):
         raise TypeError(
             "true_values must be a set/list/tuple of strings, not a bare string"
         )
-    if false_values is not None and isinstance(false_values, str):
+    if false_values is not None and isinstance(false_values, (str, bytes)):
         raise TypeError(
             "false_values must be a set/list/tuple of strings, not a bare string"
         )

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -840,6 +840,15 @@ def parse_bool_strings(
     """
     from .convert import from_pandas, to_pandas
 
+    if isinstance(true_values, (str, bytes)):
+        raise TypeError(
+            "true_values must be a set/list/tuple of strings, not a bare string"
+        )
+    if isinstance(false_values, (str, bytes)):
+        raise TypeError(
+            "false_values must be a set/list/tuple of strings, not a bare string"
+        )
+
     df = to_pandas(frame).copy()
     if true_values is None:
         true_values = {"true", "yes", "y", "1"}

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1839,6 +1839,22 @@ class TestParseBoolStrings:
         cleaned2 = ar.to_pandas(result2)
         assert cleaned2["active"].tolist() == ["True", "false", "True", "no"]
 
+    def test_parse_bool_strings_rejects_bare_strings(self):
+        df = pd.DataFrame({"active": ["yes", "no"]}, dtype=object)
+        frame = ar.from_pandas(df)
+
+        with pytest.raises(
+            TypeError,
+            match="true_values must be a set/list/tuple of strings, not a bare string",
+        ):
+            ar.parse_bool_strings(frame, true_values="yes")
+
+        with pytest.raises(
+            TypeError,
+            match="false_values must be a set/list/tuple of strings, not a bare string",
+        ):
+            ar.parse_bool_strings(frame, false_values="no")
+
 
 class TestRenameColumns:
     def test_rename(self, sample_csv):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1855,6 +1855,18 @@ class TestParseBoolStrings:
         ):
             ar.parse_bool_strings(frame, false_values="no")
 
+        with pytest.raises(
+            TypeError,
+            match="true_values must be a set/list/tuple of strings, not a bare string",
+        ):
+            ar.parse_bool_strings(frame, true_values=b"yes")
+
+        with pytest.raises(
+            TypeError,
+            match="false_values must be a set/list/tuple of strings, not a bare string",
+        ):
+            ar.parse_bool_strings(frame, false_values=b"no")
+
 
 class TestRenameColumns:
     def test_rename(self, sample_csv):


### PR DESCRIPTION
## Summary
Blocked `parse_bool_strings()` from accepting bare strings (`str` or `bytes`) as arguments for `true_values` and `false_values`. Previously, passing a bare string (like `"yes"`) would silently iterate through individual characters (`'y'`, `'e'`, `'s'`), changing parsing logic and leading to unexpected behavior. The function now immediately raises a `TypeError`.

## Linked issue
Fixes #1428

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Ran the entire test suite locally to verify the new parameter checks work perfectly without breaking existing functionality.
- [x] `make test`:  passed 1933 tests successfully.
- [x] `make lint`

## Screenshots / Media
N/A

## Performance Impact
None

## GSSoC labels
- level:beginner
- type:bug
- area:cleaning
- area:python-api

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes