### PR TITLE
fix: validate tokens argument in standardize_missing_tokens

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1850,6 +1850,21 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
             f"subset must be a list of column names, not a string. "
             f"Did you mean subset=['{subset}']?"
         )
+    if tokens is not None:
+        if isinstance(tokens, str):
+            raise TypeError(
+                f"tokens must be a list of strings, not a bare string. "
+                f"Did you mean tokens=['{tokens}']?"
+            )
+        if not isinstance(tokens, list):
+            raise TypeError(
+                f"tokens must be a list of strings, got {type(tokens).__name__!r}"
+            )
+        for item in tokens:
+            if not isinstance(item, str):
+                raise TypeError(
+                    f"tokens must be a list of strings, got {type(item).__name__!r} item"
+                )
 
     default_tokens = [
         "N/A",

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1371,6 +1371,26 @@ class TestStandardizeMissingTokens:
         assert result["value"].iloc[2] == "--"
         assert result["value"].iloc[3] == "kept"
 
+    def test_standardize_missing_tokens_scalar_int_raises(self):
+        frame = pd.DataFrame({"x": ["NA", "N", "ok"]})
+        with pytest.raises(TypeError, match="tokens must be a list of strings"):
+            ar.standardize_missing_tokens(frame, tokens=1)
+
+    def test_standardize_missing_tokens_dict_raises(self):
+        frame = pd.DataFrame({"x": ["NA", "N", "ok"]})
+        with pytest.raises(TypeError, match="tokens must be a list of strings"):
+            ar.standardize_missing_tokens(frame, tokens={"NA": "bad"})
+
+    def test_standardize_missing_tokens_bare_string_raises(self):
+        frame = pd.DataFrame({"x": ["NA", "N", "ok"]})
+        with pytest.raises(TypeError, match="tokens must be a list of strings"):
+            ar.standardize_missing_tokens(frame, tokens="NA")
+
+    def test_standardize_missing_tokens_list_with_non_string_item_raises(self):
+        frame = pd.DataFrame({"x": ["NA", "N", "ok"]})
+        with pytest.raises(TypeError, match="tokens must be a list of strings"):
+            ar.standardize_missing_tokens(frame, tokens=["NA", 1])
+
 
 class TestStripWhitespace:
     def test_strip(self, csv_with_whitespace):


### PR DESCRIPTION
## Summary
Add input validation for the `tokens` parameter in `standardize_missing_tokens()`. Non-list values (bare strings, scalars, dicts) and lists containing non-string items are now rejected with a clear TypeError, mirroring the existing `subset` guard.

## Linked issue
Fixes #1429

## Type of change
- [x] Bug fix

## Area
- [x] Python API / ArFrame

## Testing
python3 -m pytest tests/test_cleaning.py::TestStandardizeMissingTokens -v
27 passed in 1.65s

- [x] Other: pytest TestStandardizeMissingTokens (27 passed)

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).