### PR TITLE
fix: validate nested JSONL values and include line/field context

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1040,7 +1040,8 @@ def read_jsonl(
         ``nrows`` is not a non-negative integer.
     JsonlReadError
         If the file is empty (no data rows), or if a line contains invalid
-        JSON.  The error message includes the 1-based line number.
+        JSON or unsupported nested values. The error message includes the
+        1-based line number.
 
     Examples
     --------
@@ -1049,7 +1050,7 @@ def read_jsonl(
     """
     import json
 
-    from .convert import from_pandas
+    from .convert import _is_nested, from_pandas
 
     if not isinstance(encoding, str):
         raise TypeError(f"encoding must be a string, got {type(encoding).__name__!r}")
@@ -1100,6 +1101,13 @@ def read_jsonl(
                         f"Expected a JSON object on line {lineno} of {path!r}, "
                         f"got {type(obj).__name__}"
                     )
+                for key, val in obj.items():
+                    if _is_nested(val):
+                        raise JsonlReadError(
+                            f"Column {key!r} contains unsupported nested value "
+                            f"of type {type(val).__name__!r} on line {lineno} of {path!r}. "
+                            "Convert nested objects to strings or flatten them first."
+                        )
                 records.append(obj)
     except OSError as exc:
         raise JsonlReadError(str(exc)) from exc

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -306,3 +306,26 @@ def test_read_jsonl_encoding_unknown_codec(tmp_path):
     f.write_text('{"a": 1}\n')
     with pytest.raises(ValueError, match="Unknown encoding"):
         ar.read_jsonl(f, encoding="fake-codec")
+
+
+def test_read_jsonl_nested_list_raises(tmp_path):
+    f = tmp_path / "nested_list.jsonl"
+    f.write_text('{"id": 1, "tags": ["a"]}\n')
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(f)
+    assert "tags" in str(exc_info.value)
+    assert "list" in str(exc_info.value)
+    assert "line 1" in str(exc_info.value)
+    assert str(f.name) in str(exc_info.value)
+
+
+def test_read_jsonl_nested_dict_raises(tmp_path):
+    f = tmp_path / "nested_dict.jsonl"
+    # Row 1 is normal, Row 2 has nested dict
+    f.write_text('{"id": 1, "metadata": null}\n{"id": 2, "metadata": {"foo": "bar"}}\n')
+    with pytest.raises(ar.JsonlReadError) as exc_info:
+        ar.read_jsonl(f)
+    assert "metadata" in str(exc_info.value)
+    assert "dict" in str(exc_info.value)
+    assert "line 2" in str(exc_info.value)
+    assert str(f.name) in str(exc_info.value)


### PR DESCRIPTION
## Summary

When I read JSONL files with structures like lists or dictionaries the parser used to create a Pandas DataFrame. Then it would let the conversion layer throw an error with no details, about where the problem occurred.

This PR update changes the `read_jsonl` function in `arnio/io.py`. Now it checks each objects values as it reads the lines. If it finds a problem it  immediately raises a descriptive `JsonlReadError` that explains what went wrong. The error message includes the key/column ,the type of value that caused the issue, the line number and the file path. I also updated the functions description to explain how it handles errors.

## Linked issue
Fixes #1709

## Type of change
- [x] Bug fix
- [x] Documentation
- [x] Tests

## Area
- [x] CSV parser / I/O

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .