### PR TITLE
fix: make drop_columns empty list behavior return a new frame (#1654)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -247,7 +247,7 @@ def drop_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
         ),
     )
     if len(requested_columns) == 0:
-        return frame
+        return frame.drop_columns([])
     if len(requested_columns) == len(frame.columns):
         raise ValueError("drop_columns cannot remove all columns from the frame")
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -683,9 +683,12 @@ class TestDropColumns:
     def test_drop_columns_allows_empty_input_as_no_op(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        result = ar.drop_columns(frame, [])
+        result_helper = ar.drop_columns(frame, [])
+        result_method = frame.drop_columns([])
 
-        assert result is frame
+        assert result_helper is not frame
+        assert result_helper == frame
+        assert result_helper == result_method
 
     def test_drop_columns_rejects_missing_columns(self, sample_csv):
         frame = ar.read_csv(sample_csv)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -402,7 +402,9 @@ class TestPipeline:
         frame = ar.read_csv(sample_csv)
         result = ar.pipeline(frame, [("drop_columns", {"columns": []})])
 
-        assert result is frame
+        assert result is not frame
+        assert result.columns == frame.columns
+        assert len(result) == len(frame)
 
     def test_pipeline_drop_columns_rejects_missing_columns(self, sample_csv):
         import pytest


### PR DESCRIPTION
Resolves #1654

### What was done:
- Updated the public helper \r.drop_columns(frame, [])\ to delegate to the method-level \rame.drop_columns([])\ when the list of columns to drop is empty.
- This ensures consistent 'new frame' copy behavior and satisfies the docstring statement that it returns a new frame.
- Updated the test suite in \	ests/test_cleaning.py\ to verify:
  - The returned frame is not the same object as the input (\esult_helper is not frame\).
  - The returned frame preserves data and matches the input.
  - Method and helper behaviors are consistent.

Ready for review!