### PR TITLE
fix: bound quality gate ratio thresholds to valid ratio ranges 

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1337,10 +1337,10 @@ def check_quality_gates(
         "max_row_count_delta_ratio": _validate_gate_threshold(
             max_row_count_delta_ratio, "max_row_count_delta_ratio"
         ),
-        "max_duplicate_ratio_delta": _validate_gate_threshold(
+        "max_duplicate_ratio_delta": _validate_gate_ratio_threshold(
             max_duplicate_ratio_delta, "max_duplicate_ratio_delta"
         ),
-        "max_null_ratio_delta": _validate_gate_threshold(
+        "max_null_ratio_delta": _validate_gate_ratio_threshold(
             max_null_ratio_delta, "max_null_ratio_delta"
         ),
         "max_numeric_mean_delta_ratio": _validate_gate_threshold(
@@ -1538,6 +1538,16 @@ def _validate_gate_threshold(value: float | None, name: str) -> float | None:
     value = float(value)
     if not math.isfinite(value) or value < 0:
         raise ValueError(f"{name} must be a finite non-negative number")
+    return value
+
+
+def _validate_gate_ratio_threshold(value: float | None, name: str) -> float | None:
+    """Validate that a quality gate ratio threshold is between 0.0 and 1.0 inclusive."""
+    if value is None:
+        return None
+    value = _validate_gate_threshold(value, name)
+    if value > 1.0:
+        raise ValueError(f"{name} must be a ratio between 0.0 and 1.0")
     return value
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -8,7 +8,11 @@ import pandas as pd
 import pytest
 
 import arnio as ar
-from arnio.quality import _validate_gate_bool, _validate_gate_threshold
+from arnio.quality import (
+    _validate_gate_bool,
+    _validate_gate_ratio_threshold,
+    _validate_gate_threshold,
+)
 
 
 def test_profile_reports_quality_signals(tmp_path):
@@ -301,6 +305,15 @@ def test_check_quality_gates_validates_thresholds_and_flags():
 
     with pytest.raises(ValueError, match="finite non-negative"):
         ar.check_quality_gates(report, report, max_null_ratio_delta=-0.1)
+
+    with pytest.raises(ValueError, match="must be a ratio between 0.0 and 1.0"):
+        ar.check_quality_gates(report, report, max_null_ratio_delta=1.5)
+
+    with pytest.raises(ValueError, match="must be a ratio between 0.0 and 1.0"):
+        ar.check_quality_gates(report, report, max_duplicate_ratio_delta=1.0001)
+
+    result = ar.check_quality_gates(report, report, max_row_count_delta_ratio=2.5)
+    assert result.passed is True
 
     with pytest.raises(TypeError, match="allow_new_columns must be a bool"):
         ar.check_quality_gates(report, report, allow_new_columns="yes")
@@ -2931,6 +2944,32 @@ class TestValidateGateBool:
     def test_string_raises_type_error(self):
         with pytest.raises(TypeError, match="must be a bool"):
             _validate_gate_bool("true", "allow_new_columns")
+
+
+class TestValidateGateRatioThreshold:
+    def test_none_returns_none(self):
+        assert _validate_gate_ratio_threshold(None, "max_null_ratio_delta") is None
+
+    def test_valid_ratio_returns_float(self):
+        result = _validate_gate_ratio_threshold(0.5, "max_null_ratio_delta")
+        assert result == 0.5
+        assert isinstance(result, float)
+
+    def test_boundary_values(self):
+        assert _validate_gate_ratio_threshold(0.0, "max_null_ratio_delta") == 0.0
+        assert _validate_gate_ratio_threshold(1.0, "max_null_ratio_delta") == 1.0
+
+    def test_value_above_one_raises_value_error(self):
+        with pytest.raises(ValueError, match="must be a ratio between 0.0 and 1.0"):
+            _validate_gate_ratio_threshold(1.01, "max_null_ratio_delta")
+
+    def test_negative_raises_value_error(self):
+        with pytest.raises(ValueError, match="must be a finite non-negative number"):
+            _validate_gate_ratio_threshold(-0.05, "max_null_ratio_delta")
+
+    def test_string_raises_type_error(self):
+        with pytest.raises(TypeError, match="must be a non-negative number or None"):
+            _validate_gate_ratio_threshold("0.5", "max_null_ratio_delta")
 
 
 # ── ProfileComparison redaction tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary
Enforced an upper bound of 1.0 on absolute data quality ratio gates. 

Previously, `check_quality_gates()` allowed absolute ratio differences like `max_duplicate_ratio_delta` and `max_null_ratio_delta` to accept values greater than 1.0 (e.g., 1.5). Because absolute proportions are strictly bounded between 0.0 and 1.0, these settings silently weakened quality gates in CI and execution tests. 

Introduced a private helper validator `_validate_gate_ratio_threshold` to properly enforce the `[0.0, 1.0]` constraint while preserving normal scale validation for relative gates like numeric mean/std metrics.

## Linked issue
Closes #1691

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (2263 test cases passed)
- [x] `make lint` 

## Screenshots / Media

## Performance Impact

## GSSoC labels

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (feat:, fix:, docs:, test:, refactor:, chore:).

## Maintainer notes