### PR TITLE
Fix compression type validation in write_parquet

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1301,7 +1301,8 @@ def write_parquet(
             f"Unsupported file format: {path}. "
             "write_parquet only supports .parquet and .pq files."
         )
-
+    if not isinstance(compression, str):
+        raise TypeError("compression must be a string")
     if compression not in _VALID_COMPRESSIONS:
         raise ValueError(
             f"Unknown compression codec: {compression!r}. "

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -146,7 +146,7 @@ class TestWriteParquetCompression:
         frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
         with pytest.raises(ValueError, match="Unknown compression codec"):
             ar.write_parquet(frame, tmp_path / "out.parquet", compression="lz4")
-    
+
     def test_non_string_compression_raises_type_error(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
         with pytest.raises(TypeError, match="compression must be a string"):

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -146,6 +146,11 @@ class TestWriteParquetCompression:
         frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
         with pytest.raises(ValueError, match="Unknown compression codec"):
             ar.write_parquet(frame, tmp_path / "out.parquet", compression="lz4")
+    
+    def test_non_string_compression_raises_type_error(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"v": [1]}))
+        with pytest.raises(TypeError, match="compression must be a string"):
+            ar.write_parquet(frame, tmp_path / "out.parquet", compression=[])
 
 
 @skip_without_pyarrow


### PR DESCRIPTION
## Summary

Added validation to ensure `compression` is a string before codec membership checks in `write_parquet()`.

## Linked issue

Fixes #1405

## Type of change

* [x] Bug fix
* [x] Tests

## Area

* [x] Python API / ArFrame

## Testing

* [x] `python -m pytest tests/test_parquet.py -k compression`

## Changes made

* Added explicit `isinstance(compression, str)` validation
* Raised clear `TypeError` for invalid non-string compression inputs
* Added regression test for non-string compression values
* Preserved existing behavior for unknown string codecs
