### PR TITLE
feat(schema): add case-insensitive support for String(allowed=...)

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1692,6 +1692,7 @@ def String(
         nullable: Whether null values are allowed.
         pattern: Regular expression pattern that non-null values must match.
         allowed: Allowed values for the field.
+        case_sensitive: Whether allowed string matching is case-sensitive.
         unique: Whether non-null values must be unique.
         severity: Severity level for validation issues.
         min_length: Minimum allowed string length.
@@ -2545,6 +2546,7 @@ def _field_to_dict(field_def: Field) -> dict[str, Any]:
         "pattern": field_def.pattern,
         "semantic": field_def.semantic,
         "allowed": _normalize_sequence(field_def.allowed),
+        "case_sensitive": field_def.case_sensitive,
         "unique": field_def.unique,
         "min_length": field_def.min_length,
         "max_length": field_def.max_length,
@@ -2603,6 +2605,7 @@ def _field_from_json_dict(name: str, payload: Any) -> Field:
         pattern=payload.get("pattern"),
         semantic=payload.get("semantic"),
         allowed=allowed,
+        case_sensitive=payload.get("case_sensitive", True),
         unique=payload.get("unique", False),
         min_length=payload.get("min_length"),
         max_length=payload.get("max_length"),

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -690,6 +690,7 @@ class Field:
     pattern: str | None = None
     semantic: str | None = None
     allowed: set[Any] | None = None
+    case_sensitive: bool = True
     unique: bool = False
     min_length: int | None = None
     max_length: int | None = None
@@ -704,6 +705,8 @@ class Field:
             raise TypeError("nullable must be a bool")
         if not isinstance(self.unique, bool):
             raise TypeError("unique must be a bool")
+        if not isinstance(self.case_sensitive, bool):
+            raise TypeError("case_sensitive must be a bool")
 
         if self.required_if is not None:
             if not isinstance(self.required_if, tuple):
@@ -1676,6 +1679,7 @@ def String(
     nullable: bool = True,
     pattern: str | None = None,
     allowed: set[Any] | list[Any] | tuple[Any, ...] | None = None,
+    case_sensitive: bool = True,
     unique: bool = False,
     severity: str = "error",
     min_length: int | None = None,
@@ -1733,6 +1737,7 @@ def String(
         nullable=nullable,
         pattern=pattern,
         allowed=allowed_set,
+        case_sensitive=case_sensitive,
         unique=unique,
         min_length=min_length,
         max_length=max_length,
@@ -2263,7 +2268,18 @@ def _validate_column(
         )
 
     if field_def.allowed is not None:
-        invalid = non_null[~non_null.isin(field_def.allowed)]
+        if field_def.dtype == "string" and not field_def.case_sensitive:
+            allowed_values = {
+                value.casefold() if isinstance(value, str) else value
+                for value in field_def.allowed
+            }
+            comparable = non_null.map(
+                lambda value: value.casefold() if isinstance(value, str) else value
+            )
+            invalid = non_null[~comparable.isin(allowed_values)]
+        else:
+            invalid = non_null[~non_null.isin(field_def.allowed)]
+
         issues.extend(
             _row_issues(
                 invalid,
@@ -2273,7 +2289,6 @@ def _validate_column(
                 severity=field_def.severity,
             )
         )
-
     if field_def.dtype == "datetime":
         issues.extend(_validate_datetime(non_null, name, field_def))
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -313,18 +313,27 @@ def test_schema_validation_collects_row_level_issues(tmp_path):
     assert {"nullable", "max", "min", "email", "allowed"} <= rules
     assert result.summary()["issues_by_column"]["age"] == 2
 
-    def test_string_allowed_is_case_sensitive_by_default(tmp_path):
-        path = tmp_path / "status.csv"
-        path.write_text("status\nactive\nACTIVE\nActive\n")
 
-        result = ar.validate(
-            ar.read_csv(path),
-            {"status": ar.String(allowed=["active"])},
-        )
+def test_string_allowed_is_case_sensitive_by_default(tmp_path):
+    path = tmp_path / "status.csv"
+    path.write_text("status\nactive\nACTIVE\nActive\n")
 
-        assert not result.passed
-        assert result.issue_count == 2
-        assert [issue.row_index for issue in result.issues] == [2, 3]
+    result = ar.validate(
+        ar.read_csv(path),
+        {"status": ar.String(allowed=["active"])},
+    )
+
+    assert not result.passed
+    assert result.issue_count == 2
+    assert [issue.row_index for issue in result.issues] == [2, 3]
+
+
+def test_string_case_sensitive_round_trips_through_json():
+    schema = ar.Schema({"status": ar.String(allowed=["active"], case_sensitive=False)})
+
+    restored = ar.Schema.from_json(schema.to_json())
+
+    assert restored.fields["status"].case_sensitive is False
 
 
 def test_string_allowed_supports_case_insensitive_matching(tmp_path):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -313,6 +313,62 @@ def test_schema_validation_collects_row_level_issues(tmp_path):
     assert {"nullable", "max", "min", "email", "allowed"} <= rules
     assert result.summary()["issues_by_column"]["age"] == 2
 
+    def test_string_allowed_is_case_sensitive_by_default(tmp_path):
+        path = tmp_path / "status.csv"
+        path.write_text("status\nactive\nACTIVE\nActive\n")
+
+        result = ar.validate(
+            ar.read_csv(path),
+            {"status": ar.String(allowed=["active"])},
+        )
+
+        assert not result.passed
+        assert result.issue_count == 2
+        assert [issue.row_index for issue in result.issues] == [2, 3]
+
+
+def test_string_allowed_supports_case_insensitive_matching(tmp_path):
+    path = tmp_path / "status.csv"
+    path.write_text("status\nactive\nACTIVE\nActive\ninactive\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {
+            "status": ar.String(
+                allowed=["active", "inactive"],
+                case_sensitive=False,
+            )
+        },
+    )
+
+    assert result.passed
+    assert result.issue_count == 0
+
+
+def test_string_allowed_case_insensitive_rejects_invalid_values(tmp_path):
+    path = tmp_path / "status.csv"
+    path.write_text("status\nactive\nACTIVE\npending\n")
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {
+            "status": ar.String(
+                allowed=["active"],
+                case_sensitive=False,
+            )
+        },
+    )
+
+    assert not result.passed
+    assert result.issue_count == 1
+    assert result.issues[0].row_index == 3
+    assert result.issues[0].rule == "allowed"
+
+
+def test_string_case_sensitive_must_be_bool():
+    with pytest.raises(TypeError, match="case_sensitive must be a bool"):
+        ar.String(allowed=["active"], case_sensitive="false")
+
 
 def test_schema_reports_missing_and_unexpected_columns(sample_csv):
     frame = ar.read_csv(sample_csv)


### PR DESCRIPTION
### Fixes #1625 

## Summary

Adds optional case-insensitive matching support for `String(allowed=...)` validation.

## Problem

`String(allowed=...)` previously performed only case-sensitive comparisons.

Example:

```python
ar.String(allowed=["active"])
```

would treat:

```txt
active   ✅
ACTIVE   ❌
Active   ❌
```

This required users to manually normalize categorical string values before validation or duplicate multiple casing variants inside `allowed`.

## Changes made

- Added a new `case_sensitive` parameter to `String()`
- Preserved existing default behavior with:

```python
case_sensitive=True
```

- Added optional case-insensitive allowed-value matching:

```python
ar.String(
    allowed=["active"],
    case_sensitive=False,
)
```

- Updated allowed-value validation logic to normalize string comparisons using `casefold()` when `case_sensitive=False`
- Added validation ensuring `case_sensitive` must be a boolean
- Added focused regression tests covering:
  - default case-sensitive behavior
  - case-insensitive matching
  - mixed-case values
  - invalid values
  - invalid `case_sensitive` types

## Result

Users can now validate categorical string fields case-insensitively without manually preprocessing dataset capitalization, while preserving backward-compatible default behavior.

