### PR TITLE
Isolate benchmark temp files using pytest tmp_path

### DIFF
--- a/benchmarks/benchmark_sparse_nulls.py
+++ b/benchmarks/benchmark_sparse_nulls.py
@@ -107,7 +107,13 @@ DENSITY_LABELS = {
 }
 
 DRY_RUN = os.getenv("ARNIO_BENCHMARK_DRY_RUN") == "1"
-TMP_DIR = Path("benchmarks")
+TMP_DIR = Path(
+    os.environ.get(
+        "ARNIO_BENCHMARK_OUTPUT_DIR",
+        "benchmarks",
+    )
+)
+TMP_DIR.mkdir(parents=True, exist_ok=True)
 FILL_VALUE = 0
 
 _OPS = ["read_csv", "drop_nulls", "fill_nulls", "keep_rows_with_nulls"]

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -126,24 +126,27 @@ def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files(tmp_path):
     cmd = [sys.executable, str(script_path), "--rows", "10", "--runs", "1"]
 
     result = subprocess.run(
-    cmd,
-    env={
-        **env,
-        "ARNIO_BENCHMARK_OUTPUT_DIR": str(temp_benchmark_dir),
-    },
-    capture_output=True,
-    text=True,
-    cwd=str(BENCHMARKS_DIR.parent),
-    timeout=30,
+        cmd,
+        env={
+            **env,
+            "ARNIO_BENCHMARK_OUTPUT_DIR": str(temp_benchmark_dir),
+        },
+        capture_output=True,
+        text=True,
+        cwd=str(BENCHMARKS_DIR.parent),
+        timeout=30,
     )
 
     assert (
-    result.returncode == 0), f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+        result.returncode == 0
+    ), f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
 
     # Ensure temporary benchmark artifacts are cleaned up
     post_files = list(temp_benchmark_dir.glob("benchmark_sparse_nulls_*.csv"))
 
-    assert len(post_files) == 0, (f"Temp benchmark files were not cleaned up: {post_files}")
+    assert (
+        len(post_files) == 0
+    ), f"Temp benchmark files were not cleaned up: {post_files}"
 
 
 def test_check_regression_detects_slowdown():

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -109,7 +109,7 @@ def test_benchmark_script_runs_successfully(script_path):
 
 
 @pytest.mark.skipif(not HAS_CORE, reason="Arnio C++ extension is not compiled.")
-def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files():
+def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files(tmp_path):
     """Verify benchmark_sparse_nulls.py runs in dry-run mode and removes temp files."""
     script_path = BENCHMARKS_DIR / "benchmark_sparse_nulls.py"
     if not script_path.exists():
@@ -117,34 +117,37 @@ def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files():
 
     env = os.environ.copy()
     env["ARNIO_BENCHMARK_DRY_RUN"] = "1"
-
-    # Check for any existing temp files before the run
-    pre_files = list(BENCHMARKS_DIR.glob("benchmark_sparse_nulls_*.csv"))
-    for f in pre_files:
-        if f.name != "benchmark_sparse_nulls.csv":
-            f.unlink(missing_ok=True)
-
-    cmd = [sys.executable, str(script_path), "--rows", "10", "--runs", "1"]
-    result = subprocess.run(
-        cmd,
-        env=env,
-        capture_output=True,
-        text=True,
-        cwd=str(BENCHMARKS_DIR.parent),
-        timeout=30,
-    )
-
-    assert (
-        result.returncode == 0
-    ), f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
-
-    # Verify all density-specific temp CSV files were removed
-    post_files = [
-        f
-        for f in BENCHMARKS_DIR.glob("benchmark_sparse_nulls_*.csv")
-        if f.name != "benchmark_sparse_nulls.csv"
+    
+    # Isolate benchmark artifacts in pytest temp directory
+    temp_benchmark_dir = tmp_path / "benchmarks"
+    temp_benchmark_dir.mkdir()
+    cmd = [
+    sys.executable,
+    str(script_path),
+    "--rows",
+    "10",
+    "--runs",
+    "1",
     ]
-    assert len(post_files) == 0, f"Temp files not cleaned up: {post_files}"
+
+    result = subprocess.run(
+    cmd,
+    env=env,
+    capture_output=True,
+    text=True,
+    cwd=str(temp_benchmark_dir),
+    timeout=30,
+    )
+    
+    assert (
+    result.returncode == 0), f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+
+    # Ensure no temporary sparse-null benchmark files remain
+    post_files = list(
+    temp_benchmark_dir.glob("benchmark_sparse_nulls_*.csv"))
+    
+    assert len(post_files) == 0, (
+    f"Temp benchmark files were not cleaned up: {post_files}")
 
 
 def test_check_regression_detects_slowdown():

--- a/tests/test_benchmarks_smoke.py
+++ b/tests/test_benchmarks_smoke.py
@@ -117,37 +117,33 @@ def test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files(tmp_path):
 
     env = os.environ.copy()
     env["ARNIO_BENCHMARK_DRY_RUN"] = "1"
-    
-    # Isolate benchmark artifacts in pytest temp directory
+
+    # Create isolated temporary benchmark directory
     temp_benchmark_dir = tmp_path / "benchmarks"
     temp_benchmark_dir.mkdir()
-    cmd = [
-    sys.executable,
-    str(script_path),
-    "--rows",
-    "10",
-    "--runs",
-    "1",
-    ]
+
+    # Preserve original working directory structure expected by the script
+    cmd = [sys.executable, str(script_path), "--rows", "10", "--runs", "1"]
 
     result = subprocess.run(
     cmd,
-    env=env,
+    env={
+        **env,
+        "ARNIO_BENCHMARK_OUTPUT_DIR": str(temp_benchmark_dir),
+    },
     capture_output=True,
     text=True,
-    cwd=str(temp_benchmark_dir),
+    cwd=str(BENCHMARKS_DIR.parent),
     timeout=30,
     )
-    
+
     assert (
     result.returncode == 0), f"Dry-run failed.\nStdout:\n{result.stdout}\nStderr:\n{result.stderr}"
 
-    # Ensure no temporary sparse-null benchmark files remain
-    post_files = list(
-    temp_benchmark_dir.glob("benchmark_sparse_nulls_*.csv"))
-    
-    assert len(post_files) == 0, (
-    f"Temp benchmark files were not cleaned up: {post_files}")
+    # Ensure temporary benchmark artifacts are cleaned up
+    post_files = list(temp_benchmark_dir.glob("benchmark_sparse_nulls_*.csv"))
+
+    assert len(post_files) == 0, (f"Temp benchmark files were not cleaned up: {post_files}")
 
 
 def test_check_regression_detects_slowdown():


### PR DESCRIPTION
## Summary

Refactored test_benchmark_sparse_nulls_dry_run_cleans_up_temp_files() to isolate benchmark artifacts using pytest-managed temporary directories instead of deleting files from the shared repository benchmark directory.
This improves test reliability, prevents accidental deletion of local benchmark artifacts, and makes the benchmark test safer for parallel CI execution.

## Linked issue

Fixes #1540 

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [X] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test`
- [ ] `make lint`
- [X] Other:
        pytest tests/test_benchmarks_smoke.py
        pytest -n auto tests/test_benchmarks_smoke.py
        
        Verified that:

              - benchmark tests pass successfully
              - no repository benchmark files are deleted or modified
              - temporary artifacts are isolated within pytest-managed directories
              - tests behave deterministically during parallel execution


## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

This PR removes direct filesystem mutation inside the shared benchmarks/ directory during tests and replaces it with isolated pytest temporary directories for safer CI execution and improved parallel-test compatibility.
