### PR TITLE
fix(quality): add redaction options to ProfileComparison.to_dict and …

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -786,11 +786,31 @@ class ProfileComparison:
     drift_report: dict[str, dict[str, Any]]
     status_counts: dict[str, int] = field(default_factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
-        """Return a JSON-friendly dictionary representation."""
+    def to_dict(
+        self,
+        *,
+        redact_sample_values: bool = False,
+        exclude_columns: list[str] | set[str] | tuple[str, ...] | None = None,
+    ) -> dict[str, Any]:
+        """Return a JSON-friendly dictionary representation.
+
+        Parameters
+        ----------
+        redact_sample_values : bool, default False
+            When True, sample values are replaced with ``[REDACTED]`` in
+            both nested profile exports.
+        exclude_columns : list, set, or tuple of str, optional
+            Column names to omit from both nested profile exports.
+        """
         return {
-            "left_profile": self.left_profile.to_dict(),
-            "right_profile": self.right_profile.to_dict(),
+            "left_profile": self.left_profile.to_dict(
+                redact_sample_values=redact_sample_values,
+                exclude_columns=exclude_columns,
+            ),
+            "right_profile": self.right_profile.to_dict(
+                redact_sample_values=redact_sample_values,
+                exclude_columns=exclude_columns,
+            ),
             "status_counts": dict(self.status_counts),
             "drift_report": {
                 name: _clean_drift_entry(entry)
@@ -802,14 +822,35 @@ class ProfileComparison:
         self,
         *,
         indent: int | None = None,
+        redact_sample_values: bool = False,
+        exclude_columns: list[str] | set[str] | tuple[str, ...] | None = None,
         output: Any | None = None,
     ) -> str | None:
         """Return the comparison as a JSON string.
 
+        Parameters
+        ----------
+        indent : int or None, default None
+            JSON indentation level.
+        redact_sample_values : bool, default False
+            When True, sample values are replaced with ``[REDACTED]`` in
+            both nested profile exports.
+        exclude_columns : list, set, or tuple of str, optional
+            Column names to omit from both nested profile exports.
+        output : writable text stream, optional
+            If provided, the JSON is written to this stream and None is
+            returned instead of a string.
+
         Example:
         comparison.to_json(indent=2)
         """
-        json_out = json.dumps(self.to_dict(), indent=indent)
+        json_out = json.dumps(
+            self.to_dict(
+                redact_sample_values=redact_sample_values,
+                exclude_columns=exclude_columns,
+            ),
+            indent=indent,
+        )
 
         if output is None:
             return json_out

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2859,3 +2859,66 @@ class TestValidateGateBool:
     def test_string_raises_type_error(self):
         with pytest.raises(TypeError, match="must be a bool"):
             _validate_gate_bool("true", "allow_new_columns")
+
+
+# ── ProfileComparison redaction tests ────────────────────────────────────────
+
+
+def test_profile_comparison_to_dict_redacts_sample_values():
+    """redact_sample_values=True must replace sample values in both nested profiles."""
+    frame = ar.from_pandas(
+        pd.DataFrame({"email": ["alice@example.com", "bob@example.com"]})
+    )
+    left = ar.profile(frame)
+    right = ar.profile(frame)
+    comparison = ar.compare_profiles(left, right)
+
+    redacted = comparison.to_dict(redact_sample_values=True)
+    plain = comparison.to_dict()
+
+    # Sensitive values must not appear in the redacted export
+    assert "alice@example.com" not in str(redacted)
+    assert "bob@example.com" not in str(redacted)
+
+    # Sample values are replaced with the redaction sentinel
+    left_samples = redacted["left_profile"]["columns"]["email"]["sample_values"]
+    right_samples = redacted["right_profile"]["columns"]["email"]["sample_values"]
+    assert all(v == "[REDACTED]" for v in left_samples)
+    assert all(v == "[REDACTED]" for v in right_samples)
+
+    # Plain export still contains the real values
+    assert "alice@example.com" in str(plain)
+
+
+def test_profile_comparison_to_dict_exclude_columns():
+    """exclude_columns must omit the named column from both nested profiles."""
+    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob"], "score": [10, 20]}))
+    left = ar.profile(frame)
+    right = ar.profile(frame)
+    comparison = ar.compare_profiles(left, right)
+
+    result = comparison.to_dict(exclude_columns=["name"])
+
+    assert "name" not in result["left_profile"]["columns"]
+    assert "name" not in result["right_profile"]["columns"]
+    # Non-excluded column is still present
+    assert "score" in result["left_profile"]["columns"]
+    assert "score" in result["right_profile"]["columns"]
+
+
+def test_profile_comparison_to_json_redacts_sample_values():
+    """to_json(redact_sample_values=True) must not contain sensitive values."""
+    frame = ar.from_pandas(pd.DataFrame({"token": ["secret-abc", "secret-xyz"]}))
+    left = ar.profile(frame)
+    right = ar.profile(frame)
+    comparison = ar.compare_profiles(left, right)
+
+    json_redacted = comparison.to_json(redact_sample_values=True)
+    json_plain = comparison.to_json()
+
+    assert "secret-abc" not in json_redacted
+    assert "secret-xyz" not in json_redacted
+    assert "[REDACTED]" in json_redacted
+
+    # Plain export contains the real values
+    assert "secret-abc" in json_plain


### PR DESCRIPTION
Fixes #1753 

## What

ProfileComparison.to_dict() and to_json() were always exporting full
unredacted profile payloads, even though DataQualityReport.to_dict()
already supports redact_sample_values and exclude_columns. Users had no
way to get a redacted comparison export without manually building
separate artifacts.

## Changes

**arnio/quality.py**
- ProfileComparison.to_dict(): added redact_sample_values and
  exclude_columns keyword-only params; passed through to both nested
  left_profile.to_dict() and right_profile.to_dict() calls.
- ProfileComparison.to_json(): added the same two params; passed through
  to self.to_dict(). Existing indent and output params unchanged.
- Docstrings updated on both methods.

**tests/test_quality.py** — 3 regression tests:
- redact_sample_values=True: sensitive values absent, [REDACTED] present
  in both nested profiles
- exclude_columns: named column absent from both nested profiles
- to_json(redact_sample_values=True): JSON string contains no sensitive
  values

## Scope

One file changed (arnio/quality.py). No C++ changes, no schema changes.
