### PR TITLE
Bug: validate frame type consistently across cleaning helpers

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1956,6 +1956,7 @@ def coalesce_columns(
     ...                              output_column="first_non_null")
     """
     from .convert import from_pandas, to_pandas
+
     frame, is_arframe = _validate_frame(frame, allow_pandas=True)
 
     if not isinstance(output_column, str) or not output_column.strip():

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -61,6 +61,7 @@ def validate_columns_exist(
     KeyError
         If any requested column is missing.
     """
+    frame, _ = _validate_frame(frame)
     _validate_existing_column_sequence(
         columns,
         available_columns=frame.columns,
@@ -167,6 +168,20 @@ def _validate_string_mapping(
     return normalized
 
 
+def _validate_frame(
+    frame: ArFrame | pd.DataFrame,
+    *,
+    allow_pandas: bool = False,
+) -> tuple[ArFrame | pd.DataFrame, bool]:
+    if isinstance(frame, ArFrame):
+        return frame, True
+    if allow_pandas and isinstance(frame, pd.DataFrame):
+        return frame, False
+    if allow_pandas:
+        raise TypeError("frame must be an ArFrame or a pandas DataFrame")
+    raise TypeError("frame must be an ArFrame")
+
+
 def drop_nulls(
     frame: ArFrame,
     *,
@@ -192,6 +207,7 @@ def drop_nulls(
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.drop_nulls(frame, subset=["age", "name"])
     """
+    frame, _ = _validate_frame(frame)
     if subset is not None:
         subset = _validate_column_sequence(subset, argument_name="subset")
         if len(subset) == 0:
@@ -237,6 +253,7 @@ def drop_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
     --------
     >>> frame = ar.drop_columns(frame, ["debug_col"])
     """
+    frame, _ = _validate_frame(frame)
     requested_columns = _validate_existing_column_sequence(
         columns,
         available_columns=frame.columns,
@@ -295,18 +312,15 @@ def keep_rows_with_nulls(
     >>> nulls = ar.keep_rows_with_nulls(frame)
     >>> nulls_age = ar.keep_rows_with_nulls(frame, subset=["age"])
     """
-
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     if isinstance(subset, str):
         raise TypeError(
             f"keep_rows_with_nulls: 'subset' must be a list of column names, "
             f"not a string. Did you mean subset=['{subset}']?"
         )
 
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
 
-    is_arframe = not isinstance(frame, pd.DataFrame)
     df = to_pandas(frame) if is_arframe else frame
 
     if subset is not None:
@@ -355,6 +369,7 @@ def select_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
     >>> frame = ar.read_csv("data.csv")
     >>> subset = ar.select_columns(frame, ["name", "revenue"])
     """
+    frame, _ = _validate_frame(frame)
     return frame.select_columns(columns)
 
 
@@ -385,6 +400,7 @@ def fill_nulls(
     >>> frame = ar.read_csv("data.csv")
     >>> filled = ar.fill_nulls(frame, 0, subset=["age"])
     """
+    frame, _ = _validate_frame(frame)
     if subset is not None:
         subset = _validate_existing_column_sequence(
             subset,
@@ -432,6 +448,7 @@ def drop_duplicates(
     >>> frame = ar.read_csv("data.csv")
     >>> unique = ar.drop_duplicates(frame, subset=["name"], keep="first")
     """
+    frame, _ = _validate_frame(frame)
     if subset is not None:
         subset = _validate_column_sequence(subset, argument_name="subset")
         if len(subset) == 0:
@@ -484,15 +501,9 @@ def drop_constant_columns(
     >>> frame = ar.read_csv("data.csv")
     >>> reduced = ar.drop_constant_columns(frame)
     """
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
-    from .frame import ArFrame
 
-    is_arframe = isinstance(frame, ArFrame)
-    if not is_arframe and not isinstance(frame, pd.DataFrame):
-        raise TypeError("frame must be an ArFrame or a pandas DataFrame")
-
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     df = to_pandas(frame) if is_arframe else frame
     if len(df.index) == 0:
         return frame
@@ -523,6 +534,7 @@ def drop_empty_columns(frame: ArFrame) -> ArFrame:
     >>> frame = ar.read_csv("data.csv")
     >>> reduced = ar.drop_empty_columns(frame)
     """
+    frame, _ = _validate_frame(frame)
     from .convert import to_pandas
 
     if frame.shape[0] == 0:
@@ -593,6 +605,7 @@ def clip_numeric(
     >>> frame = ar.read_csv("data.csv")
     >>> clipped = ar.clip_numeric(frame, lower=0, upper=100)
     """
+    frame, _ = _validate_frame(frame)
     if lower is not None:
         if isinstance(lower, bool) or not isinstance(lower, (int, float)):
             raise TypeError(
@@ -709,7 +722,7 @@ def winsorize_outliers(
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.winsorize_outliers(frame, lower=0.01, upper=0.99, subset=["revenue"])
     """
-
+    frame, _ = _validate_frame(frame)
     if lower < 0 or upper > 1:
         raise ValueError("lower and upper must be between 0 and 1")
 
@@ -783,6 +796,7 @@ def strip_whitespace(
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.strip_whitespace(frame, subset=["name"])
     """
+    frame, _ = _validate_frame(frame)
     if subset is not None:
         subset = _validate_existing_column_sequence(
             subset,
@@ -818,7 +832,7 @@ def normalize_whitespace(frame, columns=None):
     >>> frame = ar.read_csv("data.csv")
     >>> clean = ar.pipeline(frame, [("normalize_whitespace",)])
     """
-    is_arframe = not isinstance(frame, pd.DataFrame)
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     df = to_pandas(frame) if is_arframe else frame.copy()
 
     if columns is not None:
@@ -876,6 +890,7 @@ def parse_bool_strings(
     """
     from .convert import from_pandas, to_pandas
 
+    frame, _ = _validate_frame(frame)
     if true_values is not None and isinstance(true_values, (str, bytes)):
         raise TypeError(
             "true_values must be a set/list/tuple of strings, not a bare string"
@@ -980,6 +995,7 @@ def normalize_case(
     >>> frame = ar.read_csv("data.csv")
     >>> lower = ar.normalize_case(frame, case_type="lower")
     """
+    frame, _ = _validate_frame(frame)
     if not isinstance(case_type, str):
         raise TypeError("case_type must be a string")
     if subset is not None:
@@ -1034,6 +1050,7 @@ def normalize_unicode(
     >>> frame = ar.read_csv("data.csv")
     >>> normalized = ar.normalize_unicode(frame, form="NFC")
     """
+    frame, _ = _validate_frame(frame)
     valid_forms = {"NFC", "NFD", "NFKC", "NFKD"}
     if form not in valid_forms:
         raise ValueError(f"Unsupported Unicode normalization form: {form}")
@@ -1104,6 +1121,7 @@ def rename_columns(
     >>> frame = ar.read_csv("data.csv")
     >>> renamed = ar.rename_columns(frame, {"old_name": "new_name"})
     """
+    frame, _ = _validate_frame(frame)
     mapping = _validate_string_mapping(mapping, argument_name="mapping")
     validate_columns_exist(
         frame,
@@ -1156,6 +1174,7 @@ def trim_column_names(frame: ArFrame) -> ArFrame:
     >>> frame = ar.read_csv("data.csv")  # columns: [" name ", " age "]
     >>> clean = ar.trim_column_names(frame)  # columns: ["name", "age"]
     """
+    frame, _ = _validate_frame(frame)
     trimmed = [col.strip() for col in frame.columns]
 
     if len(trimmed) != len(set(trimmed)):
@@ -1197,6 +1216,7 @@ def cast_types(
     >>> frame = ar.read_csv("data.csv")
     >>> casted = ar.cast_types(frame, {"age": "int64", "score": "float64"})
     """
+    frame, _ = _validate_frame(frame)
     if errors not in {"raise", "coerce"}:
         raise ValueError("errors must be either 'raise' or 'coerce'")
 
@@ -1252,6 +1272,7 @@ def clean(
     >>> frame = ar.read_csv("data.csv")
     >>> cleaned = ar.clean(frame, strip_whitespace=True, drop_nulls=True)
     """
+    frame, _ = _validate_frame(frame)
     if not isinstance(strip_whitespace, bool):
         raise TypeError("strip_whitespace must be a bool")
     if not isinstance(drop_nulls, bool):
@@ -1307,13 +1328,11 @@ def filter_rows(
     >>> frame = ar.read_csv("data.csv")
     >>> filtered = ar.filter_rows(frame, column="age", op=">", value=18)
     """
-
-    import pandas as pd
     from pandas.api.types import is_scalar
 
     from .convert import from_pandas, to_pandas
 
-    is_arframe = not isinstance(frame, pd.DataFrame)
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
 
     df = to_pandas(frame) if is_arframe else frame
 
@@ -1380,16 +1399,14 @@ def round_numeric_columns(
     >>> frame = ar.read_csv("data.csv")
     >>> rounded = ar.round_numeric_columns(frame, decimals=2)
     """
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
 
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     if subset is not None and not isinstance(subset, list):
         raise TypeError("subset must be a list of column names")
     if isinstance(decimals, bool) or not isinstance(decimals, int):
         raise TypeError("decimals must be an integer")
 
-    is_arframe = not isinstance(frame, pd.DataFrame)
     df = to_pandas(frame) if is_arframe else frame.copy()
 
     if subset is not None:
@@ -1454,18 +1471,11 @@ def combine_columns(
     >>> result = ar.combine_columns(frame, subset=["first_name", "last_name"],
     ...                             separator=" ", output_column="full_name")
     """
-    import pandas as pd
-
-    from .frame import ArFrame
-
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     if not isinstance(separator, str):
         raise TypeError("separator must be a string")
     if not isinstance(output_column, str) or not output_column.strip():
         raise ValueError("output_column must be a non-empty string")
-
-    is_arframe = isinstance(frame, ArFrame)
-    if not is_arframe and not isinstance(frame, pd.DataFrame):
-        raise TypeError("frame must be an ArFrame or a pandas DataFrame")
 
     column_names = list(frame.columns)
 
@@ -1541,13 +1551,10 @@ def safe_divide_columns(
     >>> frame = ar.read_csv("data.csv")
     >>> result = ar.safe_divide_columns(frame, numerator="revenue", denominator="cost", output_column="ratio")
     """
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
 
-    is_arframe = isinstance(frame, ArFrame)
-
-    columns = frame.columns if is_arframe else frame.columns
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
+    columns = frame.columns
 
     if numerator not in columns:
         raise ValueError(f"Numerator column '{numerator}' not found in frame.")
@@ -1652,9 +1659,9 @@ def drop_columns_matching(frame, pattern):
     """
     import re
 
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
+
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
 
     if not isinstance(pattern, str):
         raise TypeError(f"pattern must be a string, got {type(pattern).__name__}")
@@ -1664,7 +1671,6 @@ def drop_columns_matching(frame, pattern):
     except re.error as e:
         raise re.error(f"Invalid regex pattern: {pattern!r}") from e
 
-    is_arframe = not isinstance(frame, pd.DataFrame)
     df = to_pandas(frame) if is_arframe else frame
 
     cols_to_drop = [col for col in df.columns if re.search(pattern, str(col))]
@@ -1735,9 +1741,9 @@ def replace_values(
     >>> replaced = ar.replace_values(frame, {"old_value": "new_value"}, column="name")
     """
 
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
+
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
 
     mapping = _validate_mapping(
         mapping,
@@ -1748,7 +1754,6 @@ def replace_values(
             f"not {type(mapping).__name__}."
         ),
     )
-    is_arframe = not isinstance(frame, pd.DataFrame)
     # Avoid mutating the caller's DataFrame in the direct pandas API path.
     df = to_pandas(frame) if is_arframe else frame.copy()
 
@@ -1837,11 +1842,9 @@ def standardize_missing_tokens(frame, tokens=None, subset=None):
     >>> result = ar.standardize_missing_tokens(frame)
     """
 
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
 
-    is_arframe = not isinstance(frame, pd.DataFrame)
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     df = to_pandas(frame) if is_arframe else frame
 
     df = df.copy()
@@ -1952,14 +1955,8 @@ def coalesce_columns(
     >>> result = ar.coalesce_columns(frame, subset=["col_a", "col_b"],
     ...                              output_column="first_non_null")
     """
-    import pandas as pd
-
     from .convert import from_pandas, to_pandas
-    from .frame import ArFrame
-
-    is_arframe = isinstance(frame, ArFrame)
-    if not is_arframe and not isinstance(frame, pd.DataFrame):
-        raise TypeError("frame must be an ArFrame or a pandas DataFrame")
+    frame, is_arframe = _validate_frame(frame, allow_pandas=True)
 
     if not isinstance(output_column, str) or not output_column.strip():
         raise ValueError("output_column must be a non-empty string")
@@ -2018,6 +2015,7 @@ def clean_column_names(
     ValueError
         If case_type is invalid or if cleaning would create duplicate column names.
     """
+    frame, _ = _validate_frame(frame)
     if not isinstance(case_type, str):
         raise TypeError("case_type must be a string")
     if case_type not in {"lower", "upper", "none"}:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2234,7 +2234,10 @@ class TestMixedFrameValidation:
     @pytest.mark.parametrize(
         ("func", "kwargs"),
         [
-            ("combine_columns", {"subset": ["a"], "separator": "-", "output_column": "combined"}),
+            (
+                "combine_columns",
+                {"subset": ["a"], "separator": "-", "output_column": "combined"},
+            ),
             ("drop_constant_columns", {}),
         ],
     )

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2184,6 +2184,10 @@ class TestTrimColumnNames:
         result = ar.trim_column_names(frame)
         assert to_pandas(result).columns.tolist() == ["name", "age"]
 
+    def test_trim_column_names_rejects_non_frame_input(self):
+        with pytest.raises(TypeError, match="frame must be an ArFrame"):
+            ar.trim_column_names([])
+
     def test_trim_column_names_already_clean(self):
         df = pd.DataFrame({"name": [1], "age": [2]})
         frame = from_pandas(df)
@@ -2224,6 +2228,21 @@ class TestTrimColumnNames:
         frame = from_pandas(pd.DataFrame({" name ": [1]}))
         result = ar.trim_column_names(frame)
         assert result.columns == ["name"]
+
+
+class TestMixedFrameValidation:
+    @pytest.mark.parametrize(
+        ("func", "kwargs"),
+        [
+            ("combine_columns", {"subset": ["a"], "separator": "-", "output_column": "combined"}),
+            ("drop_constant_columns", {}),
+        ],
+    )
+    def test_mixed_helpers_reject_non_frame_input(self, func, kwargs):
+        with pytest.raises(
+            TypeError, match="frame must be an ArFrame or a pandas DataFrame"
+        ):
+            getattr(ar, func)([], **kwargs)
 
 
 def test_from_pandas_multiindex_columns_are_stringified():


### PR DESCRIPTION
I added a shared `_validate_frame` guard in cleaning.py and wired it into the frame-based cleaning entry points, so invalid inputs now fail with the explicit contract instead of falling through to `AttributeError` or mixed behavior. That includes the ArFrame-only paths like cleaning.py, cleaning.py, cleaning.py, and cleaning.py, plus the mixed pandas/DataFrame helpers.

I also added regression coverage in test_cleaning.py and test_cleaning.py for the explicit `TypeError` on `trim_column_names` and for mixed helpers rejecting non-frame inputs with the broader frame/DataFrame message.

Validation-wise, `get_errors` is clean for the touched files, and I also verified the new guard behavior with a lightweight stubbed import of `arnio.cleaning`. 


closes #1781