### PR TITLE
test: add runtime vs stub parity test for _arnio_cpp

### DIFF
--- a/tests/test_stub_runtime_parity.py
+++ b/tests/test_stub_runtime_parity.py
@@ -6,23 +6,19 @@ from pathlib import Path
 import pytest
 
 
-def _find_stub_file():
+def _find_stub_file(stub_name):
     repo_root = Path(__file__).resolve().parent.parent
-    candidates = [repo_root / "arnio" / "_arnio_cpp.pyi", repo_root / "arnio" / "_core.pyi"]
-    for p in candidates:
-        if p.exists():
-            return p
-    # fallback: first .pyi under arnio/
-    for p in (repo_root / "arnio").glob("*.pyi"):
-        return p
+    stub_path = repo_root / "arnio" / stub_name
+    if stub_path.exists():
+        return stub_path
     return None
 
 
 @pytest.mark.parametrize("module_name, stub_name", [("arnio._arnio_cpp", "_arnio_cpp.pyi")])
 def test_stub_runtime_symbol_parity(module_name, stub_name):
-    stub_path = _find_stub_file()
+    stub_path = _find_stub_file(stub_name)
     if stub_path is None:
-        pytest.skip("No .pyi stub found in arnio/; skipping parity test")
+        pytest.skip(f"Stub file arnio/{stub_name} not found; skipping parity test")
 
     try:
         mod = importlib.import_module(module_name)

--- a/tests/test_stub_runtime_parity.py
+++ b/tests/test_stub_runtime_parity.py
@@ -14,7 +14,10 @@ def _find_stub_file(stub_name):
     return None
 
 
-@pytest.mark.parametrize("module_name, stub_name", [("arnio._arnio_cpp", "_arnio_cpp.pyi")])
+@pytest.mark.parametrize(
+    "module_name, stub_name",
+    [("arnio._arnio_cpp", "_arnio_cpp.pyi")],
+)
 def test_stub_runtime_symbol_parity(module_name, stub_name):
     stub_path = _find_stub_file(stub_name)
     if stub_path is None:
@@ -29,7 +32,11 @@ def test_stub_runtime_symbol_parity(module_name, stub_name):
 
     # collect top-level defs and classes (avoid indented methods)
     names = set()
-    for m in re.finditer(r"^(?:class|def)\s+([A-Za-z_][A-Za-z0-9_]*)", text, flags=re.MULTILINE):
+    for m in re.finditer(
+        r"^(?:class|def)\s+([A-Za-z_][A-Za-z0-9_]*)",
+        text,
+        flags=re.MULTILINE,
+    ):
         names.add(m.group(1))
 
     assert names, f"No top-level symbols parsed from {stub_path}"
@@ -50,6 +57,7 @@ def test_stub_runtime_symbol_parity(module_name, stub_name):
 
     if missing:
         pytest.fail(
-            f"Runtime module {module_name} is missing symbols or shape for: {', '.join(missing)}\n"
+            f"Runtime module {module_name} is missing symbols or shape for: "
+            f"{', '.join(missing)}\n"
             f"Stub file: {stub_path}"
         )

--- a/tests/test_stub_runtime_parity.py
+++ b/tests/test_stub_runtime_parity.py
@@ -1,0 +1,59 @@
+import importlib
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _find_stub_file():
+    repo_root = Path(__file__).resolve().parent.parent
+    candidates = [repo_root / "arnio" / "_arnio_cpp.pyi", repo_root / "arnio" / "_core.pyi"]
+    for p in candidates:
+        if p.exists():
+            return p
+    # fallback: first .pyi under arnio/
+    for p in (repo_root / "arnio").glob("*.pyi"):
+        return p
+    return None
+
+
+@pytest.mark.parametrize("module_name, stub_name", [("arnio._arnio_cpp", "_arnio_cpp.pyi")])
+def test_stub_runtime_symbol_parity(module_name, stub_name):
+    stub_path = _find_stub_file()
+    if stub_path is None:
+        pytest.skip("No .pyi stub found in arnio/; skipping parity test")
+
+    try:
+        mod = importlib.import_module(module_name)
+    except Exception as exc:  # pragma: no cover - import may fail on dev machines
+        pytest.skip(f"Could not import {module_name}: {exc}")
+
+    text = stub_path.read_text(encoding="utf8")
+
+    # collect top-level defs and classes (avoid indented methods)
+    names = set()
+    for m in re.finditer(r"^(?:class|def)\s+([A-Za-z_][A-Za-z0-9_]*)", text, flags=re.MULTILINE):
+        names.add(m.group(1))
+
+    assert names, f"No top-level symbols parsed from {stub_path}"
+
+    missing = []
+    for name in sorted(names):
+        if not hasattr(mod, name):
+            missing.append(name)
+            continue
+        attr = getattr(mod, name)
+        # best-effort check: classes should be class-like, defs callable
+        if name[0].isupper():
+            if not inspect.isclass(attr):
+                missing.append(name)
+        else:
+            if not (callable(attr) or inspect.isbuiltin(attr)):
+                missing.append(name)
+
+    if missing:
+        pytest.fail(
+            f"Runtime module {module_name} is missing symbols or shape for: {', '.join(missing)}\n"
+            f"Stub file: {stub_path}"
+        )


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [ ] I read the contributing guide.
- [ ] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
