### PR TITLE
fix: align schema export validation with yaml serialization

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -90,7 +90,7 @@ def _emit_scalar(value: Any) -> str:
     raise TypeError(f"Unsupported scalar type: {type(value)!r}")
 
 
-# changed this too
+# Validate nested container values recursively.
 def _validate_serializable(value: Any) -> None:
     """Validate recursively that a value can be serialized."""
 
@@ -136,7 +136,8 @@ def _normalize_serializable(value: Any) -> Any:
 
     if isinstance(value, dict):
         return {k: _normalize_serializable(v) for k, v in sorted(value.items())}
-
+    # Convert sets into deterministic sorted lists since YAML
+    # emission only supports list-like serialized output.
     if isinstance(value, set):
         return sorted(_normalize_serializable(v) for v in value)
 
@@ -261,7 +262,9 @@ def schema_to_dict(schema: dict | Any) -> dict:
         if field_name in {"strict", "unique"}:
             metadata[field_name] = value
             continue
-        # changed here also minimizing the content
+
+        # Recursively normalize nested containers so schema_to_dict()
+        # always returns serialization-ready values.
         if isinstance(value, str):
             normalised[field_name] = {"type": value}
         else:

--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -90,13 +90,11 @@ def _emit_scalar(value: Any) -> str:
     raise TypeError(f"Unsupported scalar type: {type(value)!r}")
 
 
+# changed this too
 def _validate_serializable(value: Any) -> None:
-    if isinstance(value, _SCALAR_TYPES):
-        return
+    """Validate recursively that a value can be serialized."""
 
-    if isinstance(value, set):
-        for item in value:
-            _validate_serializable(item)
+    if isinstance(value, _SCALAR_TYPES):
         return
 
     if isinstance(value, list):
@@ -104,12 +102,48 @@ def _validate_serializable(value: Any) -> None:
             _validate_serializable(item)
         return
 
-    if isinstance(value, dict):
-        for item in value.values():
+    if isinstance(value, set):
+        for item in value:
             _validate_serializable(item)
         return
 
-    raise TypeError(f"schema_to_yaml does not support values of type {type(value)!r}.")
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise TypeError("schema dict keys must be strings")
+
+            _validate_serializable(v)
+
+        return
+
+    raise TypeError(
+        f"schema_to_yaml does not support values of type "
+        f"{type(value)!r}. Only str, int, float, bool, "
+        "None, list, and dict are allowed."
+    )
+
+
+# added normalize_serializable function
+def _normalize_serializable(value: Any) -> Any:
+    """Recursively normalize serialization-safe values.
+
+    - dict keys are sorted deterministically
+    - sets are converted into sorted lists
+    - lists are normalized recursively
+    - unsupported values raise TypeError
+    """
+    _validate_serializable(value)
+
+    if isinstance(value, dict):
+        return {k: _normalize_serializable(v) for k, v in sorted(value.items())}
+
+    if isinstance(value, set):
+        return sorted(_normalize_serializable(v) for v in value)
+
+    if isinstance(value, list):
+        return [_normalize_serializable(v) for v in value]
+
+    return value
 
 
 def _emit_value(value: Any, depth: int) -> str:
@@ -227,25 +261,11 @@ def schema_to_dict(schema: dict | Any) -> dict:
         if field_name in {"strict", "unique"}:
             metadata[field_name] = value
             continue
-
+        # changed here also minimizing the content
         if isinstance(value, str):
             normalised[field_name] = {"type": value}
-
-        elif isinstance(value, dict):
-            cleaned = {}
-
-            for k, v in sorted(value.items()):
-                if isinstance(v, set):
-                    cleaned[k] = sorted(v)
-                else:
-                    cleaned[k] = v
-
-            _validate_serializable(cleaned)
-
-            normalised[field_name] = cleaned
-
         else:
-            normalised[field_name] = value
+            normalised[field_name] = _normalize_serializable(value)
 
     result = {"fields": normalised}
     result.update(metadata)

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -271,3 +271,28 @@ def test_real_schema_with_rules_raises():
     schema = ar.Schema({"col": ar.Field(dtype="STRING")}, rules=[lambda df: []])
     with pytest.raises(ValueError, match="rules"):
         schema_to_dict(schema)
+
+
+# test unsupported raw field value
+def test_raw_field_object_raises():
+    with pytest.raises(TypeError):
+        schema_to_dict({"x": object()})
+
+
+# test for nested set normalization
+def test_nested_set_normalized():
+    result = schema_to_dict({"x": {"meta": {"tags": {"b", "a"}}}})
+
+    assert result == {"fields": {"x": {"meta": {"tags": ["a", "b"]}}}}
+
+
+# test for nested unsupported object inside dict
+def test_nested_unsupported_object_raises():
+    with pytest.raises(TypeError):
+        schema_to_dict({"x": {"meta": {"bad": object()}}})
+
+
+# test for nested unsupported object inside list
+def test_list_with_unsupported_object_raises():
+    with pytest.raises(TypeError):
+        schema_to_dict({"x": {"values": [1, object()]}})


### PR DESCRIPTION
## Summary
Fix schema export validation inconsistencies between schema_to_dict() and schema_to_yaml().This PR ensures schema_to_dict() always returns serialization-ready data and aligns validation behavior with YAML emission behavior.Fixes unsupported raw values bypassing validation and normalizes nested sets recursively into deterministic lists.

## Fixes #1441 

## Type of change
- [x] Bug
- [x] Tests

## Area
- [x] Python API / ArFrame
- [x] Schema validation

## Testing
- [x] Other:
- [x] pytest tests/test_schema_export.py -v 
- [x] pytest
##Result:
- [x] All existing tests passed
- [x] Added regression tests for unsupported raw field values, nested sets normalization, and nested unsupported objects inside dictionaries and lists
## Screenshots / Media
N/A

## Performance Impact
No significant performance impact expected. Changes are limited to recursive normalization and validation during schema export.

## GSSoC labels
 `area:schema`, `gssoc:approved`, `level:beginner`, `gssoc:level-1`, `priority:low`, `size:xs` `type:bug`.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
 * Previously:
1)schema_to_dict({"x": object()}) returned non-serializable values unchanged
2)nested sets passed validation but later failed during YAML emission

 * Solution
-Added recursive normalization helper for serialization-safe values
-Validate raw non-dict field values before returning from schema_to_dict()
-Normalize nested sets recursively into deterministic sorted lists
-Ensure nested lists/dicts are recursively validated
