### PR TITLE
Validate report exclude columns

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -233,6 +233,14 @@ class DataQualityReport:
 
             exclude_columns = set(exclude_columns)
 
+        unknown_exclude_columns = sorted(exclude_columns - set(self.columns))
+        if unknown_exclude_columns:
+            available_columns = ", ".join(self.columns) or "<none>"
+            raise KeyError(
+                "Unknown exclude_columns: "
+                f"{unknown_exclude_columns}. Available columns: {available_columns}"
+            )
+
         def _redact_reason(reason: str | None) -> str | None:
             if not reason or not exclude_columns:
                 return reason

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2429,7 +2429,9 @@ def test_data_quality_report_to_dict_unknown_column():
 
     report = ar.profile(frame)
 
-    with pytest.raises(KeyError, match="Unknown exclude_columns: \\['missing_column'\\]"):
+    with pytest.raises(
+        KeyError, match="Unknown exclude_columns: \\['missing_column'\\]"
+    ):
         report.to_dict(exclude_columns=["missing_column"])
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -2400,6 +2400,20 @@ def test_data_quality_report_to_dict_exclude_columns():
     assert "name" in result["columns"]
 
 
+def test_data_quality_report_to_dict_exclude_columns_accepts_set_and_tuple():
+    frame = ar.read_csv(io.StringIO("name,age,secret_token\nalice,20,a\nbob,30,b\n"))
+
+    report = ar.profile(frame)
+
+    set_result = report.to_dict(exclude_columns={"secret_token"})
+    tuple_result = report.to_dict(exclude_columns=("age",))
+
+    assert "secret_token" not in set_result["columns"]
+    assert "name" in set_result["columns"]
+    assert "age" not in tuple_result["columns"]
+    assert "name" in tuple_result["columns"]
+
+
 def test_data_quality_report_to_dict_default_behavior():
     frame = ar.read_csv(io.StringIO("name\nalice\nbob\n"))
 
@@ -2415,9 +2429,20 @@ def test_data_quality_report_to_dict_unknown_column():
 
     report = ar.profile(frame)
 
-    result = report.to_dict(exclude_columns=["missing_column"])
+    with pytest.raises(KeyError, match="Unknown exclude_columns: \\['missing_column'\\]"):
+        report.to_dict(exclude_columns=["missing_column"])
 
-    assert "name" in result["columns"]
+
+def test_data_quality_report_to_dict_multiple_unknown_columns():
+    frame = ar.read_csv(io.StringIO("name\nalice\nbob\n"))
+
+    report = ar.profile(frame)
+
+    with pytest.raises(
+        KeyError,
+        match="Unknown exclude_columns: \\['missing_column', 'secret_tokn'\\]",
+    ):
+        report.to_dict(exclude_columns=["secret_tokn", "missing_column"])
 
 
 def test_data_quality_report_to_dict_invalid_exclude_columns_type():
@@ -2439,6 +2464,16 @@ def test_data_quality_report_to_dict_invalid_exclude_columns_entries():
 
 
 def test_data_quality_report_to_dict_excludes_columns_from_suggestions():
+    columns = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": [" Alice ", "Bob"],
+                    "age": [30, 40],
+                }
+            )
+        )
+    ).columns
     report = ar.DataQualityReport(
         row_count=2,
         column_count=2,
@@ -2447,7 +2482,7 @@ def test_data_quality_report_to_dict_excludes_columns_from_suggestions():
         duplicate_ratio=0.0,
         quality_score=1.0,
         score_components={},
-        columns={},
+        columns=columns,
         suggestions=[
             (
                 "strip_whitespace",
@@ -2471,6 +2506,7 @@ def test_data_quality_report_to_dict_excludes_columns_from_suggestions():
 
 
 def test_data_quality_report_to_dict_preserves_non_column_suggestion_values():
+    columns = ar.profile(ar.from_pandas(pd.DataFrame({"age": [30, 40]}))).columns
     report = ar.DataQualityReport(
         row_count=2,
         column_count=1,
@@ -2479,7 +2515,7 @@ def test_data_quality_report_to_dict_preserves_non_column_suggestion_values():
         duplicate_ratio=0.0,
         quality_score=1.0,
         score_components={},
-        columns={},
+        columns=columns,
         suggestions=[
             (
                 "custom_step",
@@ -2647,6 +2683,22 @@ def test_data_quality_report_to_json_exclude_columns():
 
     assert "name" in parsed["columns"]
     assert "age" not in parsed["columns"]
+
+
+def test_data_quality_report_to_json_unknown_exclude_column():
+    report = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", "Bob"],
+                    "secret_token": ["abc", "def"],
+                }
+            )
+        )
+    )
+
+    with pytest.raises(KeyError, match="Unknown exclude_columns: \\['secret_tokn'\\]"):
+        report.to_json(exclude_columns=["secret_tokn"])
 
 
 def test_data_quality_report_to_json_redact_sample_values():


### PR DESCRIPTION
## Summary

- Validate `DataQualityReport.to_dict(exclude_columns=...)` against the report's real columns.
- Let `to_json(exclude_columns=...)` fail fast through the existing `to_dict()` path.
- Update focused quality report tests for valid excludes, single/multiple unknown excludes, and JSON export behavior.

## Why

Misspelled sensitive column names were silently ignored, which could leave the real column in exported reports. This changes report export to fail closed with a `KeyError` that names the unknown exclusions and available report columns.

Closes #1752.

## Verification

- `.venv/bin/python -m pytest tests/test_quality.py -k "data_quality_report_to_dict_exclude_columns or data_quality_report_to_dict_unknown_column or data_quality_report_to_dict_multiple_unknown_columns or data_quality_report_to_json_exclude_columns or data_quality_report_to_json_unknown_exclude_column or data_quality_report_to_dict_excludes_columns_from_suggestions or data_quality_report_to_dict_preserves_non_column_suggestion_values"`
- `.venv/bin/python -m pytest tests/test_quality.py`
