### PR TITLE
test : add missing tests for typecasting nullable integer series

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1143,6 +1143,51 @@ class TestNullableInt64ObjectConversion:
         assert list(result["col"]) == [1, pd.NA, 3]
 
 
+class TestCastNullableInt:
+    """Tests for casting object series with None/NaN and valid integers."""
+
+    def test_cast_object_series_with_none_and_valid_integers(self):
+        """Casting object column with None and integer strings to int64."""
+        df = pd.DataFrame({"val": [1, None, 3, "4", None]})
+        frame = ar.from_pandas(df)
+        result = ar.cast_types(frame, {"val": "int64"}, errors="coerce")
+        df_result = ar.to_pandas(result)
+        assert result.dtypes["val"] == "int64"
+        assert df_result["val"].iloc[0] == 1
+        assert pd.isna(df_result["val"].iloc[1])  # type: ignore[arg-type]
+        assert df_result["val"].iloc[2] == 3
+        assert df_result["val"].iloc[3] == 4
+        assert pd.isna(df_result["val"].iloc[4])  # type: ignore[arg-type]
+
+    def test_cast_object_series_with_nan_and_valid_integers(self):
+        """Casting object column with float NaN and integer values to int64."""
+        df = pd.DataFrame({"val": pd.Series([1, float("nan"), 3, 4], dtype=object)})
+        frame = ar.from_pandas(df)
+        result = ar.cast_types(frame, {"val": "int64"}, errors="coerce")
+        df_result = ar.to_pandas(result)
+        assert result.dtypes["val"] == "int64"
+        assert df_result["val"].iloc[0] == 1
+        assert pd.isna(df_result["val"].iloc[1])  # type: ignore[arg-type]
+        assert df_result["val"].iloc[2] == 3
+        assert df_result["val"].iloc[3] == 4
+
+    def test_cast_object_series_all_valid_integers_from_object(self):
+        """Casting object column with all valid integers to int64."""
+        df = pd.DataFrame({"val": ["10", "20", "30"]})
+        frame = ar.from_pandas(df)
+        result = ar.cast_types(frame, {"val": "int64"})
+        df_result = ar.to_pandas(result)
+        assert result.dtypes["val"] == "int64"
+        assert list(df_result["val"]) == [10, 20, 30]
+
+    def test_cast_object_series_raises_on_invalid(self):
+        """Casting object column with invalid string raises TypeCastError."""
+        df = pd.DataFrame({"val": [1, 2, "not_a_number"]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(ar.TypeCastError, match="Cannot cast column 'val'"):
+            ar.cast_types(frame, {"val": "int64"})
+
+
 def test_from_records_rejects_string_columns():
     import pytest
 


### PR DESCRIPTION
## Summary
- Added `TestCastNullableInt` class with 4 tests for casting object series with None/NaN and valid integers to int64

## Changes
- `tests/test_convert.py`: Added 4 new tests for nullable integer series typecasting