### PR TITLE
fix(schema): reject bare string values in String(allowed=...)

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1692,6 +1692,11 @@ def String(
     if min_length is not None and max_length is not None and min_length > max_length:
         raise ValueError("min_length must be less than or equal to max_length")
 
+    if isinstance(allowed, (str, bytes)):
+        raise TypeError(
+            "allowed must be a sequence of allowed values, not a bare string"
+        )
+
     allowed_set = set(allowed) if allowed is not None else None
 
     return Field(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1521,6 +1521,32 @@ def test_string_max_length_boundary(tmp_path):
     assert result.issues[0].row_index == 2
 
 
+def test_string_allowed_rejects_bare_string():
+    with pytest.raises(
+        TypeError,
+        match="allowed must be a sequence of allowed values, not a bare string",
+    ):
+        ar.String(allowed="active")
+
+
+def test_string_allowed_rejects_bare_bytes():
+    with pytest.raises(
+        TypeError,
+        match="allowed must be a sequence of allowed values, not a bare string",
+    ):
+        ar.String(allowed=b"active")
+
+
+def test_string_allowed_accepts_list_tuple_and_set():
+    list_field = ar.String(allowed=["active"])
+    tuple_field = ar.String(allowed=("active",))
+    set_field = ar.String(allowed={"active"})
+
+    assert list_field.allowed == {"active"}
+    assert tuple_field.allowed == {"active"}
+    assert set_field.allowed == {"active"}
+
+
 def test_null_values_skip_length_validation(tmp_path):
     path = tmp_path / "names.csv"
     path.write_text("name\n\nabcd\n")


### PR DESCRIPTION
### Fixes #1417 

## Summary

Fixes a schema-configuration issue where `String(allowed=...)` accepted bare string values and incorrectly converted them into character sets using `set(allowed)`.

### Problem

The previous implementation converted any non-`None` `allowed` value using:

```python id="t0gml3"
allowed_set = set(allowed)
```

This worked correctly for sequences such as:

```python id="dj4egq"
["active"]
("active",)
{"active"}
```

but incorrectly accepted bare strings:

```python id="0n3k11"
ar.String(allowed="active")
```

which produced:

```python id="8uzhll"
{"a", "c", "t", "i", "v", "e"}
```

instead of treating `"active"` as a single allowed value.

### Changes made

* Added explicit validation to reject bare `str` and `bytes` values before converting `allowed` into a set
* Raised a clear:

  ```txt
  TypeError: allowed must be a sequence of allowed values, not a bare string
  ```
* Added focused regression coverage for:

  * `allowed="active"`
  * `allowed=b"active"`
  * `allowed=["active"]`
  * `allowed=("active",)`
  * `allowed={"active"}`

### Result

`String(allowed=...)` now rejects ambiguous bare string configurations while preserving existing list/tuple/set behavior unchanged.


