### PR TITLE
test(csv): add regression coverage for quoted empty CSV fields

### DIFF
--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1647,8 +1647,7 @@ def test_extra_empty_field_is_rejected(tmp_path):
 
 def test_quoted_empty_csv_field_preserved(tmp_path):
     import warnings
-    import pandas as pd
-    import arnio as ar
+    
 
     csv_path = tmp_path / "quoted_empty.csv"
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1645,6 +1645,30 @@ def test_extra_empty_field_is_rejected(tmp_path):
         ar.read_csv(csv_path)
 
 
+def test_quoted_empty_csv_field_preserved(tmp_path):
+    import warnings
+    import pandas as pd
+    import arnio as ar
+
+    csv_path = tmp_path / "quoted_empty.csv"
+
+    csv_path.write_text(
+        'a,b,c\n'
+        '"",2,3\n'
+        ',4,5\n'
+        '6,7,8\n'
+    )
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+    df = ar.to_pandas(frame)
+
+    assert df["a"].iloc[0] == ""
+    assert pd.isna(df["a"].iloc[1])
+
+    
 def test_permissive_mode_rejects_extra_fields(tmp_path):
     csv_path = tmp_path / "permissive_extra.csv"
 


### PR DESCRIPTION
## Summary

Adds regression coverage for quoted empty CSV fields when using `read_csv(..., on_bad_lines="warn")`.

This test verifies that:

* quoted empty fields (`""`) are preserved as empty strings
* unquoted empty fields continue behaving as null values
* behavior remains stable under permissive/warn parsing flow

## Linked issue

Fixes #1541

## Type of change

* Tests

## Testing

* Added focused regression coverage in `tests/test_csv.py`

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits.
