### PR TITLE
fix: (ci) anchor regex for dry-run version validation (#1712)

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -21,7 +21,7 @@ jobs:
           with open("pyproject.toml", "rb") as f:
               data = tomllib.load(f)
           version = data["project"]["version"]
-          if not re.match(r"^\d+\.\d+\.\d+", version):
+          if not re.match(r"^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?$", version):
               print(f"❌ Invalid version format: {version}", file=sys.stderr)
               sys.exit(1)
           print(f"✅ Version looks valid: {version}")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from pathlib import Path
 
@@ -55,3 +56,22 @@ def test_pyproject_metadata_is_valid():
     assert project.get("name"), "Project name must be specified"
     assert project.get("version"), "Project version must be specified"
     assert project.get("description"), "Project description must be specified"
+
+
+def test_release_workflow_version_regex():
+    version_pattern = r"^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?$"
+
+    with PYPROJECT_PATH.open("rb") as f:
+        pyproject = tomllib.load(f)
+    current_version = pyproject.get("project", {}).get("version", "")
+    assert (
+        bool(re.match(version_pattern, current_version)) is True
+    ), f"Current version '{current_version}' fails validation pattern"
+
+    assert bool(re.match(version_pattern, "1.18.0")) is True
+    assert bool(re.match(version_pattern, "0.1.0")) is True
+    assert bool(re.match(version_pattern, "1.18.0-rc.1")) is True
+
+    assert bool(re.match(version_pattern, "1.18.0oops")) is False
+    assert bool(re.match(version_pattern, "1.2.3valid-until-here")) is False
+    assert bool(re.match(version_pattern, "v1.0.0")) is False


### PR DESCRIPTION
## Summary
Tightened the project version validation pattern in the release dry-run workflow (`.github/workflows/release-dry-run.yml`) by introducing an end-anchor (`$`). The previous unanchored match permitted malformed entries with trailing characters (e.g., `1.2.3oops`) to satisfy checks. The updated pattern gracefully manages standard semantic versions as well as optional pre-release strings, ensuring secure publishing state analysis.

Additionally, a corresponding validation test has been integrated into the existing metadata suite to track regex matching resilience over time.

## Linked issue
Fixes #1712

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [x] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
- [x] `make test` ( 2171 passed, including `test_release_workflow_version_regex()`)
- [x] `make lint`
- [ ] Other:

## Screenshots / Media
## Performance Impact

## GSSoC labels
- level:beginner
- type:devops
- area:ci-packaging


## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes