### PR TITLE
fix: validate numeric min/max types in Field.__post_init__

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -713,12 +713,13 @@ class Field:
                 )
             if not isinstance(self.required_if[0], str):
                 raise TypeError("required_if column name must be a string")
-        if self.min is not None:
-            if isinstance(self.min, bool) or not isinstance(self.min, (int, float)):
-                raise TypeError("min must be numeric or None")
-        if self.max is not None:
-            if isinstance(self.max, bool) or not isinstance(self.max, (int, float)):
-                raise TypeError("max must be numeric or None")
+        if self.dtype in {"int64", "float64"}:
+            if self.min is not None:
+                if isinstance(self.min, bool) or not isinstance(self.min, (int, float)):
+                    raise TypeError("min must be numeric or None")
+            if self.max is not None:
+                if isinstance(self.max, bool) or not isinstance(self.max, (int, float)):
+                    raise TypeError("max must be numeric or None")
 
         _validate_severity(self.severity)
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1599,6 +1599,12 @@ def Int64(
         Field: Configured int64 schema field.
     """
 
+    if min is not None:
+        if isinstance(min, bool) or not isinstance(min, (int, float)):
+            raise TypeError("min must be numeric or None")
+    if max is not None:
+        if isinstance(max, bool) or not isinstance(max, (int, float)):
+            raise TypeError("max must be numeric or None")
     if min is not None and max is not None and min > max:
         raise ValueError("min must be less than or equal to max")
 
@@ -1636,6 +1642,12 @@ def Float64(
         Field: Configured float64 schema field.
     """
 
+    if min is not None:
+        if isinstance(min, bool) or not isinstance(min, (int, float)):
+            raise TypeError("min must be numeric or None")
+    if max is not None:
+        if isinstance(max, bool) or not isinstance(max, (int, float)):
+            raise TypeError("max must be numeric or None")
     if min is not None and max is not None and min > max:
         raise ValueError("min must be less than or equal to max")
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -713,6 +713,12 @@ class Field:
                 )
             if not isinstance(self.required_if[0], str):
                 raise TypeError("required_if column name must be a string")
+        if self.min is not None:
+            if isinstance(self.min, bool) or not isinstance(self.min, (int, float)):
+                raise TypeError("min must be numeric or None")
+        if self.max is not None:
+            if isinstance(self.max, bool) or not isinstance(self.max, (int, float)):
+                raise TypeError("max must be numeric or None")
 
         _validate_severity(self.severity)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3017,3 +3017,28 @@ def test_int64_accepts_float_bounds():
 
 def test_int64_accepts_none_bounds():
     assert ar.Int64(min=None, max=None) is not None
+
+
+def test_int64_rejects_string_min_with_valid_max():
+    with pytest.raises(TypeError, match="min must be numeric or None"):
+        ar.Int64(min="a", max=1)
+
+
+def test_int64_rejects_valid_min_with_string_max():
+    with pytest.raises(TypeError, match="max must be numeric or None"):
+        ar.Int64(min=1, max="z")
+
+
+def test_int64_rejects_bool_pair():
+    with pytest.raises(TypeError, match="min must be numeric or None"):
+        ar.Int64(min=True, max=False)
+
+
+def test_float64_rejects_string_min_with_valid_max():
+    with pytest.raises(TypeError, match="min must be numeric or None"):
+        ar.Float64(min="a", max=1.0)
+
+
+def test_float64_rejects_bool_pair():
+    with pytest.raises(TypeError, match="min must be numeric or None"):
+        ar.Float64(min=True, max=False)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2985,3 +2985,35 @@ class TestIsSafelyConvertibleToDtype:
     def test_all_null_series_returns_false(self):
         series = pd.Series([None, None])
         assert _is_safely_convertible_to_dtype(series, "int64", "col") is False
+
+
+def test_int64_rejects_string_min():
+    with pytest.raises(TypeError, match="min must be numeric or None"):
+        ar.Int64(min="a")
+
+
+def test_int64_rejects_string_max():
+    with pytest.raises(TypeError, match="max must be numeric or None"):
+        ar.Int64(max="z")
+
+
+def test_int64_rejects_bool_min():
+    with pytest.raises(TypeError, match="min must be numeric or None"):
+        ar.Int64(min=True)
+
+
+def test_int64_rejects_bool_max():
+    with pytest.raises(TypeError, match="max must be numeric or None"):
+        ar.Int64(max=False)
+
+
+def test_int64_accepts_valid_numeric_bounds():
+    assert ar.Int64(min=0, max=10) is not None
+
+
+def test_int64_accepts_float_bounds():
+    assert ar.Int64(min=0.5, max=9.9) is not None
+
+
+def test_int64_accepts_none_bounds():
+    assert ar.Int64(min=None, max=None) is not None


### PR DESCRIPTION
## Summary
Numeric schema fields (`Int64`, `Float64`, etc.) silently accepted non-numeric `min`/`max` values, causing low-level `UFuncTypeError` from NumPy during validation.

This fix adds early type checking in `Field.__post_init__()` to reject invalid bounds with a clear `TypeError` at field construction time.

`bool` values are explicitly rejected since `bool` is a subclass of `int` in Python.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #1414

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [X] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [X] Other: `python -m pytest tests/test_schema.py -v`  # all passed

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

