### PR TITLE
fix: reject non-null push_back into NULL_TYPE columns

### DIFF
--- a/cpp/src/column.cpp
+++ b/cpp/src/column.cpp
@@ -171,6 +171,16 @@ struct PushbackVisitor {
 void Column::push_back(const CellValue& value) {
     assert_type_consistency();
     bool is_null_val = std::holds_alternative<std::monostate>(value);
+
+    // Guard: reject non-null insertions into NULL_TYPE columns before
+    // mutating any internal state.  NULL_TYPE storage is std::monostate
+    // and has no backing vector, so allowing a non-null value would grow
+    // null_mask_ without a corresponding data element, leaving the
+    // variant storage and null tracking permanently out of sync.
+    if (dtype_ == DType::NULL_TYPE && !is_null_val) {
+        throw std::invalid_argument("Cannot push non-null value into a NULL_TYPE column");
+    }
+
     null_mask_.push_back(is_null_val);
 
     PushbackVisitor pv{data_};

--- a/cpp/tests/test_column.cpp
+++ b/cpp/tests/test_column.cpp
@@ -48,6 +48,51 @@ TEST_CASE("Column NULL_TYPE has zero size", "[column]") {
     REQUIRE(col.size() == 0);
 }
 
+TEST_CASE("NULL_TYPE column rejects non-null push_back", "[column]") {
+    Column col("test", DType::NULL_TYPE);
+
+    SECTION("int64 value is rejected") {
+        REQUIRE_THROWS_AS(col.push_back(int64_t{10}), std::invalid_argument);
+    }
+    SECTION("string value is rejected") {
+        REQUIRE_THROWS_AS(col.push_back(std::string("hi")), std::invalid_argument);
+    }
+    SECTION("double value is rejected") {
+        REQUIRE_THROWS_AS(col.push_back(double{3.14}), std::invalid_argument);
+    }
+    SECTION("bool value is rejected") {
+        REQUIRE_THROWS_AS(col.push_back(bool{true}), std::invalid_argument);
+    }
+}
+
+TEST_CASE("NULL_TYPE column state unchanged after rejected push_back", "[column]") {
+    Column col("guard", DType::NULL_TYPE);
+
+    // Attempt a non-null insertion that must be rejected
+    REQUIRE_THROWS_AS(col.push_back(int64_t{42}), std::invalid_argument);
+
+    // null_mask_ must not have grown — column size stays 0
+    REQUIRE(col.size() == 0);
+
+    // dtype and variant storage remain consistent
+    REQUIRE(col.dtype() == DType::NULL_TYPE);
+    REQUIRE(std::holds_alternative<std::monostate>(col.data()));
+}
+
+TEST_CASE("NULL_TYPE column allows null insertion", "[column]") {
+    Column col("nulls", DType::NULL_TYPE);
+
+    // Pushing an explicit null (std::monostate) is valid
+    col.push_back(std::monostate{});
+    REQUIRE(col.size() == 1);
+    REQUIRE(col.is_null(0) == true);
+
+    // push_null also works
+    col.push_null();
+    REQUIRE(col.size() == 2);
+    REQUIRE(col.is_null(1) == true);
+}
+
 TEST_CASE("Inconsistent column throws on operations", "[column]") {
     ColumnData bad_data = std::vector<std::string>{"hello"};
     Column bad("x", DType::INT64, std::move(bad_data), std::vector<bool>{false});


### PR DESCRIPTION
fixes #1595 
`Column::push_back` was mutating `null_mask_` before validating the column dtype, so non-null values would grow the mask while the backing variant storage stayed `std::monostate` -- leaving null tracking and data storage permanently out of sync

### root cause
the guard-before-mutate ordering was missing. `null_mask_.push_back(is_null_val)` ran unconditionally on line 174 before the `PushbackVisitor` dispatch, and since `PushbackVisitor::operator()(std::monostate)` is a no-op for monostate storage, non-null values just silently corrupted the column

### fix
added a dtype check in `push_back` that throws `std::invalid_argument` **before** any internal state is touched when a non-null value targets a NULL_TYPE column. null insertions (`std::monostate`) still work fine, consistent with `push_null` behavior

### changes
- `cpp/src/column.cpp` - NULL_TYPE validation guard before `null_mask_.push_back`
- - `cpp/tests/test_column.cpp` - 3 regression tests
### test coverage
- non-null int64/string/double/bool into NULL_TYPE -> all throw `std::invalid_argument`
- - column size stays 0 after rejected push (no state mutation)
- - dtype and variant storage remain consistent after rejection
- - `push_back(std::monostate{})` and `push_null()` still work on NULL_TYPE