### PR TITLE
fix: gate Catch2 behind native test option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DARNIO_BUILD_CPP_TESTS=ON \
             -DCMAKE_PREFIX_PATH=$(python3 -c "import pybind11; print(pybind11.get_cmake_dir())")
       - name: Build
         run: cmake --build build --parallel

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,12 +1,3 @@
-include(FetchContent)
-
-FetchContent_Declare(
-    Catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.5.3
-)
-FetchContent_MakeAvailable(Catch2)
-
 add_library(arnio_core STATIC
     src/column.cpp
     src/frame.cpp
@@ -18,14 +9,27 @@ target_include_directories(arnio_core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 target_compile_features(arnio_core PUBLIC cxx_std_17)
-enable_testing()
-macro(arnio_test target source)
-    add_executable(${target} ${source})
-    target_link_libraries(${target} PRIVATE arnio_core Catch2::Catch2WithMain)
-    add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
-endmacro()
 
-arnio_test(test_column     tests/test_column.cpp)
-arnio_test(test_frame      tests/test_frame.cpp)
-arnio_test(test_cleaning   tests/test_cleaning.cpp)
-arnio_test(test_csv_parser tests/test_csv_parser.cpp)
+option(ARNIO_BUILD_CPP_TESTS "Build Arnio C++ tests" OFF)
+
+if(ARNIO_BUILD_CPP_TESTS)
+    include(FetchContent)
+
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v3.5.3
+    )
+    FetchContent_MakeAvailable(Catch2)
+
+    macro(arnio_test target source)
+        add_executable(${target} ${source})
+        target_link_libraries(${target} PRIVATE arnio_core Catch2::Catch2WithMain)
+        add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
+    endmacro()
+
+    arnio_test(test_column     tests/test_column.cpp)
+    arnio_test(test_frame      tests/test_frame.cpp)
+    arnio_test(test_cleaning   tests/test_cleaning.cpp)
+    arnio_test(test_csv_parser tests/test_csv_parser.cpp)
+endif()


### PR DESCRIPTION
## Summary
- add ARNIO_BUILD_CPP_TESTS with a default OFF value so wheel/default native builds do not fetch Catch2
- keep Catch2 FetchContent and C++ test targets behind that explicit opt-in
- update the native C++ CI job to enable ARNIO_BUILD_CPP_TESTS when tests are meant to run

Closes #1715

## Verification
- python -m build --wheel
- default CMake configure/build without Catch2 FetchContent dirs
- cmake -DARNIO_BUILD_CPP_TESTS=ON opt-in native build
- ctest --test-dir build-cpp-tests --output-on-failure (4/4 passed)
- git diff --check origin/main...HEAD