### PR TITLE
fix(ci): clarify aggregate wheel matrix status in release dry-run summary

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -99,9 +99,9 @@ jobs:
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Version validation     | ${{ needs.validate-version.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| sdist build + twine    | ${{ needs.build_sdist.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Wheels + smoke (Linux) | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Wheels + smoke (macOS) | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Wheels + smoke (Win)   | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          # build_wheels is a matrix job, so needs.build_wheels.result
+          # represents the aggregate status across all wheel platforms.
+          echo "| Wheels + smoke (matrix) | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Package version:** ${{ needs.validate-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Fixes #1442 


## Summary

Fixes a misleading status summary in the release dry-run workflow where Linux, macOS, and Windows wheel rows all displayed the same aggregate matrix result from `needs.build_wheels.result`.

### Problem

`build_wheels` is implemented as a matrix job across:

* ubuntu-latest
* macos-latest
* windows-latest

However, the summary section used:

```yaml
needs.build_wheels.result
```

for separate Linux/macOS/Windows rows, even though this value represents the aggregate matrix result rather than platform-specific statuses.

This could incorrectly imply that all platforms failed when only a single matrix leg failed.

### Changes made

* Replaced the misleading per-platform wheel rows with a single aggregate matrix row
* Added a workflow comment clarifying that:

  * `needs.build_wheels.result` is aggregate for matrix jobs
  * the summary intentionally reports aggregate wheel status

### Result

The release dry-run summary now accurately reflects the available workflow status information without implying platform-specific results that are not actually available.


