### PR TITLE
fix: validate safe_divide_columns fill_value

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1578,7 +1578,9 @@ def safe_divide_columns(
     if isinstance(fill_value, bool):
         raise TypeError("fill_value must be a finite float, not bool")
     if not isinstance(fill_value, (int, float)):
-        raise TypeError(f"fill_value must be a finite float, got {type(fill_value).__name__!r}")
+        raise TypeError(
+            f"fill_value must be a finite float, got {type(fill_value).__name__!r}"
+        )
     if not math.isfinite(fill_value):
         raise ValueError(f"fill_value must be finite, got {fill_value}")
     if output_column in columns:

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -6,6 +6,7 @@ Data cleaning functions.
 from __future__ import annotations
 
 import copy
+import math
 import unicodedata
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
@@ -1574,6 +1575,12 @@ def safe_divide_columns(
         raise ValueError(f"Denominator column '{denominator}' not found in frame.")
     if not isinstance(output_column, str) or not output_column.strip():
         raise ValueError("output_column must be a non-empty string.")
+    if isinstance(fill_value, bool):
+        raise TypeError("fill_value must be a finite float, not bool")
+    if not isinstance(fill_value, (int, float)):
+        raise TypeError(f"fill_value must be a finite float, got {type(fill_value).__name__!r}")
+    if not math.isfinite(fill_value):
+        raise ValueError(f"fill_value must be finite, got {fill_value}")
     if output_column in columns:
         import warnings
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3331,9 +3331,12 @@ class TestSafeDivideColumns:
             ar.safe_divide_columns(
                 frame, numerator="num", denominator="den", output_column="ratio"
             )
+
     def test_fill_value_bool_raises(self):
         frame = ar.from_pandas(pd.DataFrame({"a": [1.0, 2.0], "b": [1.0, 0.0]}))
-        with pytest.raises(TypeError, match="fill_value must be a finite float, not bool"):
+        with pytest.raises(
+            TypeError, match="fill_value must be a finite float, not bool"
+        ):
             ar.safe_divide_columns(frame, "a", "b", "ratio", fill_value=True)
 
     def test_fill_value_nan_raises(self):
@@ -3353,10 +3356,12 @@ class TestSafeDivideColumns:
 
     def test_fill_value_valid_float_passes(self):
         frame = ar.from_pandas(
-            pd.DataFrame({
-                "a": [1.0, 2.0],
-                "b": [1.0, 0.0],
-            })
+            pd.DataFrame(
+                {
+                    "a": [1.0, 2.0],
+                    "b": [1.0, 0.0],
+                }
+            )
         )
 
         result = ar.safe_divide_columns(

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3331,6 +3331,44 @@ class TestSafeDivideColumns:
             ar.safe_divide_columns(
                 frame, numerator="num", denominator="den", output_column="ratio"
             )
+    def test_fill_value_bool_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1.0, 2.0], "b": [1.0, 0.0]}))
+        with pytest.raises(TypeError, match="fill_value must be a finite float, not bool"):
+            ar.safe_divide_columns(frame, "a", "b", "ratio", fill_value=True)
+
+    def test_fill_value_nan_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1.0, 2.0], "b": [1.0, 0.0]}))
+        with pytest.raises(ValueError, match="fill_value must be finite"):
+            ar.safe_divide_columns(frame, "a", "b", "ratio", fill_value=float("nan"))
+
+    def test_fill_value_inf_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1.0, 2.0], "b": [1.0, 0.0]}))
+        with pytest.raises(ValueError, match="fill_value must be finite"):
+            ar.safe_divide_columns(frame, "a", "b", "ratio", fill_value=float("inf"))
+
+    def test_fill_value_negative_inf_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1.0, 2.0], "b": [1.0, 0.0]}))
+        with pytest.raises(ValueError, match="fill_value must be finite"):
+            ar.safe_divide_columns(frame, "a", "b", "ratio", fill_value=float("-inf"))
+
+    def test_fill_value_valid_float_passes(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({
+                "a": [1.0, 2.0],
+                "b": [1.0, 0.0],
+            })
+        )
+
+        result = ar.safe_divide_columns(
+            frame,
+            "a",
+            "b",
+            "ratio",
+            fill_value=0.5,
+        )
+
+        df = ar.to_pandas(result)
+        assert df["ratio"].tolist() == [1.0, 0.5]
 
 
 class TestClipNumericNativeRegression:


### PR DESCRIPTION
## Summary
Added validation for `fill_value` in `safe_divide_columns()`.

Previously, boolean and non-finite values (`nan`, `inf`, `-inf`) 
were accepted and could propagate silently into the output column.

## Changes
- Reject boolean values explicitly
- Reject NaN, inf, and -inf values
- Added focused validation tests

Fixes #1840