### PR TITLE
feat: extend df.arnio cleaning wrappers (#1606)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ clean_df = df.arnio.clean([
 ])
 
 report = clean_df.arnio.profile()
+
+trimmed_df = (
+    df.arnio.strip_whitespace(subset=["customer_name"])
+      .arnio.clip_numeric(upper=100, subset=["loyalty_score"])
+      .arnio.drop_nulls(subset=["customer_name"])
+)
 ```
 ## Cross-field validation rules
 

--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -7,6 +7,12 @@ from typing import Any
 
 import pandas as pd
 
+from arnio.cleaning import (
+    clip_numeric as clip_numeric_values,
+    drop_nulls as drop_null_rows,
+    fill_nulls as fill_null_values,
+    strip_whitespace as strip_whitespace_values,
+)
 from arnio.convert import from_pandas, to_pandas
 from arnio.frame import ArFrame
 from arnio.pipeline import pipeline as run_pipeline
@@ -59,6 +65,37 @@ class ArnioPandasAccessor:
             strip_whitespace=strip_whitespace,
             drop_nulls=drop_nulls,
             drop_duplicates=drop_duplicates,
+        )
+        return to_pandas(frame)
+
+    def strip_whitespace(self, *, subset: list[str] | None = None) -> pd.DataFrame:
+        """Trim leading/trailing whitespace and return pandas output."""
+        frame = strip_whitespace_values(self.to_arframe(), subset=subset)
+        return to_pandas(frame)
+
+    def drop_nulls(self, *, subset: list[str] | None = None) -> pd.DataFrame:
+        """Drop rows with nulls in the selected columns."""
+        frame = drop_null_rows(self.to_arframe(), subset=subset)
+        return to_pandas(frame)
+
+    def fill_nulls(self, value: Any, *, subset: list[str] | None = None) -> pd.DataFrame:
+        """Fill nulls in the selected columns and return pandas output."""
+        frame = fill_null_values(self.to_arframe(), value, subset=subset)
+        return to_pandas(frame)
+
+    def clip_numeric(
+        self,
+        *,
+        lower: int | float | None = None,
+        upper: int | float | None = None,
+        subset: list[str] | None = None,
+    ) -> pd.DataFrame:
+        """Clip numeric values in the selected columns and return pandas output."""
+        frame = clip_numeric_values(
+            self.to_arframe(),
+            lower=lower,
+            upper=upper,
+            subset=subset,
         )
         return to_pandas(frame)
 

--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -9,8 +9,14 @@ import pandas as pd
 
 from arnio.cleaning import (
     clip_numeric as clip_numeric_values,
+)
+from arnio.cleaning import (
     drop_nulls as drop_null_rows,
+)
+from arnio.cleaning import (
     fill_nulls as fill_null_values,
+)
+from arnio.cleaning import (
     strip_whitespace as strip_whitespace_values,
 )
 from arnio.convert import from_pandas, to_pandas
@@ -78,7 +84,9 @@ class ArnioPandasAccessor:
         frame = drop_null_rows(self.to_arframe(), subset=subset)
         return to_pandas(frame)
 
-    def fill_nulls(self, value: Any, *, subset: list[str] | None = None) -> pd.DataFrame:
+    def fill_nulls(
+        self, value: Any, *, subset: list[str] | None = None
+    ) -> pd.DataFrame:
         """Fill nulls in the selected columns and return pandas output."""
         frame = fill_null_values(self.to_arframe(), value, subset=subset)
         return to_pandas(frame)

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -40,6 +40,36 @@ def test_pandas_accessor_runs_convenience_clean():
     assert list(result["score"]) == [10]
 
 
+def test_pandas_accessor_supports_direct_cleaning_wrapper_chains():
+    df = pd.DataFrame({"name": [" Alice ", "Bob", None], "age": [25, 150, 30]})
+
+    result = (
+        df.arnio.strip_whitespace(subset=["name"])
+        .arnio.clip_numeric(upper=100, subset=["age"])
+        .arnio.drop_nulls()
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["name"]) == ["Alice", "Bob"]
+    assert list(result["age"]) == [25, 100]
+    assert list(df["name"]) == [" Alice ", "Bob", None]
+    assert list(df["age"]) == [25, 150, 30]
+
+
+def test_pandas_accessor_fill_nulls_updates_selected_columns_only():
+    df = pd.DataFrame(
+        {"name": ["Alice", None], "city": [None, "Delhi"], "score": [10, 20]}
+    )
+
+    result = df.arnio.fill_nulls("unknown", subset=["city"])
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result["city"]) == ["unknown", "Delhi"]
+    assert pd.isna(result.loc[1, "name"])
+    assert list(result["score"]) == [10, 20]
+    assert pd.isna(df.loc[0, "city"])
+
+
 def test_pandas_accessor_profiles_dataframe_quality():
     df = pd.DataFrame({"name": [" Alice ", "Bob"], "score": [1.5, None]})
 

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -52,7 +52,8 @@ def test_pandas_accessor_supports_direct_cleaning_wrapper_chains():
     assert isinstance(result, pd.DataFrame)
     assert list(result["name"]) == ["Alice", "Bob"]
     assert list(result["age"]) == [25, 100]
-    assert list(df["name"]) == [" Alice ", "Bob", None]
+    assert list(df["name"][:2]) == [" Alice ", "Bob"]
+    assert pd.isna(df.loc[2, "name"])
     assert list(df["age"]) == [25, 150, 30]
 
 


### PR DESCRIPTION
## Summary
- extend `df.arnio` with direct pandas-chain wrappers for `strip_whitespace`, `drop_nulls`, `fill_nulls`, and `clip_numeric`
- add focused accessor tests for chained cleaning usage and subset-scoped null filling
- document the direct-wrapper chaining pattern in the README pandas example

## Testing
- `python -m py_compile arnio/integrations/pandas.py tests/test_pandas_accessor.py`
- `python -m ruff check arnio/integrations/pandas.py tests/test_pandas_accessor.py`
- `python -m black --check arnio/integrations/pandas.py tests/test_pandas_accessor.py`
- `python -m pytest tests/test_pandas_accessor.py -k "direct_cleaning_wrapper_chains or fill_nulls_updates_selected_columns_only or runs_convenience_clean"` *(blocked locally by an existing `from_pandas` -> `_Frame.from_dict(...)` signature mismatch in this checkout's compiled extension, so accessor integration execution could not be fully verified on this machine)*
- `python -m pytest tests/test_pandas_accessor.py` *(same existing local blocker as above)*
- `git diff --check`

Closes #1606
