### PR TITLE
fix(cleaning): validate scalar comparison values in filter_rows

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1263,6 +1263,8 @@ def filter_rows(
 
     import pandas as pd
 
+    from pandas.api.types import is_scalar
+
     from .convert import from_pandas, to_pandas
 
     is_arframe = not isinstance(frame, pd.DataFrame)
@@ -1283,6 +1285,9 @@ def filter_rows(
 
     if column not in df.columns:
         raise ValueError(f"Unknown column: {column}")
+    
+    if not is_scalar(value):
+        raise TypeError("filter_rows value must be a scalar")
 
     try:
         mask = getattr(df[column], ops[op])(value)

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1262,7 +1262,6 @@ def filter_rows(
     """
 
     import pandas as pd
-
     from pandas.api.types import is_scalar
 
     from .convert import from_pandas, to_pandas
@@ -1285,7 +1284,7 @@ def filter_rows(
 
     if column not in df.columns:
         raise ValueError(f"Unknown column: {column}")
-    
+
     if not is_scalar(value):
         raise TypeError("filter_rows value must be a scalar")
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2268,6 +2268,22 @@ class TestFilterRows:
         ):
             ar.filter_rows(df, "name", ">", 1)
 
+    def test_filter_rows_rejects_list_like_values(self):
+        df = pd.DataFrame({"a": [1, 2, 3]})
+
+        list_like_values = [
+            [1, 2],
+            (1, 2),
+            {"a": 1},
+            pd.Series([1, 2]),
+            pd.Index([1, 2]),
+            np.array([1, 2]),
+        ]
+
+        for value in list_like_values:
+            with pytest.raises(TypeError, match="filter_rows value must be a scalar"):
+                ar.filter_rows(df, "a", "==", value)
+
 
 class TestMappingValidation:
     def test_rename_columns_rejects_invalid_mapping_value_type(self, sample_csv):

--- a/tests/test_filter_rows_invalid_comparison.py
+++ b/tests/test_filter_rows_invalid_comparison.py
@@ -64,9 +64,10 @@ class TestFilterRowsInvalidComparisonTypesPipeline:
             )
 
     def test_gt_int_column_with_list_value(self):
-        """Comparing an int column against a list raises ValueError (length mismatch)."""
+        """Comparing with a list raises a clear scalar-value TypeError."""
         frame = _make_frame({"score": [80, 90, 100]})
-        with pytest.raises(ValueError, match="Lengths must be equal"):
+
+        with pytest.raises(TypeError, match="filter_rows value must be a scalar"):
             ar.pipeline(
                 frame,
                 [("filter_rows", {"column": "score", "op": ">", "value": [50]})],


### PR DESCRIPTION
### Fixes #1432 

## Summary

Fixes an input-validation issue in `filter_rows()` where list-like comparison values leaked raw pandas length-mismatch errors instead of raising a clear Arnio error.

### Problem

`filter_rows()` documents `value` as a scalar comparison value, but list-like inputs were passed directly into pandas comparison operations.

Example:

```python
frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
ar.filter_rows(frame, "a", "==", [1, 2])
```

Previously raised:

```txt
ValueError: Lengths must be equal
```

from pandas internals.

### Changes made

* Added explicit scalar validation for the `value` argument using `pandas.api.types.is_scalar`
* Rejected list-like comparison values with a clear:

  ```txt
  TypeError: filter_rows value must be a scalar
  ```
* Added focused regression coverage for:

  * list
  * tuple
  * dict
  * pandas Series
  * pandas Index
  * NumPy ndarray

### Result

`filter_rows()` now validates its documented scalar-comparison contract before calling pandas comparison logic, preventing raw pandas length-mismatch errors from leaking to users.


