### PR TITLE
Fix sniff delimiter invalid utf8 nul

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1150,20 +1150,20 @@ def sniff_delimiter(
         raise FileNotFoundError(f"File not found: {path!r}") from e
 
     try:
-        with open(path, "rb") as f:
-            if b"\0" in f.read(1024):
-                raise CsvReadError(
-                    "CSV input contains NUL bytes and appears to be binary or corrupted"
-                )
+        _reject_utf8_nul_bytes(path)
     except FileNotFoundError:
         pass
 
     # 3. Read Sample
     try:
-        with open(path, encoding=encoding, errors="replace") as f:
+        with open(path, encoding=encoding, errors="strict") as f:
             sample = f.read(sample_size)
     except LookupError as e:
         raise ValueError(f"Unknown encoding: {encoding}") from e
+    except UnicodeDecodeError as e:
+        raise CsvReadError(
+            f"Could not decode {path!r} using encoding {encoding!r}"
+        ) from e
 
     if not sample:
         raise CsvReadError(f"CSV file is empty: {path!r}")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -2152,6 +2152,39 @@ class TestSniffDelimiter:
         ):
             ar.sniff_delimiter(csv_path)
 
+    def test_sniff_delimiter_rejects_invalid_utf8(self, tmp_path):
+        path = tmp_path / "bad_utf8.csv"
+
+        path.write_bytes(b"name,city\nAlice,\xff\xffYork\n")
+
+        with pytest.raises(
+            ar.CsvReadError,
+            match="Could not decode",
+        ):
+            ar.sniff_delimiter(path, encoding="utf-8")
+
+    def test_sniff_delimiter_rejects_late_nul_bytes(self, tmp_path):
+        path = tmp_path / "late_nul.csv"
+
+        payload = b"a,b\n" + b"1,2\n" * 300 + b"3,\x004\n"
+
+        path.write_bytes(payload)
+        with pytest.raises(
+            ar.CsvReadError,
+            match="NUL bytes",
+        ):
+            ar.sniff_delimiter(path)
+
+    def test_sniff_delimiter_valid_csv_still_works(self, tmp_path):
+        path = tmp_path / "valid.csv"
+
+        path.write_text(
+            "name;age\nAlice;30\nBob;40\n",
+            encoding="utf-8",
+        )
+
+        assert ar.sniff_delimiter(path) == ";"
+
 
 class TestArFrameGetItem:
     def test_getitem_existing_column(self, sample_csv):


### PR DESCRIPTION
## Summary

Fixes #1456

Align `sniff_delimiter()` corruption handling with `read_csv()` by:

* rejecting invalid UTF-8 instead of silently masking decode failures
* rejecting late NUL bytes beyond the previous 1024-byte validation window
* preserving existing delimiter inference behavior for valid CSV inputs

## Changes

### `arnio/io.py`

* replaced the partial first-1024-byte NUL scan with shared `_reject_utf8_nul_bytes()` validation
* switched delimiter sampling from `errors="replace"` to strict decoding
* added `UnicodeDecodeError -> CsvReadError` conversion for consistent API behavior

### Tests

Added focused regression coverage for:

* invalid UTF-8 payloads
* late NUL bytes beyond the original validation window
* unchanged valid delimiter inference behavior

## Validation

```bash
py -3.12 -m pytest tests/test_csv.py -k sniff_delimiter -v
py -3.12 -m ruff check . --fix
py -3.12 -m ruff format .
```

## Notes

This keeps the PR narrowly scoped to corruption handling consistency between `sniff_delimiter()` and `read_csv()`, without changing valid delimiter inference semantics.
