### PR TITLE
fix: validate case_type is a string in normalize_case() before native…

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -935,6 +935,8 @@ def normalize_case(
     >>> frame = ar.read_csv("data.csv")
     >>> lower = ar.normalize_case(frame, case_type="lower")
     """
+    if not isinstance(case_type, str):
+        raise TypeError("case_type must be a string")
     if subset is not None:
         subset = _validate_existing_column_sequence(
             subset,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1320,6 +1320,27 @@ class TestNormalizeCase:
 
         assert df["word"].tolist() == ["éclair", "ñandú", "über-Cool"]
 
+    def test_invalid_case_type_int(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"x": ["A"]}))
+        with pytest.raises(TypeError, match="case_type must be a string"):
+            ar.normalize_case(frame, case_type=123)
+
+    def test_invalid_case_type_none(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"x": ["A"]}))
+        with pytest.raises(TypeError, match="case_type must be a string"):
+            ar.normalize_case(frame, case_type=None)
+
+    def test_invalid_case_type_string(self):
+        import pandas as pd
+
+        frame = ar.from_pandas(pd.DataFrame({"x": ["A"]}))
+        with pytest.raises(ValueError):
+            ar.normalize_case(frame, case_type="invalid")
+
 
 class TestNormalizeUnicode:
     def test_normalize_unicode(self):


### PR DESCRIPTION
## Summary
`normalize_case()` did not validate that `case_type` is a string before passing it to the native C++ implementation. Non-string values like `123` or `None` produced confusing `pybind` signature errors instead of clear Python API errors. Added a Python-side `isinstance(case_type, str)` check that raises a clean `TypeError` before the native call is reached.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue

Fixes #1427

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [X] C++ cleaning engine
- [X] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [X] Other: `python -m pytest tests/test_cleaning.py::TestNormalizeCase -v`

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).


