### PR TITLE
fix: keyboard activation for install command copy control

### DIFF
--- a/website/js/code.js
+++ b/website/js/code.js
@@ -52,23 +52,38 @@
     });
 
     // ── Install command click-to-copy ─────────────────────────
-    document.querySelectorAll('.install-cmd, .hero-install').forEach(function (el) {
-      el.addEventListener('click', function () {
-        const cmd = el.getAttribute('data-cmd') || el.textContent.replace(/^\$\s*/, '').replace(/click to copy/i, '').trim();
+    // Handler function for copy action (triggered by click or keyboard)
+    function handleInstallCommandCopy(el) {
+      const cmd = el.getAttribute('data-cmd') || el.textContent.replace(/^\$\s*/, '').replace(/click to copy/i, '').trim();
 
-        navigator.clipboard.writeText(cmd).then(function () {
-          showCopyFeedback(el);
-        }).catch(function () {
-          const textarea = document.createElement('textarea');
-          textarea.value = cmd;
-          textarea.style.position = 'fixed';
-          textarea.style.opacity = '0';
-          document.body.appendChild(textarea);
-          textarea.select();
-          document.execCommand('copy');
-          document.body.removeChild(textarea);
-          showCopyFeedback(el);
-        });
+      navigator.clipboard.writeText(cmd).then(function () {
+        showCopyFeedback(el);
+      }).catch(function () {
+        const textarea = document.createElement('textarea');
+        textarea.value = cmd;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+        showCopyFeedback(el);
+      });
+    }
+
+    document.querySelectorAll('.install-cmd, .hero-install').forEach(function (el) {
+      // Click handler
+      el.addEventListener('click', function () {
+        handleInstallCommandCopy(el);
+      });
+
+      // Keyboard handler for Enter and Space keys (WCAG 2.1 Level A)
+      el.addEventListener('keydown', function (event) {
+        // Enter (key code 13) or Space (key code 32)
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault(); // Prevent default Space scroll behavior
+          handleInstallCommandCopy(el);
+        }
       });
     });
 


### PR DESCRIPTION
## Summary
Added keyboard event handlers (Enter and Space keys) to the install command copy control (`.hero-install`). The element was marked with `role="button"` and `tabindex="0"` but only responded to mouse clicks, creating an accessibility gap between element semantics and behavior.

This change makes the install command copyable via keyboard navigation, aligning with WCAG 2.1 Level A standards and WAI-ARIA button patterns.

## Linked issue
Fixes #1641 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
Manual verification in browser (no terminal tests needed):

1. **Keyboard activation (Enter key):**
   - Tab to install command → Press Enter → Verify "Copied!" feedback and command is in clipboard

2. **Keyboard activation (Space key):**
   - Tab to install command → Press Space → Verify "Copied!" feedback and command is in clipboard

3. **Mouse click (regression test):**
   - Click install command directly → Verify copy still works normally

4. **Visual feedback:**
   - Verify `.copy-hint` text shows "Copied!" then resets to "click to copy" after 2 seconds


## GSSoC labels
<!-- Maintainers only-->

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] No new tests added (keyboard behavior is frontend-only; manual verification provided).
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

Closes #1641 