### PR TITLE
fix: quote numeric-looking strings in schema_to_yaml 

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -47,9 +47,17 @@ def _emit_scalar(value: Any) -> str:
             return "-.inf"
         return repr(value)
     if isinstance(value, str):
+        looks_numeric = False
+        try:
+            float(value)
+            looks_numeric = True
+        except ValueError:
+            pass
+
         # Quote strings that would be misread as YAML scalars or are empty.
         needs_quoting = (
             not value
+            or looks_numeric
             or value.lower() in {"true", "false", "null", "yes", "no", "on", "off"}
             or any(c in value for c in ("\n", "\r"))
             or value[0]

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -127,6 +127,34 @@ class TestSchemaToYamlOutput:
         out = schema_to_yaml(raw)
         assert '"key: value"' in out
 
+    def test_numeric_looking_strings_quoted(self):
+        raw = {
+            "status": {
+                "type": "STRING",
+                "allowed": ["001", "123", "1.5", "-45"],
+            }
+        }
+        out = schema_to_yaml(raw)
+
+        assert '"001"' in out
+        assert '"123"' in out
+        assert '"1.5"' in out
+        assert '"-45"' in out
+
+    def test_genuine_numbers_remain_unquoted(self):
+        raw = {
+            "metrics": {
+                "count": 100,
+                "score": 4.5,
+            }
+        }
+        out = schema_to_yaml(raw)
+
+        assert "count: 100" in out
+        assert "score: 4.5" in out
+        assert '"100"' not in out
+        assert '"4.5"' not in out
+
     def test_empty_string_quoted(self):
         raw = {"col": {"type": "STRING", "default": ""}}
         out = schema_to_yaml(raw)


### PR DESCRIPTION
## Summary
Updated `_emit_scalar()` in `arnio/schema_export.py` to identify and wrap numeric-looking strings (such as `"001"`, `"123"`, and `"1.5"`) in double quotes. This ensures schema exports preserve string semantics exactly and prevents downstream YAML parsers from misinterpreting string variables as numbers. Real integers and floats pass through untouched.

## Linked issue
Fixes #1419

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Ran the comprehensive local validation suite. All existing and new test cases passed successfully.
- [x] `make test`: 1982 passed
- [x] `make lint`
- [ ] Other:

## Screenshots / Media
N/A

## Performance Impact
None

## GSSoC labels
- level:beginner
- type:bug
- area:schema

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: quote numeric-looking strings in schema_to_yaml`).

## Maintainer notes