### PR TITLE
fix : reject unsupported object casts in ArFrame.astype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,22 +50,44 @@ jobs:
             | xargs clang-format-17 --dry-run --Werror
 
   cpp_tests:
-    name: C++ Native Tests (CMake + Catch2)
-    runs-on: ubuntu-latest
+    name: C++ Native Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            shell: bash
+          - os: windows-latest
+            shell: bash
+          - os: macos-latest
+            shell: bash
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Install dependencies
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install native build dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq cmake ninja-build python3-dev
-          pip install pybind11
+          python -m pip install --upgrade pip
+          pip install pybind11 ninja
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Configure CMake
         run: |
-          cmake -S . -B build \
+          cmake -S . -B build -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DARNIO_BUILD_CPP_TESTS=ON \
-            -DCMAKE_PREFIX_PATH=$(python3 -c "import pybind11; print(pybind11.get_cmake_dir())")
+            -DCMAKE_PREFIX_PATH="$(python -c 'import pybind11; print(pybind11.get_cmake_dir())')"
       - name: Build
         run: cmake --build build --parallel
       - name: Run C++ tests

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -246,6 +246,25 @@ class ArFrame:
         if dtype is None:
             raise TypeError("dtype cannot be None")
 
+        if dtype is object:
+            raise TypeError(
+                "Cannot cast to 'object' dtype: Arnio does not preserve "
+                "object columns because values are re-inferred from Python "
+                "objects on conversion. Use a specific dtype (int, float, "
+                "bool, string) or a dict of column names to dtypes."
+            )
+
+        if isinstance(dtype, dict):
+            for col, col_dtype in dtype.items():
+                if col_dtype is object:
+                    raise TypeError(
+                        f"Cannot cast column {col!r} to 'object' dtype: "
+                        "Arnio does not preserve object columns because "
+                        "values are re-inferred from Python objects on "
+                        "conversion. Use a specific dtype (int, float, "
+                        "bool, string)."
+                    )
+
         if isinstance(dtype, dict):
             missing = [col for col in dtype if col not in self.columns]
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1200,8 +1200,35 @@ def test_astype_rejects_invalid_mapping_dtype():
 def test_astype_rejects_object_dtype_aliases(invalid_dtype):
     frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}])
 
-    with pytest.raises(TypeError, match="dtype must"):
+    with pytest.raises(TypeError, match="dtype must|Cannot cast to 'object' dtype"):
         frame.astype(invalid_dtype)
+
+
+def test_astype_object_whole_frame_raises():
+    """astype(object) must be rejected because Arnio re-infers dtypes on conversion."""
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2], "b": [True, False]}))
+
+    with pytest.raises(TypeError, match="Cannot cast to 'object' dtype"):
+        frame.astype(object)
+
+
+def test_astype_object_dict_raises():
+    """astype({col: object}) must be rejected because Arnio re-infers dtypes on conversion."""
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2], "b": [True, False]}))
+
+    with pytest.raises(TypeError, match="Cannot cast column 'a' to 'object' dtype"):
+        frame.astype({"a": object})
+
+    with pytest.raises(TypeError, match="Cannot cast column 'b' to 'object' dtype"):
+        frame.astype({"b": object})
+
+
+def test_astype_object_dict_mixed_raises_on_object_column():
+    """A dict with one object cast and one valid cast must still reject the whole request."""
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}))
+
+    with pytest.raises(TypeError, match="Cannot cast column 'a' to 'object' dtype"):
+        frame.astype({"a": object, "b": float})
 
 
 # ── drop_columns ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Superseded by the merged fix in commit 24c7e20 (author: Rohini S).

This PR was addressed independently by the upstream maintainer. The astype object-dtype validation is now merged in the main branch.

Please close this PR as it is now redundant.