### PR TITLE
fix: raise TypeError for non-bool redact_values in ValidationResult.to_markdown()

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1009,6 +1009,8 @@ class ValidationResult:
             raise TypeError("max_issues must be an integer or None")
         if max_issues is not None and max_issues < 0:
             raise ValueError("max_issues must be non-negative")
+        if not isinstance(redact_values, bool):
+            raise TypeError("redact_values must be a bool")
 
         status = "passed" if self.passed else "failed"
         lines = [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -859,6 +859,8 @@ def test_validation_result_to_markdown_none_value_redacted():
     markdown_raw = result.to_markdown()  # default redaction is False
     # None -> empty cell in raw mode
     assert "[REDACTED]" not in markdown_raw
+
+
 def _make_failing_result() -> ar.ValidationResult:
     """Helper: a ValidationResult with one issue, for redact_values type tests."""
     return ar.ValidationResult(
@@ -885,9 +887,9 @@ def test_to_markdown_rejects_non_bool_redact_values():
         try:
             result.to_markdown(redact_values=invalid)  # type: ignore[arg-type]
         except TypeError as exc:
-            assert "redact_values must be a bool" in str(exc), (
-                f"Wrong error message for {invalid!r}: {exc}"
-            )
+            assert "redact_values must be a bool" in str(
+                exc
+            ), f"Wrong error message for {invalid!r}: {exc}"
         else:
             raise AssertionError(
                 f"Expected TypeError for redact_values={invalid!r}, but no exception was raised"
@@ -904,6 +906,7 @@ def test_to_markdown_accepts_bool_redact_values():
     assert "0" in md_false, "Raw value should appear when redact_values=False"
     assert "[REDACTED]" in md_true, "[REDACTED] should appear when redact_values=True"
     assert "0" not in md_true.split("| Value |")[-1] or "[REDACTED]" in md_true
+
 
 def test_unique_constraint_detects_duplicates(tmp_path):
     path = tmp_path / "unique.csv"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -859,7 +859,51 @@ def test_validation_result_to_markdown_none_value_redacted():
     markdown_raw = result.to_markdown()  # default redaction is False
     # None -> empty cell in raw mode
     assert "[REDACTED]" not in markdown_raw
+def _make_failing_result() -> ar.ValidationResult:
+    """Helper: a ValidationResult with one issue, for redact_values type tests."""
+    return ar.ValidationResult(
+        row_count=1,
+        issue_count=1,
+        issues=[
+            ar.ValidationIssue(
+                column="col",
+                rule="min",
+                row_index=1,
+                value=0,
+                message="below minimum",
+            )
+        ],
+        bad_rows=[1],
+    )
 
+
+def test_to_markdown_rejects_non_bool_redact_values():
+    """to_markdown() must raise TypeError for any non-bool redact_values argument."""
+    result = _make_failing_result()
+
+    for invalid in ("false", "true", "", 0, 1, None, [], {}):
+        try:
+            result.to_markdown(redact_values=invalid)  # type: ignore[arg-type]
+        except TypeError as exc:
+            assert "redact_values must be a bool" in str(exc), (
+                f"Wrong error message for {invalid!r}: {exc}"
+            )
+        else:
+            raise AssertionError(
+                f"Expected TypeError for redact_values={invalid!r}, but no exception was raised"
+            )
+
+
+def test_to_markdown_accepts_bool_redact_values():
+    """to_markdown() must not raise for redact_values=True or redact_values=False."""
+    result = _make_failing_result()
+
+    md_false = result.to_markdown(redact_values=False)
+    md_true = result.to_markdown(redact_values=True)
+
+    assert "0" in md_false, "Raw value should appear when redact_values=False"
+    assert "[REDACTED]" in md_true, "[REDACTED] should appear when redact_values=True"
+    assert "0" not in md_true.split("| Value |")[-1] or "[REDACTED]" in md_true
 
 def test_unique_constraint_detects_duplicates(tmp_path):
     path = tmp_path / "unique.csv"


### PR DESCRIPTION
Fixes #1471

## Summary
`ValidationResult.to_markdown()` silently accepted any truthy/falsy value for
`redact_values` (e.g. `"false"`, `0`, `None`). This PR adds a strict bool type
check so invalid inputs raise a clear `TypeError` immediately, matching the
pattern already used for `max_issues` in the same method.

## Linked issue
Fixes #1471

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] Schema validation
- [x] Python API / ArFrame

## Testing
Ran locally on Windows with Python 3.11:

Result: **12 passed**

Includes 2 new tests:
- `test_to_markdown_rejects_non_bool_redact_values` — confirms `"false"`, `0`, `None`, `[]`, etc. raise `TypeError` with the correct message.
- `test_to_markdown_accepts_bool_redact_values` — regression test confirming `True` and `False` still work and redaction behaviour is unchanged.

- [x] Other: `python -m pytest tests/test_schema.py -k "to_markdown" -v` — 12 passed

## Screenshots / Media
N/A — no UI or terminal output changes.

## Performance Impact
None. The added check is a single `isinstance` call on a boolean parameter,
with negligible cost.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix:`).