### PR TITLE
fix(pandas): add max_errors passthrough to ArnioPandasAccessor.validate

### DIFF
--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -105,6 +105,21 @@ class ArnioPandasAccessor:
 
         return to_pandas(result)
 
-    def validate(self, schema: Schema | dict[str, Any]) -> ValidationResult:
-        """Validate the DataFrame against an Arnio schema."""
-        return validate(self.to_arframe(), schema)
+    def validate(
+        self,
+        schema: Schema | dict[str, Any],
+        *,
+        max_errors: int | None = None,
+    ) -> ValidationResult:
+        """Validate the DataFrame against an Arnio schema.
+
+        Parameters
+        ----------
+        schema : Schema or dict[str, Field]
+            Schema to validate against.
+        max_errors : int or None, default None
+            Maximum number of validation issues to collect. Mirrors the
+            ``max_errors`` parameter of ``ar.validate()``. When None all
+            issues are collected.
+        """
+        return validate(self.to_arframe(), schema, max_errors=max_errors)

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -134,3 +134,18 @@ def test_auto_clean_dry_run_safe_mode_does_not_mutate():
     assert isinstance(result, ar.DataQualityReport)
     # Frame must not be mutated — score stays as string
     assert frame.dtypes["score"] == "string"
+
+
+def test_pandas_accessor_validate_respects_max_errors():
+    # max_errors=1 should cap the result at one issue even when multiple rows fail.
+    df = pd.DataFrame({"age": [-1, -2, -3]})
+    schema = ar.Schema({"age": ar.Int64(min=0)})
+
+    result_capped = df.arnio.validate(schema, max_errors=1)
+    result_full = df.arnio.validate(schema)
+
+    assert isinstance(result_capped, ar.ValidationResult)
+    assert not result_capped.passed
+    assert result_capped.issue_count == 1
+    # Full run should report all three failures
+    assert result_full.issue_count == 3


### PR DESCRIPTION
Summary

Fixes the missing max_errors passthrough in the pandas accessor API.

Changes
pandas.py
df.arnio.validate() now accepts max_errors: int | None = None as a keyword-only argument
forwards the value directly to the core validate() implementation
updated the docstring accordingly
test_pandas_accessor.py
added a regression test verifying:
max_errors=1 stops after the first validation issue
uncapped validation still returns all issues

This is a small accessor-layer fix only — no schema logic or C++ changes were required since the core validation path already supported max_errors.

Fixes #1396 