### PR TITLE
fix(pandas): add max_errors passthrough to ArnioPandasAccessor.validate

### DIFF
--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -134,6 +134,21 @@ class ArnioPandasAccessor:
 
         return to_pandas(result)
 
-    def validate(self, schema: Schema | dict[str, Any]) -> ValidationResult:
-        """Validate the DataFrame against an Arnio schema."""
-        return validate(self.to_arframe(), schema)
+    def validate(
+        self,
+        schema: Schema | dict[str, Any],
+        *,
+        max_errors: int | None = None,
+    ) -> ValidationResult:
+        """Validate the DataFrame against an Arnio schema.
+
+        Parameters
+        ----------
+        schema : Schema or dict[str, Field]
+            Schema to validate against.
+        max_errors : int or None, default None
+            Maximum number of validation issues to collect. Mirrors the
+            ``max_errors`` parameter of ``ar.validate()``. When None all
+            issues are collected.
+        """
+        return validate(self.to_arframe(), schema, max_errors=max_errors)

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -160,3 +160,18 @@ def test_pandas_accessor_auto_clean_return_report_and_explain():
     assert list(result["name"]) == ["Alice", "Bob"]
     assert isinstance(report, ar.DataQualityReport)
     assert isinstance(explanation, ar.CleanExplanation)
+
+
+def test_pandas_accessor_validate_respects_max_errors():
+    # max_errors=1 should cap the result at one issue even when multiple rows fail.
+    df = pd.DataFrame({"age": [-1, -2, -3]})
+    schema = ar.Schema({"age": ar.Int64(min=0)})
+
+    result_capped = df.arnio.validate(schema, max_errors=1)
+    result_full = df.arnio.validate(schema)
+
+    assert isinstance(result_capped, ar.ValidationResult)
+    assert not result_capped.passed
+    assert result_capped.issue_count == 1
+    # Full run should report all three failures
+    assert result_full.issue_count == 3


### PR DESCRIPTION
# Title

fix(pandas): add max_errors passthrough to ArnioPandasAccessor.validate

# Description

Fixes #1396

## What

`ArnioPandasAccessor.validate()` was missing the `max_errors` parameter already supported by the core `ar.validate()` API. Because of this, pandas-first users had to manually convert DataFrames just to limit validation output.

## Changes

* `arnio/integrations/pandas.py`

  * added `max_errors: int | None = None` as a keyword-only argument to `ArnioPandasAccessor.validate()`
  * forwarded the value to the core `validate()` call
  * updated the docstring

* `tests/test_pandas_accessor.py`

  * added `test_pandas_accessor_validate_respects_max_errors`
  * verifies that `max_errors=1` caps the output to one issue while the uncapped call still returns all three validation failures

## Before / After

```python
# Before — TypeError
pdf.arnio.validate(schema, max_errors=1)

# After — works, mirrors ar.validate()
pdf.arnio.validate(schema, max_errors=1)
```

## Scope

Two files only. No C++ changes and no schema validation logic changes.

The core `validate()` implementation already supported `max_errors`; this PR simply exposes the existing functionality through the pandas accessor layer.
