### PR TITLE
fix: validate unequal column lengths in from_dict

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -417,9 +417,22 @@ def from_dict(data: dict) -> ArFrame:
         raise TypeError(f"Expected dict datatype but instead got {type(data).__name__}")
     if not all(isinstance(k, str) for k in data.keys()):
         raise TypeError("All dictionary keys must be strings")
+    lengths = {}
+
     for col_name, value in data.items():
         if isinstance(value, dict):
-            raise ValueError(f"Nested objects are not supported in column{col_name}")
+            raise ValueError(f"Nested objects are not supported in column {col_name}")
+
+        if hasattr(value, "__len__") and not isinstance(value, (str, bytes)):
+            lengths[col_name] = len(value)
+
+    if lengths:
+        unique_lengths = set(lengths.values())
+
+        if len(unique_lengths) > 1:
+            details = ", ".join(f"{name}={length}" for name, length in lengths.items())
+
+            raise ValueError(f"from_dict() column lengths differ: {details}")
     df = pd.DataFrame(data)
     for col_name in df.columns:
         _check_unsupported_dtype(col_name, df[col_name])

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -670,6 +670,36 @@ class TestFromPandas:
 
         assert roundtripped.shape == (2, 0)
 
+    def test_from_dict_mismatched_column_lengths(self):
+        with pytest.raises(
+            ValueError,
+            match="from_dict\\(\\) column lengths differ",
+        ) as exc_info:
+            ar.from_dict(
+                {
+                    "id": [1, 2, 3],
+                    "name": ["a", "b"],
+                }
+            )
+
+        message = str(exc_info.value)
+
+        assert "id=3" in message
+        assert "name=2" in message
+
+    def test_from_dict_equal_length_columns(self):
+        frame = ar.from_dict(
+            {
+                "id": [1, 2],
+                "name": ["a", "b"],
+            }
+        )
+
+        result = ar.to_pandas(frame)
+
+        assert result.shape == (2, 2)
+        assert list(result.columns) == ["id", "name"]
+
 
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):


### PR DESCRIPTION
## Summary

Add explicit column-length validation in `from_dict()` before pandas `DataFrame` construction.

This prevents pandas' generic `ValueError: All arrays must be of the same length` from leaking through the Arnio API and instead raises a clearer Arnio-specific error naming the mismatched columns and lengths.

Example:

```python
ar.from_dict({
    "id": [1, 2, 3],
    "name": ["a", "b"],
})
```

now raises:

```python
ValueError: from_dict() column lengths differ: id=3, name=2
```

Fixes #1705 

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [x] Other:

```bash
ruff check arnio/convert.py tests/test_convert.py
black arnio/convert.py tests/test_convert.py
pytest tests/test_convert.py -q
```

Result:

* 97 passed
* 12 skipped

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
