### PR TITLE
fix: pipeline dry_run validates against intermediate transformed frame

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -340,6 +340,7 @@ def pipeline(
     )
 
     result = frame
+    working_frame = frame
 
     step_timings: list[dict[str, Any]] = []
     applied_steps: list[str] = []
@@ -372,26 +373,29 @@ def pipeline(
             if name == "rename_columns" and (
                 "mapping" not in kwargs or not isinstance(kwargs["mapping"], dict)
             ):
-                step_result = fn(result, mapping=kwargs)
+                step_result = fn(working_frame, mapping=kwargs)
 
                 if not dry_run:
                     result = step_result
+                working_frame = step_result
 
             elif name == "cast_types" and (
                 "mapping" not in kwargs or not isinstance(kwargs["mapping"], dict)
             ):
-                step_result = fn(result, kwargs)
+                step_result = fn(working_frame, kwargs)
 
                 if not dry_run:
                     result = step_result
+                working_frame = step_result
 
             else:
-                target_frame = result
+                target_frame = working_frame
 
                 step_result = fn(target_frame, **kwargs)
 
                 if not dry_run:
                     result = step_result
+                working_frame = step_result
 
             elapsed_sec = perf_counter() - started_at
             elapsed_ms = elapsed_sec * 1000
@@ -434,7 +438,7 @@ def pipeline(
 
             fn = python_step_registry[name]
 
-            df = to_pandas(result)
+            df = to_pandas(working_frame)
 
             # Isolate genuine custom steps from internal core library functions
             is_builtin = _is_builtin_python_step(name, fn)
@@ -469,6 +473,7 @@ def pipeline(
             step_result = from_pandas(returned)
             if not dry_run:
                 result = step_result
+            working_frame = step_result
 
             elapsed_sec = perf_counter() - started_at
             elapsed_ms = elapsed_sec * 1000

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -840,6 +840,176 @@ class TestPipeline:
         assert row_counts[0]["dry_run"] is True
 
 
+class TestPipelineDryRunIntermediateFrame:
+    """Regression tests for dry_run validating against intermediate frame."""
+
+    def test_dry_run_rename_then_validate(self):
+        frame = ar.from_pandas(pd.DataFrame({"old_name": [" Alice "]}))
+        result = ar.pipeline(
+            frame,
+            [
+                ("rename_columns", {"old_name": "name"}),
+                ("validate_columns_exist", {"columns": ["name"]}),
+            ],
+            dry_run=True,
+        )
+        assert result is frame
+        assert "old_name" in ar.to_pandas(result).columns
+
+    def test_dry_run_drop_then_validate_column_gone(self):
+        frame = ar.from_pandas(pd.DataFrame({"keep_me": [1], "drop_me": [2]}))
+        result = ar.pipeline(
+            frame,
+            [
+                ("drop_columns", {"columns": ["drop_me"]}),
+                ("validate_columns_exist", {"columns": ["keep_me"]}),
+            ],
+            dry_run=True,
+        )
+        assert result is frame
+
+    def test_dry_run_drop_then_validate_missing_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"keep_me": [1], "drop_me": [2]}))
+        with pytest.raises(KeyError, match="Missing columns"):
+            ar.pipeline(
+                frame,
+                [
+                    ("drop_columns", {"columns": ["keep_me"]}),
+                    ("validate_columns_exist", {"columns": ["keep_me"]}),
+                ],
+                dry_run=True,
+            )
+
+    def test_dry_run_rename_then_validate_missing_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"old_name": [" Alice "]}))
+        with pytest.raises(KeyError, match="Missing columns"):
+            ar.pipeline(
+                frame,
+                [
+                    ("rename_columns", {"old_name": "name"}),
+                    ("validate_columns_exist", {"columns": ["old_name"]}),
+                ],
+                dry_run=True,
+            )
+
+    def test_dry_run_select_then_validate(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1], "y": [2], "z": [3]}))
+        result = ar.pipeline(
+            frame,
+            [
+                ("select_columns", {"columns": ["x", "y"]}),
+                ("validate_columns_exist", {"columns": ["x", "y"]}),
+            ],
+            dry_run=True,
+        )
+        assert result is frame
+
+    def test_dry_run_select_then_validate_dropped_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1], "y": [2], "z": [3]}))
+        with pytest.raises(KeyError, match="Missing columns"):
+            ar.pipeline(
+                frame,
+                [
+                    ("select_columns", {"columns": ["x", "y"]}),
+                    ("validate_columns_exist", {"columns": ["z"]}),
+                ],
+                dry_run=True,
+            )
+
+    def test_dry_run_and_real_consistency(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"old_name": [" Alice "], "extra": [" Bob "]})
+        )
+        dry_result = ar.pipeline(
+            frame,
+            [
+                ("rename_columns", {"old_name": "name"}),
+                ("drop_columns", {"columns": ["extra"]}),
+                ("strip_whitespace",),
+            ],
+            dry_run=True,
+        )
+        real_result = ar.pipeline(
+            frame,
+            [
+                ("rename_columns", {"old_name": "name"}),
+                ("drop_columns", {"columns": ["extra"]}),
+                ("strip_whitespace",),
+            ],
+            dry_run=False,
+        )
+        assert dry_result is frame
+        assert "name" in ar.to_pandas(real_result).columns
+        assert "old_name" not in ar.to_pandas(real_result).columns
+        assert "extra" not in ar.to_pandas(real_result).columns
+
+    def test_dry_run_does_not_mutate_original(self):
+        original = pd.DataFrame({"delete_me": [1, 2], "keep": [3, 4]})
+        frame = ar.from_pandas(original.copy())
+        ar.pipeline(
+            frame,
+            [
+                ("drop_columns", {"columns": ["delete_me"]}),
+                ("validate_columns_exist", {"columns": ["keep"]}),
+            ],
+            dry_run=True,
+        )
+        pd.testing.assert_frame_equal(ar.to_pandas(frame), original, check_dtype=False)
+
+    def test_dry_run_python_step_advances_intermediate_frame(self):
+        def add_column_step(df):
+            df["added"] = "present"
+            return df
+
+        ar.register_step("test_dry_add_column", add_column_step)
+        frame = ar.from_pandas(pd.DataFrame({"x": [1]}))
+        ar.pipeline(
+            frame,
+            [
+                ("test_dry_add_column",),
+                ("validate_columns_exist", {"columns": ["added"]}),
+            ],
+            dry_run=True,
+        )
+
+    def test_dry_run_transform_then_validate_column_content_type(self):
+        frame = ar.from_pandas(pd.DataFrame({"age_str": ["10", "20", "30"]}))
+        result = ar.pipeline(
+            frame,
+            [
+                ("cast_types", {"age_str": "int64"}),
+                ("validate_columns_exist", {"columns": ["age_str"]}),
+            ],
+            dry_run=True,
+        )
+        assert result is frame
+
+    def test_dry_run_rename_with_mapping_shorthand_then_validate(self):
+        frame = ar.from_pandas(pd.DataFrame({"old": [1], "other": [2]}))
+        result = ar.pipeline(
+            frame,
+            [
+                ("rename_columns", {"old": "new"}),
+                ("validate_columns_exist", {"columns": ["new"]}),
+            ],
+            dry_run=True,
+        )
+        assert result is frame
+
+    def test_dry_run_metadata_still_uses_original_rows(self):
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", None, "Bob", None]}))
+        original_rows = frame.shape[0]
+        _, meta = ar.pipeline(
+            frame,
+            [("drop_nulls",), ("validate_columns_exist", {"columns": ["name"]})],
+            dry_run=True,
+            return_metadata=True,
+        )
+        for entry in meta["row_counts"]:
+            assert entry["after"] == original_rows
+            assert entry["dry_run"] is True
+
+
 def test_get_builtin_step_signatures_returns_normalized_signatures():
     signatures = ar.get_builtin_step_signatures()
 


### PR DESCRIPTION
## PR Description

Fixes #1627

## Summary

`pipeline(frame, steps, dry_run=True)` executed each step but validated all later steps against the **original** `ArFrame` instead of the transformed intermediate frame produced by prior steps.

This caused dry-run mode to incorrectly fail for valid multi-step pipelines where earlier steps modified the schema before later validation steps.

### Example

```python

steps = [

    ("rename_columns", {"old_name": "name"}),  # step 1 renames column

    ("validate_columns_exist", {"columns": ["name"]}),  # step 2 checks renamed column

]

ar.pipeline(frame, steps, dry_run=True)

```

Before this fix:

- step 2 still validated against the original frame

- `name` appeared missing

- dry-run falsely failed

Real execution (`dry_run=False`) succeeded correctly.

---

## Root Cause

The pipeline execution flow only advanced:

```python

result = step_result

```

when:

```python

dry_run == False

```

During dry-run mode, every later step re-read from the original frame instead of the intermediate transformed state.

---

## Fix

Introduced an internal `working_frame` variable that advances after every successful step execution, regardless of `dry_run`.

### Important behavior preserved

- `pipeline(..., dry_run=True)` still returns the original unmodified frame

- no external mutation behavior changed

- only internal validation state progression changed

This preserves the public API contract while making dry-run validation accurate.

---

## What changed

| File | Changes |

|---|---|

| `arnio/pipeline.py` | Added `working_frame` progression logic for dry-run execution |

| `tests/test_pipeline.py` | Added regression tests covering intermediate-frame validation behavior |

---

## Added regression coverage

Tests now cover:

- rename → validate flow

- drop_columns → validate flow

- chained schema-changing operations

- dry-run consistency with real execution

- metadata preservation

- external mutation safety

- Python/custom step execution paths

- cast/transform validation chains

---

## Why this fix is safe

The change is isolated to internal dry-run execution flow.

- No public API changes

- No behavior changes for normal execution

- No persistence/mutation changes

- Existing execution, streaming, and transform logic remain unchanged

The fix only ensures later dry-run steps validate against the correct intermediate state.

---

## Type of change

- [x] Bug fix

- [ ] New feature

- [ ] Breaking change

- [ ] Documentation update

---

## Validation

- Added dedicated regression tests

- Existing pipeline behavior preserved

- Multi-step dry-run pipelines now behave consistently with real execution

---

## Result

`dry_run=True` now correctly simulates step-by-step pipeline execution while still returning the original frame as intended.