### PR TITLE
fix: add encoding validation to read_jsonl()

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -5,6 +5,7 @@ CSV reading and writing functions.
 
 from __future__ import annotations
 
+import codecs
 import io
 import os
 import shutil
@@ -1043,6 +1044,13 @@ def read_jsonl(
 
     from .convert import from_pandas
 
+    if not isinstance(encoding, str):
+        raise TypeError(f"encoding must be a string, got {type(encoding).__name__!r}")
+    try:
+        codecs.lookup(encoding)
+    except LookupError:
+        raise ValueError(f"Unknown encoding: {encoding!r}")
+
     path = os.fspath(path)
     path_lower = path.lower()
     if not (path_lower.endswith(".jsonl") or path_lower.endswith(".ndjson")):
@@ -1050,7 +1058,6 @@ def read_jsonl(
             f"Unsupported file format: {path}. "
             "read_jsonl only supports .jsonl and .ndjson files."
         )
-
     if nrows is not None:
         if isinstance(nrows, bool) or not isinstance(nrows, int):
             raise TypeError("nrows must be an integer")

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -277,3 +277,24 @@ class TestReadJsonlPipelineCompat:
 
         assert report.row_count == 3
         assert report.duplicate_rows == 1
+
+
+def test_read_jsonl_encoding_non_string(tmp_path):
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"a": 1}\n')
+    with pytest.raises(TypeError, match="encoding must be a string"):
+        ar.read_jsonl(f, encoding=123)
+
+
+def test_read_jsonl_encoding_none(tmp_path):
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"a": 1}\n')
+    with pytest.raises(TypeError, match="encoding must be a string"):
+        ar.read_jsonl(f, encoding=None)
+
+
+def test_read_jsonl_encoding_unknown_codec(tmp_path):
+    f = tmp_path / "x.jsonl"
+    f.write_text('{"a": 1}\n')
+    with pytest.raises(ValueError, match="Unknown encoding"):
+        ar.read_jsonl(f, encoding="fake-codec")


### PR DESCRIPTION
## Summary
Closes #1439

`read_jsonl()` was passing `encoding` directly to `open()` without validation, producing raw Python errors instead of clear Arnio-style messages.

## Changes
- Added `import codecs` to `arnio/io.py`
- Added validation block in `read_jsonl()` before file is opened:
  - Raises `TypeError` for non-string encoding (including `None`)
  - Raises `ValueError` for unknown codec names via `codecs.lookup()`
- Added 3 tests in `tests/test_jsonl.py` covering invalid type, `None`, and unknown codec

## Testing
- All 37 `test_jsonl.py` tests pass
- Full suite: 1943 passed, 0 failed