### PR TITLE
fix: reject non-boolean Schema strict values

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -561,6 +561,8 @@ class Schema:
                     raise TypeError(
                         f"Schema 'unique' members must be strings, got {type(item).__name__} for element {item!r}."
                     )
+        if not isinstance(self.strict, bool):
+            raise TypeError("Schema 'strict' must be a boolean")
 
     def validate(
         self,

--- a/tests/test_schema_typecheck.py
+++ b/tests/test_schema_typecheck.py
@@ -6,3 +6,19 @@ import arnio as ar
 def test_schema_raises_type_error_for_list_of_fields():
     with pytest.raises(TypeError, match="Schema 'fields' must be a mapping"):
         ar.Schema([ar.String()])
+
+
+@pytest.mark.parametrize("bad_strict", ["yes", 1, None, 0, "false", 1.0])
+def test_schema_strict_rejects_non_bool(bad_strict):
+    with pytest.raises(TypeError, match="strict.*bool"):
+        ar.Schema({"x": ar.Int64()}, strict=bad_strict)
+
+
+def test_schema_strict_accepts_true():
+    schema = ar.Schema({"x": ar.Int64()}, strict=True)
+    assert schema.strict is True
+
+
+def test_schema_strict_accepts_false():
+    schema = ar.Schema({"x": ar.Int64()}, strict=False)
+    assert schema.strict is False


### PR DESCRIPTION
## Summary
Add `isinstance(strict, bool)` validation in `Schema.__post_init__()` so that non-boolean values like `"yes"`, `1`, or `None` are rejected at construction time with a clear `TypeError` instead of being silently interpreted by Python truthiness during validation.

## Linked issue
Fixes #1412 

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] Schema validation

## Testing
`python -m pytest tests/test_schema.py tests/test_schema_typecheck.py -v`
All 8 new strict-bool tests passed. Pre-existing failures are unrelated (C++ extension ABI mismatch, present before this change).
- [x] `make lint` — ruff and black clean on changed files

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: reject non-boolean Schema strict values`).

## Maintainer notes
No migration needed. `strict=True` and `strict=False` behavior is unchanged. The fix mirrors the existing pattern already used for `Field.nullable` and `Field.unique`.
