### PR TITLE
test : add edge case tests for coalesce_columns

### DIFF
--- a/tests/test_coalesce_columns.py
+++ b/tests/test_coalesce_columns.py
@@ -117,3 +117,104 @@ def test_coalesce_columns_pandas_index() -> None:
     expected["result"] = [10.0, 2.0, 40.0]
 
     pd.testing.assert_frame_equal(res_df, expected, check_dtype=False)
+
+
+def test_coalesce_columns_all_none() -> None:
+    """When all source columns are NA, result should be all NA."""
+    df = pd.DataFrame(
+        {
+            "a": pd.Series([None, None, None], dtype="Int64"),
+            "b": pd.Series([None, None, None], dtype="Int64"),
+        }
+    )
+    frame = ar.from_pandas(df)
+    res_frame = ar.coalesce_columns(frame, subset=["a", "b"], output_column="result")
+    res_df = ar.to_pandas(res_frame)
+    assert list(res_df["result"]) == [pd.NA, pd.NA, pd.NA]
+
+
+def test_coalesce_columns_no_nulls() -> None:
+    """When no source columns have nulls, result is first column values."""
+    df = pd.DataFrame(
+        {
+            "a": [1.0, 2.0, 3.0],
+            "b": [10.0, 20.0, 30.0],
+        }
+    )
+    frame = ar.from_pandas(df)
+    res_frame = ar.coalesce_columns(frame, subset=["a", "b"], output_column="result")
+    res_df = ar.to_pandas(res_frame)
+    assert list(res_df["result"]) == [1.0, 2.0, 3.0]
+
+
+def test_coalesce_columns_single_column_subset() -> None:
+    """Single-column subset does not bfill across rows; values stay row-wise."""
+    df = pd.DataFrame(
+        {
+            "a": pd.Series([None, "hello", None], dtype="string[python]"),
+            "b": ["world", "foo", "bar"],
+        }
+    )
+    frame = ar.from_pandas(df)
+    res_frame = ar.coalesce_columns(frame, subset=["a"], output_column="result")
+    res_df = ar.to_pandas(res_frame)
+    assert list(res_df["result"]) == [pd.NA, "hello", pd.NA]
+
+
+def test_coalesce_columns_preserves_original_columns() -> None:
+    """Coalesce does not modify original columns."""
+    df = pd.DataFrame(
+        {
+            "a": pd.Series([None, 2.0], dtype="float64"),
+            "b": pd.Series([1.0, None], dtype="float64"),
+        }
+    )
+    frame = ar.from_pandas(df)
+    res_frame = ar.coalesce_columns(frame, subset=["a", "b"], output_column="result")
+    res_df = ar.to_pandas(res_frame)
+    assert pd.isna(res_df["a"][0])
+    assert res_df["a"][1] == 2.0
+    assert res_df["b"][0] == 1.0
+    assert pd.isna(res_df["b"][1])
+
+
+def test_coalesce_columns_empty_string_vs_none() -> None:
+    """Empty string is a valid value, not treated as null."""
+    df = pd.DataFrame(
+        {
+            "a": ["", None, "value"],
+            "b": [None, "b", None],
+        }
+    )
+    frame = ar.from_pandas(df)
+    res_frame = ar.coalesce_columns(frame, subset=["a", "b"], output_column="result")
+    res_df = ar.to_pandas(res_frame)
+    assert list(res_df["result"]) == ["", "b", "value"]
+
+
+def test_coalesce_columns_boolean_values() -> None:
+    """Coalesce works correctly with boolean columns."""
+    df = pd.DataFrame(
+        {
+            "a": pd.Series([None, True, None, False], dtype="boolean"),
+            "b": pd.Series([False, None, True, None], dtype="boolean"),
+        }
+    )
+    frame = ar.from_pandas(df)
+    res_frame = ar.coalesce_columns(frame, subset=["a", "b"], output_column="result")
+    res_df = ar.to_pandas(res_frame)
+    assert list(res_df["result"]) == [False, True, True, False]
+
+
+def test_coalesce_columns_integer_and_float_mix() -> None:
+    """Coalesce works across integer and float columns."""
+    df = pd.DataFrame(
+        {
+            "a": pd.Series([None, 2, None, 4], dtype="Int64"),
+            "b": pd.Series([1.5, None, 3.5, None], dtype="float64"),
+        }
+    )
+    frame = ar.from_pandas(df)
+    res_frame = ar.coalesce_columns(frame, subset=["a", "b"], output_column="result")
+    res_df = ar.to_pandas(res_frame)
+    assert list(res_df["result"]) == [1.5, 2, 3.5, 4]


### PR DESCRIPTION
Refs #1822

Adds 7 additional edge case tests for coalesce_columns:
- `test_coalesce_columns_all_none`: all source columns are NA
- `test_coalesce_columns_no_nulls`: no source columns have nulls
- `test_coalesce_columns_single_column_subset`: subset with one column
- `test_coalesce_columns_preserves_original_columns`: original columns not modified
- `test_coalesce_columns_empty_string_vs_none`: empty string treated as valid value
- `test_coalesce_columns_boolean_values`: works with boolean columns
- `test_coalesce_columns_integer_and_float_mix`: works across integer and float columns