### PR TITLE
fix(io): detect duplicate keys in read_jsonl rows

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1107,7 +1107,7 @@ def read_jsonl(
 
     records: list[dict] = []
 
-    def _reject_duplicate_keys(pairs):
+    def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
         seen = set()
         result = {}
         for k, v in pairs:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1106,6 +1106,17 @@ def read_jsonl(
         )
 
     records: list[dict] = []
+
+    def _reject_duplicate_keys(pairs):
+        seen = set()
+        result = {}
+        for k, v in pairs:
+            if k in seen:
+                raise ValueError(f"duplicate key {k!r}")
+            seen.add(k)
+            result[k] = v
+        return result
+
     try:
         with open(path, encoding=encoding) as fh:
             for lineno, raw_line in enumerate(fh, start=1):
@@ -1115,10 +1126,14 @@ def read_jsonl(
                 if nrows is not None and len(records) >= nrows:
                     break
                 try:
-                    obj = json.loads(line)
+                    obj = json.loads(line, object_pairs_hook=_reject_duplicate_keys)
                 except json.JSONDecodeError as exc:
                     raise JsonlReadError(
                         f"Invalid JSON on line {lineno} of {path!r}: {exc}"
+                    ) from exc
+                except ValueError as exc:
+                    raise JsonlReadError(
+                        f"Duplicate key on line {lineno} of {path!r}: {exc}"
                     ) from exc
                 if not isinstance(obj, dict):
                     raise JsonlReadError(

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -306,3 +306,41 @@ def test_read_jsonl_encoding_unknown_codec(tmp_path):
     f.write_text('{"a": 1}\n')
     with pytest.raises(ValueError, match="Unknown encoding"):
         ar.read_jsonl(f, encoding="fake-codec")
+
+
+class TestReadJsonlDuplicateKeys:
+    def test_duplicate_key_raises(self, tmp_path):
+        p = tmp_path / "dupes.jsonl"
+        p.write_text('{"id": 1, "id": 2}\n', encoding="utf-8")
+
+        with pytest.raises(ar.JsonlReadError, match="line 1"):
+            ar.read_jsonl(p)
+
+    def test_duplicate_key_names_the_key(self, tmp_path):
+        p = tmp_path / "dupes.jsonl"
+        p.write_text('{"id": 1, "id": 2}\n', encoding="utf-8")
+
+        with pytest.raises(ar.JsonlReadError, match="id"):
+            ar.read_jsonl(p)
+
+    def test_duplicate_key_reports_correct_line_number(self, tmp_path):
+        p = tmp_path / "mixed.jsonl"
+        p.write_text('{"id": 1}\n{"id": 2, "id": 3}\n', encoding="utf-8")
+
+        with pytest.raises(ar.JsonlReadError, match="line 2"):
+            ar.read_jsonl(p)
+
+    def test_unique_keys_not_affected(self, tmp_path):
+        p = tmp_path / "clean.jsonl"
+        p.write_text('{"id": 1, "val": "a"}\n{"id": 2, "val": "b"}\n', encoding="utf-8")
+
+        frame = ar.read_jsonl(p)
+        df = ar.to_pandas(frame)
+        assert df["id"].tolist() == [1, 2]
+
+    def test_duplicate_key_error_is_jsonl_read_error(self, tmp_path):
+        p = tmp_path / "dupes.jsonl"
+        p.write_text('{"x": 1, "x": 2}\n', encoding="utf-8")
+
+        with pytest.raises(ar.JsonlReadError):
+            ar.read_jsonl(p)


### PR DESCRIPTION
## Summary
`read_jsonl()` previously called `json.loads(line)` directly, which silently dropped duplicate keys and retained only the last value.

This change adds an `object_pairs_hook` to detect duplicate keys per line and raise `JsonlReadError` with the corresponding 1-based line number.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #1708 

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [X] CSV parser / I/O
- [ ] C++ cleaning engine
- [X] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [X] Other: pytest tests/test_jsonl.py -v  ->43 passed in 1.24s

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

