### PR TITLE
fix : handle empty DataFrame gracefully in schema_summary utility

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -195,25 +195,25 @@ def schema_to_dict(schema: dict | Any) -> dict:
 
     # ── List of ColumnSummary path ──────────────────────────────────────────
     if isinstance(schema, list):
-        normalised = {}
+        normalised_list = {}
         for entry in schema:
             if hasattr(entry, "name") and hasattr(entry, "dtype"):
                 name = entry.name
-                normalised[name] = {
+                normalised_list[name] = {
                     "type": str(entry.dtype).upper(),
                 }
                 if hasattr(entry, "nullable"):
-                    normalised[name]["nullable"] = entry.nullable
+                    normalised_list[name]["nullable"] = entry.nullable
             elif isinstance(entry, dict) and "name" in entry and "dtype" in entry:
                 name = entry["name"]
-                normalised[name] = {
+                normalised_list[name] = {
                     "type": str(entry["dtype"]).upper(),
                 }
                 if "nullable" in entry:
-                    normalised[name]["nullable"] = entry["nullable"]
+                    normalised_list[name]["nullable"] = entry["nullable"]
             else:
                 raise TypeError(f"Unsupported list item type: {type(entry)!r}")
-        return {"fields": normalised}
+        return {"fields": normalised_list}
 
     # ── Schema object path ──────────────────────────────────────────────────
     if hasattr(schema, "fields"):

--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -177,6 +177,7 @@ def schema_to_dict(schema: dict | Any) -> dict:
         Either the raw ``dict`` returned by ``ar.scan_csv`` / ``ar.Schema``,
         or any object that exposes a ``fields`` attribute (mapping of field
         name → field descriptor) – whichever arnio uses internally.
+        Also supports ArFrame objects and lists of ColumnSummary.
 
     Returns
     -------
@@ -186,9 +187,34 @@ def schema_to_dict(schema: dict | Any) -> dict:
     Raises
     ------
     TypeError
-        If *schema* is neither a ``dict`` nor an object with a ``fields``
-        attribute.
+        If *schema* is not of a supported type.
     """
+    # ── ArFrame path ────────────────────────────────────────────────────────
+    if hasattr(schema, "schema_summary"):
+        schema = schema.schema_summary
+
+    # ── List of ColumnSummary path ──────────────────────────────────────────
+    if isinstance(schema, list):
+        normalised = {}
+        for entry in schema:
+            if hasattr(entry, "name") and hasattr(entry, "dtype"):
+                name = entry.name
+                normalised[name] = {
+                    "type": str(entry.dtype).upper(),
+                }
+                if hasattr(entry, "nullable"):
+                    normalised[name]["nullable"] = entry.nullable
+            elif isinstance(entry, dict) and "name" in entry and "dtype" in entry:
+                name = entry["name"]
+                normalised[name] = {
+                    "type": str(entry["dtype"]).upper(),
+                }
+                if "nullable" in entry:
+                    normalised[name]["nullable"] = entry["nullable"]
+            else:
+                raise TypeError(f"Unsupported list item type: {type(entry)!r}")
+        return {"fields": normalised}
+
     # ── Schema object path ──────────────────────────────────────────────────
     if hasattr(schema, "fields"):
         if getattr(schema, "rules", None):
@@ -261,7 +287,7 @@ def schema_to_dict(schema: dict | Any) -> dict:
         return result
 
     raise TypeError(
-        f"Expected a dict or an object with a 'fields' attribute, "
+        f"Expected a dict, an ArFrame, or an object with a 'fields' attribute, "
         f"got {type(schema)!r}."
     )
 

--- a/tests/test_schema_summary.py
+++ b/tests/test_schema_summary.py
@@ -226,3 +226,21 @@ class TestSchemaSummaryEdgeCases:
         frame = ar.from_pandas(df)
         for entry in frame.schema_summary:
             assert isinstance(entry, CS)
+
+    def test_schema_to_dict_empty_dataframe(self):
+        df = pd.DataFrame()
+        frame = ar.from_pandas(df)
+        res = ar.schema_export.schema_to_dict(frame)
+        assert res == {"fields": {}}
+
+    def test_schema_to_yaml_empty_dataframe(self):
+        df = pd.DataFrame()
+        frame = ar.from_pandas(df)
+        res = ar.schema_export.schema_to_yaml(frame)
+        assert res == "fields: {}\n"
+
+    def test_schema_to_dict_with_column_summary_list(self):
+        df = pd.DataFrame({"age": [20]})
+        frame = ar.from_pandas(df)
+        res = ar.schema_export.schema_to_dict(frame.schema_summary)
+        assert res == {"fields": {"age": {"type": "INT64", "nullable": False}}}


### PR DESCRIPTION
Enhance schema_to_dict and schema_to_yaml in schema_export.py to gracefully support ArFrame objects (resolving their schema_summary property) and lists of ColumnSummary. This avoids TypeError or validation crashes when exporting schemas of empty DataFrames, returning a cleanly structured empty schema description dict instead. Unit tests added to verify correct serialization behavior.