### PR TITLE
Expose pipeline metadata and dry-run options in pandas accessor

### DIFF
--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -25,10 +25,47 @@ class ArnioPandasAccessor:
         """Convert the DataFrame into an Arnio frame."""
         return from_pandas(self._df)
 
-    def pipeline(self, steps: Sequence[Any]) -> pd.DataFrame:
-        """Run an Arnio pipeline and return a pandas DataFrame."""
+    def pipeline(
+        self,
+        steps: Sequence[Any],
+        *,
+        return_metadata: bool = False,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> pd.DataFrame | tuple[pd.DataFrame, dict[str, Any]]:
+        """Run an Arnio pipeline and return a pandas DataFrame.
+
+        Parameters
+        ----------
+        steps : Sequence[tuple]
+            List of pipeline steps to apply.
+        return_metadata : bool, default False
+            When True, also return a metadata dictionary with per-step timing
+            and row count information.
+        dry_run : bool, default False
+            Validate pipeline structure without applying transformations.
+        verbose : bool, default False
+            Enable diagnostic logging for each pipeline step.
+
+        Returns
+        -------
+        pd.DataFrame or tuple[pd.DataFrame, dict]
+            If return_metadata is False (default), returns a pandas DataFrame.
+            If return_metadata is True, returns (DataFrame, metadata_dict).
+        """
         frame = self.to_arframe()
-        return to_pandas(run_pipeline(frame, steps))
+        result = run_pipeline(
+            frame,
+            steps,
+            return_metadata=return_metadata,
+            dry_run=dry_run,
+            verbose=verbose,
+        )
+
+        if return_metadata:
+            ar_frame, metadata = result
+            return to_pandas(ar_frame), metadata
+        return to_pandas(result)
 
     def clean(
         self,

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -134,3 +134,124 @@ def test_auto_clean_dry_run_safe_mode_does_not_mutate():
     assert isinstance(result, ar.DataQualityReport)
     # Frame must not be mutated — score stays as string
     assert frame.dtypes["score"] == "string"
+
+
+# --- Tests for df.arnio.pipeline() keyword arguments ---
+
+
+def test_pandas_accessor_pipeline_returns_dataframe_by_default():
+    """Default behavior: pipeline returns a pandas DataFrame."""
+    df = pd.DataFrame({"name": [" Alice ", " Bob "], "age": [30, 40]})
+
+    result = df.arnio.pipeline(
+        [
+            ("strip_whitespace", {"subset": ["name"]}),
+        ]
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["Alice", "Bob"]
+
+
+def test_pandas_accessor_pipeline_with_return_metadata():
+    """return_metadata=True returns (DataFrame, metadata) tuple."""
+    df = pd.DataFrame({"name": [" Alice ", " Bob "]})
+
+    result, metadata = df.arnio.pipeline(
+        [
+            ("strip_whitespace", {"subset": ["name"]}),
+            ("normalize_case", {"subset": ["name"], "case_type": "lower"}),
+        ],
+        return_metadata=True,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["alice", "bob"]
+
+    # Verify metadata structure
+    assert isinstance(metadata, dict)
+    assert set(metadata.keys()) == {"applied_steps", "row_counts", "step_timings"}
+    assert metadata["applied_steps"] == ["strip_whitespace", "normalize_case"]
+    assert len(metadata["row_counts"]) == 2
+    assert metadata["row_counts"][0]["step"] == "strip_whitespace"
+    assert metadata["row_counts"][0]["before"] == 2
+    assert metadata["row_counts"][0]["after"] == 2
+    assert metadata["row_counts"][0]["dry_run"] is False
+    assert len(metadata["step_timings"]) == 2
+
+
+def test_pandas_accessor_pipeline_with_dry_run():
+    """dry_run=True validates without mutating."""
+    df = pd.DataFrame({"name": [" Alice ", " Bob "]})
+
+    result = df.arnio.pipeline(
+        [
+            ("strip_whitespace", {"subset": ["name"]}),
+        ],
+        dry_run=True,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    # With dry_run=True, the result should be the original frame
+    assert list(result["name"]) == [" Alice ", " Bob "]
+
+
+def test_pandas_accessor_pipeline_with_verbose(caplog):
+    """verbose=True enables diagnostic logging."""
+    df = pd.DataFrame({"name": [" Alice "]})
+
+    caplog.set_level("INFO", logger="arnio")
+
+    result = df.arnio.pipeline(
+        [
+            ("strip_whitespace", {"subset": ["name"]}),
+        ],
+        verbose=True,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert any("strip_whitespace" in record.message for record in caplog.records)
+
+
+def test_pandas_accessor_pipeline_with_return_metadata_and_dry_run():
+    """return_metadata=True with dry_run=True returns (original_df, metadata)."""
+    df = pd.DataFrame({"value": [None, 10, 20]})
+
+    result, metadata = df.arnio.pipeline(
+        [
+            ("drop_nulls", {}),
+        ],
+        return_metadata=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 3  # Original frame unchanged in dry_run
+    assert isinstance(metadata, dict)
+    assert metadata["row_counts"][0]["dry_run"] is True
+    # In dry_run, after should equal before
+    assert metadata["row_counts"][0]["after"] == metadata["row_counts"][0]["before"]
+
+
+def test_pandas_accessor_pipeline_invalid_step_raises():
+    """Invalid pipeline input raises appropriate error."""
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    with pytest.raises(Exception):  # Could be UnknownStepError or ValueError
+        df.arnio.pipeline(
+            [
+                ("nonexistent_step",),
+            ]
+        )
+
+
+def test_pandas_accessor_pipeline_invalid_step_kwargs_raises():
+    """Invalid step kwargs raises appropriate error."""
+    df = pd.DataFrame({"name": ["Alice"]})
+
+    with pytest.raises(Exception):  # Could be KeyError or similar
+        df.arnio.pipeline(
+            [
+                ("drop_nulls", {"subset": ["nonexistent_column"]}),
+            ]
+        )


### PR DESCRIPTION
Closes #1398
## Summary

This PR extends the pandas accessor pipeline API to expose the same production-oriented options supported by the core `ar.pipeline(...)` API.

Previously, `df.arnio.pipeline()` only accepted `steps` and always returned a pandas `DataFrame`, preventing pandas users from accessing:
- `return_metadata`
- `dry_run`
- `verbose`

This update forwards those options through the accessor while preserving backward compatibility.

---

## Changes Made

### `arnio/integrations/pandas.py`
- Extended `ArnioPandasAccessor.pipeline()` signature to support:
  - `return_metadata=False`
  - `dry_run=False`
  - `verbose=False`
- Forwarded all options to the core pipeline API
- Preserved existing default behavior
- Added metadata-aware return handling:
  - Default → returns `pd.DataFrame`
  - `return_metadata=True` → returns `(pd.DataFrame, metadata)`

### `tests/test_pandas_accessor.py`
Added coverage for:
- [x] Default DataFrame return behavior
- [x] `return_metadata=True`
- [x] `dry_run=True`
- [x] `verbose=True`
- [x] Combined metadata + dry-run usage
- [x] Invalid pipeline step handling
- [x] Invalid kwargs/error propagation

---

## Example

### Before
```python
pdf.arnio.pipeline(steps, return_metadata=True)
# TypeError