### PR TITLE
Fix: Add validation for String min_length and max_length

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -6,6 +6,7 @@ Production data contracts and validation.
 from __future__ import annotations
 
 import json
+import numbers
 import re
 import warnings
 from dataclasses import dataclass, field
@@ -1662,6 +1663,30 @@ def Float64(
     )
 
 
+def _normalize_length(name: str, val: Any) -> int | None:
+    """Validate and normalize string length constraints."""
+
+    if val is None:
+        return None
+
+    # Reject boolean values explicitly.
+    # numpy.bool_ may satisfy numbers.Integral in some environments.
+    if isinstance(val, bool) or (
+        type(val).__module__ == "numpy" and type(val).__name__ == "bool_"
+    ):
+        raise TypeError(f"{name} must be an integer or None")
+
+    if not isinstance(val, numbers.Integral):
+        raise TypeError(f"{name} must be an integer or None")
+
+    val = int(val)
+
+    if val < 0:
+        raise ValueError(f"{name} must be >= 0")
+
+    return val
+
+
 def String(
     *,
     nullable: bool = True,
@@ -1688,6 +1713,8 @@ def String(
     Returns:
         Field: Configured string schema field.
     """
+    min_length = _normalize_length("min_length", min_length)
+    max_length = _normalize_length("max_length", max_length)
 
     if min_length is not None and max_length is not None and min_length > max_length:
         raise ValueError("min_length must be less than or equal to max_length")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3042,3 +3042,52 @@ def test_float64_rejects_string_min_with_valid_max():
 def test_float64_rejects_bool_pair():
     with pytest.raises(TypeError, match="min must be numeric or None"):
         ar.Float64(min=True, max=False)
+
+
+def test_string_length_integer_subclass_serialization():
+    class MyInt(int):
+        pass
+
+    schema = ar.Schema(
+        {
+            "x": ar.String(
+                min_length=MyInt(3),
+                max_length=MyInt(5),
+            )
+        }
+    )
+
+    json_data = schema.to_json()
+    loaded = ar.Schema.from_json(json_data)
+
+    loaded_field = loaded.fields["x"]
+
+    assert loaded_field.min_length == 3
+    assert loaded_field.max_length == 5
+
+    assert loaded_field.min_length.__class__ is int
+    assert loaded_field.max_length.__class__ is int
+
+
+def test_string_length_validation_invalid_types():
+    with pytest.raises(TypeError, match="min_length must be an integer or None"):
+        ar.String(min_length="a")
+
+    with pytest.raises(TypeError, match="max_length must be an integer or None"):
+        ar.String(max_length=1.5)
+
+
+def test_string_length_validation_booleans():
+    with pytest.raises(TypeError, match="min_length must be an integer or None"):
+        ar.String(min_length=True)
+
+    with pytest.raises(TypeError, match="max_length must be an integer or None"):
+        ar.String(max_length=False)
+
+
+def test_string_length_validation_negative():
+    with pytest.raises(ValueError, match="min_length must be >= 0"):
+        ar.String(min_length=-1)
+
+    with pytest.raises(ValueError, match="max_length must be >= 0"):
+        ar.String(max_length=-1)


### PR DESCRIPTION
## Summary
Added type and value validation for `min_length` and `max_length` in the `String` field constructor. 
- Prevents `UFuncTypeError` from NumPy by rejecting non-integer types (strings, floats).
- Explicitly rejects `bool` types.
- Rejects negative integers with a clear `ValueError`.
- Added new test cases to ensure edge cases are handled.

## Linked issue
Fixes #1415

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Tested locally using pytest:
- Ran `pytest tests/test_schema.py`
- Verified that `ar.String(min_length="a")` raises `TypeError`.
- Verified that `ar.String(min_length=-1)` raises `ValueError`.

## Screenshots / Media
Testing the validation logic locally with `pytest`:
<img width="999" height="110" alt="testcases" src="https://github.com/user-attachments/assets/4601db6e-05c4-4dfd-8fcd-323446ca7823" />

`schema.py`:
<img width="765" height="190" alt="schema py" src="https://github.com/user-attachments/assets/12d8f3b0-25ba-4b8d-b13d-50a7ad6c91c9" />


`test_schema.py`:
<img width="515" height="361" alt="testcase_code" src="https://github.com/user-attachments/assets/69e06cd2-491e-4ab9-8f0b-51f9e957cc0d" />

## Performance Impact
None. Basic integer validation in the constructor is lightweight.

## GSSoC labels
## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: validate string length bounds`).