### PR TITLE
fix: reject non-finite approx_top_values_min_ratio values

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1113,8 +1113,15 @@ def profile(
         approx_top_values_min_ratio, bool
     ):
         raise TypeError("approx_top_values_min_ratio must be a float")
+
+    if not math.isfinite(approx_top_values_min_ratio):
+        raise ValueError(
+            "approx_top_values_min_ratio must be a finite number between 0 and 1"
+        )
+
     if approx_top_values_min_ratio < 0 or approx_top_values_min_ratio > 1:
         raise ValueError("approx_top_values_min_ratio must be between 0 and 1")
+
     if not isinstance(approx_top_values_sample_size, int) or isinstance(
         approx_top_values_sample_size, bool
     ):

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -768,6 +768,24 @@ def test_profile_approx_top_values_validation(tmp_path):
         ar.profile(frame, approx_top_values_min_ratio=1.5)
 
     with pytest.raises(
+        ValueError,
+        match="approx_top_values_min_ratio must be a finite number between 0 and 1",
+    ):
+        ar.profile(frame, approx_top_values_min_ratio=float("nan"))
+
+    with pytest.raises(
+        ValueError,
+        match="approx_top_values_min_ratio must be a finite number between 0 and 1",
+    ):
+        ar.profile(frame, approx_top_values_min_ratio=float("inf"))
+
+    with pytest.raises(
+        ValueError,
+        match="approx_top_values_min_ratio must be a finite number between 0 and 1",
+    ):
+        ar.profile(frame, approx_top_values_min_ratio=float("-inf"))
+
+    with pytest.raises(
         TypeError, match="approx_top_values_sample_size must be an integer"
     ):
         ar.profile(frame, approx_top_values_sample_size="10")


### PR DESCRIPTION
## Summary

Add explicit non-finite float validation for `approx_top_values_min_ratio` in `arnio.profile()`.

Previously, `float("nan")` was accepted because the existing range checks (`< 0` and `> 1`) do not reject NaN values. This could silently disable approximate top-value counting instead of failing fast with a clear error.

This change:

* rejects `NaN`
* rejects positive infinity
* rejects negative infinity
* preserves existing behavior for valid finite ratios between `0` and `1`

Fixes #1786 

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [x] Data quality / profiling
* [ ] Python API / ArFrame
* [ ] CSV parser / I/O
* [ ] pandas interoperability
* [ ] Developer tooling
* [ ] Docs / website

## Testing

```bash id="u2x6kv"
ruff check arnio/quality.py tests/test_quality.py
black arnio/quality.py tests/test_quality.py
pytest tests/test_quality.py -q
```

Result:

* all tests passed

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits.
