### PR TITLE
ci: smoke test sdist install in release dry run

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -45,6 +45,26 @@ jobs:
           pip install twine
           twine check dist/*.tar.gz && echo "✅ Twine check passed" || { echo "❌ Twine check failed"; exit 1; }
 
+      - name: Install package from sdist
+        run: python -m pip install dist/*.tar.gz
+
+      - name: Smoke test sdist import
+        run: |
+          python - <<'PY'
+          import os
+          import subprocess
+          import sys
+          import tempfile
+
+          with tempfile.TemporaryDirectory() as tmp:
+              subprocess.run(
+                  [sys.executable, "-c", "import arnio"],
+                  cwd=tmp,
+                  check=True,
+                  env={**os.environ, "PYTHONPATH": ""},
+              )
+          PY
+
       - uses: actions/upload-artifact@v6
         with:
           name: sdist
@@ -98,7 +118,7 @@ jobs:
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Version validation     | ${{ needs.validate-version.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| sdist build + twine    | ${{ needs.build_sdist.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| sdist build + install smoke | ${{ needs.build_sdist.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY
           # build_wheels is a matrix job, so needs.build_wheels.result
           # represents the aggregate status across all wheel platforms.
           echo "| Wheels + smoke (matrix) | ${{ needs.build_wheels.result == 'success' && '✅ Pass' || '❌ Fail' }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes #1643

This PR strengthens the release dry-run sdist check so it mirrors the publish workflow more closely. The dry-run job already built the sdist and ran `twine check`; it now also installs the generated `dist/*.tar.gz` and verifies `import arnio` from a temporary directory with `PYTHONPATH` cleared.

This is for GSSoC 2026 and stays scoped to the assigned release dry-run workflow issue.

## What changed

- Added `python -m pip install dist/*.tar.gz` after the Twine metadata check.
- Added an isolated import smoke test using a temporary working directory.
- Updated the dry-run summary row from `sdist build + twine` to `sdist build + install smoke` so the reported gate matches the actual workflow.

## Workflow command path covered

The release dry-run sdist job now exercises:

```bash
pipx run build --sdist
pip install twine
twine check dist/*.tar.gz
python -m pip install dist/*.tar.gz
python -c "import arnio"  # from outside the checkout, with PYTHONPATH cleared
```

## Validation

- `git diff --check`
- YAML syntax load check with Ruby/Psych for `.github/workflows/release-dry-run.yml`
