### PR TITLE
fix: update PyPI documentation URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/im-anishraj/arnio"
-Documentation = "https://arnio.vercel.app/docs.html"
+Documentation = "https://arniolib.vercel.app/docs.html"
 Repository = "https://github.com/im-anishraj/arnio"
 Issues = "https://github.com/im-anishraj/arnio/issues"
 Changelog = "https://github.com/im-anishraj/arnio/blob/main/CHANGELOG.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/im-anishraj/arnio"
-Documentation = "https://github.com/im-anishraj/arnio#readme"
+Documentation = "https://arnio.vercel.app/docs.html"
 Repository = "https://github.com/im-anishraj/arnio"
 Issues = "https://github.com/im-anishraj/arnio/issues"
 Changelog = "https://github.com/im-anishraj/arnio/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Updated the Documentation URL in `pyproject.toml` to point to the official Arnio documentation website instead of the GitHub README.

## Linked issue

Fixes #1645

## Type of change

* [x] Documentation
* [x] CI / packaging

## Area

* [x] Docs / website
* [x] Developer tooling

## Testing

* [x] Other: Verified the updated documentation URL points to the official Arnio docs website.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
