### PR TITLE
Adds upfront dtype validation inside ArFrame.astype() before pandas casting

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -193,10 +193,64 @@ class ArFrame:
         ValueError
             If invalid values are passed or column conversion fails.
         """
+        import numpy as np
+        import pandas as pd
+
         from .convert import from_pandas, to_pandas
+
+        def _validate_dtype_value(value):
+            if isinstance(value, (list, tuple, set, dict)):
+                raise TypeError(
+                    "dtype must be a string, Python type, "
+                    "NumPy/pandas dtype, or mapping "
+                    "of column names to dtypes"
+                )
+
+            if value in (object, "object"):
+                raise TypeError(
+                    "dtype must be a string, Python type, "
+                    "NumPy/pandas dtype, or mapping "
+                    "of column names to dtypes"
+                )
+
+            try:
+                resolved = pd.api.types.pandas_dtype(value)
+
+                if resolved == np.dtype("O"):
+                    raise TypeError(
+                        "dtype must be a string, Python type, "
+                        "NumPy/pandas dtype, or mapping "
+                        "of column names to dtypes"
+                    )
+
+            except (TypeError, ValueError):
+                raise TypeError(
+                    "dtype must be a string, Python type, "
+                    "NumPy/pandas dtype, or mapping "
+                    "of column names to dtypes"
+                )
 
         if dtype is None:
             raise TypeError("dtype cannot be None")
+
+        if isinstance(dtype, dict):
+            missing = [col for col in dtype if col not in self.columns]
+
+            if missing:
+                raise ValueError(f"Unknown column(s) in dtype mapping: {missing}")
+
+            for value in dtype.values():
+                _validate_dtype_value(value)
+
+        elif isinstance(dtype, (list, tuple, set)):
+            raise TypeError(
+                "dtype must be a string, Python type, "
+                "NumPy/pandas dtype, or mapping "
+                "of column names to dtypes"
+            )
+
+        else:
+            _validate_dtype_value(dtype)
 
         try:
             df = to_pandas(self)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -5,6 +5,7 @@ Tests for ArFrame.preview()
 import copy
 import math
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -935,6 +936,39 @@ def test_astype_invalid_raises_error():
     # Trying to pass None should raise a TypeError
     with pytest.raises(TypeError, match="dtype cannot be None"):
         frame.astype(None)
+
+
+@pytest.mark.parametrize("invalid_dtype", [[], (), set()])
+def test_astype_rejects_invalid_dtype_containers(invalid_dtype):
+    frame = ar.ArFrame.from_records([{"a": 1, "b": "x"}, {"a": 2, "b": "y"}])
+
+    with pytest.raises(TypeError, match="dtype must"):
+        frame.astype(invalid_dtype)
+
+
+def test_astype_rejects_unknown_mapping_columns():
+    frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}])
+
+    with pytest.raises(ValueError, match="Unknown column"):
+        frame.astype({"missing": int})
+
+
+def test_astype_rejects_invalid_mapping_dtype():
+    frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}])
+
+    with pytest.raises(TypeError, match="dtype must"):
+        frame.astype({"a": []})
+
+
+@pytest.mark.parametrize(
+    "invalid_dtype",
+    [object, "object", np.object_, np.dtype("O")],
+)
+def test_astype_rejects_object_dtype_aliases(invalid_dtype):
+    frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}])
+
+    with pytest.raises(TypeError, match="dtype must"):
+        frame.astype(invalid_dtype)
 
 
 # ── drop_columns ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds upfront dtype validation inside `ArFrame.astype()` before pandas casting. Unsupported dtype argument shapes are now rejected early with clear API level errors, and mapping inputs now validate existing column names before casting.

## Linked issue

Fixes #1694

## Type of change

- [x] Bug fix
- [x] Tests

## Area

- [x] Python API / ArFrame
- [x] pandas interoperability

## Testing

python -m pytest tests/test_frame.py

131 tests passed successfully.

## Maintainer notes

This PR keeps the existing pandas casting flow intact and only adds upfront dtype argument validation along with focused invalid input tests for unsupported dtype containers and invalid mapping validation.