### PR TITLE
fix(io): add skiprows alias to read_csv_chunked for API consistency

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -596,7 +596,10 @@ def read_csv(
     try:
         effective_encoding = "utf-8" if is_materialized_text else encoding
         with _utf8_csv_path(
-            path, effective_encoding, encoding_errors=encoding_errors, delimiter=delimiter
+            path,
+            effective_encoding,
+            encoding_errors=encoding_errors,
+            delimiter=delimiter,
         ) as native_path:
             cpp_frame, bad_rows = reader.read(native_path, on_bad_lines)
 
@@ -627,6 +630,7 @@ def read_csv_chunked(
     usecols: list[str] | None = None,
     nrows: int | None = None,
     skip_rows: int = 0,
+    skiprows: int | None = None,
     encoding: str = "utf-8",
     trim_headers: bool = True,
     decimal_separator: str = ".",
@@ -658,6 +662,12 @@ def read_csv_chunked(
         Maximum total number of data rows to read across all chunks.
     skip_rows : int, default 0
         Number of data rows to skip after the header row.
+    skiprows : int, optional
+        Alias for ``skip_rows`` for API consistency with ``read_csv``.
+        Note: in chunked mode both ``skip_rows`` and ``skiprows`` skip
+        data rows *after* the header, not lines before it.
+        If both are supplied they must agree; conflicting values raise
+        ``ValueError``.
     encoding : str, default "utf-8"
         File encoding.
     trim_headers : bool, default True
@@ -725,6 +735,24 @@ def read_csv_chunked(
         delimiter = _validate_delimiter(delimiter)
         mode = _validate_parser_mode(mode)
         chunksize = _validate_chunksize(chunksize)
+
+        # Resolve skiprows / skip_rows alias.
+        # Both skip data rows after the header in chunked mode.
+        # skip_rows is kept for backward compatibility; skiprows matches
+        # the read_csv parameter name. Both may be passed as long as they
+        # agree; conflicting values raise ValueError.
+        if skiprows is not None:
+            if isinstance(skiprows, bool) or not isinstance(skiprows, int):
+                raise TypeError("skiprows must be an integer")
+            if skiprows < 0:
+                raise ValueError("skiprows must be non-negative")
+            if skip_rows != 0 and skip_rows != skiprows:
+                raise ValueError(
+                    f"Conflicting values: skiprows={skiprows!r} and "
+                    f"skip_rows={skip_rows!r}. Pass only one of them."
+                )
+            skip_rows = skiprows
+
         skip_rows = _validate_skip_rows(skip_rows)
         on_bad_lines = _validate_on_bad_lines(on_bad_lines)
 
@@ -754,7 +782,9 @@ def read_csv_chunked(
         raise
     try:
         effective_encoding = "utf-8" if is_materialized_text else encoding
-        with _utf8_csv_path(path, effective_encoding, delimiter=delimiter) as native_path:
+        with _utf8_csv_path(
+            path, effective_encoding, delimiter=delimiter
+        ) as native_path:
             reader.open(native_path)
             while True:
                 chunk = reader.next_chunk(chunksize, on_bad_lines)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -2296,6 +2296,69 @@ class TestReadCsvSkipRows:
             ar.read_csv(csv_path, skiprows=1.5)
 
 
+class TestReadCsvChunkedSkiprowsAlias:
+    """Tests for the skiprows alias in read_csv_chunked (issue #1293).
+
+    skip_rows / skiprows in chunked mode skip data rows *after* the header.
+    skiprows is a naming alias only — semantics are unchanged.
+    """
+
+    def test_skiprows_alias_skips_rows(self, tmp_path):
+        # skiprows=2 skips the first 2 data rows after the header.
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("name,age\nAlice,30\nBob,25\nCharlie,35\n")
+        chunks = list(ar.read_csv_chunked(csv_path, skiprows=2))
+        assert len(chunks) == 1
+        df = ar.to_pandas(chunks[0])
+        assert df["name"].tolist() == ["Charlie"]
+
+    def test_skiprows_alias_zero_is_noop(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("name,age\nAlice,30\n")
+        chunks = list(ar.read_csv_chunked(csv_path, skiprows=0))
+        assert sum(c.shape[0] for c in chunks) == 1
+
+    def test_skip_rows_still_works(self, tmp_path):
+        # Existing skip_rows parameter must remain backward-compatible.
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("name,age\nAlice,30\nBob,25\n")
+        chunks = list(ar.read_csv_chunked(csv_path, skip_rows=1))
+        df = ar.to_pandas(chunks[0])
+        assert df["name"].tolist() == ["Bob"]
+
+    def test_skiprows_and_skip_rows_agree_no_error(self, tmp_path):
+        # Both may be passed if they have the same value.
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("name,age\nAlice,30\nBob,25\n")
+        chunks = list(ar.read_csv_chunked(csv_path, skiprows=1, skip_rows=1))
+        df = ar.to_pandas(chunks[0])
+        assert df["name"].tolist() == ["Bob"]
+
+    def test_skiprows_and_skip_rows_conflict_raises(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("name,age\nAlice,30\n")
+        with pytest.raises(ValueError, match="Conflicting values"):
+            list(ar.read_csv_chunked(csv_path, skiprows=1, skip_rows=2))
+
+    def test_skiprows_invalid_negative_raises(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(ValueError, match="non-negative"):
+            list(ar.read_csv_chunked(csv_path, skiprows=-1))
+
+    def test_skiprows_invalid_bool_raises(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(TypeError, match="integer"):
+            list(ar.read_csv_chunked(csv_path, skiprows=True))
+
+    def test_skiprows_invalid_float_raises(self, tmp_path):
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(TypeError, match="integer"):
+            list(ar.read_csv_chunked(csv_path, skiprows=1.5))
+
+
 class TestInferTypeLocaleAndNumericEdgeCases:
     def test_float_decimal_dot(self, tmp_path):
         path = tmp_path / "decimal.csv"
@@ -2745,6 +2808,7 @@ def test_streaming_late_type_promotion_float(tmp_path):
 
 def test_read_csv_text_stream_encoding_override():
     import io
+
     csv_text = "col1,col2\nhello,café\n"
     # Even if caller passes a different encoding, text streams are handled as UTF-8
     stream = io.StringIO(csv_text)
@@ -2755,6 +2819,7 @@ def test_read_csv_text_stream_encoding_override():
 
 def test_read_csv_chunked_text_stream_encoding_override():
     import io
+
     csv_text = "col1,col2\nhello,café\n"
     stream = io.StringIO(csv_text)
     chunks = list(ar.read_csv_chunked(stream, encoding="utf-16"))


### PR DESCRIPTION
Fixes #1293

## What
read_csv() uses `skiprows` (matching pandas convention) but read_csv_chunked()
only accepted `skip_rows`, causing a confusing TypeError when users switched
between the two functions.

## Changes
- `arnio/io.py`: added `skiprows: int | None = None` as a keyword-only alias
  in `read_csv_chunked()`. `skip_rows` is fully preserved for backward compat.
- `tests/test_csv.py`: added `TestReadCsvChunkedSkiprowsAlias` with 8 tests.

## Conflict resolution
| Inputs | Behaviour |
|---|---|
| Only `skiprows` | used as the row-skip count |
| Only `skip_rows` | existing behaviour unchanged |
| Both, same value | no error |
| Both, different values | `ValueError` with clear message |

## Scope
Two files only. No C++ changes. `skip_rows` semantics are unchanged —
both parameters skip data rows *after* the header in chunked mode.
