### PR TITLE
fix: validate unsafe CSV delimiters

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -194,6 +194,7 @@ def _validate_decimal_separator(decimal_separator: str) -> str:
     return decimal_separator
 
 
+_INVALID_DELIMITERS: frozenset[str] = frozenset({"\n", "\r", "\0", '"'})
 def _validate_delimiter(delimiter: str) -> str:
     """Validate CSV delimiter."""
     if not isinstance(delimiter, str):
@@ -201,7 +202,13 @@ def _validate_delimiter(delimiter: str) -> str:
 
     if len(delimiter) != 1:
         raise ValueError("delimiter must be exactly one character")
-
+    
+    if delimiter in _INVALID_DELIMITERS:
+        raise ValueError(
+            f"delimiter {delimiter!r} is not allowed; the following characters "
+            f'cannot be used as field delimiters: newline (\\n), '
+            f'carriage-return (\\r), NUL (\\0), double-quote (").'
+        )
     return delimiter
 
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -195,6 +195,8 @@ def _validate_decimal_separator(decimal_separator: str) -> str:
 
 
 _INVALID_DELIMITERS: frozenset[str] = frozenset({"\n", "\r", "\0", '"'})
+
+
 def _validate_delimiter(delimiter: str) -> str:
     """Validate CSV delimiter."""
     if not isinstance(delimiter, str):
@@ -202,11 +204,11 @@ def _validate_delimiter(delimiter: str) -> str:
 
     if len(delimiter) != 1:
         raise ValueError("delimiter must be exactly one character")
-    
+
     if delimiter in _INVALID_DELIMITERS:
         raise ValueError(
             f"delimiter {delimiter!r} is not allowed; the following characters "
-            f'cannot be used as field delimiters: newline (\\n), '
+            f"cannot be used as field delimiters: newline (\\n), "
             f'carriage-return (\\r), NUL (\\0), double-quote (").'
         )
     return delimiter

--- a/tests/test_csv_validation_delimiter.py
+++ b/tests/test_csv_validation_delimiter.py
@@ -18,7 +18,8 @@ _CSV_CONTENT = "a,b\n1,2\n3,4\n"
 @pytest.mark.parametrize("delim", _INVALID_DELIMITERS)
 def test_read_csv_rejects_invalid_delimiter(delim, tmp_path):
     csv_file = tmp_path / "sample.csv"
-    csv_file.write_text(_CSV_CONTENT, newline="")
+    csv_file.write_bytes(_CSV_CONTENT.encode())
+
 
     with pytest.raises(ValueError, match="delimiter"):
         ar.read_csv(str(csv_file), delimiter=delim)
@@ -30,7 +31,8 @@ def test_read_csv_rejects_invalid_delimiter(delim, tmp_path):
 @pytest.mark.parametrize("delim", _INVALID_DELIMITERS)
 def test_read_csv_chunked_rejects_invalid_delimiter(delim, tmp_path):
     csv_file = tmp_path / "sample.csv"
-    csv_file.write_text(_CSV_CONTENT, newline="")
+    csv_file.write_bytes(_CSV_CONTENT.encode())
+
 
     with pytest.raises(ValueError, match="delimiter"):
         # Consume the generator so validation actually runs.
@@ -43,7 +45,8 @@ def test_read_csv_chunked_rejects_invalid_delimiter(delim, tmp_path):
 @pytest.mark.parametrize("delim", _INVALID_DELIMITERS)
 def test_scan_csv_rejects_invalid_delimiter(delim, tmp_path):
     csv_file = tmp_path / "sample.csv"
-    csv_file.write_text(_CSV_CONTENT, newline="")
+    csv_file.write_bytes(_CSV_CONTENT.encode())
+
 
     with pytest.raises(ValueError, match="delimiter"):
         ar.scan_csv(str(csv_file), delimiter=delim)
@@ -62,7 +65,7 @@ def test_scan_csv_rejects_invalid_delimiter(delim, tmp_path):
 )
 def test_read_csv_accepts_valid_delimiter(delim, content, tmp_path):
     csv_file = tmp_path / "sample.csv"
-    csv_file.write_text(content, newline="")
+    csv_file.write_bytes(content.encode())
 
     frame = ar.read_csv(str(csv_file), delimiter=delim)
     assert frame.shape == (1, 2)

--- a/tests/test_csv_validation_delimiter.py
+++ b/tests/test_csv_validation_delimiter.py
@@ -20,7 +20,6 @@ def test_read_csv_rejects_invalid_delimiter(delim, tmp_path):
     csv_file = tmp_path / "sample.csv"
     csv_file.write_bytes(_CSV_CONTENT.encode())
 
-
     with pytest.raises(ValueError, match="delimiter"):
         ar.read_csv(str(csv_file), delimiter=delim)
 
@@ -32,7 +31,6 @@ def test_read_csv_rejects_invalid_delimiter(delim, tmp_path):
 def test_read_csv_chunked_rejects_invalid_delimiter(delim, tmp_path):
     csv_file = tmp_path / "sample.csv"
     csv_file.write_bytes(_CSV_CONTENT.encode())
-
 
     with pytest.raises(ValueError, match="delimiter"):
         # Consume the generator so validation actually runs.
@@ -46,7 +44,6 @@ def test_read_csv_chunked_rejects_invalid_delimiter(delim, tmp_path):
 def test_scan_csv_rejects_invalid_delimiter(delim, tmp_path):
     csv_file = tmp_path / "sample.csv"
     csv_file.write_bytes(_CSV_CONTENT.encode())
-
 
     with pytest.raises(ValueError, match="delimiter"):
         ar.scan_csv(str(csv_file), delimiter=delim)

--- a/tests/test_csv_validation_delimiter.py
+++ b/tests/test_csv_validation_delimiter.py
@@ -1,17 +1,15 @@
-
 import pytest
-import arnio as ar
 
+import arnio as ar
 
 _INVALID_DELIMITERS = [
     pytest.param("\n", id="newline"),
     pytest.param("\r", id="carriage-return"),
     pytest.param("\0", id="NUL"),
-    pytest.param('"',  id="double-quote"),
+    pytest.param('"', id="double-quote"),
 ]
 
 _CSV_CONTENT = "a,b\n1,2\n3,4\n"
-
 
 
 # read_csv
@@ -26,7 +24,6 @@ def test_read_csv_rejects_invalid_delimiter(delim, tmp_path):
         ar.read_csv(str(csv_file), delimiter=delim)
 
 
-
 # read_csv_chunked
 
 
@@ -38,7 +35,6 @@ def test_read_csv_chunked_rejects_invalid_delimiter(delim, tmp_path):
     with pytest.raises(ValueError, match="delimiter"):
         # Consume the generator so validation actually runs.
         list(ar.read_csv_chunked(str(csv_file), delimiter=delim))
-
 
 
 # scan_csv
@@ -56,11 +52,14 @@ def test_scan_csv_rejects_invalid_delimiter(delim, tmp_path):
 # Sanity: valid non-default delimiters still work
 
 
-@pytest.mark.parametrize("delim,content", [
-    pytest.param("|",  "a|b\n1|2\n",  id="pipe"),
-    pytest.param(";",  "a;b\n1;2\n",  id="semicolon"),
-    pytest.param("\t", "a\tb\n1\t2\n", id="tab"),
-])
+@pytest.mark.parametrize(
+    "delim,content",
+    [
+        pytest.param("|", "a|b\n1|2\n", id="pipe"),
+        pytest.param(";", "a;b\n1;2\n", id="semicolon"),
+        pytest.param("\t", "a\tb\n1\t2\n", id="tab"),
+    ],
+)
 def test_read_csv_accepts_valid_delimiter(delim, content, tmp_path):
     csv_file = tmp_path / "sample.csv"
     csv_file.write_text(content, newline="")

--- a/tests/test_csv_validation_delimiter.py
+++ b/tests/test_csv_validation_delimiter.py
@@ -1,0 +1,70 @@
+
+import pytest
+import arnio as ar
+
+
+_INVALID_DELIMITERS = [
+    pytest.param("\n", id="newline"),
+    pytest.param("\r", id="carriage-return"),
+    pytest.param("\0", id="NUL"),
+    pytest.param('"',  id="double-quote"),
+]
+
+_CSV_CONTENT = "a,b\n1,2\n3,4\n"
+
+
+
+# read_csv
+
+
+@pytest.mark.parametrize("delim", _INVALID_DELIMITERS)
+def test_read_csv_rejects_invalid_delimiter(delim, tmp_path):
+    csv_file = tmp_path / "sample.csv"
+    csv_file.write_text(_CSV_CONTENT, newline="")
+
+    with pytest.raises(ValueError, match="delimiter"):
+        ar.read_csv(str(csv_file), delimiter=delim)
+
+
+
+# read_csv_chunked
+
+
+@pytest.mark.parametrize("delim", _INVALID_DELIMITERS)
+def test_read_csv_chunked_rejects_invalid_delimiter(delim, tmp_path):
+    csv_file = tmp_path / "sample.csv"
+    csv_file.write_text(_CSV_CONTENT, newline="")
+
+    with pytest.raises(ValueError, match="delimiter"):
+        # Consume the generator so validation actually runs.
+        list(ar.read_csv_chunked(str(csv_file), delimiter=delim))
+
+
+
+# scan_csv
+
+
+@pytest.mark.parametrize("delim", _INVALID_DELIMITERS)
+def test_scan_csv_rejects_invalid_delimiter(delim, tmp_path):
+    csv_file = tmp_path / "sample.csv"
+    csv_file.write_text(_CSV_CONTENT, newline="")
+
+    with pytest.raises(ValueError, match="delimiter"):
+        ar.scan_csv(str(csv_file), delimiter=delim)
+
+
+# Sanity: valid non-default delimiters still work
+
+
+@pytest.mark.parametrize("delim,content", [
+    pytest.param("|",  "a|b\n1|2\n",  id="pipe"),
+    pytest.param(";",  "a;b\n1;2\n",  id="semicolon"),
+    pytest.param("\t", "a\tb\n1\t2\n", id="tab"),
+])
+def test_read_csv_accepts_valid_delimiter(delim, content, tmp_path):
+    csv_file = tmp_path / "sample.csv"
+    csv_file.write_text(content, newline="")
+
+    frame = ar.read_csv(str(csv_file), delimiter=delim)
+    assert frame.shape == (1, 2)
+    assert list(frame.columns) == ["a", "b"]


### PR DESCRIPTION
 Summary
Hardens _validate_delimiter() in arnio/io.py to reject characters that cannot safely act as CSV field delimiters: newline (\n), carriage-return (\r), NUL (\0), and double-quote ("). Previously, passing any of these produced silent misparses (single-column output) instead of an immediate error. All three CSV entry points (read_csv, read_csv_chunked, scan_csv) already called the shared helper, so no call-site changes were needed.

Linked issue
Fixes #1470

Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

Testing
pytest tests/test_csv_validation_delimiter.py   

15 tests collected and passed: 12 parametrized cases covering \n, \r, \0, and " across read_csv, read_csv_chunked, and scan_csv; 3 sanity checks confirming valid delimiters (|, ;, \t) still work.

Performance Impact
None — the added check is a single frozenset lookup before any parsing begins.

Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

Maintainer notes
write_csv has its own inline delimiter checks for \n, \r, and " that don't go through the shared helper — that inconsistency is out of scope for this PR but could be a follow-up.
