### PR TITLE
fix: raise TypeError for unsupported non-scalar fill values in fill_nulls

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -395,6 +395,11 @@ def fill_nulls(
                 f"Available columns: {available}"
             ),
         )
+    if not isinstance(value, (str, int, float, bool)):
+        raise TypeError(
+            f"fill value must be a supported scalar (str, int, float, or bool), "
+            f"got {type(value).__name__!r}"
+        )
     result = _fill_nulls(frame._frame, value, subset=subset)
     return ArFrame(result)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -136,7 +136,27 @@ class TestFillNulls:
 
         with pytest.raises(ValueError, match="Fill value is incompatible"):
             ar.fill_nulls(frame, "bad", subset=["x"])
+    
+    def test_fill_nulls_rejects_unsupported_types(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, None], "b": ["x", None]}))
 
+        for bad_value in [[1, 2], {"key": "val"}, object()]:
+            with pytest.raises(TypeError, match="fill value must be a supported scalar"):
+                ar.fill_nulls(frame, bad_value)
+
+    def test_fill_nulls_accepts_valid_scalars(self):
+        # numeric column → fill with numeric
+        frame_num = ar.from_pandas(pd.DataFrame({"a": [1.0, None]}))
+        for good_value in [0, 0.0, False]:
+            result = ar.fill_nulls(frame_num, good_value)
+            df = ar.to_pandas(result)
+            assert df["a"].isnull().sum() == 0, f"Nulls remain after filling with {good_value!r}"
+
+        # string column → fill with string
+        frame_str = ar.from_pandas(pd.DataFrame({"b": ["x", None]}))
+        result = ar.fill_nulls(frame_str, "missing")
+        df = ar.to_pandas(result)
+        assert df["b"].isnull().sum() == 0, "Nulls remain after filling with 'missing'"
 
 class TestWinsorizeOutliers:
     def test_winsorize_outliers_clips_numeric_values(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -136,12 +136,14 @@ class TestFillNulls:
 
         with pytest.raises(ValueError, match="Fill value is incompatible"):
             ar.fill_nulls(frame, "bad", subset=["x"])
-    
+
     def test_fill_nulls_rejects_unsupported_types(self):
         frame = ar.from_pandas(pd.DataFrame({"a": [1, None], "b": ["x", None]}))
 
         for bad_value in [[1, 2], {"key": "val"}, object()]:
-            with pytest.raises(TypeError, match="fill value must be a supported scalar"):
+            with pytest.raises(
+                TypeError, match="fill value must be a supported scalar"
+            ):
                 ar.fill_nulls(frame, bad_value)
 
     def test_fill_nulls_accepts_valid_scalars(self):
@@ -150,13 +152,16 @@ class TestFillNulls:
         for good_value in [0, 0.0, False]:
             result = ar.fill_nulls(frame_num, good_value)
             df = ar.to_pandas(result)
-            assert df["a"].isnull().sum() == 0, f"Nulls remain after filling with {good_value!r}"
+            assert (
+                df["a"].isnull().sum() == 0
+            ), f"Nulls remain after filling with {good_value!r}"
 
         # string column → fill with string
         frame_str = ar.from_pandas(pd.DataFrame({"b": ["x", None]}))
         result = ar.fill_nulls(frame_str, "missing")
         df = ar.to_pandas(result)
         assert df["b"].isnull().sum() == 0, "Nulls remain after filling with 'missing'"
+
 
 class TestWinsorizeOutliers:
     def test_winsorize_outliers_clips_numeric_values(self):


### PR DESCRIPTION
## Summary
`fill_nulls()` was passing unsupported types (lists, dicts, arbitrary objects) directly to the native `_fill_nulls()` call with no Python-side validation, causing nulls to silently remain unfilled with no error raised. This PR adds an `isinstance` check that rejects unsupported non-scalar fill values with a clear `TypeError` before the native call is made.

## Linked issue
Fixes #1434

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- Ran `python -m pytest tests/test_cleaning.py -v` before and after the change — pre-existing failure count unchanged.
- New test `test_fill_nulls_rejects_unsupported_types`: asserts `TypeError` is raised for `list`, `dict`, and `object()` — **1 passed**.
- New test `test_fill_nulls_accepts_valid_scalars`: asserts valid scalars (`int`, `float`, `str`, `bool`) still fill nulls correctly — **1 passed**.
- Manually verified non-finite numeric values (`inf`, `-inf`, `nan`) still raise `ValueError` from the native layer — behavior unchanged.
- [ ] `make test`
- [ ] `make lint`
- [x] Other: `python -m pytest tests/test_cleaning.py -v` — passed (pre-existing failure count unchanged)
- [x] Other: `python -m ruff check arnio/cleaning.py` — no issues
- [x] Other: `python -m black arnio/cleaning.py tests/test_cleaning.py` — clean
 
## Screenshots / Media
N/A

## Performance Impact
None — the added `isinstance` check is a negligible constant-time operation before the native call.

## GSSoC labels
<!-- Maintainers only -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The fix is intentionally limited to Python-side validation only — no changes to the C++ native layer. Non-finite numeric rejection (`inf`, `-inf`, `nan`) is already handled by the native layer and is fully preserved.