### PR TITLE
fix: validate direct Field() constructor options

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -721,7 +721,48 @@ class Field:
             if self.max is not None:
                 if isinstance(self.max, bool) or not isinstance(self.max, (int, float)):
                     raise TypeError("max must be numeric or None")
+        if self.dtype is not None and not isinstance(self.dtype, str):
+            raise TypeError(
+                f"dtype must be a str or None, got {type(self.dtype).__name__}"
+            )
 
+        if self.pattern is not None:
+            if not isinstance(self.pattern, str):
+                raise TypeError(
+                    f"pattern must be a str or None, got {type(self.pattern).__name__}"
+                )
+            try:
+                re.compile(self.pattern)
+            except re.error as exc:
+                raise ValueError(
+                    f"pattern is not a valid regular expression: {exc}"
+                ) from exc
+
+        if self.allowed is not None:
+            if isinstance(self.allowed, str):
+                raise TypeError(
+                    "allowed must be a list, set, or tuple — not a bare string"
+                )
+            if not hasattr(self.allowed, "__iter__"):
+                raise TypeError(
+                    f"allowed must be an iterable collection, got {type(self.allowed).__name__}"
+                )
+        for _name, _val in [
+            ("min_length", self.min_length),
+            ("max_length", self.max_length),
+        ]:
+            if _val is not None:
+                if isinstance(_val, bool) or not isinstance(_val, int):
+                    raise TypeError(
+                        f"{_name} must be an int or None, got {type(_val).__name__}"
+                    )
+                if _val < 0:
+                    raise ValueError(f"{_name} must be >= 0, got {_val}")
+        if self.min_length is not None and self.max_length is not None:
+            if self.min_length > self.max_length:
+                raise ValueError(
+                    f"min_length ({self.min_length}) must be <= max_length ({self.max_length})"
+                )
         _validate_severity(self.severity)
 
 

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -739,13 +739,9 @@ class Field:
                 ) from exc
 
         if self.allowed is not None:
-            if isinstance(self.allowed, str):
+            if not isinstance(self.allowed, (list, tuple, set)):
                 raise TypeError(
-                    "allowed must be a list, set, or tuple — not a bare string"
-                )
-            if not hasattr(self.allowed, "__iter__"):
-                raise TypeError(
-                    f"allowed must be an iterable collection, got {type(self.allowed).__name__}"
+                    f"allowed must be a list, tuple, or set, got {type(self.allowed).__name__}"
                 )
         for _name, _val in [
             ("min_length", self.min_length),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3248,7 +3248,7 @@ def test_field_pattern_rejects_invalid_regex():
 
 
 def test_field_allowed_rejects_bare_string():
-    with pytest.raises(TypeError, match="not a bare string"):
+    with pytest.raises(TypeError, match="allowed must be a list, tuple, or set"):
         ar.Field(allowed="abc")
 
 
@@ -3282,3 +3282,18 @@ def test_field_valid_direct_construction():
         dtype="string", pattern=r"\d+", allowed=["a", "b"], min_length=1, max_length=5
     )
     assert f.pattern == r"\d+"
+
+
+def test_field_allowed_rejects_dict():
+    with pytest.raises(TypeError, match="allowed must be a list, tuple, or set"):
+        ar.Field(allowed={"a": 1})
+
+
+def test_field_allowed_rejects_generator():
+    with pytest.raises(TypeError, match="allowed must be a list, tuple, or set"):
+        ar.Field(allowed=(x for x in ["a"]))
+
+
+def test_field_allowed_rejects_bytes():
+    with pytest.raises(TypeError, match="allowed must be a list, tuple, or set"):
+        ar.Field(allowed=b"abc")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3230,3 +3230,55 @@ def test_custom_rule_with_invalid_severity_fails_validation_execution():
 
     with pytest.raises(ValueError, match="severity must be 'error' or 'warning'"):
         schema.validate(frame)
+
+
+def test_field_dtype_rejects_non_string():
+    with pytest.raises(TypeError, match="dtype must be a str or None"):
+        ar.Field(dtype=123)
+
+
+def test_field_pattern_rejects_non_string():
+    with pytest.raises(TypeError, match="pattern must be a str or None"):
+        ar.Field(pattern=123)
+
+
+def test_field_pattern_rejects_invalid_regex():
+    with pytest.raises(ValueError, match="not a valid regular expression"):
+        ar.Field(pattern="[unclosed")
+
+
+def test_field_allowed_rejects_bare_string():
+    with pytest.raises(TypeError, match="not a bare string"):
+        ar.Field(allowed="abc")
+
+
+def test_field_max_length_rejects_non_int():
+    with pytest.raises(TypeError, match="max_length must be an int or None"):
+        ar.Field(max_length="x")
+
+
+def test_field_min_length_rejects_non_int():
+    with pytest.raises(TypeError, match="min_length must be an int or None"):
+        ar.Field(min_length="x")
+
+
+def test_field_min_length_rejects_negative():
+    with pytest.raises(ValueError, match="min_length must be >= 0"):
+        ar.Field(min_length=-1)
+
+
+def test_field_max_length_rejects_negative():
+    with pytest.raises(ValueError, match="max_length must be >= 0"):
+        ar.Field(max_length=-1)
+
+
+def test_field_min_length_exceeds_max_length():
+    with pytest.raises(ValueError, match="min_length.*must be <= max_length"):
+        ar.Field(min_length=10, max_length=3)
+
+
+def test_field_valid_direct_construction():
+    f = ar.Field(
+        dtype="string", pattern=r"\d+", allowed=["a", "b"], min_length=1, max_length=5
+    )
+    assert f.pattern == r"\d+"


### PR DESCRIPTION
Closes #1800

Extended `Field.__post_init__()` to validate:
- `dtype` — must be `str | None`
- `pattern` — must be `str | None` and a valid regex
- `allowed` — must not be a bare string, must be iterable
- `min_length` / `max_length` — non-negative `int | None`, and `min <= max`

Added 11 regression tests in `tests/test_schema.py` covering all new invariants.