### PR TITLE
fix: handle zero-column frames in preview

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -775,6 +775,11 @@ class ArFrame:
             raise ValueError(f"`n` must be a positive integer, got {n!r}")
 
         num_rows, num_cols = self.shape
+        if num_cols == 0:
+            return (
+                f"ArFrame preview: {num_rows} rows x 0 columns "
+                f"(no columns to display)"
+            )
 
         if num_rows == 0:
             return "ArFrame preview: (empty frame)"

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -778,7 +778,7 @@ class ArFrame:
         if num_cols == 0:
             return (
                 f"ArFrame preview: {num_rows} rows x 0 columns "
-                f"(no columns to display)"
+                "(no columns to display)"
             )
 
         if num_rows == 0:

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -775,7 +775,7 @@ class ArFrame:
             raise ValueError(f"`n` must be a positive integer, got {n!r}")
 
         num_rows, num_cols = self.shape
-        if num_cols == 0:
+        if num_rows > 0 and num_cols == 0:
             return (
                 f"ArFrame preview: {num_rows} rows x 0 columns "
                 "(no columns to display)"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -118,7 +118,7 @@ def test_preview_invalid_n_none(sample_csv):
     frame = ar.read_csv(sample_csv)
     with pytest.raises(ValueError):
         frame.preview(n=None)
-        
+
 def test_preview_zero_column_frame():
     frame = ar.from_pandas(pd.DataFrame(index=range(3)))
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -119,13 +119,11 @@ def test_preview_invalid_n_none(sample_csv):
     with pytest.raises(ValueError):
         frame.preview(n=None)
 
+
 def test_preview_zero_column_frame():
     frame = ar.from_pandas(pd.DataFrame(index=range(3)))
 
-    expected = (
-        "ArFrame preview: 3 rows x 0 columns "
-        "(no columns to display)"
-    )
+    expected = "ArFrame preview: 3 rows x 0 columns " "(no columns to display)"
 
     assert frame.preview() == expected
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -130,6 +130,7 @@ def test_preview_zero_column_frame():
 
     assert result == expected
 
+
 def test_select_columns_valid():
     df = pd.DataFrame(
         {

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -118,6 +118,16 @@ def test_preview_invalid_n_none(sample_csv):
     frame = ar.read_csv(sample_csv)
     with pytest.raises(ValueError):
         frame.preview(n=None)
+        
+def test_preview_zero_column_frame():
+    frame = ar.from_pandas(pd.DataFrame(index=range(3)))
+
+    expected = (
+        "ArFrame preview: 3 rows x 0 columns "
+        "(no columns to display)"
+    )
+
+    assert frame.preview() == expected
 
 
 def test_select_columns_valid():

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -119,16 +119,13 @@ def test_preview_invalid_n_none(sample_csv):
     with pytest.raises(ValueError):
         frame.preview(n=None)
 
+
 def test_preview_zero_column_frame():
-    frame = ar.from_pandas(pd.DataFrame(index=range(3)))
-
-    expected = (
-        "ArFrame preview: 3 rows x 0 columns "
-        "(no columns to display)"
-    )
-
-    assert frame.preview() == expected
-
+    df = pd.DataFrame(index=range(3))
+    frame = ar.from_pandas(df)
+    result = frame.preview()
+    expected = "ArFrame preview: 3 rows x 0 columns (no columns to display)"
+    assert result == expected
 
 def test_select_columns_valid():
     df = pd.DataFrame(


### PR DESCRIPTION
Summary:
Fixes blank preview output for zero-column frames.

Changes:
- Added explicit num_cols == 0 handling in ArFrame.preview()
- Added regression test for zero-column frames

Fixes #1401