### PR TITLE
fix: quote date-like strings in schema_to_yaml

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -19,11 +19,15 @@ for anything else so the contract stays explicit.
 from __future__ import annotations
 
 import pathlib
+import re
 from typing import Any
 
 from arnio.schema import _field_to_dict
 
 _INDENT = "  "
+
+# Matches ISO date and datetime strings that YAML 1.1 resolves as timestamps.
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}(:\d{2})?.*)?$")
 
 # Types that arnio's Schema / scan_csv can legitimately produce.
 _SCALAR_TYPES = (str, int, float, bool, type(None))
@@ -59,6 +63,7 @@ def _emit_scalar(value: Any) -> str:
             not value
             or looks_numeric
             or value.lower() in {"true", "false", "null", "yes", "no", "on", "off"}
+            or bool(_DATE_RE.match(value))
             or any(c in value for c in ("\n", "\r"))
             or value[0]
             in (

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -363,3 +363,53 @@ def test_schema_object_fields_named_strict_and_unique_not_dropped():
     # Schema-level metadata must still be top-level
     assert result["strict"] is True
     assert result["unique"] == ["name"]
+
+
+# ── Regression tests for issue #1730 ────────────────────────────────────────
+
+
+class TestDateLikeStringQuoting:
+    """Date-like string values must be quoted to prevent YAML timestamp resolution."""
+
+    def test_bare_date_in_allowed_is_quoted(self):
+        raw = {"field": {"type": "string", "allowed": ["2026-05-28"]}}
+        out = schema_to_yaml(raw)
+        assert '"2026-05-28"' in out
+
+    def test_iso_datetime_in_default_is_quoted(self):
+        raw = {"field": {"type": "string", "default": "2026-05-28T10:30:00"}}
+        out = schema_to_yaml(raw)
+        assert '"2026-05-28T10:30:00"' in out
+
+    def test_space_separated_datetime_is_quoted(self):
+        raw = {"field": {"type": "string", "default": "2026-05-28 10:30:00"}}
+        out = schema_to_yaml(raw)
+        assert '"2026-05-28 10:30:00"' in out
+
+    def test_yaml_roundtrip_preserves_date_string(self):
+        """Date values survive a YAML round-trip as strings, not date objects."""
+        import yaml  # soft dep – skip if not installed
+
+        raw = {"field": {"type": "string", "allowed": ["2026-05-28"]}}
+        yaml_text = schema_to_yaml(raw)
+        loaded = yaml.safe_load(yaml_text)
+        value = loaded["fields"]["field"]["allowed"][0]
+        assert isinstance(value, str)
+        assert value == "2026-05-28"
+
+    def test_non_date_strings_unaffected(self):
+        """Partial date-like strings must NOT be quoted."""
+        raw = {
+            "field": {
+                "type": "string",
+                "allowed": ["05-28", "hello"],
+            }
+        }
+        out = schema_to_yaml(raw)
+        assert "- 05-28" in out  # MM-DD fragment, not a full date
+        assert "- hello" in out  # regular string
+
+    def test_date_with_time_zone_suffix_is_quoted(self):
+        raw = {"field": {"type": "string", "default": "2026-05-28T10:30:00+05:30"}}
+        out = schema_to_yaml(raw)
+        assert '"2026-05-28T10:30:00+05:30"' in out


### PR DESCRIPTION
## Summary

Fixes #1730 — `_emit_scalar()` now quotes ISO date/datetime strings that YAML 1.1 parsers would otherwise resolve as timestamps.

## Changes

### `arnio/schema_export.py`
- Added `_DATE_RE` compiled regex matching `YYYY-MM-DD` with optional time (`T` or space separator) and timezone suffix
- Added `or bool(_DATE_RE.match(value))` to the `needs_quoting` condition in `_emit_scalar()`

### `tests/test_schema_export.py`
- `test_bare_date_in_allowed_is_quoted` — bare `2026-05-28` in `allowed` is emitted quoted
- `test_iso_datetime_in_default_is_quoted` — ISO datetime string in `default` is quoted
- `test_space_separated_datetime_is_quoted` — space-separated datetime is quoted
- `test_yaml_roundtrip_preserves_date_string` — YAML loaded back has `str` type, not `date`
- `test_non_date_strings_unaffected` — partial fragments like `05-28` and plain strings are unaffected
- `test_date_with_time_zone_suffix_is_quoted` — datetime with timezone offset is quoted

## Scope

This PR is limited to the date-quoting fix and regression tests only. No other changes.