### PR TITLE
fix: validate normalize_whitespace columns input (#1371)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -786,14 +786,16 @@ def normalize_whitespace(frame, columns=None):
     df = to_pandas(frame) if is_arframe else frame.copy()
 
     if columns is not None:
-        cols = list(columns)
-        missing = [c for c in cols if c not in df.columns]
-        if missing:
-            available = list(df.columns)
-            raise ValueError(
+        cols = _validate_existing_column_sequence(
+            columns,
+            available_columns=df.columns,
+            argument_name="columns",
+            missing_error=ValueError,
+            missing_message=lambda missing, available: (
                 f"Missing columns for normalize_whitespace: {missing}. "
                 f"Available columns: {available}"
-            )
+            ),
+        )
         cols = [c for c in cols if df[c].dtype in ("object", "string")]
     else:
         cols = list(df.select_dtypes(include=["object", "string"]).columns)

--- a/tests/test_normalize_whitespace.py
+++ b/tests/test_normalize_whitespace.py
@@ -4,6 +4,12 @@ import pandas as pd
 import pytest
 
 import arnio as ar
+from arnio._core import _Frame
+from arnio.frame import ArFrame
+
+
+def _make_frame(columns: dict[str, list[object]]) -> ArFrame:
+    return ArFrame(_Frame.from_dict(columns, {}))
 
 
 def test_collapses_multiple_internal_spaces():
@@ -75,6 +81,33 @@ def test_missing_column_raises_value_error():
     frame = ar.from_pandas(pd.DataFrame({"name": ["hello world"]}))
     with pytest.raises(ValueError, match="Missing columns for normalize_whitespace"):
         ar.pipeline(frame, [("normalize_whitespace", {"columns": ["nonexistent"]})])
+
+
+def test_columns_string_raises_type_error():
+    frame = _make_frame({"name": ["hello world"]})
+    with pytest.raises(
+        TypeError,
+        match="columns must be a sequence of column names, not a string",
+    ):
+        ar.normalize_whitespace(frame, columns="name")
+
+
+def test_columns_with_non_string_item_raises_type_error():
+    frame = _make_frame({"name": ["hello world"]})
+    with pytest.raises(
+        TypeError,
+        match="columns must contain only string column names",
+    ):
+        ar.normalize_whitespace(frame, columns=[123])
+
+
+def test_pipeline_columns_string_raises_type_error():
+    frame = _make_frame({"name": ["hello world"]})
+    with pytest.raises(
+        TypeError,
+        match="columns must be a sequence of column names, not a string",
+    ):
+        ar.pipeline(frame, [("normalize_whitespace", {"columns": "name"})])
 
 
 def test_explicit_non_string_column_is_skipped():


### PR DESCRIPTION
## Summary
- reuse the shared column-sequence validator in normalize_whitespace()
- reject bare-string columns inputs and non-string column entries with clear TypeErrors
- keep the existing missing-column error and valid selected-column behavior unchanged
- add focused regression coverage for direct invalid columns input and pipeline invalid input

## Verification
- python -m pytest tests/test_normalize_whitespace.py -q -k "columns_string_raises_type_error or columns_with_non_string_item_raises_type_error or pipeline_columns_string_raises_type_error"
- python -m ruff check arnio/cleaning.py tests/test_normalize_whitespace.py
- python -m black --check arnio/cleaning.py tests/test_normalize_whitespace.py

Notes:
- The current local checkout has an unrelated from_pandas()/C++ binding mismatch on the broader normalize_whitespace test file, so I kept the local pytest verification focused on the new validation coverage that exercises this PR's exact scope.

Fixes #1371
