### PR TITLE
fix : validate String schema configuration

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1706,6 +1706,26 @@ def String(
             "allowed must be a sequence of allowed values, not a bare string"
         )
 
+    if pattern is not None:
+        if not isinstance(pattern, str):
+            raise TypeError("pattern must be a string or None")
+
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise ValueError(f"Invalid regex pattern: {pattern!r}") from exc
+
+    for name, value in (
+        ("min_length", min_length),
+        ("max_length", max_length),
+    ):
+        if value is not None:
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+
+            if value < 0:
+                raise ValueError(f"{name} must be greater than or equal to 0")
+
     allowed_set = set(allowed) if allowed is not None else None
 
     return Field(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1595,6 +1595,56 @@ def test_string_rejects_impossible_length_bounds():
         raise AssertionError("Expected invalid String bounds to raise")
 
 
+def test_string_rejects_non_string_pattern():
+    with pytest.raises(
+        TypeError,
+        match="pattern must be a string or None",
+    ):
+        ar.String(pattern=123)
+
+
+def test_string_rejects_invalid_regex_pattern():
+    with pytest.raises(
+        ValueError,
+        match="Invalid regex pattern",
+    ):
+        ar.String(pattern=r"[invalid")
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_string_rejects_boolean_min_length(value):
+    with pytest.raises(
+        TypeError,
+        match="min_length must be an integer",
+    ):
+        ar.String(min_length=value)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_string_rejects_boolean_max_length(value):
+    with pytest.raises(
+        TypeError,
+        match="max_length must be an integer",
+    ):
+        ar.String(max_length=value)
+
+
+def test_string_rejects_negative_min_length():
+    with pytest.raises(
+        ValueError,
+        match="min_length must be greater than or equal to 0",
+    ):
+        ar.String(min_length=-1)
+
+
+def test_string_rejects_negative_max_length():
+    with pytest.raises(
+        ValueError,
+        match="max_length must be greater than or equal to 0",
+    ):
+        ar.String(max_length=-1)
+
+
 def test_equal_numeric_bounds_are_valid():
     field = ar.Int64(min=5, max=5)
 


### PR DESCRIPTION
## Summary

Add constructor-time validation for `String()` schema configuration in `arnio/schema.py`.

This change ensures invalid schema configuration fails early with clear errors instead of surfacing later during schema validation.

Added validation for:

* invalid `pattern` types
* invalid regex patterns
* boolean `min_length` / `max_length` values
* negative `min_length` / `max_length` values

The existing `min_length <= max_length` validation behavior is preserved.

Fixes #1759

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [x] Schema validation
* [ ] Python API / ArFrame
* [ ] CSV parser / I/O
* [ ] pandas interoperability
* [ ] Developer tooling
* [ ] Docs / website

## Testing

```bash id="m5y4qt"
ruff check arnio/schema.py tests/test_schema.py
black arnio/schema.py tests/test_schema.py
pytest tests/test_schema.py -q
```

Result:

* 239 passed

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits.
