### PR TITLE
fix: validate custom validator names before registry lookup

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2743,6 +2743,10 @@ def Custom(
     >>> ar.register_validator("positive", lambda v: v > 0)
     >>> schema = ar.Schema({"score": ar.Custom("positive", nullable=False)})
     """
+
+    if not isinstance(name, str) or not name:
+        raise ValueError("name must be a non-empty string")
+
     if name not in _CUSTOM_VALIDATORS:
         raise ValueError(
             f"No validator registered under {name!r}. "

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -303,3 +303,39 @@ class TestCustomValidatorReturnNormalization:
         failing_rows = {i.row_index for i in result.issues if i.rule == "custom"}
         # rows at index 2 (v=2), 3 (v=3), 4 (v=4) should fail (1-based)
         assert failing_rows == {2, 3, 4}
+
+
+class TestCustomValidatorNameValidation:
+    """Input-validation tests for Custom() name parameter."""
+
+    def setup_method(self):
+        self._original_validators = dict(schema._CUSTOM_VALIDATORS)
+
+    def teardown_method(self):
+        schema._CUSTOM_VALIDATORS.clear()
+        schema._CUSTOM_VALIDATORS.update(self._original_validators)
+
+    def test_raises_value_error_when_name_is_empty_string(self):
+        """Custom raises ValueError when name is an empty string."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            Custom("")
+
+    def test_raises_value_error_when_name_is_integer(self):
+        """Custom raises ValueError when name is an integer."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            Custom(123)
+
+    def test_raises_value_error_when_name_is_none(self):
+        """Custom raises ValueError when name is None."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            Custom(None)
+
+    def test_raises_value_error_when_name_is_list(self):
+        """Custom raises ValueError when name is a list."""
+        with pytest.raises(ValueError, match="non-empty string"):
+            Custom(["my_validator"])
+
+    def test_valid_name_still_raises_when_unregistered(self):
+        """A valid string name that isn't registered raises the registry error, not the name error."""
+        with pytest.raises(ValueError, match="No validator registered"):
+            Custom("unregistered_name_xyz")


### PR DESCRIPTION
## Summary

- Added validation for the name parameter in `arnio/schema.py` within the `Custom` function before performing the registry lookup.
- Added test cases for non-string and empty name values.

## Linked issue
Fixes #1637 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` 
- [x] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other: Explicitly test by calling Custom() function.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
