### PR TITLE
fix: validate non-string field names in schema

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -539,6 +539,13 @@ class Schema:
             raise TypeError(
                 f"Schema 'fields' must be a mapping (like a dict), got {type(self.fields).__name__}"
             )
+
+        for key in self.fields:
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"Schema field names must be strings, got {type(key).__name__!r}: {key!r}"
+                )
+
         for name, field_def in self.fields.items():
             if not isinstance(field_def, Field):
                 raise TypeError(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -268,6 +268,24 @@ def test_schema_rejects_invalid_field_values_none(sample_csv):
         ar.validate(frame, {"id": None})
 
 
+def test_schema_rejects_non_string_field_name_integer(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(TypeError, match="Schema field names must be strings"):
+        ar.validate(frame, {1: ar.String()})
+
+
+def test_schema_rejects_non_string_field_name_none(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(TypeError, match="Schema field names must be strings"):
+        ar.validate(frame, {None: ar.String()})
+
+
+def test_schema_rejects_non_string_field_name_tuple(sample_csv):
+    frame = ar.read_csv(sample_csv)
+    with pytest.raises(TypeError, match="Schema field names must be strings"):
+        ar.validate(frame, {("a", "b"): ar.String()})
+
+
 def test_schema_validation_collects_row_level_issues(tmp_path):
     path = tmp_path / "bad.csv"
     path.write_text(

--- a/tests/test_schema_typecheck.py
+++ b/tests/test_schema_typecheck.py
@@ -6,3 +6,18 @@ import arnio as ar
 def test_schema_raises_type_error_for_list_of_fields():
     with pytest.raises(TypeError, match="Schema 'fields' must be a mapping"):
         ar.Schema([ar.String()])
+
+
+def test_schema_raises_type_error_for_integer_key():
+    with pytest.raises(TypeError, match="Schema field names must be strings"):
+        ar.Schema({1: ar.String()})
+
+
+def test_schema_raises_type_error_for_none_key():
+    with pytest.raises(TypeError, match="Schema field names must be strings"):
+        ar.Schema({None: ar.String()})
+
+
+def test_schema_raises_type_error_for_tuple_key():
+    with pytest.raises(TypeError, match="Schema field names must be strings"):
+        ar.Schema({("a", "b"): ar.String()})


### PR DESCRIPTION
## Summary
Add key-type validation in `Schema.__post_init__()` to reject non-string field names with a clear `TypeError`.

## Linked issue
Fixes #1410 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test`
- [x] `make lint`
- [x] Other: Verified locally by running `pytest tests/test_schema.py tests/test_schema_typecheck.py -v` and one little example.

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->
<img width="603" height="155" alt="image" src="https://github.com/user-attachments/assets/7ebd645e-35a9-4464-87d2-b679ef5fb64b" />

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
