### PR TITLE
Fix schema handling and clean up whitespace in tests

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -275,11 +275,7 @@ def schema_to_dict(schema: dict | Any) -> dict:
             if isinstance(raw_field, str):
                 normalised[name] = {"type": raw_field}
             elif isinstance(raw_field, dict):
-                cleaned = {}
-                for k, v in sorted(raw_field.items()):
-                    cleaned[k] = sorted(v) if isinstance(v, set) else v
-                _validate_serializable(cleaned)
-                normalised[name] = cleaned
+                normalised[name] = _normalize_serializable(raw_field)
             else:
                 normalised[name] = raw_field
 


### PR DESCRIPTION
This pull request introduces improvements to how empty columns are handled in data frames and enhances the normalization and serialization of set values (including nested sets) in schema exports. It also adds or updates tests to ensure these behaviors are correct.

**Data cleaning improvements:**
* [`arnio/cleaning.py`](diffhunk://#diff-138b7884870118e7d98bb187177a6ed372cc4aa29ee51cb90b9a7ecafb3935f5R489-R491): The `drop_empty_columns` function now immediately returns the input frame if it has zero rows, preserving the schema even when the frame is empty.
* [`tests/test_cleaning.py`](diffhunk://#diff-6460affcd3ff926e6dd0a5315467a6f72a06a3c36126ca72344f94176dc66fc4R812-R821): Added a test to verify that `drop_empty_columns` preserves the schema (column names) for empty frames.

**Schema export and normalization improvements:**
* [`arnio/schema_export.py`](diffhunk://#diff-fa8e2a5de77223081155f59cd66ee00708daf8288d1b9e8e8bc13e1b532a8f46R152-R161): Introduced a `_deep_convert_sets` helper function to recursively convert sets (including nested sets) to sorted lists, ensuring consistent serialization and normalization.
* [`arnio/schema_export.py`](diffhunk://#diff-fa8e2a5de77223081155f59cd66ee00708daf8288d1b9e8e8bc13e1b532a8f46L232-R237): Updated the schema normalization logic to use `_deep_convert_sets`, so all set values (even nested) are properly handled during export.
* [`tests/test_schema_export.py`](diffhunk://#diff-17e36aebc5daf318d253b32348849e28f84a0eea9943b391919521dca0405501R226-R231): Added a test to confirm that nested sets are normalized to sorted lists of lists in schema exports.

**Other changes:**
* [`arnio/schema_export.py`](diffhunk://#diff-fa8e2a5de77223081155f59cd66ee00708daf8288d1b9e8e8bc13e1b532a8f46L91-L95): Removed explicit set handling from `_validate_serializable`, since sets are now always normalized before validation.


Closes #1266 