### PR TITLE
Fix read_jsonl nrows=0 extension validation ordering

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1042,12 +1042,6 @@ def read_jsonl(
     from .convert import from_pandas
 
     path = os.fspath(path)
-    path_lower = path.lower()
-    if not (path_lower.endswith(".jsonl") or path_lower.endswith(".ndjson")):
-        raise ValueError(
-            f"Unsupported file format: {path}. "
-            "read_jsonl only supports .jsonl and .ndjson files."
-        )
 
     if nrows is not None:
         if isinstance(nrows, bool) or not isinstance(nrows, int):
@@ -1060,9 +1054,14 @@ def read_jsonl(
             # must not raise when nrows=0.
             import pandas as pd
 
-            from .convert import from_pandas
-
             return from_pandas(pd.DataFrame())
+
+    path_lower = path.lower()
+    if not (path_lower.endswith(".jsonl") or path_lower.endswith(".ndjson")):
+        raise ValueError(
+            f"Unsupported file format: {path}. "
+            "read_jsonl only supports .jsonl and .ndjson files."
+        )
 
     records: list[dict] = []
     try:

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -150,6 +150,14 @@ class TestReadJsonlNrows:
         frame = ar.read_jsonl(path, nrows=0)
         assert frame.shape[0] == 0
 
+    def test_nrows_zero_skips_extension_validation(self, tmp_path):
+        # nrows=0 short-circuits before extension validation — an unsupported
+        # extension must not raise when the caller requests zero rows.
+        path = tmp_path / "probe.txt"
+        path.write_text("not json\n", encoding="utf-8")
+        frame = ar.read_jsonl(path, nrows=0)
+        assert frame.shape[0] == 0
+
     def test_nrows_larger_than_file_reads_all(self, tmp_path):
         path = _write(tmp_path, "data.jsonl", [{"x": i} for i in range(5)])
         frame = ar.read_jsonl(path, nrows=100)


### PR DESCRIPTION
## Summary

`read_jsonl` validated the file extension before checking `nrows`, so `nrows=0` callers still received a `ValueError` for unsupported extensions even though the documented contract says zero-row reads must short-circuit before any file inspection.

This PR fixes the behavior by moving the `nrows == 0` early-return block above the extension validation guard.

## Linked issue

Closes #1457

## Type of change

* [x] Bug fix
* [x] Tests

## Area

* [x] CSV parser / I/O
* [x] Python API / ArFrame

## Testing

* [ ] `make test` — blocked locally (Windows environment without MSVC build tools); GitHub Actions CI covers the full native-build matrix
* [ ] `make lint`
* [x] Lightweight mock-based verification confirmed the short-circuit executes before extension validation

Verification output:

```txt
PASS — nrows=0 returned without raising on bad extension
```

## Screenshots / Media

### Before

```txt
ValueError: Unsupported file format: probe.txt. read_jsonl only supports .jsonl and .ndjson files.
```

### After

```txt
PASS — nrows=0 returned without raising on bad extension
```

## Performance Impact

None. The change only affects the `nrows=0` early-return path and does not touch normal parsing or hot-path execution.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue / one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
  No public API change; implementation now matches existing documented behavior.
* [x] I checked that generated files, logs, and local verification helpers are not committed.
* [x] My PR title follows Conventional Commits:
  `fix: skip extension validation when nrows=0 in read_jsonl`

## Maintainer notes

* Removed the duplicate `from .convert import from_pandas` import inside the `nrows == 0` branch since the import already exists at function scope. No behavior change, cleanup only.
* Existing coverage (`test_nrows_zero_does_not_inspect_file_contents`) validated malformed content handling under a valid `.jsonl` extension but never exercised the extension guard itself.
* Added `test_nrows_zero_skips_extension_validation` to explicitly cover unsupported extensions with `nrows=0`.

@im-anishraj Please review this PR. If there are any suggestions or requested changes, I’ll update them and mark them resolved once completed.
