### PR TITLE
docs: Add comprehensive API reference documentation with MkDocs

### DIFF
--- a/.test-branch
+++ b/.test-branch
@@ -1,3 +1,0 @@
-# API Reference Documentation
-
-Please see [the full docs](https://github.com/im-anishraj/arnio)

--- a/.test-branch
+++ b/.test-branch
@@ -1,0 +1,3 @@
+# API Reference Documentation
+
+Please see [the full docs](https://github.com/im-anishraj/arnio)

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1,0 +1,519 @@
+# Arnio API Reference
+
+A technical reference guide to the public classes and functions within the **Arnio** library.
+
+## Arnio API Reference Index
+
+| Category              | Components                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| :-------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Core Class**        | [**`ArFrame`**](#arframe) • Properties: [`shape`](#shape), [`columns`](#columns), [`dtypes`](#dtypes) • [`is_empty`](#is_empty) • Methods: [`memory_usage`](#memory_usage), [`preview`](#preview), [`select_columns`](#select_columns), [`select_dtypes`](#select_dtypes)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **I/O**               | [`read_csv`](#read_csv) • [`scan_csv`](#scan_csv) • [`write_csv`](#write_csv) • [`sniff_delimiter`](#sniff_delimiter)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Cleaning**          | [`cast_types`](#cast_types) • [`clean`](#clean) • [`clip_numeric`](#clip_numeric) • [`combine_columns`](#combine_columns) • [`drop_columns`](#drop_columns) • [`drop_constant_columns`](#drop_constant_columns) • [`drop_duplicates`](#drop_duplicates) • [`drop_nulls`](#drop_nulls) • [`fill_nulls`](#fill_nulls) • [`filter_rows`](#filter_rows) • [`keep_rows_with_nulls`](#keep_rows_with_nulls) • [`normalize_case`](#normalize_case) • [`normalize_unicode`](#normalize_unicode) • [`rename_columns`](#rename_columns) • [`replace_values`](#replace_values) • [`round_numeric_columns`](#round_numeric_columns) • [`safe_divide_columns`](#safe_divide_columns) • [`strip_whitespace`](#strip_whitespace) • [`trim_column_names`](#trim_column_names) • [`validate_columns_exist`](#validate_columns_exist) |
+| **Conversion**        | [`from_pandas`](#from_pandas) • [`to_pandas`](#to_pandas)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **Integration**       | [`ArnioPandasAccessor`](#arniopandasaccessor)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **Pipeline**          | [`pipeline`](#pipeline) • [`register_step`](#register_step)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| **Data Quality**      | [`profile`](#profile) â€¢ [`suggest_cleaning`](#suggest_cleaning) â€¢ [`auto_clean`](#auto_clean) â€¢ [`check_quality_gates`](#check_quality_gates) â€¢ [`DataQualityReport`](#dataqualityreport) â€¢ [`ColumnProfile`](#columnprofile)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **Schema Validation** | [`Schema`](#schema) â€¢ [`Field`](#field) â€¢ [`validate`](#validate) â€¢ [`ValidationResult`](#validationresult) â€¢ [`ValidationIssue`](#validationissue) â€¢ [`Int64`](#int64) â€¢ [`Float64`](#float64) â€¢ [`String`](#string) â€¢ [`Bool`](#bool) â€¢ [`Email`](#email) â€¢ [`URL`](#url) â€¢ [`CountryCode`](#countrycode) â€¢ [`DateTime`](#datetime)                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Custom Exceptions** | [`ArnioError`](#arnioerror) â€¢ [`CsvReadError`](#csvreaderror) â€¢ [`TypeCastError`](#typecasterror) â€¢ [`UnknownStepError`](#unknownsteperror)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+
+---
+
+## Prerequisites
+
+```python
+import arnio as ar
+
+df = ar.read_csv("data.csv")
+```
+
+### ArFrame
+
+| Property                            | Return Type       |
+| :---------------------------------- | :---------------- |
+| <a name="columns"></a>**columns**   | `list[str]`       |
+| <a name="dtypes"></a>**dtypes**     | `dict[str, str]`  |
+| <a name="shape"></a>**shape**       | `tuple[int, int]` |
+| <a name="is_empty"></a>**is_empty** | `bool`            |
+
+| Method                                            | Return Type |
+| :------------------------------------------------ | :---------- |
+| <a name="memory_usage"></a>**memory_usage()**     | `int`       |
+| <a name="preview"></a>**preview()**               | `str`       |
+| <a name="select_columns"></a>**select_columns()** | `ArFrame`   |
+| <a name="select_dtypes"></a>**select_dtypes()**   | `ArFrame`   |
+
+```python
+print(f"Column Names: {df.columns}")
+print(f"Data Types: {df.dtypes}")
+print(f"Dataset Shape: {df.shape}")
+print(f"Memory: {df.memory_usage()} bytes")
+print(df.preview())
+df = df.select_columns(columns=["id", "name"])
+df = df.select_dtypes(include=["int64", "float64"])
+```
+
+---
+
+### read_csv
+
+Loads a CSV, TSV, or TXT file into an `ArFrame`.
+
+```python
+df = ar.read_csv("data.csv")
+```
+
+### scan_csv
+
+Return schema (column names + inferred types) without loading data.
+
+```python
+schema = ar.scan_csv("large_dataset.csv")
+```
+
+### write_csv
+
+Writes an `ArFrame` to a CSV file via the C++ backend.
+
+```python
+ar.write_csv(frame, "output.csv")
+```
+
+#### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | required | The data frame to write |
+| `path` | `str \| os.PathLike[str]` | required | Destination file path. Supports `.csv`, `.txt`, `.tsv` |
+| `delimiter` | `str` | `","` | Single character field separator |
+| `write_header` | `bool` | `True` | Whether to write the column header row |
+| `line_terminator` | `str` | `"\n"` | Line terminator between rows |
+
+#### Raises
+
+| Error | When |
+|-------|------|
+| `ValueError` | File extension is not `.csv`, `.txt`, or `.tsv` |
+| `ValueError` | `delimiter` is not exactly one character |
+| `RuntimeError` | File cannot be opened or written |
+
+#### Examples
+
+```python
+# Default comma-separated
+ar.write_csv(frame, "output.csv")
+
+# Tab-separated
+ar.write_csv(frame, "output.tsv", delimiter="\t")
+
+# Without header row
+ar.write_csv(frame, "output.csv", write_header=False)
+
+# Windows line endings
+ar.write_csv(frame, "output.csv", line_terminator="\r\n")
+```
+
+### sniff_delimiter
+
+Sniffs and returns the field delimiter character from a CSV file.
+
+```python
+delimiter = ar.sniff_delimiter("data.csv")
+```
+
+#### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | `str \| os.PathLike[str]` | required | Path to the CSV file |
+| `encoding` | `str` | `"utf-8"` | File encoding |
+| `sample_size` | `int` | `2048` | Number of bytes to sample from the start of the file for sniffing |
+
+#### Returns
+
+`str`
+The detected delimiter (one of `","`, `";"`, `"\t"`, `"|"`).
+
+#### Raises
+
+| Error | When |
+|-------|------|
+| `TypeError` | `encoding` is not a string, or `sample_size` is not an integer |
+| `ValueError` | `sample_size` is <= 0, the encoding is unknown, or the delimiter is ambiguous / tied |
+| `CsvReadError` | The file is empty, or contains binary data (NUL bytes) |
+| `FileNotFoundError` | The file does not exist |
+
+#### Examples
+
+```python
+# Sniff comma-separated file
+delim = ar.sniff_delimiter("comma.csv")  # returns ","
+
+# Sniff semicolon-separated file with custom sample size
+delim = ar.sniff_delimiter("semicolon.csv", sample_size=1024)  # returns ";"
+```
+
+---
+
+### cast_types
+
+Converts specific columns to a new data type using a mapping dictionary.
+
+```python
+df = ar.cast_types(df, {"id": "float64"})
+```
+
+### clean
+
+A high-level wrapper that applies `strip_whitespace`, `drop_nulls`, and `drop_duplicates` in a single call.
+
+```python
+df = ar.clean(df)
+```
+
+### clip_numeric
+
+Clip numeric values to lower and/or upper bounds.
+
+```python
+df = ar.clip_numeric(df, lower=0, upper=100)
+```
+
+### combine_columns
+
+Combine multiple columns into a single output column.
+
+```python
+df = ar.combine_columns(df, separator=",", output_column="combined_col")
+```
+
+### drop_constant_columns
+
+Removes columns with only one unique value.
+
+```python
+df = ar.drop_constant_columns(df)
+```
+
+### drop_columns
+
+Removes the requested columns while preserving the order of the remaining ones.
+
+```python
+frame = ar.drop_columns(frame, ["debug_col"])
+```
+
+### drop_duplicates
+
+Removes identical rows from the dataset.
+
+```python
+df = ar.drop_duplicates(df, keep="first")
+```
+
+### drop_nulls
+
+Excludes rows containing empty or null fields
+
+```python
+df = ar.drop_nulls(df, subset=["email"])
+```
+
+### fill_nulls
+
+Replaces null entry values with a designated static value.
+
+```python
+df = ar.fill_nulls(df, 0, subset=["score"])
+```
+
+### filter_rows
+
+Subsets rows matching an evaluation operator constraint.
+
+```python
+df = ar.filter_rows(df, column="age", op=">", value=18)
+```
+
+### keep_rows_with_nulls
+
+Keep only rows that contain at least one null/empty value.
+
+```python
+df = ar.keep_rows_with_nulls(df)
+```
+
+### normalize_case
+
+Adjusts text casing for consistency.
+
+```python
+df = ar.normalize_case(df, case_type="title")
+```
+
+### normalize_unicode
+
+Normalize Unicode text columns.
+
+```python
+df = ar.normalize_unicode(df, subset=["uni_col"], form="NFC")
+```
+
+### rename_columns
+
+Modifies headers using a translation dictionary mapping old names to new names.
+
+```python
+df = ar.rename_columns(df, {"old": "new"})
+```
+
+### replace_values
+
+Replace values based on a mapping dict.
+
+```python
+df = ar.replace_values(df, {"old_value": "new_value"}, column="name")
+```
+
+### round_numeric_columns
+
+Round numeric columns.
+
+```python
+df = ar.round_numeric_columns(df, decimals=2)
+```
+
+### safe_divide_columns
+
+Divide one column by another.
+
+```python
+df = ar.safe_divide_columns(
+    df,
+    numerator="revenue",
+    denominator="cost",
+    output_column="ratio"
+)
+```
+
+### strip_whitespace
+
+Trims extra spaces from the beginning and end of text entries.
+
+```python
+df = ar.strip_whitespace(df)
+```
+
+### trim_column_names
+
+Trims leading and trailing whitespace from column names.
+
+```python
+df = ar.trim_column_names(df)
+```
+
+### validate_columns_exist
+
+Fail early when required columns are missing.
+
+```python
+df = ar.validate_columns_exist(df, ["age"])
+```
+
+---
+
+### from_pandas
+
+Converts a `pandas.DataFrame` into an Arnio `ArFrame`.
+
+### to_pandas
+
+Converts an `ArFrame` into a `pandas.DataFrame`
+
+```python
+import pandas as pd
+
+pdf = pd.DataFrame(data)
+
+af = ar.from_pandas(pdf)
+df = ar.to_pandas(af)
+```
+
+---
+
+### ArnioPandasAccessor
+
+Run Arnio preparation helpers from an existing pandas DataFrame.
+
+---
+
+### pipeline
+
+Apply a sequence of cleaning steps to an `ArFrame`.
+
+```python
+ops = [
+    ("strip_whitespace",),
+    ("normalize_case", {"case_type": "title"}),
+    ("fill_nulls", {"value": 0, "subset": ["revenue"]}),
+    ("fill_nulls", {"value": "Unknown", "subset": ["name"]}),
+    ("drop_duplicates",),
+]
+df = ar.pipeline(df, ops)
+```
+
+```python
+clean, metadata = ar.pipeline(df, ops, return_metadata=True)
+print(metadata["step_timings"])
+```
+
+### register_step
+
+Extend the pipeline by adding your own custom Python functions.
+
+```python
+def custom_func(df, column):
+    pass
+
+ar.register_step("custom_func", custom_func)
+```
+
+---
+
+### profile
+
+Analyze an `ArFrame` and get a structural `DataQualityReport`.
+
+Key options:
+- `sample_size`: number of non-null sample values stored per column.
+- `approx_top_values`: enable approximate top values for high-cardinality string columns.
+- `approx_top_values_min_unique`: minimum unique count to trigger approximation.
+- `approx_top_values_min_ratio`: minimum unique ratio to trigger approximation.
+- `approx_top_values_sample_size`: sample size for top-value estimation.
+
+When `approx_top_values` is enabled, `top_values` counts/ratios are computed on
+the sample, and `top_values_is_approximate`, `top_values_sample_count`, and
+`top_values_sample_ratio` are included in each `ColumnProfile`.
+
+### suggest_cleaning
+
+Examine a report or frame and get a list of recommended cleaning steps.
+
+### auto_clean
+
+Profile the data and immediately apply repairs.
+
+### check_quality_gates
+
+Compare two `DataQualityReport` objects and return a pass/fail
+`QualityGateResult` for CI or monitoring workflows.
+
+```python
+baseline = ar.profile(ar.read_csv("baseline.csv"))
+current = ar.profile(ar.read_csv("current.csv"))
+
+result = ar.check_quality_gates(
+    baseline,
+    current,
+    max_row_count_delta_ratio=0.10,
+    max_null_ratio_delta=0.05,
+)
+
+print(result.passed)
+print(result.to_markdown())
+```
+
+### DataQualityReport
+
+Summary of structural data quality metrics.
+
+#### Methods:
+* **`to_html(file_path: str | None = None) -> str`**: Generates a self-contained, offline-friendly, beautiful HTML dashboard report of your dataset's metrics, columns, and cleaning suggestions. Dynamically escapes all data values to prevent XSS. If `file_path` is provided, writes the HTML output to a file.
+* **`to_markdown() -> str`**: Returns a GitHub-friendly markdown representation of the report.
+* **`summary() -> dict`**: Returns a high-signal dictionary representation of the report metrics.
+
+### ColumnProfile
+
+Detailed health check for a single column.
+
+```python
+report = ar.profile(df)
+summary = report.summary()
+suggestions = ar.suggest_cleaning(df)
+
+# Export the report as a beautiful, self-contained HTML file
+html_report = report.to_html(file_path="quality_report.html")
+
+safe = ar.auto_clean(df)
+print(ar.to_pandas(safe))
+```
+
+---
+
+#### Schema
+
+The top-level container for validation rules.
+
+#### Field
+
+Defines the specific constraints for a single column.
+
+#### validate
+
+The primary function used to check an `ArFrame` against a `Schema`. It returns a `ValidationResult`.
+
+#### <a name="validationresult"></a>ValidationResult / <a name="validationissue"></a>ValidationIssue
+
+The objects returned after calling `validate()`.
+
+**Row index convention:** `ValidationIssue.row_index` is **1-based** and refers to
+data rows only â€” the CSV header is not counted. So `row_index=1` means the first
+data row, `row_index=2` means the second, and so on.
+
+```python
+# CSV content:
+# name,age        â† header (not counted)
+# Alice,30        â† row 1
+# Bob,-1          â† row 2  â† row_index=2 will appear here for a min violation
+
+result = ar.validate(frame, {"age": ar.Int64(min=0)})
+print(result.issues[0].row_index)  # 2
+```
+
+#### Field Type Helpers
+
+Each helper maps to a specific data type rule.
+
+| Function                                  | Description                                     |
+| :---------------------------------------- | :---------------------------------------------- |
+| <a name="int64"></a>**Int64**             | Validates whole numbers.                        |
+| <a name="float64"></a>**Float64**         | Validates decimal numbers.                      |
+| <a name="string"></a>**String**           | Validates text.                                 |
+| <a name="bool"></a>**Bool**               | Validates True/False boolean values.            |
+| <a name="email"></a>**Email**             | Specialized String validator for email formats. |
+| <a name="url"></a>**URL**                 | Specialized String validator for web links.     |
+| <a name="countrycode"></a>**CountryCode** | Validates uppercase ISO alpha-2 country-code.   |
+| <a name="datetime"></a>**DateTime**       | Validates string timestamps.                    |
+
+---
+
+```python
+user_schema = ar.Schema({
+    "id": ar.Int64(unique=True, nullable=False),
+    "name": ar.String(nullable=False),
+    "revenue": ar.Float64(min=180, max=1000)
+})
+result = ar.validate(df, user_schema)
+```
+
+---
+
+### Custom Exceptions
+
+| Error Name                                                               | Meaning                                                 |
+| :----------------------------------------------------------------------- | :------------------------------------------------------ |
+| <a name="arnioerror"></a>[**ArnioError**](#arnioerror)                   | Base exception for all Arnio errors.                    |
+| <a name="csvreaderror"></a>[**CsvReadError**](#csvreaderror)             | Triggered when a CSV file cannot be read.               |
+| <a name="typecasterror"></a>[**TypeCastError**](#typecasterror)          | Raised when cast_types encounters an incompatible type. |
+| <a name="unknownsteperror"></a>[**UnknownStepError**](#unknownsteperror) | Triggered when a pipeline step name is not registered   |
+
+---

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,16 +4,23 @@ Arnio is designed to provide high-performance, memory-efficient data ingestion a
 
 This document outlines the core architecture and the boundary between Python and C++.
 
+---
+
 ## 1. The Core Philosophy
 
 Data preprocessing often involves operations that are inherently slow in Python (e.g., string manipulation, repeated passes over data). Arnio solves this by:
+
 1. **Loading data directly into C++ memory structures.**
-2. **Performing all cleaning operations natively in C++ without Python GIL contention.**
-3. **Translating the final, pristine dataset to a pandas DataFrame via a zero-copy (or near zero-copy) boundary.**
+
+2. **Prioritizing native C++ execution for core cleaning operations to avoid Python GIL contention, while seamlessly supporting Python-backed and custom steps.**
+
+3. **Translating the final dataset to a `pandas.DataFrame` via a boundary that aims to minimize unnecessary copies.**
+
+---
 
 ## 2. Python ↔ C++ Boundary
 
-The boundary is managed using [`pybind11`](https://github.com/pybind/pybind11). 
+The boundary is managed using [`pybind11`](https://github.com/pybind/pybind11).
 
 The C++ core is compiled into a Python extension module (`_arnio_cpp`). The Python API (in `arnio/`) serves as a lightweight, type-hinted wrapper around this compiled extension.
 
@@ -21,38 +28,246 @@ The C++ core is compiled into a Python extension module (`_arnio_cpp`). The Pyth
 graph TD
     A[Python User Code] --> B[Arnio Python API]
     B -->|pybind11| C[C++ Core _arnio_cpp]
-    
+
     subgraph C++ Runtime
         C --> D[CsvReader]
         C --> E[Frame / Column]
         C --> F[Cleaning Primitives]
     end
-    
+
     F -->|Return| E
     E -->|to_pandas| A
 ```
+
+---
 
 ## 3. Data Model
 
 Arnio's data model is columnar, strongly resembling Apache Arrow or modern Pandas internals.
 
-### `Column`
-A `Column` represents a single 1D array of homogeneous data.
-- **Variant Storage**: Data is stored using `std::variant` over strongly-typed `std::vector`s (e.g., `std::vector<int64_t>`, `std::vector<std::string>`).
-- **Null Handling**: Nulls are tracked via a separate boolean mask (`std::vector<bool>`), allowing the underlying data vectors to remain dense and cache-friendly.
+### Column
 
-### `Frame`
-A `Frame` is an ordered collection of `Column` objects, representing a 2D dataset.
-- The `Frame` maintains an index mapping column names to their respective `Column` objects for `O(1)` access.
+A Column represents a single 1D array of homogeneous data.
 
-## 4. Pipeline Execution
+- **Variant Storage:** Data is stored using `std::variant` over strongly-typed `std::vector`s (e.g., `std::vector<int64_t>`, `std::vector<std::string>`).
 
-The `pipeline()` function in Python accepts a list of declarative steps. 
+- **Null Handling:** Nulls are tracked via a separate boolean mask (`std::vector<bool>`), allowing the underlying data vectors to remain dense and cache-friendly.
 
-1. **Step Registry**: Arnio maintains a registry mapping string names (e.g., `"strip_whitespace"`) to function pointers.
-2. **C++ Execution**: For natively supported operations, the Python wrapper calls the C++ function directly, passing the `Frame` pointer. The operation modifies the data or returns a new `Frame` entirely within C++.
-3. **Python Fallback**: If a step is registered via pure Python (`ar.register_step()`), the `Frame` is temporarily converted to a pandas DataFrame, the Python function executes, and the result is converted back. *(Note: This incurs a conversion penalty and is intended for prototyping or operations not yet supported in C++).*
+### Frame
 
-## 5. Converting to Pandas
+A Frame is an ordered collection of Column objects, representing a 2D dataset.
 
-The `to_pandas()` function is the most critical boundary. It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory directly to pandas, avoiding expensive element-by-element copies where possible (zero-copy for numerics and booleans). String columns currently require instantiation of Python `str` objects.
+The Frame maintains an index mapping column names to their respective Column objects for O(1) access.
+
+---
+
+## 4. Pandas Dtype Compatibility
+
+Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model.
+
+### Fully Supported
+
+- `int64`
+
+- `float64`
+
+- `bool`
+
+- `string`
+
+These allow efficient parsing and cleaning operations within the C++ core.
+
+### Limited/Unsupported Support
+
+- `category`
+
+- Mixed `object` columns
+
+- Nullable pandas dtypes (e.g., `Int64`)
+
+These may require conversion.
+
+`datetime64[ns]` and `timedelta64[ns]` are currently unsupported in the native runtime.
+
+---
+
+## 5. Pipeline Execution & Dispatch Flow
+
+The `pipeline()` function orchestrates data flow by prioritizing C++ efficiency while allowing Python extensibility.
+
+Arnio supports a mix of C++-backed steps, Python-backed built-ins, and custom pipeline steps.
+
+When a step is invoked, the system follows a priority-based dispatch model:
+
+### Built-in Step Path
+
+The system first queries `_STEP_REGISTRY`.
+
+This built-in registry routes operations to highly optimized native C++ backed steps executing directly within the `Frame` / C++ core.
+
+### Custom Pipeline Steps
+
+If the name is absent from `_STEP_REGISTRY`, the system then checks `_PYTHON_STEP_REGISTRY` for Python-backed built-ins and custom user-defined fallback steps.
+
+### The Conversion Penalty
+
+Because Python-based steps expect a `pandas.DataFrame`, the system performs a roundtrip:
+
+```text
+Frame → to_pandas() → from_pandas() → Frame
+```
+
+### Performance Note
+
+This roundtrip involves memory re-allocation.
+
+- `to_pandas()` creates a DataFrame representation.
+
+- `from_pandas()` re-infers types to re-populate the internal data structures.
+
+Core cleaning primitives should ideally be implemented as C++ built-ins to bypass this overhead.
+
+---
+
+### Step Backend Execution Map
+
+This map reflects the current pipeline registry defined in `arnio/pipeline.py`.
+
+The current pipeline registry is split into native C++ backed steps and Python/pandas backed steps.
+
+| Step | Backend |
+|---|---|
+| drop_nulls | Native C++ |
+| keep_rows_with_nulls | Native C++ |
+| fill_nulls | Native C++ |
+| validate_columns_exist | Native C++ |
+| drop_duplicates | Native C++ |
+| drop_constant_columns | Native C++ |
+| clip_numeric | Native C++ |
+| strip_whitespace | Native C++ |
+| parse_bool_strings | Native C++ |
+| normalize_case | Native C++ |
+| normalize_unicode | Native C++ |
+| rename_columns | Native C++ |
+| cast_types | Native C++ |
+| round_numeric_columns | Native C++ |
+| combine_columns | Native C++ |
+| trim_column_names | Native C++ |
+| standardize_missing_tokens | Python/pandas |
+| filter_rows | Python/pandas |
+| drop_columns_matching | Python/pandas |
+| safe_divide_columns | Python/pandas |
+| replace_values | Python/pandas |
+| custom registered steps | Python/pandas |
+
+### Why backend selection matters
+
+Native C++ backed steps execute directly inside the Arnio runtime and avoid pandas conversion overhead.
+
+Python/pandas backed steps use the slower conversion path:
+
+```text
+Frame → to_pandas() → from_pandas() → Frame
+```
+
+---
+
+## 6. Converting to Pandas
+
+The `to_pandas()` function is a critical boundary.
+
+It uses the NumPy C-API (via pybind11's buffer protocol) to expose the underlying C++ `std::vector` memory to pandas, aiming to avoid element-by-element copies for numerics and booleans where supported.
+
+String columns currently require instantiation of Python `str` objects.
+
+---
+
+## 7. Data Quality and Schema Validation
+
+Arnio is split into two layers:
+
+- The C++ layer handles parsing CSVs, storing data in memory, and cleaning operations such as `drop_nulls()` and `strip_whitespace()`. These execute through pybind11 directly in C++.
+
+- The Python/pandas layer handles data quality: profiling, validation, and schema checks.
+
+Each function in the quality layer behaves as follows:
+
+### `profile()`
+
+- Converts an `ArFrame` to a pandas DataFrame internally.
+- Computes per-column statistics including null counts, duplicate rows, data types, and unique value ratios.
+- Returns a `DataQualityReport`.
+
+### `suggest_cleaning()`
+
+- Accepts an `ArFrame` or an existing `DataQualityReport`.
+- If given an `ArFrame`, it calls `profile()` first.
+- Returns a list of cleaning steps that can be passed to `pipeline()`.
+
+### `auto_clean()`
+
+- Accepts an `ArFrame`.
+- Calls `profile()` internally.
+- Applies suggested cleaning steps directly to the original `ArFrame`.
+- Returns a cleaned `ArFrame`.
+
+### `validate()`
+
+- Converts `ArFrame` to a pandas DataFrame internally.
+- Evaluates each column against rules defined in a `Schema` including nullability, dtype, range, pattern, and semantic constraints.
+- Returns a `ValidationResult`.
+
+### Flow Diagram
+
+```mermaid
+graph TD
+    A[ArFrame] -->|or| D[suggest_cleaning]
+    A --> B[profile]
+    A --> C[auto_clean]
+    A --> H[validate]
+    B --> E[DataQualityReport]
+    E -->|or| D
+    D --> F[step list]
+    C --> G[cleaned ArFrame]
+    H --> I[ValidationResult]
+```
+
+---
+
+## 8. Cleaning Module Architecture
+
+The cleaning module is designed around immutable semantics to ensure data integrity across pipeline steps.
+
+To ensure consistency, the C++ core utilizes internal helper functions:
+
+- `resolve_subset`: Translates user-provided column names into integer indices.
+
+- `select_rows`: A utility that takes a list of row indices and constructs a new `Frame`.
+
+- `row_key`: Generates a deterministic string serialization key for a row to facilitate duplicate detection.
+
+### Copy-Always Semantics
+
+Arnio follows an immutable design pattern.
+
+Most cleaning operations do not modify the existing `Frame` in-place; instead, they produce a new `std::vector<Column>` and return a brand-new `Frame` instance, often utilizing `std::move` to transfer ownership efficiently.
+
+---
+
+## 9. Error Handling & Translation
+
+Arnio uses a unified exception hierarchy to bridge the C++/Python boundary.
+
+### Base Exception
+
+- `ArnioError`: The base exception class.
+
+### Specialized Exceptions
+
+- `CsvReadError`
+
+- `UnknownStepError`
+
+- `TypeCastError`
+
+When supported by the specific implementation, exceptions raised within the core are translated into standard Python exceptions to maintain interpreter stability.

--- a/AUTO_CLEAN_GUIDE.md
+++ b/AUTO_CLEAN_GUIDE.md
@@ -1,0 +1,79 @@
+# auto_clean Strict Mode — Data-Loss Risks
+
+This guide explains what `auto_clean(mode="strict")` changes
+and what data it may permanently remove.
+
+## Mode comparison
+
+| Mode | What it applies |
+|------|----------------|
+| `safe` | `strip_whitespace` only — no data removed |
+| `strict` | `strip_whitespace` + `cast_types` + `drop_duplicates` |
+
+## Preview before applying
+
+Use `ar.profile()` and `ar.suggest_cleaning()` to inspect
+what strict mode would change before applying it:
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+
+# Step 1 — preview suggested changes
+report = ar.profile(frame)
+suggestions = ar.suggest_cleaning(frame)
+print(suggestions)
+
+# Step 2 — apply if satisfied
+clean = ar.auto_clean(frame, mode="strict")
+```
+
+## Data-loss risks in strict mode
+
+### 1. drop_duplicates — rows permanently removed
+
+Exact duplicate rows are dropped and cannot be recovered:
+
+```python
+# These two rows are identical — one will be dropped
+# order_id  customer  city
+# 1002      Prasoon   London
+# 1002      Prasoon   London
+
+clean = ar.auto_clean(frame, mode="strict")
+```
+
+### 2. cast_types — lossy type conversion
+
+Strict mode may cast string columns to `int64`, `float64`,
+or `bool`. Leading zeros and mixed-type values can be lost:
+
+```python
+# "007" may become 7 after cast
+# Mixed-type columns may partially fail
+clean = ar.auto_clean(frame, mode="strict")
+```
+
+## Safe workflow recommendation
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+
+# Always profile first
+report = ar.profile(frame)
+print(report.summary())
+
+suggestions = ar.suggest_cleaning(frame)
+print(suggestions)
+
+# Apply strict only after reviewing suggestions
+clean = ar.auto_clean(frame, mode="strict")
+```
+
+## Related docs
+
+- `README.md` — quickstart and auto-clean tutorial
+- `ARCHITECTURE.md` — pipeline and cleaning engine design

--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -1,0 +1,75 @@
+# CLI Reference and Roadmap
+
+This document covers the current command-line workflows and
+planned CLI goals for Arnio contributors and users.
+
+## Development Commands
+
+```bash
+# Install in development mode with all dev dependencies
+make install
+
+# Run the full test suite with coverage
+make test
+
+# Run linter and formatter checks
+make lint
+
+# Run benchmarks against pandas
+make benchmark
+```
+
+## Common Python Workflow Examples
+
+```python
+import arnio as ar
+
+# Load a CSV file through C++
+frame = ar.read_csv("data.csv")
+
+# Run a cleaning pipeline
+clean = ar.pipeline(frame, [
+    ("strip_whitespace",),
+    ("normalize_case", {"case_type": "lower"}),
+    ("drop_nulls",),
+    ("drop_duplicates",),
+])
+
+# Profile your dataset
+report = ar.profile(frame)
+print(report.summary())
+
+# Get cleaning suggestions
+suggestions = ar.suggest_cleaning(frame)
+print(suggestions)
+
+# Auto clean safely
+clean = ar.auto_clean(frame, mode="safe")
+
+# Auto clean strictly (includes deduplication)
+clean = ar.auto_clean(frame, mode="strict")
+
+# Convert to pandas
+df = ar.to_pandas(clean)
+```
+
+## CLI Roadmap
+
+| Focus Area | Status |
+|-----------|--------|
+| CSV parsing and cleaning | 🔨 Current |
+| Data quality and schema validation | 🔨 Current |
+| Chunked and streaming processing | 📋 Near Term |
+| Native CSV writers | 📋 Near Term |
+| Parallel column processing | 💭 Long Term |
+| SIMD string operations | 💭 Long Term |
+| JSON Lines and Parquet support | 💭 Long Term |
+
+> Full roadmap: [ROADMAP.md](ROADMAP.md)
+
+## Related Docs
+
+- `ROADMAP.md` — full version roadmap
+- `ARCHITECTURE.md` — system architecture
+- `GSSOC_GUIDE.md` — contributor onboarding guide
+- `README.md` — quickstart and examples

--- a/COLAB_SMOKE_TEST.md
+++ b/COLAB_SMOKE_TEST.md
@@ -1,0 +1,56 @@
+# Google Colab install smoke test
+
+This is a lightweight, copy-pasteable smoke test to verify that `pip install arnio` works in a fresh Google Colab runtime.
+
+## 1) Install
+
+Run this in a new Colab notebook cell:
+
+```python
+!pip install arnio
+```
+
+## 2) Verify import
+
+```python
+import arnio as ar
+
+print("arnio version:", ar.__version__)
+print("arnio imported successfully")
+```
+
+## 3) Create a tiny CSV
+
+This creates a small file directly in Colab (no uploads needed):
+
+```python
+from pathlib import Path
+
+csv_text = """name,revenue,city
+ Ishan ,10,London
+ Pranay, ,Paris
+ Ishan ,10,London
+"""
+
+Path("sample.csv").write_text(csv_text, encoding="utf-8")
+print("wrote sample.csv")
+```
+
+## 4) Minimal validation
+
+```python
+import arnio as ar
+
+print("scan_csv:", ar.scan_csv("sample.csv"))
+
+frame = ar.read_csv("sample.csv")
+df = ar.to_pandas(frame)
+
+print("shape:", df.shape)
+df
+```
+
+## Troubleshooting
+
+- If you get unexpected import errors after re-running cells, use **Runtime → Restart runtime**, then re-run the notebook top to bottom.
+- If `pip install arnio` fails, copy the full error output into a GitHub issue and include your Colab runtime type (Python version) and the exact install commands you ran.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,155 @@
+# Guide for troubleshooting
+
+If you are setting up Arnio from source, remember that `pip install -e ".[dev]"`
+must build the native C++ extension before most examples and tests can run. The Core Stability Sprint tracks this as a release
+gate because import failures are usually build/setup problems, not test logic
+problems.
+
+Run the environment doctor before debugging build failures:
+
+```bash
+python examples/check_env.py
+```
+
+On Windows, `[BUILD BLOCKED]` usually means PowerShell cannot see Visual Studio
+Build Tools commands such as `cl` or `nmake`. Install the `Desktop development
+with C++` workload, then retry from an x64 Developer Command Prompt.
+
+## MemoryError when reading large CSV files
+
+### Problem
+
+Some users may encounter a MemoryError when trying to load large CSV files.
+
+### Why it happens
+
+Large datasets may not fully fit into memory, even if the machine appears to have enough resources. In some cases, automatic column type inference can also increase memory usage.
+
+### What to do about it
+- Use `usecols` in `ar.read_csv(...)` to load only required columns
+- Use `select_columns()` to reduce unnecessary data before processing
+- Avoid unnecessary `cast_types()` operations unless they are required
+
+### Quick example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv(
+    "large.csv",
+    usecols=["id", "name"]
+)
+```
+
+## Numeric columns inferred as strings
+
+### Problem
+
+Sometimes a numeric column gets detected as a string, even when you expect it to contain only numbers.
+
+### Why it happens
+
+This usually happens when the column contains mixed values, missing entries, or unexpected characters. The loader may then treat the entire column as text instead of numeric data.
+
+### What to do about it
+
+- Use `cast_types()` to apply explicit Arnio datatypes when needed
+- Check columns for invalid values or unexpected symbols before validation
+
+### Quick example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+
+frame = ar.cast_types(
+    frame,
+    {"age": "int64"}
+)
+```
+
+## ValidationResult.passed returning False
+
+### Problem
+
+Sometimes a dataset may appear valid but still fail validation checks.
+
+### Why it happens
+
+This usually happens because the dataset contains missing values, incorrect datatypes, unexpected nulls, or schema mismatches.
+
+### What to do about it
+
+- Review the validation output from `ar.validate(...)` carefully
+- Inspect rows containing null or unexpected values before validation
+- Verify that column names and datatypes match the expected `Schema`
+- Ensure all required fields defined in the schema are present
+
+### Quick example
+
+```python
+result = ar.validate(frame, schema)
+
+print(result.passed)
+print(result.issues)
+```
+
+## Unknown or custom steps not running
+
+### Problem
+
+Sometimes custom pipeline steps fail to execute or appear as unknown during runtime.
+
+### Why it happens
+
+This usually happens when the custom step is not registered correctly or required imports are missing.
+
+### What to do about it
+
+- Verify that the custom step is registered using `ar.register_step(...)`
+- Check that the custom step function and imports are available before running the pipeline
+- Restart the environment after adding new custom pipeline steps
+- Ensure the correct step name is referenced inside `ar.pipeline(...)`
+
+### Quick example
+
+```python
+def clean_data(frame):
+    return frame
+
+ar.register_step("clean_data", clean_data)
+
+ops = [
+    ("clean_data",),
+]
+frame = ar.pipeline(frame, ops)
+```
+
+## Slow CSV parsing and performance issues
+
+### Problem
+
+Large CSV files may take a long time to load or process.
+
+### Why it happens
+
+Performance issues usually occur when unnecessary columns are loaded, datatype inference becomes expensive, or the entire dataset is processed at once.
+
+### What to do about it
+
+- Use `usecols` in `ar.read_csv(...)` to load only required columns
+- Avoid unnecessary `cast_types()` operations unless they are needed
+- Use `select_columns()` to reduce unnecessary data before processing
+- Remove unused columns with `drop_columns()` when possible
+
+### Quick example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv(
+    "large.csv",
+    usecols=["id", "name"]
+)
+```

--- a/docs/api/cleaning.md
+++ b/docs/api/cleaning.md
@@ -1,0 +1,199 @@
+# Cleaning — `arnio.cleaning`
+
+Data cleaning operations for `ArFrame` objects. All functions return a **new** `ArFrame` (immutable pattern).
+
+## `clean`
+
+```python
+arnio.clean(frame, *, strip_whitespace=True, drop_nulls=False, drop_duplicates=False) -> ArFrame
+```
+
+Convenience function to apply common cleaning operations in one call. Operations are applied in order:
+
+1. `strip_whitespace` (if enabled)
+2. `drop_nulls` (if enabled)
+3. `drop_duplicates` (if enabled)
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `strip_whitespace` | `bool` | `True` | Trim leading/trailing whitespace from string columns. |
+| `drop_nulls` | `bool` | `False` | Remove rows containing null/empty values. |
+| `drop_duplicates` | `bool` | `False` | Remove duplicate rows. |
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("messy.csv")
+cleaned = ar.clean(frame, strip_whitespace=True, drop_nulls=True, drop_duplicates=True)
+```
+
+---
+
+## `drop_nulls`
+
+```python
+arnio.drop_nulls(frame, *, subset=None) -> ArFrame
+```
+
+Remove rows containing null/empty values.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to check. If `None`, checks all columns. A row is dropped if ANY column in the subset contains a null. |
+
+```python
+clean = ar.drop_nulls(frame, subset=["age", "name"])
+```
+
+---
+
+## `fill_nulls`
+
+```python
+arnio.fill_nulls(frame, value, *, subset=None) -> ArFrame
+```
+
+Replace null/empty values with a given fill value.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `value` | `Any` | *required* | Value to replace nulls with. |
+| `subset` | `list[str] \| None` | `None` | Columns to fill. If `None`, fills all columns. |
+
+```python
+filled = ar.fill_nulls(frame, 0, subset=["age"])
+filled = ar.fill_nulls(frame, "unknown", subset=["name"])
+```
+
+---
+
+## `drop_duplicates`
+
+```python
+arnio.drop_duplicates(frame, *, subset=None, keep="first") -> ArFrame
+```
+
+Remove duplicate rows.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to consider. If `None`, uses all columns. |
+| `keep` | `str \| bool` | `"first"` | Which duplicate to keep: `"first"`, `"last"`, `"none"`, or `False` (drop all). |
+
+```python
+unique = ar.drop_duplicates(frame, subset=["email"], keep="first")
+# Drop ALL duplicates (keep neither)
+strict = ar.drop_duplicates(frame, subset=["id"], keep=False)
+```
+
+---
+
+## `strip_whitespace`
+
+```python
+arnio.strip_whitespace(frame, *, subset=None) -> ArFrame
+```
+
+Trim leading and trailing whitespace from string columns.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to strip. If `None`, applies to all string columns. |
+
+```python
+clean = ar.strip_whitespace(frame, subset=["name", "email"])
+```
+
+---
+
+## `normalize_case`
+
+```python
+arnio.normalize_case(frame, *, subset=None, case_type="lower") -> ArFrame
+```
+
+Normalize string columns to a specified case.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `subset` | `list[str] \| None` | `None` | Columns to normalize. If `None`, applies to all string columns. |
+| `case_type` | `str` | `"lower"` | Case to normalize to: `"lower"`, `"upper"`, or `"title"`. |
+
+```python
+lower = ar.normalize_case(frame, case_type="lower")
+title = ar.normalize_case(frame, subset=["name"], case_type="title")
+```
+
+---
+
+## `rename_columns`
+
+```python
+arnio.rename_columns(frame, mapping) -> ArFrame
+```
+
+Rename columns via a `{old_name: new_name}` dictionary.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `mapping` | `dict[str, str]` | *required* | Dictionary mapping old column names to new names. |
+
+```python
+renamed = ar.rename_columns(frame, {"Old Name": "new_name", "User ID": "user_id"})
+```
+
+---
+
+## `cast_types`
+
+```python
+arnio.cast_types(frame, mapping) -> ArFrame
+```
+
+Cast columns to specified types.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `mapping` | `dict[str, str]` | *required* | Dictionary mapping column names to target types: `"int64"`, `"float64"`, `"bool"`, `"string"`. |
+
+### Raises
+
+- `TypeCastError` — If a cast fails (e.g., non-numeric value in an int column).
+
+```python
+casted = ar.cast_types(frame, {"age": "int64", "score": "float64", "active": "bool"})
+```
+
+---
+
+## `filter_rows`
+
+```python
+arnio.filter_rows(frame, column, op, value) -> ArFrame
+```
+
+Filter rows based on a column condition. Supports comparison operators.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame (or pandas DataFrame). |
+| `column` | `str` | *required* | Column name to filter on. |
+| `op` | `str` | *required* | Comparison operator: `>`, `<`, `>=`, `<=`, `==`, `!=`. |
+| `value` | `Any` | *required* | Value to compare against. |
+
+```python
+adults = ar.filter_rows(frame, "age", ">=", 18)
+high_score = ar.filter_rows(frame, "score", ">", 90)
+```

--- a/docs/api/convert.md
+++ b/docs/api/convert.md
@@ -1,0 +1,92 @@
+# Conversion — `arnio.convert`
+
+Functions for converting between `ArFrame` and pandas `DataFrame`.
+
+## `to_pandas`
+
+```python
+arnio.to_pandas(frame) -> pd.DataFrame
+```
+
+Convert an `ArFrame` to a pandas `DataFrame` with proper dtypes and null handling.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input ArFrame to convert. |
+
+### Returns
+
+`pd.DataFrame` — Equivalent pandas DataFrame. Null values are represented using pandas nullable dtypes (`Int64Dtype`, `BooleanDtype`, `StringDtype`).
+
+### Type Mapping
+
+| Arnio (C++) | pandas |
+|-------------|--------|
+| `int64` | `pd.Int64Dtype()` (nullable integer) |
+| `float64` | `float64` with `NaN` for nulls |
+| `bool` | `pd.BooleanDtype()` (nullable boolean) |
+| `string` | `pd.StringDtype()` (nullable string) |
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+df = ar.to_pandas(frame)
+print(df.dtypes)
+```
+
+---
+
+## `from_pandas`
+
+```python
+arnio.from_pandas(df) -> ArFrame
+```
+
+Convert a pandas `DataFrame` to an `ArFrame` with inferred types.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `df` | `pd.DataFrame` | *required* | Input pandas DataFrame. |
+
+### Returns
+
+`ArFrame` — Equivalent ArFrame with inferred types.
+
+### Raises
+
+- `TypeError` — If the DataFrame contains unsupported nested/complex types (list, dict, tuple, set, ndarray).
+
+### Type Coercion Rules
+
+- Mixed `int` + `float` columns → `float`
+- Mixed `bool` + other types → `string`
+- Mixed `string` + other types → `string`
+- `NaN`/`NA` → `None`
+
+### Edge Cases & Limitations
+
+- **Nested types** (lists, dicts, arrays) are not supported and will raise `TypeError`.
+- **Mixed-type columns** are coerced to the most general type (usually `string`).
+- **Boolean values** mixed with non-boolean types are converted to strings.
+
+### Example
+
+```python
+import pandas as pd
+import arnio as ar
+
+df = pd.DataFrame({
+    "name": ["Alice", "Bob", "Charlie"],
+    "age": [25, 30, 35],
+    "score": [95.5, 87.3, 92.1],
+})
+
+frame = ar.from_pandas(df)
+```

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,0 +1,86 @@
+# Exceptions — `arnio.exceptions`
+
+Custom exception classes for Arnio.
+
+## Exception Hierarchy
+
+```
+ArnioError (base)
+├── CsvReadError
+├── TypeCastError
+└── UnknownStepError
+```
+
+## `ArnioError`
+
+Base exception for all Arnio errors.
+
+```python
+class ArnioError(Exception)
+```
+
+---
+
+## `CsvReadError`
+
+Raised when CSV reading fails (e.g., NUL bytes, unsupported format, decoding errors).
+
+```python
+class CsvReadError(ArnioError)
+```
+
+### Example
+
+```python
+import arnio as ar
+from arnio import CsvReadError
+
+try:
+    frame = ar.read_csv("corrupted.csv")
+except CsvReadError as e:
+    print(f"CSV read failed: {e}")
+```
+
+---
+
+## `TypeCastError`
+
+Raised when a type cast operation fails (e.g., non-numeric value in an int column).
+
+```python
+class TypeCastError(ArnioError)
+```
+
+### Example
+
+```python
+import arnio as ar
+from arnio import TypeCastError
+
+try:
+    frame = ar.cast_types(frame, {"age": "int64"})
+except TypeCastError as e:
+    print(f"Cast failed: {e}")
+```
+
+---
+
+## `UnknownStepError`
+
+Raised when a pipeline step name is not found in the registry.
+
+```python
+class UnknownStepError(ArnioError)
+```
+
+### Example
+
+```python
+import arnio as ar
+from arnio import UnknownStepError
+
+try:
+    ar.pipeline(frame, [("unknown_step",)])
+except UnknownStepError as e:
+    print(f"Unknown step: {e}")
+```

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,0 +1,106 @@
+# I/O — `arnio.io`
+
+CSV reading functions powered by the C++ backend.
+
+## `read_csv`
+
+```python
+arnio.read_csv(
+    path,
+    *,
+    delimiter=",",
+    has_header=True,
+    usecols=None,
+    nrows=None,
+    encoding="utf-8",
+) -> ArFrame
+```
+
+Read a CSV file into an `ArFrame` via the C++ backend.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | `str \| PathLike` | *required* | Path to the CSV file. Supports `.csv`, `.txt`, and `.tsv` extensions. |
+| `delimiter` | `str` | `","` | Field delimiter character. |
+| `has_header` | `bool` | `True` | Whether the file has a header row. |
+| `usecols` | `list[str] \| None` | `None` | Columns to read. If `None`, reads all columns. |
+| `nrows` | `int \| None` | `None` | Number of rows to read. If `None`, reads all rows. |
+| `encoding` | `str` | `"utf-8"` | File encoding. Non-UTF-8 inputs are automatically transcoded. |
+
+### Returns
+
+`ArFrame` — Data frame containing the CSV data.
+
+### Raises
+
+- `ValueError` — If file format is unsupported.
+- `CsvReadError` — If CSV input contains NUL bytes or is corrupted.
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv", delimiter=",", has_header=True)
+
+# Read specific columns only
+frame = ar.read_csv("data.csv", usecols=["name", "age"])
+
+# Read first 100 rows
+frame = ar.read_csv("data.csv", nrows=100)
+
+# Handle non-UTF-8 encoding
+frame = ar.read_csv("data.csv", encoding="latin-1")
+```
+
+---
+
+## `scan_csv`
+
+```python
+arnio.scan_csv(
+    path,
+    *,
+    delimiter=",",
+    encoding="utf-8",
+) -> dict[str, str]
+```
+
+Return schema (column names + inferred types) **without loading data**. Useful for inspecting large files before committing to a full read.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `path` | `str \| PathLike` | *required* | Path to the CSV file. |
+| `delimiter` | `str` | `","` | Field delimiter character. |
+| `encoding` | `str` | `"utf-8"` | File encoding. |
+
+### Returns
+
+`dict[str, str]` — Dictionary mapping column names to inferred type strings (e.g., `"int64"`, `"float64"`, `"string"`).
+
+### Raises
+
+- `ValueError` — If file format is unsupported.
+- `CsvReadError` — If CSV input contains NUL bytes.
+
+### Example
+
+```python
+import arnio as ar
+
+schema = ar.scan_csv("large_data.csv")
+# {'name': 'string', 'age': 'int64', 'score': 'float64'}
+
+# Check types before loading
+for col, dtype in schema.items():
+    print(f"{col}: {dtype}")
+```
+
+### When to Use `scan_csv` vs `read_csv`
+
+- Use `scan_csv` when you need to inspect schema without the memory cost of loading data.
+- Use `read_csv` when you need the actual data for processing.

--- a/docs/api/pipeline.md
+++ b/docs/api/pipeline.md
@@ -1,0 +1,110 @@
+# Pipeline — `arnio.pipeline`
+
+Chained cleaning pipeline for composing multiple operations.
+
+## `pipeline`
+
+```python
+arnio.pipeline(frame, steps) -> ArFrame
+```
+
+Apply a list of cleaning steps sequentially. Each step is a tuple of `(step_name,)` or `(step_name, kwargs_dict)`.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input data frame. |
+| `steps` | `list[tuple]` | *required* | List of steps. Each step is `(name,)` or `(name, kwargs)`. |
+
+### Returns
+
+`ArFrame` — Data frame with all steps applied sequentially.
+
+### Raises
+
+- `ValueError` — If step format is invalid.
+- `UnknownStepError` — If step name is not registered.
+
+### Built-in Steps
+
+| Step Name | Parameters | Description |
+|-----------|------------|-------------|
+| `drop_nulls` | `subset: list[str]` | Remove null rows |
+| `fill_nulls` | `value, subset: list[str]` | Fill null values |
+| `drop_duplicates` | `subset: list[str], keep: str` | Remove duplicates |
+| `strip_whitespace` | `subset: list[str]` | Trim whitespace |
+| `normalize_case` | `subset: list[str], case_type: str` | Normalize case |
+| `rename_columns` | `mapping: dict` | Rename columns |
+| `cast_types` | `mapping: dict` | Cast column types |
+| `filter_rows` | `column, op, value` | Filter rows |
+
+### Step Format
+
+For `rename_columns` and `cast_types`, the kwargs dict is passed directly as the mapping:
+
+```python
+("rename_columns", {"old_name": "new_name"})
+("cast_types", {"age": "int64"})
+```
+
+For all other steps, use standard keyword arguments:
+
+```python
+("drop_nulls", {"subset": ["age"]})
+("strip_whitespace",)  # no kwargs needed
+```
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("data.csv")
+
+cleaned = ar.pipeline(frame, [
+    ("strip_whitespace",),
+    ("drop_nulls", {"subset": ["email"]}),
+    ("normalize_case", {"subset": ["name"], "case_type": "title"}),
+    ("drop_duplicates", {"subset": ["email"], "keep": "first"}),
+    ("cast_types", {"age": "int64", "score": "float64"}),
+])
+```
+
+---
+
+## `register_step`
+
+```python
+arnio.register_step(name, fn)
+```
+
+Register a custom Python pipeline step.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | `str` | *required* | Name of the step for use in pipelines. |
+| `fn` | `Callable` | *required* | Function to call. Should accept `(df, **kwargs)` and return a modified DataFrame. |
+
+### Example
+
+```python
+import arnio as ar
+
+def remove_outliers(df, column="value", threshold=3.0):
+    mean = df[column].mean()
+    std = df[column].std()
+    return df[(df[column] - mean).abs() <= threshold * std]
+
+ar.register_step("remove_outliers", remove_outliers)
+
+cleaned = ar.pipeline(frame, [
+    ("strip_whitespace",),
+    ("remove_outliers", {"column": "price", "threshold": 2.5}),
+])
+```
+
+!!! note
+    Custom Python steps convert the frame to pandas internally, so they are slower than built-in C++-backed steps.

--- a/docs/api/quality.md
+++ b/docs/api/quality.md
@@ -1,0 +1,142 @@
+# Data Quality — `arnio.quality`
+
+Data quality profiling, cleaning suggestions, and automatic cleaning.
+
+## `profile`
+
+```python
+arnio.profile(frame, *, sample_size=5) -> DataQualityReport
+```
+
+Profile data quality for an `ArFrame`. Returns a comprehensive report with null counts, uniqueness, basic stats, semantic hints, and safe cleaning suggestions.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input frame to inspect. |
+| `sample_size` | `int` | `5` | Number of non-null sample values per column. |
+
+### Returns
+
+`DataQualityReport` — Full quality report.
+
+### Example
+
+```python
+import arnio as ar
+
+frame = ar.read_csv("raw.csv")
+report = ar.profile(frame)
+
+# Access summary
+print(report.summary())
+
+# Check specific columns
+for name, col in report.columns.items():
+    print(f"{name}: {col.null_count} nulls, {col.unique_count} unique")
+    if col.warnings:
+        print(f"  Warnings: {col.warnings}")
+```
+
+---
+
+## `suggest_cleaning`
+
+```python
+arnio.suggest_cleaning(frame_or_report) -> list[tuple[str, dict]]
+```
+
+Suggest safe built-in cleaning steps. Returns pipeline-compatible step tuples.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame_or_report` | `ArFrame \| DataQualityReport` | *required* | Frame to profile or existing report. |
+
+### Returns
+
+`list[tuple[str, dict]]` — Pipeline-compatible cleaning suggestions.
+
+### Example
+
+```python
+suggestions = ar.suggest_cleaning(frame)
+# [("strip_whitespace", {"subset": ["name"]}), ("drop_duplicates", {"keep": "first"})]
+
+# Apply suggestions directly
+clean = ar.pipeline(frame, suggestions)
+```
+
+---
+
+## `auto_clean`
+
+```python
+arnio.auto_clean(frame, *, mode="safe", return_report=False) -> ArFrame | tuple[ArFrame, DataQualityReport]
+```
+
+Apply built-in automatic cleaning based on data quality profiling.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input frame. |
+| `mode` | `str` | `"safe"` | `"safe"` applies only low-risk cleanup (whitespace). `"strict"` also applies casts and duplicate removal. |
+| `return_report` | `bool` | `False` | Whether to return the pre-cleaning quality report. |
+
+### Returns
+
+- `ArFrame` if `return_report=False`
+- `tuple[ArFrame, DataQualityReport]` if `return_report=True`
+
+### Example
+
+```python
+import arnio as ar
+
+# Safe mode (default) - only whitespace trimming
+clean = ar.auto_clean(frame)
+
+# Strict mode - full auto-cleaning
+clean, report = ar.auto_clean(frame, mode="strict", return_report=True)
+print(f"Cleaned {report.issue_count} issues")
+```
+
+---
+
+## `DataQualityReport`
+
+| Property/Method | Type | Description |
+|----------------|------|-------------|
+| `row_count` | `int` | Total rows. |
+| `column_count` | `int` | Total columns. |
+| `memory_usage` | `int` | Memory usage in bytes. |
+| `duplicate_rows` | `int` | Number of duplicate rows. |
+| `duplicate_ratio` | `float` | Ratio of duplicates. |
+| `columns` | `dict[str, ColumnProfile]` | Per-column profiles. |
+| `suggestions` | `list[tuple]` | Suggested cleaning steps. |
+| `to_dict()` | `dict` | JSON-friendly representation. |
+| `summary()` | `dict` | Compact summary. |
+| `to_pandas()` | `pd.DataFrame` | One row per column. |
+
+## `ColumnProfile`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `str` | Column name. |
+| `dtype` | `str` | Detected dtype. |
+| `semantic_type` | `str` | Semantic category: `"email"`, `"url"`, `"numeric"`, `"categorical"`, etc. |
+| `row_count` | `int` | Total rows. |
+| `null_count` | `int` | Null count. |
+| `null_ratio` | `float` | Null ratio (0.0–1.0). |
+| `unique_count` | `int` | Unique value count. |
+| `unique_ratio` | `float` | Unique ratio. |
+| `empty_string_count` | `int` | Empty string count. |
+| `whitespace_count` | `int` | Leading/trailing whitespace count. |
+| `suggested_dtype` | `str \| None` | Suggested alternative dtype. |
+| `min` / `max` / `mean` | `Any` | Basic stats (numeric columns). |
+| `sample_values` | `list` | Sample non-null values. |
+| `warnings` | `list[str]` | Warnings like `"contains_nulls"`, `"leading_or_trailing_whitespace"`. |

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -1,0 +1,160 @@
+# Schema Validation — `arnio.schema`
+
+Production data contracts and validation for `ArFrame` objects.
+
+## `validate`
+
+```python
+arnio.validate(frame, schema) -> ValidationResult
+```
+
+Validate an `ArFrame` against a schema.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `ArFrame` | *required* | Input frame. |
+| `schema` | `Schema \| dict[str, Field]` | *required* | Validation contract. |
+
+### Returns
+
+`ValidationResult` — Contains all issues and bad row indexes.
+
+### Example
+
+```python
+import arnio as ar
+
+schema = ar.Schema({
+    "email": ar.Email(nullable=False, unique=True),
+    "age": ar.Int64(min=0, max=150),
+    "name": ar.String(nullable=False, min_length=1),
+})
+
+result = ar.validate(frame, schema)
+if not result.passed:
+    print(f"Found {result.issue_count} issues")
+    for issue in result.issues:
+        print(f"  {issue.column}: {issue.message}")
+```
+
+---
+
+## `Schema`
+
+```python
+Schema(fields, strict=False)
+```
+
+Named column validation contract.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `fields` | `dict[str, Field]` | *required* | Column validation rules. |
+| `strict` | `bool` | `False` | If `True`, rejects unexpected columns. |
+
+---
+
+## `Field`
+
+```python
+Field(
+    dtype=None, nullable=True, min=None, max=None,
+    pattern=None, semantic=None, allowed=None,
+    unique=False, min_length=None, max_length=None,
+)
+```
+
+Validation rules for one column.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `dtype` | `str \| None` | `None` | Expected dtype: `"int64"`, `"float64"`, `"bool"`, `"string"`. |
+| `nullable` | `bool` | `True` | Whether null values are allowed. |
+| `min` | `int \| float \| None` | `None` | Minimum value (numeric columns). |
+| `max` | `int \| float \| None` | `None` | Maximum value (numeric columns). |
+| `pattern` | `str \| None` | `None` | Regex pattern the values must match. |
+| `semantic` | `str \| None` | `None` | Semantic type: `"email"`, `"url"`, `"phone"`. |
+| `allowed` | `set \| None` | `None` | Set of allowed values. |
+| `unique` | `bool` | `False` | Whether all values must be unique. |
+| `min_length` | `int \| None` | `None` | Minimum string length. |
+| `max_length` | `int \| None` | `None` | Maximum string length. |
+
+---
+
+## Type Helper Functions
+
+### `Int64`
+
+```python
+Int64(*, nullable=True, min=None, max=None, unique=False) -> Field
+```
+
+Create an `int64` schema field with optional range and uniqueness constraints.
+
+### `Float64`
+
+```python
+Float64(*, nullable=True, min=None, max=None, unique=False) -> Field
+```
+
+Create a `float64` schema field.
+
+### `String`
+
+```python
+String(*, nullable=True, pattern=None, allowed=None, unique=False,
+       min_length=None, max_length=None) -> Field
+```
+
+Create a `string` schema field.
+
+### `Bool`
+
+```python
+Bool(*, nullable=True) -> Field
+```
+
+Create a `bool` schema field.
+
+### `Email`
+
+```python
+Email(*, nullable=True, unique=False) -> Field
+```
+
+Create an email-address schema field (validates against email regex).
+
+### `URL`
+
+```python
+URL(*, nullable=True, unique=False) -> Field
+```
+
+Create a URL schema field (validates against `http(s)://` pattern).
+
+---
+
+## `ValidationResult`
+
+| Property/Method | Type | Description |
+|----------------|------|-------------|
+| `passed` | `bool` | Whether validation passed with zero issues. |
+| `row_count` | `int` | Total rows in the validated frame. |
+| `issue_count` | `int` | Number of validation issues found. |
+| `issues` | `list[ValidationIssue]` | All validation issues. |
+| `bad_rows` | `list[int]` | Row indexes with issues. |
+| `to_dict()` | `dict` | JSON-friendly representation. |
+| `summary()` | `dict` | Compact summary grouped by rule and column. |
+| `to_pandas()` | `pd.DataFrame` | Issues as a pandas DataFrame. |
+
+## `ValidationIssue`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `column` | `str \| None` | Column name (None for frame-level issues). |
+| `rule` | `str` | Rule that failed (e.g., `"nullable"`, `"dtype"`, `"unique"`). |
+| `message` | `str` | Human-readable description. |
+| `row_index` | `int \| None` | Row index of the failing value. |
+| `value` | `Any` | The failing value. |

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,0 +1,45 @@
+# DType System — `arnio.schema`
+
+Arnio uses a simple type system for column dtypes.
+
+## Built-in DTypes
+
+| DType | Python Type | Description |
+|-------|-------------|-------------|
+| `int64` | `int` | 64-bit signed integer |
+| `float64` | `float` | 64-bit floating point |
+| `bool` | `bool` | Boolean |
+| `string` | `str` | UTF-8 string |
+
+## Type Inference
+
+When reading CSV files, Arnio automatically infers column types:
+
+- **Integer-looking values** → `int64`
+- **Float-looking values** → `float64`
+- **`true`/`false`/`1`/`0`** → `bool`
+- **Everything else** → `string`
+
+## Type Casting
+
+Use `cast_types` to explicitly convert between types:
+
+```python
+frame = ar.cast_types(frame, {
+    "age": "int64",
+    "score": "float64",
+    "active": "bool",
+    "notes": "string",
+})
+```
+
+## Nullable Handling
+
+All types support null values. When converting to pandas, nullable dtypes are used:
+
+| Arnio | pandas |
+|-------|--------|
+| `int64` | `pd.Int64Dtype()` |
+| `float64` | `float64` with `NaN` |
+| `bool` | `pd.BooleanDtype()` |
+| `string` | `pd.StringDtype()` |

--- a/docs/chunked_from_pandas_design.md
+++ b/docs/chunked_from_pandas_design.md
@@ -1,0 +1,58 @@
+# Design: Chunked `from_pandas()` Conversion
+
+## Current Memory Behavior
+
+`from_pandas()` converts each column via `.tolist()`, materializing the entire
+column as a Python list before passing it to the C++ layer. This causes a peak
+allocation proportional to the full frame size.
+
+### Measured Peak Allocations (tracemalloc)
+
+| Row Count | Peak Memory (MB) |
+|-----------|-----------------|
+| 10,000    | 0.93            |
+| 100,000   | 8.71            |
+| 1,000,000 | 88.77           |
+
+### Per-Column Hotspot (100k rows)
+
+| Column    | Peak (MB) |
+|-----------|-----------|
+| col_int   | 4.13      |
+| col_float | 3.82      |
+| col_bool  | 1.53      |
+| col_str   | 1.53      |
+
+Numeric columns (int, float) are the primary allocation hotspot.
+
+## Proposed Public API
+
+```python
+ar.from_pandas(df, chunk_size=None)
+```
+
+- `chunk_size=None` current behavior, no change.
+- `chunk_size=N` splits DataFrame into row batches of N, converts each
+  independently, then concatenates.
+
+## Limitations
+
+- Index is reset and ignored per chunk.
+- Nullable dtypes (`Int64`, `Float64`, `boolean`) supported via existing routing.
+- Mixed-type columns raise the same errors as today.
+- No parallelism in v1 sequential chunk processing only.
+
+## First PR Scope
+
+Design and measurement only:
+- Benchmark script (`benchmarks/benchmark_from_pandas_memory.py`)
+- This design document
+- No public API change
+
+## Follow-up Implementation Plan
+
+1. Add `chunk_size` parameter to `from_pandas()` in `arnio/convert.py`.
+2. Implement row slicing and per-chunk conversion.
+3. Add concatenation of ArFrame chunks.
+4. Tests: normal chunked, chunk_size > frame, single-row chunks, empty frame.
+5. Benchmark comparison: chunked vs non-chunked peak memory.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,43 @@
+# Arnio API Reference
+
+Your CSV hits C++ before Python even wakes up.
+
+**Arnio** is a compiled C++ data cleaning engine that slots in _before_ pandas. It parses, infers types, strips whitespace, deduplicates, and normalizes — all natively, in columnar memory — then hands you a pristine `DataFrame`.
+
+## Installation
+
+```bash
+pip install arnio
+```
+
+## Quick Start
+
+```python
+import arnio as ar
+
+# Read a CSV file
+frame = ar.read_csv("data.csv")
+
+# Profile data quality
+report = ar.profile(frame)
+print(report.summary())
+
+# Clean automatically
+clean = ar.auto_clean(frame)
+
+# Convert to pandas
+import pandas as pd
+df = ar.to_pandas(clean)
+```
+
+## Module Overview
+
+| Module | Description |
+|--------|-------------|
+| [`arnio.io`](api/io.md) | CSV reading and schema scanning |
+| [`arnio.cleaning`](api/cleaning.md) | Data cleaning operations |
+| [`arnio.convert`](api/convert.md) | Pandas ↔ ArFrame conversion |
+| [`arnio.pipeline`](api/pipeline.md) | Chained cleaning pipelines |
+| [`arnio.schema`](api/schema.md) | Data contracts and validation |
+| [`arnio.quality`](api/quality.md) | Data quality profiling and auto-cleaning |
+| [`arnio.exceptions`](api/exceptions.md) | Custom exception classes |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,31 @@
+site_name: Arnio API Reference
+site_description: API reference documentation for Arnio – Fast CSV processing and data cleaning
+theme:
+  name: material
+  palette:
+    primary: indigo
+  features:
+    - navigation.instant
+    - navigation.sections
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - API Reference:
+    - I/O: api/io.md
+    - Cleaning: api/cleaning.md
+    - Conversion: api/convert.md
+    - Pipeline: api/pipeline.md
+    - Schema Validation: api/schema.md
+    - Data Quality: api/quality.md
+    - Exceptions: api/exceptions.md
+    - Types: api/types.md
+  - Troubleshooting: TROUBLESHOOTING.md
+  - Design Notes: chunked_from_pandas_design.md
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - admonition
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary
Resolves #38 - Creates complete API reference documentation using MkDocs with Material theme.

Rebased onto upstream main with docs link added to README.

Closes #38