### PR TITLE
fix: Added footer animation and focus state to  footer-navigation-links

### DIFF
--- a/website/css/components.css
+++ b/website/css/components.css
@@ -631,7 +631,7 @@ pre:hover .copy-btn {
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-wide);
-  color: #f97316;
+  color: var(--color-text);
   margin-bottom: var(--space-4);
 }
 

--- a/website/css/components.css
+++ b/website/css/components.css
@@ -631,7 +631,7 @@ pre:hover .copy-btn {
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: var(--letter-spacing-wide);
-  color: var(--color-text);
+  color: #f97316;
   margin-bottom: var(--space-4);
 }
 
@@ -646,13 +646,36 @@ pre:hover .copy-btn {
 }
 
 .footer-links a {
+  position: relative;
+  display: inline-block;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   text-decoration: none;
+  transition: color var(--transition-fast);
 }
 
-.footer-links a:hover {
-  color: var(--color-accent-text);
+.footer-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -2px;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(to right, #ef4444, #f97316);
+  border-radius: var(--radius-full);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.3s ease;
+}
+
+.footer-links a:hover,
+.footer-links a:focus-visible {
+  color: var(--color-text);
+}
+
+.footer-links a:hover::after,
+.footer-links a:focus-visible::after {
+  transform: scaleX(1);
 }
 
 .footer-bottom {


### PR DESCRIPTION
## Summary
- Added smooth underline slide-in animation to footer navigation links on hover and keyboard focus, matching the existing navbar interaction style
- Added `:focus-visible` state for keyboard accessibility


## Linked issue
Fixes #1486 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other: Opened website/index.html in browser, verified hover underline animation, keyboard tab focus, and appearance in both light and dark mode.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
No breaking changes. Only website/css/components.css is modified. The heading color and animation reuse the same gradient (#ef4444 → #f97316) already present in the navbar, so no new design tokens are introduced.

##preview - for visual review
<img width="1575" height="417" alt="image" src="https://github.com/user-attachments/assets/3044cb9d-07b7-4b5a-ae97-856d14c94a3e" />

