### PR TITLE
test : add unit tests for convert.to_dict under duplicate column names

### DIFF
--- a/tests/test_to_dict.py
+++ b/tests/test_to_dict.py
@@ -114,5 +114,7 @@ class TestArFrameToDictExtended:
 
     def test_to_dict_duplicate_column_names_blocked(self):
         """from_pandas raises error for duplicate column names."""
-        with pytest.raises(ValueError, match="does not support duplicate column labels"):
-            frame = ar.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["a", "b", "a"]))
+        with pytest.raises(
+            ValueError, match="does not support duplicate column labels"
+        ):
+            ar.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["a", "b", "a"]))

--- a/tests/test_to_dict.py
+++ b/tests/test_to_dict.py
@@ -1,6 +1,7 @@
 """Tests for ArFrame.to_dict method - additional coverage."""
 
 import pandas as pd
+import pytest
 
 import arnio as ar
 
@@ -110,3 +111,8 @@ class TestArFrameToDictExtended:
         result = frame.to_dict()
         assert len(result["a"]) == len(frame)
         assert len(result["b"]) == len(frame)
+
+    def test_to_dict_duplicate_column_names_blocked(self):
+        """from_pandas raises error for duplicate column names."""
+        with pytest.raises(ValueError, match="does not support duplicate column labels"):
+            frame = ar.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["a", "b", "a"]))


### PR DESCRIPTION
## Summary
- Add test documenting that from_pandas raises error for duplicate column names
- Ensure to_dict behavior is properly validated with valid input

## Verification
`pytest tests/test_to_dict.py -v`