### PR TITLE
test: add unit tests for JsonlReadError class structure and serialization

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -97,9 +97,7 @@ def test_jsonl_read_error_for_blank_lines_only_file(tmp_path):
 def test_jsonl_read_error_for_invalid_json_includes_line_number(tmp_path):
     bad_json_file = tmp_path / "bad.jsonl"
     bad_json_file.write_text(
-        '{"name": "Alice"}\n'
-        'NOT VALID JSON\n'
-        '{"name": "Bob"}\n',
+        '{"name": "Alice"}\n' "NOT VALID JSON\n" '{"name": "Bob"}\n',
         encoding="utf-8",
     )
 
@@ -114,8 +112,7 @@ def test_jsonl_read_error_for_invalid_json_includes_line_number(tmp_path):
 def test_jsonl_read_error_for_non_object_json_line(tmp_path):
     array_file = tmp_path / "array.jsonl"
     array_file.write_text(
-        '{"name": "Alice"}\n'
-        '[1, 2, 3]\n',
+        '{"name": "Alice"}\n' "[1, 2, 3]\n",
         encoding="utf-8",
     )
 
@@ -150,4 +147,3 @@ def test_jsonl_read_error_can_be_caught_as_arnio_error(tmp_path):
 def test_jsonl_read_error_message_is_non_empty_string():
     err = ar.JsonlReadError("test error message")
     assert str(err) == "test error message"
-

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -8,6 +8,7 @@ def test_public_exception_hierarchy():
     public_exceptions = [
         ar.ArnioError,
         ar.CsvReadError,
+        ar.JsonlReadError,
         ar.TypeCastError,
         ar.UnknownStepError,
     ]
@@ -51,3 +52,102 @@ def test_unknown_step_error_has_clear_message():
     assert message
     assert "unknown pipeline step" in message.lower()
     assert "available steps" in message.lower()
+
+
+def test_jsonl_read_error_is_arnio_error():
+    assert issubclass(ar.JsonlReadError, ar.ArnioError)
+    assert issubclass(ar.JsonlReadError, Exception)
+
+
+def test_jsonl_read_error_for_missing_file_has_clear_message(tmp_path):
+    missing_path = tmp_path / "missing.jsonl"
+
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(str(missing_path))
+
+    message = str(exc_info.value)
+    assert message
+    assert "missing.jsonl" in message
+
+
+def test_jsonl_read_error_for_empty_file_has_clear_message(tmp_path):
+    empty_file = tmp_path / "empty.jsonl"
+    empty_file.write_text("", encoding="utf-8")
+
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(str(empty_file))
+
+    message = str(exc_info.value)
+    assert message
+    assert "empty" in message.lower()
+
+
+def test_jsonl_read_error_for_blank_lines_only_file(tmp_path):
+    blank_file = tmp_path / "blank.jsonl"
+    blank_file.write_text("\n\n   \n\t\n", encoding="utf-8")
+
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(str(blank_file))
+
+    message = str(exc_info.value)
+    assert message
+    assert "empty" in message.lower()
+
+
+def test_jsonl_read_error_for_invalid_json_includes_line_number(tmp_path):
+    bad_json_file = tmp_path / "bad.jsonl"
+    bad_json_file.write_text(
+        '{"name": "Alice"}\n'
+        'NOT VALID JSON\n'
+        '{"name": "Bob"}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(str(bad_json_file))
+
+    message = str(exc_info.value)
+    assert message
+    assert "line 2" in message
+
+
+def test_jsonl_read_error_for_non_object_json_line(tmp_path):
+    array_file = tmp_path / "array.jsonl"
+    array_file.write_text(
+        '{"name": "Alice"}\n'
+        '[1, 2, 3]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(str(array_file))
+
+    message = str(exc_info.value)
+    assert message
+    assert "line 2" in message
+    assert "json object" in message.lower()
+
+
+def test_jsonl_read_error_for_invalid_json_on_first_line(tmp_path):
+    bad_first = tmp_path / "bad_first.jsonl"
+    bad_first.write_text("{invalid json}\n", encoding="utf-8")
+
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(str(bad_first))
+
+    message = str(exc_info.value)
+    assert message
+    assert "line 1" in message
+
+
+def test_jsonl_read_error_can_be_caught_as_arnio_error(tmp_path):
+    missing_path = tmp_path / "nope.jsonl"
+
+    with pytest.raises(ar.ArnioError):
+        ar.read_jsonl(str(missing_path))
+
+
+def test_jsonl_read_error_message_is_non_empty_string():
+    err = ar.JsonlReadError("test error message")
+    assert str(err) == "test error message"
+


### PR DESCRIPTION
Closes #1577. Adds comprehensive unit tests for `JsonlReadError` in `tests/test_exceptions.py`:

- Verifies `JsonlReadError` is a subclass of `ArnioError` and `Exception`
- Tests that a missing file raises `JsonlReadError` with the filename in the message
- Tests that an empty file raises `JsonlReadError` with 'empty' in the message
- Tests that a blank-lines-only file raises `JsonlReadError` as empty
- Tests that invalid JSON on a specific line raises `JsonlReadError` with the correct line number
- Tests that a non-object JSON line (e.g., array) raises `JsonlReadError` with line number and 'JSON object'
- Tests that `JsonlReadError` can be caught as the parent `ArnioError`
- Tests that the error message string is preserved correctly