### PR TITLE
fix: reject empty usecols in CSV readers

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -213,6 +213,9 @@ def _validate_usecols(usecols: Sequence[str]) -> list[str]:
     if not isinstance(usecols, Sequence):
         raise TypeError("usecols must be a sequence of strings")
 
+    if len(usecols) == 0:
+        raise ValueError("usecols must not be empty")
+
     for col in usecols:
         if not isinstance(col, str):
             raise TypeError("usecols must contain only strings")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -208,6 +208,22 @@ class TestReadCsv:
         ):
             ar.read_csv(csv_path, usecols=["id", "id"])
 
+        with pytest.raises(
+            ValueError,
+            match="usecols must not be empty",
+        ):
+            ar.read_csv(csv_path, usecols=[])
+
+    def test_invalid_empty_usecols_chunked(self, tmp_path):
+        csv_path = tmp_path / "chunked.csv"
+        csv_path.write_text("id,name\n1,Alice\n2,Bob\n")
+
+        with pytest.raises(
+            ValueError,
+            match="usecols must not be empty",
+        ):
+            list(ar.read_csv_chunked(csv_path, chunksize=1, usecols=[]))
+
     def test_invalid_nrows(self, tmp_path):
         csv_path = tmp_path / "test.csv"
         csv_path.write_text("a,b\n1,2\n")


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->
Empty `usecols` is now rejected up front in io.py with `ValueError("usecols must not be empty")`, so both `read_csv(...)` and `read_csv_chunked(...)` fail fast instead of producing misleading zero-column, zero-row frames.

I added regression coverage in test_csv.py for both entry points.


<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
closes #1728
## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling




## Contributor checklist
- [ ] I read the contributing guide.
- [ ] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).


