### PR TITLE
fix: validate URL allowed_schemes case-insensitively

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1816,7 +1816,7 @@ def URL(
                     "allowed_schemes must contain URL scheme names such as 'http' or 'https'"
                 )
 
-            normalized_schemes.add(scheme)
+            normalized_schemes.add(scheme.lower())
 
         if len(normalized_schemes) == 0:
             raise ValueError("allowed_schemes must be a non-empty sequence")
@@ -1824,7 +1824,6 @@ def URL(
         schemes = "|".join(re.escape(scheme) for scheme in sorted(normalized_schemes))
 
         semantic = f"url:{schemes}"
-
     else:
         semantic = "url"
     return Field(
@@ -2328,7 +2327,7 @@ def _validate_column(
             pattern = _SEMANTIC_PATTERNS.get(field_def.semantic)
             if pattern is None and field_def.semantic.startswith("url:"):
                 schemes = field_def.semantic[len("url:") :]
-                pattern = rf"({schemes})://[^\s]+"
+                pattern = rf"(?i)({schemes})://[^\s]+"
             if pattern is None:
                 issues.append(
                     ValidationIssue(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,4 @@
-"""Tests for schema validation."""
+﻿"""Tests for schema validation."""
 
 import io
 import json
@@ -664,7 +664,7 @@ def test_validation_result_to_markdown_includes_issue_table(sample_csv):
         {"age": ar.Int64(min=31), "missing": ar.String()},
     )
 
-    # Default: redact_values=False — raw values are shown
+    # Default: redact_values=False â€” raw values are shown
     markdown = result.to_markdown()
 
     assert "- Status: **failed**" in markdown
@@ -709,7 +709,7 @@ def test_validation_result_to_markdown_escapes_table_cells():
     assert "left\\|right<br>next" in markdown
     assert "Expected one\\|two<br>lines" in markdown
 
-    # Opt-in to redaction — value is replaced with [REDACTED]
+    # Opt-in to redaction â€” value is replaced with [REDACTED]
     markdown_redacted = result.to_markdown(redact_values=True)
     assert "notes\\|raw" in markdown_redacted
     assert "[REDACTED]" in markdown_redacted
@@ -2259,7 +2259,7 @@ def test_row_index_convention_is_documented_and_correct(tmp_path):
 
     assert not result.passed
     assert len(result.issues) == 1
-    # Bob is the second data row → row_index must be 2, not 0 or 1
+    # Bob is the second data row â†’ row_index must be 2, not 0 or 1
     assert result.issues[0].row_index == 2
     assert result.issues[0].column == "age"
     assert result.issues[0].rule == "min"
@@ -3138,3 +3138,38 @@ def test_custom_rule_with_invalid_severity_fails_validation_execution():
 
     with pytest.raises(ValueError, match="severity must be 'error' or 'warning'"):
         schema.validate(frame)
+
+
+def test_url_uppercase_scheme_accepted_with_lowercase_allowed(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nHTTPS://example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["https"])})
+    assert result.passed
+
+
+def test_url_mixed_case_scheme_accepted(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nHttps://example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["https"])})
+    assert result.passed
+
+
+def test_url_uppercase_allowed_scheme_matches_lowercase_url(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nhttps://example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["HTTPS"])})
+    assert result.passed
+
+
+def test_url_uppercase_scheme_rejected_when_not_in_allowed(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nFTP://files.example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["https"])})
+    assert not result.passed
+
+
+def test_url_mixed_case_allowed_scheme_and_mixed_case_url(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nHTTPS://example.com\nHttps://test.org\nhttps://lower.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["HTTPS"])})
+    assert result.passed


### PR DESCRIPTION
Summary
URL(allowed_schemes=...) treated URL schemes case-sensitively, causing HTTPS://example.com to fail validation when allowed_schemes=["https"] was set. This fix normalises both the allowed schemes and the incoming URL scheme to lowercase before matching, making validation RFC 3986 compliant.
Linked issue
Fixes #1699
Type of change

 Bug fix

Area

 Schema validation

Testing

 Other: python -m pytest tests/test_schema.py → 236 passed in 2.88s

Screenshots / Media
NA
Performance Impact
NA
Contributor checklist

 I read the contributing guide.
 I kept the PR focused on one issue or one logical change.
 I added or updated tests for behavior changes.
 I added or updated docs/examples for public API changes.
 I checked that generated files, logs, and local build artifacts are not committed.
 My PR title uses Conventional Commits (fix: validate URL allowed_schemes case-insensitively).

Maintainer notes
Two minimal changes in arnio/schema.py:

In URL() — normalised allowed_schemes to lowercase before building the semantic string
In _validate_column() — added (?i) flag to the URL scheme regex for case-insensitive matching

Five new tests added to tests/test_schema.py covering: uppercase scheme in URL, mixed case scheme, uppercase allowed scheme, rejected unlisted uppercase scheme, and combined mixed case scenarios.