### PR TITLE
fix: validate ValidationIssue severity values 

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -919,6 +919,9 @@ class ValidationIssue:
     value: Any = None
     severity: str = "error"
 
+    def __post_init__(self) -> None:
+        _validate_severity(self.severity)
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
         return {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3068,3 +3068,35 @@ def test_float64_rejects_string_min_with_valid_max():
 def test_float64_rejects_bool_pair():
     with pytest.raises(TypeError, match="min must be numeric or None"):
         ar.Float64(min=True, max=False)
+
+
+def test_validation_issue_accepts_valid_severities():
+    error_issue = ar.ValidationIssue(
+        column="age", rule="min", message="Too small", severity="error"
+    )
+    warning_issue = ar.ValidationIssue(
+        column="age", rule="min", message="Too small", severity="warning"
+    )
+
+    assert error_issue.severity == "error"
+    assert warning_issue.severity == "warning"
+
+
+def test_validation_issue_rejects_invalid_severity_typo():
+    with pytest.raises(ValueError, match="severity must be 'error' or 'warning'"):
+        ar.ValidationIssue(
+            column="score", rule="custom", message="bad", severity="erorr"
+        )
+
+
+def test_custom_rule_with_invalid_severity_fails_validation_execution():
+    def bad_custom_rule(df):
+        return [
+            ar.ValidationIssue(column="x", rule="demo", message="bad", severity="erorr")
+        ]
+
+    frame = ar.from_pandas(pd.DataFrame({"x": [1]}))
+    schema = ar.Schema({"x": ar.Field()}, rules=[bad_custom_rule])
+
+    with pytest.raises(ValueError, match="severity must be 'error' or 'warning'"):
+        schema.validate(frame)


### PR DESCRIPTION
## Summary
Added an explicit `__post_init__` validation hook to the `ValidationIssue` frozen dataclass to call the internal `_validate_severity()` method. This ensures that any invalid string value or typo (such as `"erorr"`) passed to a validation issue fails fast by throwing a `ValueError`. This addresses a critical gap where typos in custom schema rules allowed invalid issues to bypass `ValidationResult.passed` checks and silently validate failing frames.

## Linked issue
Fixes #1638

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Ran the test suite locally using pytest to ensure both the new edge cases and all regression tests pass cleanly.
- [x] `make test` (2182 passed, including `test_validation_issue_accepts_valid_severities()`, `test_validation_issue_rejects_invalid_severity_typo()`, `test_custom_rule_with_invalid_severity_fails_validation_execution()`)
- [x] `make lint`
- [ ] Other:

## Screenshots / Media
N/A

## Performance Impact
None

## GSSoC labels
- `gssoc:approved`, `level:intermediate`, `type:bug` and `area:schema`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes