### PR TITLE
fix: respect system color-scheme preference before manual toggle

### DIFF
--- a/website/js/theme.js
+++ b/website/js/theme.js
@@ -12,8 +12,12 @@
   function getPreferred() {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === DARK || stored === LIGHT) return stored;
-    // Default to light — only use dark if user explicitly toggles
-    return LIGHT;
+    // Fall back to system preference
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? DARK : LIGHT;
+  }
+  function applyWithoutSaving(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    updateToggleIcon(theme);
   }
 
   function apply(theme) {
@@ -35,7 +39,7 @@
   }
 
   // Apply immediately to prevent flash
-  apply(getPreferred());
+  applyWithoutSaving(getPreferred());
 
   // Listen for system preference changes
   if (window.matchMedia) {

--- a/website/js/theme.js
+++ b/website/js/theme.js
@@ -45,7 +45,7 @@
   if (window.matchMedia) {
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
       if (!localStorage.getItem(STORAGE_KEY)) {
-        apply(e.matches ? DARK : LIGHT);
+        applyWithoutSaving(e.matches ? DARK : LIGHT);
       }
     });
   }


### PR DESCRIPTION
## Summary
Fix system color-scheme preference being ignored on first visit.

## Linked issue
Fixes #1769

## Type of change
- [x] Bug fix

## Area
- [x] Docs / website

## What changed in `website/js/theme.js`
1. `getPreferred()` now falls back to `prefers-color-scheme` instead of hardcoding `LIGHT`
2. Added `applyWithoutSaving()` — applies theme on load without writing to localStorage
3. Initial page load uses `applyWithoutSaving()` so system preference stays active until user manually toggles

## Testing
No build required — open website in browser with OS set to dark mode,
confirm dark theme loads on first visit without manual toggle.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] My PR title uses Conventional Commits (`fix:`).