### PR TITLE
fix: add strip_whitespace tab and newline edge case coverage

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1223,6 +1223,23 @@ class TestStripWhitespace:
         df = ar.to_pandas(result)
         assert df["name"].iloc[0] == "Alice"
 
+    def test_strip_tabs_and_newlines(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["\tAlice\n", "  Bob\t"],
+                    "city": ["\nLondon ", "\tParis\t"],
+                }
+            )
+        )
+
+        result = ar.strip_whitespace(frame)
+
+        df = ar.to_pandas(result)
+
+        assert df["name"].tolist() == ["Alice", "Bob"]
+        assert df["city"].tolist() == ["London", "Paris"]
+
 
 class TestNormalizeCase:
     def test_lower(self, sample_csv):


### PR DESCRIPTION
## Summary

Adds focused edge-case test coverage for `strip_whitespace()` to verify handling of tab (`\t`) and newline (`\n`) characters in mixed whitespace scenarios.

## Changes

* added `test_strip_tabs_and_newlines` in `tests/test_cleaning.py`
* verified stripping of:

  * tabs
  * newlines
  * mixed leading/trailing whitespace
* validated consistent cleanup across multiple rows

## Validation

Test verified locally using:

```bash
pytest test_cleaning.py -k tabs_and_newlines
```

## Related Issue

Fixes #1515
