### PR TITLE
fix: reject duplicate columns in schema unique constraints(#1696)

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -768,6 +768,11 @@ class Schema:
                     raise TypeError(
                         f"Schema 'unique' members must be strings, got {type(item).__name__} for element {item!r}."
                     )
+
+            if len(set(self.unique)) != len(self.unique):
+                raise ValueError(
+                    "Schema 'unique' must not contain duplicate column names"
+                )
         if not isinstance(self.strict, bool):
             raise TypeError("Schema 'strict' must be a boolean")
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1745,6 +1745,39 @@ def test_schema_unique_accepts_valid_types():
     assert schema_tuple.unique == ("user_id", "course_id")
 
 
+def test_schema_unique_rejects_duplicate_columns():
+    with pytest.raises(
+        ValueError,
+        match="Schema 'unique' must not contain duplicate column names",
+    ):
+        ar.Schema(
+            {
+                "user_id": ar.Int64(),
+            },
+            unique=["user_id", "user_id"],
+        )
+
+
+def test_schema_from_json_rejects_duplicate_unique_columns():
+    payload = {
+        "fields": {
+            "user_id": {
+                "dtype": "int64",
+                "nullable": True,
+                "unique": False,
+            }
+        },
+        "strict": False,
+        "unique": ["user_id", "user_id"],
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Schema 'unique' must not contain duplicate column names",
+    ):
+        ar.Schema.from_json(json.dumps(payload))
+
+
 @pytest.mark.parametrize("value", ["false", 1, None])
 def test_field_nullable_rejects_non_bool_values(value):
     with pytest.raises(TypeError, match="nullable must be a bool"):


### PR DESCRIPTION
Adds validation for duplicate column names in Schema(unique=...).

Previously, schemas like:

ar.Schema(
    {"id": ar.Int64()},
    unique=["id", "id"],
)

were accepted and later produced confusing composite uniqueness validation messages.

This change now raises a clear ValueError during schema construction.

Fixes #1696

Changes
Added duplicate-name validation in Schema.__post_init__()
Added regression tests for:
direct schema construction
Schema.from_json() deserialization
Tests
pytest tests/test_schema.py -v