### PR TITLE
test: cover PipelineStepError properties (#1579)

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -197,3 +197,21 @@ def test_schema_validation_error_optional_result():
 
     assert str(exc) == message
     assert exc.result is None
+
+
+def test_pipeline_step_error_preserves_step_name_and_original_error():
+    orig_err = ValueError("bad custom transform")
+    step_err = ar.PipelineStepError("normalize_names", orig_err)
+
+    assert step_err.step_name == "normalize_names"
+    assert step_err.orig_err is orig_err
+
+
+def test_pipeline_step_error_has_clear_string_representation():
+    step_err = ar.PipelineStepError("normalize_names", RuntimeError("boom"))
+
+    message = str(step_err)
+    assert message
+    assert "custom pipeline step" in message.lower()
+    assert "normalize_names" in message
+    assert "boom" in message


### PR DESCRIPTION
## Summary
- add direct unit tests for \PipelineStepError\ in \	ests/test_exceptions.py\
- verify the exception preserves both \step_name\ and \orig_err\
- verify the string representation includes the step context and original error message

## Testing
- \python -m pytest tests/test_exceptions.py -k pipeline_step_error\
- \python -m pytest tests/test_exceptions.py::test_pipeline_step_error_preserves_step_name_and_original_error tests/test_exceptions.py::test_pipeline_step_error_has_clear_string_representation\
- \git diff --check\

## Notes
- I also tried \python -m pytest tests/test_exceptions.py\ locally, but unrelated existing environment/runtime issues in other tests in that file prevented a clean full-file pass here. The two new tests added in this PR pass locally.

Closes #1579