### PR TITLE
feat: expose explain= param on pandas accessor auto_clean

### DIFF
--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -10,7 +10,13 @@ import pandas as pd
 from arnio.convert import from_pandas, to_pandas
 from arnio.frame import ArFrame
 from arnio.pipeline import pipeline as run_pipeline
-from arnio.quality import DataQualityReport, auto_clean, profile, suggest_cleaning
+from arnio.quality import (
+    CleanExplanation,
+    DataQualityReport,
+    auto_clean,
+    profile,
+    suggest_cleaning,
+)
 from arnio.schema import Schema, ValidationResult, validate
 
 
@@ -86,22 +92,45 @@ class ArnioPandasAccessor:
         return_report: bool = False,
         dry_run: bool = False,
         allow_lossy_casts: bool = False,
-    ) -> pd.DataFrame | DataQualityReport | tuple[pd.DataFrame, DataQualityReport]:
-        """Run Arnio's automatic cleaning and return pandas output."""
+        explain: bool = False,
+    ) -> (
+        pd.DataFrame
+        | DataQualityReport
+        | tuple[pd.DataFrame, DataQualityReport]
+        | tuple[pd.DataFrame, CleanExplanation]
+        | tuple[pd.DataFrame, DataQualityReport, CleanExplanation]
+    ):
+        """Run Arnio's automatic cleaning and return pandas output.
+
+        Parameters
+        ----------
+        explain : bool, default False
+            When ``True``, also return a :class:`~arnio.quality.CleanExplanation`
+            audit trail describing which steps ran and why.
+        """
         result = auto_clean(
             self.to_arframe(),
             mode=mode,
             return_report=return_report,
             dry_run=dry_run,
             allow_lossy_casts=allow_lossy_casts,
+            explain=explain,
         )
 
-        if dry_run and not return_report:
+        if dry_run:
             return result
+
+        if return_report and explain:
+            frame, report, explanation = result
+            return to_pandas(frame), report, explanation
 
         if return_report:
             frame, report = result
             return to_pandas(frame), report
+
+        if explain:
+            frame, explanation = result
+            return to_pandas(frame), explanation
 
         return to_pandas(result)
 

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -134,3 +134,29 @@ def test_auto_clean_dry_run_safe_mode_does_not_mutate():
     assert isinstance(result, ar.DataQualityReport)
     # Frame must not be mutated — score stays as string
     assert frame.dtypes["score"] == "string"
+
+
+# --- Issue #1397: expose explain= on pandas accessor auto_clean ---
+
+
+def test_pandas_accessor_auto_clean_explain_returns_dataframe_and_explanation():
+    df = pd.DataFrame({"name": [" Alice ", "Bob"]})
+
+    result, explanation = df.arnio.auto_clean(explain=True)
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["Alice", "Bob"]
+    assert isinstance(explanation, ar.CleanExplanation)
+    assert explanation.mode == "safe"
+    assert any(s.step == "strip_whitespace" for s in explanation.steps)
+
+
+def test_pandas_accessor_auto_clean_return_report_and_explain():
+    df = pd.DataFrame({"name": [" Alice ", "Bob"]})
+
+    result, report, explanation = df.arnio.auto_clean(return_report=True, explain=True)
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["Alice", "Bob"]
+    assert isinstance(report, ar.DataQualityReport)
+    assert isinstance(explanation, ar.CleanExplanation)


### PR DESCRIPTION
## Summary
Add `explain: bool = False` to `ArnioPandasAccessor.auto_clean()` for parity with the core `ar.auto_clean()` API.

The parameter is forwarded to the core function, and all return shapes (`explain` only, `return_report + explain`) are handled correctly.

Existing `dry_run` and `return_report` behavior remains unchanged.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
fixes #1397 

## Type of change
- [ ] Bug fix
- [X] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [X] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [X] Other: `python -m pytest tests/test_pandas_accessor.py -v` # 13 passed in 1.13s

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

