### PR TITLE
(fix): Reject dropping all columns across drop_columns APIs

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -460,13 +460,9 @@ class ArFrame:
         drop_set = set(unique_cols)
         remaining = [col for col in self.columns if col not in drop_set]
 
-        # Dropping all columns — preserve row count
+        # Dropping all columns is not supported
         if not remaining:
-            import pandas as pd
-
-            from .convert import from_pandas
-
-            return from_pandas(pd.DataFrame(index=range(len(self))))
+            raise ValueError("drop_columns cannot remove all columns from the frame")
 
         return ArFrame(self._frame.select_columns(remaining))
 

--- a/examples/ignite_arnio_cleaning.ipynb
+++ b/examples/ignite_arnio_cleaning.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "\n",
     "import arnio as ar\n",
     "\n",
     "# 1. Setup sample messy dataset with generic tracking tokens\n",

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -643,11 +643,22 @@ class TestDropColumns:
         with pytest.raises(TypeError, match="only string column names"):
             ar.drop_columns(frame, ["age", 1])
 
-    def test_drop_columns_rejects_removing_all_columns(self):
+    def test_drop_columns_rejects_removing_all_columns_across_entry_points(self):
         frame = ar.from_pandas(pd.DataFrame({"id": [1, 2], "name": ["a", "b"]}))
 
         with pytest.raises(ValueError, match="drop_columns cannot remove all columns"):
+            frame.drop_columns(["id", "name"])
+
+        with pytest.raises(ValueError, match="drop_columns cannot remove all columns"):
             ar.drop_columns(frame, ["id", "name"])
+
+        with pytest.raises(ValueError, match="drop_columns cannot remove all columns"):
+            ar.pipeline(
+                frame,
+                [
+                    ("drop_columns", {"columns": ["id", "name"]}),
+                ],
+            )
 
 
 class TestDropConstantColumns:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -833,13 +833,6 @@ class TestDropColumns:
         assert result.columns == ["a", "b"]
         assert result.shape == frame.shape
 
-    def test_drop_all_columns_returns_empty_frame(self):
-        df = pd.DataFrame({"a": [1], "b": [2]})
-        frame = ar.from_pandas(df)
-        result = frame.drop_columns(["a", "b"])
-        assert result.columns == []
-        assert result.shape == (1, 0)
-
     def test_drop_duplicate_names_in_cols(self):
         df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
         frame = ar.from_pandas(df)


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->
ArFrame.drop_columns() now raises a ValueError when asked to remove all columns, matching the existing behavior of the top-level arnio.drop_columns() and the pipeline step. 
This aligns the public APIs to prevent surprising runtime failures when moving a drop step between instance, functional, and pipeline usage.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
Fixes #1458 
## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
python -m pytest -q tests/test_frame.py::TestDropColumns -q — all tests passed
python -m pytest -q tests/test_cleaning.py::TestDropColumns::test_drop_columns_rejects_removing_all_columns_across_entry_points — passed

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->
<img width="1238" height="92" alt="image" src="https://github.com/user-attachments/assets/0c5a0372-b22d-4a27-99ef-562c8d1c23c1" />
<img width="1266" height="331" alt="image" src="https://github.com/user-attachments/assets/02311ca5-28ed-49d3-953b-a2a375ee3146" />

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
