### PR TITLE
fix(schema): include severity in _field_to_dict for diff_schema detection

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2454,6 +2454,7 @@ def _field_to_dict(field_def: Field) -> dict[str, Any]:
         "datetime_min": _clean_scalar(field_def._datetime_min),
         "datetime_max": _clean_scalar(field_def._datetime_max),
         "required_if": _normalize_sequence(field_def.required_if),
+        "severity": field_def.severity,
     }
 
 

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -164,19 +164,21 @@ class TestDiffSchema:
         assert len(changed) == 1
         assert changed[0].expected is None
         assert changed[0].observed == "^[A-Z][a-z]+$"
-        
-    def test_severity_warning_to_error():
-        expected = ar.Schema({"age": ar.Int64(severity="warning")})
-        observed = ar.Schema({"age": ar.Int64(severity="error")})
-        diff = ar.diff_schema(expected, observed)
+
+    def test_severity_warning_to_error(self):
+        """diff_schema detects severity change from warning to error."""
+        expected = Schema({"age": Field(dtype="int64", severity="warning")})
+        observed = Schema({"age": Field(dtype="int64", severity="error")})
+        diff = diff_schema(expected, observed)
         assert diff.changed is True
         assert diff.difference_count == 1
         assert diff.differences[0].attribute == "severity"
 
-    def test_severity_error_to_warning():
-        expected = ar.Schema({"age": ar.Int64(severity="error")})
-        observed = ar.Schema({"age": ar.Int64(severity="warning")})
-        diff = ar.diff_schema(expected, observed)
+    def test_severity_error_to_warning(self):
+        """diff_schema detects severity change from error to warning."""
+        expected = Schema({"age": Field(dtype="int64", severity="error")})
+        observed = Schema({"age": Field(dtype="int64", severity="warning")})
+        diff = diff_schema(expected, observed)
         assert diff.changed is True
         assert diff.difference_count == 1
         assert diff.differences[0].attribute == "severity"

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -182,4 +182,3 @@ class TestDiffSchema:
         assert diff.changed is True
         assert diff.difference_count == 1
         assert diff.differences[0].attribute == "severity"
-        

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -182,3 +182,4 @@ class TestDiffSchema:
         assert diff.changed is True
         assert diff.difference_count == 1
         assert diff.differences[0].attribute == "severity"
+        

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -164,3 +164,19 @@ class TestDiffSchema:
         assert len(changed) == 1
         assert changed[0].expected is None
         assert changed[0].observed == "^[A-Z][a-z]+$"
+        
+    def test_severity_warning_to_error():
+        expected = ar.Schema({"age": ar.Int64(severity="warning")})
+        observed = ar.Schema({"age": ar.Int64(severity="error")})
+        diff = ar.diff_schema(expected, observed)
+        assert diff.changed is True
+        assert diff.difference_count == 1
+        assert diff.differences[0].attribute == "severity"
+
+    def test_severity_error_to_warning():
+        expected = ar.Schema({"age": ar.Int64(severity="error")})
+        observed = ar.Schema({"age": ar.Int64(severity="warning")})
+        diff = ar.diff_schema(expected, observed)
+        assert diff.changed is True
+        assert diff.difference_count == 1
+        assert diff.differences[0].attribute == "severity"


### PR DESCRIPTION
Fixes #1455

## Problem
diff_schema() was not detecting severity changes because _field_to_dict() 
did not include the severity attribute, even though _field_to_json_dict() did.

## Fix
Added severity to _field_to_dict() so both serialization methods are consistent.

## Tests
Added two new tests in tests/test_diff_schema.py:
- warning -> error change is detected
- error -> warning change is detected