### PR TITLE
fix: validate schema rules during construction

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -564,6 +564,13 @@ class Schema:
         if not isinstance(self.strict, bool):
             raise TypeError("Schema 'strict' must be a boolean")
 
+        if self.rules is not None:
+            if not isinstance(self.rules, (list, tuple)):
+                raise TypeError("Schema 'rules' must be a list of callables")
+            for rule in self.rules:
+                if not callable(rule):
+                    raise TypeError("Schema 'rules' must be a list of callables")
+
     def validate(
         self,
         frame: ArFrame,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -720,6 +720,30 @@ def test_validation_result_to_markdown_rejects_non_integer_max_issues(sample_csv
             raise AssertionError(f"Expected max_issues={invalid!r} to raise")
 
 
+def test_schema_construction_validates_rules():
+    with pytest.raises(TypeError, match="Schema 'rules' must be a list of callables"):
+        ar.Schema({"x": ar.Int64()}, rules="abc")
+
+    with pytest.raises(TypeError, match="Schema 'rules' must be a list of callables"):
+        ar.Schema({"x": ar.Int64()}, rules=123)
+
+    with pytest.raises(TypeError, match="Schema 'rules' must be a list of callables"):
+        ar.Schema({"x": ar.Int64()}, rules=object())
+
+    with pytest.raises(TypeError, match="Schema 'rules' must be a list of callables"):
+        ar.Schema({"x": ar.Int64()}, rules=[object()])
+
+    def valid_rule(df):
+        return []
+
+    with pytest.raises(TypeError, match="Schema 'rules' must be a list of callables"):
+        ar.Schema({"x": ar.Int64()}, rules=[valid_rule, 456])
+
+    assert ar.Schema({"x": ar.Int64()}, rules=[valid_rule]).rules is not None
+    assert ar.Schema({"x": ar.Int64()}, rules=(valid_rule,)).rules is not None
+    assert ar.Schema({"x": ar.Int64()}, rules=None).rules is None
+
+
 # ---------------------------------------------------------------------------
 # Regression tests: redaction policy for ValidationResult.to_markdown
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Validated the `rules` argument inside `Schema.__post_init__()` during schema configuration rather than waiting for validation time. The class now explicitly checks that `rules` is either `None` or a list/tuple containing only callable items, raising a clear `TypeError` if invalid inputs (such as bare strings, integers, or mixed sequences) are detected. This prevents downstream runtime errors like `TypeError: 'str' object is not callable` during execution.

## Linked issue
Fixes #1411

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` : 1974 passed
- [x] `make lint`

## Screenshots / Media
N/A

## Performance Impact
None.

## GSSoC labels
- level:beginner
- type:bug
- area:schema

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes