### PR TITLE
fix: validate from_pandas input type before accessing columns (#1422)

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -374,7 +374,8 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
     Raises
     ------
     TypeError
-        If DataFrame contains unsupported nested/complex types.
+        If the input is not a pandas DataFrame, or if DataFrame contains
+        unsupported nested/complex types.
 
     Examples
     --------
@@ -382,6 +383,11 @@ def from_pandas(df: pd.DataFrame) -> ArFrame:
     >>> df = pd.DataFrame({"name": ["Alice"], "age": [25]})
     >>> frame = ar.from_pandas(df)
     """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(
+            f"from_pandas() expects a pandas DataFrame, got {type(df).__name__}"
+        )
+
     _validate_unique_column_labels(df.columns)
 
     columns = {}

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1032,3 +1032,20 @@ class TestToArrow:
         assert ages[1] == 25
         assert ages[2] is None
         assert ages[3] == 28
+
+    def test_from_pandas_rejects_dict(self):
+        with pytest.raises(TypeError, match="expects a pandas DataFrame"):
+            ar.from_pandas({"x": [1]})
+
+    def test_from_pandas_rejects_none(self):
+        with pytest.raises(TypeError, match="expects a pandas DataFrame"):
+            ar.from_pandas(None)
+
+    def test_from_pandas_rejects_series(self):
+        with pytest.raises(TypeError, match="expects a pandas DataFrame"):
+            ar.from_pandas(pd.Series([1, 2, 3]))
+
+    def test_from_pandas_accepts_valid_dataframe(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        frame = ar.from_pandas(df)
+        assert frame.shape == (3, 1)


### PR DESCRIPTION
## Summary
Adds an explicit `isinstance(df, pd.DataFrame)` check at the start of `from_pandas()` to reject non-DataFrame inputs with a clear `TypeError` instead of a raw `AttributeError`.

## Linked issue
Fixes #1422

## Type of change
- [x] Bug fix

## Area
- [x] pandas interoperability
- [x] Python API / ArFrame

## Testing
- Added 4 tests: `test_from_pandas_rejects_dict`, `test_from_pandas_rejects_none`, `test_from_pandas_rejects_series`, `test_from_pandas_accepts_valid_dataframe`
- [x] Other: Tests added in `tests/test_convert.py`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] My PR title uses Conventional Commits (`fix: validate from_pandas input type before accessing columns`)
