### PR TITLE
fix: validate clip_numeric subset before native execution

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -592,9 +592,15 @@ def clip_numeric(
         return dtypes.get(col_name) in ("int64", "float64")
 
     if subset is not None:
-        unknown_columns = [col for col in subset if col not in dtypes]
-        if unknown_columns:
-            raise ValueError(f"Unknown columns in subset: {unknown_columns}")
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_error=ValueError,
+            missing_message=lambda missing, _available: (
+                f"Unknown columns in subset: {missing}"
+            ),
+        )
 
         non_numeric_columns = [col for col in subset if not _is_supported_numeric(col)]
         if non_numeric_columns:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -903,6 +903,44 @@ class TestClipNumeric:
         assert list(df["b"]) == [0, 5, 8]
         assert list(df["label"]) == ["x", "y", "z"]
 
+    def test_clip_numeric_string_subset_rejected_before_native_execution(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2], "age": [1, 2]}))
+
+        with pytest.raises(
+            TypeError,
+            match="subset must be a sequence of column names, not a string",
+        ):
+            ar.clip_numeric(frame, lower=0, subset="age")
+
+    def test_clip_numeric_non_string_subset_item_rejected_before_native_execution(
+        self,
+    ):
+        frame = ar.from_pandas(pd.DataFrame({"age": [1, 2, 3]}))
+
+        with pytest.raises(
+            TypeError,
+            match="subset must contain only string column names",
+        ):
+            ar.clip_numeric(frame, lower=0, subset=[1])
+
+    def test_clip_numeric_valid_tuple_subset_preserves_supported_behavior(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [-5, 0, 10],
+                    "b": [-10, 5, 20],
+                    "label": ["x", "y", "z"],
+                }
+            )
+        )
+
+        result = ar.clip_numeric(frame, lower=0, upper=8, subset=("b",))
+        df = ar.to_pandas(result)
+
+        assert list(df["a"]) == [-5, 0, 10]
+        assert list(df["b"]) == [0, 5, 8]
+        assert list(df["label"]) == ["x", "y", "z"]
+
     def test_clip_numeric_keeps_missing_values(self):
         frame = ar.from_pandas(pd.DataFrame({"value": [None, -5.0, 10.0]}))
 


### PR DESCRIPTION
## Summary
- validate `clip_numeric(..., subset=...)` with the shared column-sequence helper before any native call
- reject bare strings and non-string subset items in Python with clear errors
- preserve valid list/tuple handling, current unknown-column behavior, and current empty-subset behavior

## Linked issue
Fixes #1424

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:
  - `python3 -m pytest tests/test_cleaning.py -k clip_numeric -v`
  - `python3 -m ruff check arnio/cleaning.py tests/test_cleaning.py`
  - `python3 -m black --check arnio/cleaning.py tests/test_cleaning.py`

## Screenshots / Media
N/A - no UI, README visual, or terminal UX changes that need screenshots.

## Performance Impact
None expected. The fix stays in the Python wrapper validation path and does not alter the native clipping implementation for valid inputs.

## GSSoC labels
Maintainers only.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
- Scope kept limited to `clip_numeric()` `subset` validation per the assignment comment.
- Added focused regression coverage for bare-string rejection, invalid subset-item rejection, and valid tuple subset behavior.
