### PR TITLE
fix: validate writer output path before os.fspath in write_csv and write_parquet

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -861,7 +861,7 @@ def write_csv(
         raise TypeError(
             f"path must be a string, bytes, or os.PathLike object, got {type(path).__name__!r}"
         )
-    path = os.fspath(path)
+    path = os.fsdecode(os.fspath(path))
     path_lower = path.lower()
     if not (
         path_lower.endswith(".csv")
@@ -1375,7 +1375,7 @@ def write_parquet(
             f"path must be a string, bytes, or os.PathLike object, got {type(path).__name__!r}"
         )
 
-    path = os.fspath(path)
+    path = os.fsdecode(os.fspath(path))
     path_lower = path.lower()
     if not (path_lower.endswith(".parquet") or path_lower.endswith(".pq")):
         raise ValueError(

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1369,6 +1369,7 @@ def write_parquet(
     >>> ar.write_parquet(frame, "output.parquet", row_group_size=50_000)
     """
     from .convert import to_pandas
+
     if not isinstance(path, (str, bytes, os.PathLike)):
         raise TypeError(
             f"path must be a string, bytes, or os.PathLike object, got {type(path).__name__!r}"

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -857,6 +857,10 @@ def write_csv(
     >>> ar.write_csv(frame, "output.csv")
     >>> ar.write_csv(frame, "output.tsv", delimiter="\\t")
     """
+    if not isinstance(path, (str, bytes, os.PathLike)):
+        raise TypeError(
+            f"path must be a string, bytes, or os.PathLike object, got {type(path).__name__!r}"
+        )
     path = os.fspath(path)
     path_lower = path.lower()
     if not (
@@ -1365,6 +1369,10 @@ def write_parquet(
     >>> ar.write_parquet(frame, "output.parquet", row_group_size=50_000)
     """
     from .convert import to_pandas
+    if not isinstance(path, (str, bytes, os.PathLike)):
+        raise TypeError(
+            f"path must be a string, bytes, or os.PathLike object, got {type(path).__name__!r}"
+        )
 
     path = os.fspath(path)
     path_lower = path.lower()

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -204,3 +204,26 @@ class TestWriteParquetErrors:
         with patch.dict("sys.modules", {"pyarrow": None}):
             with pytest.raises(ImportError, match="pip install arnio\\[parquet\\]"):
                 ar.write_parquet(frame, tmp_path / "out.parquet")
+
+
+def test_write_parquet_rejects_bool_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_parquet(frame, True)
+
+
+def test_write_parquet_rejects_int_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_parquet(frame, 42)
+
+def test_write_parquet_rejects_bool_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_parquet(frame, True)
+
+
+def test_write_parquet_rejects_int_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_parquet(frame, 42)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -8,6 +8,7 @@ validation tests always run regardless of whether pyarrow is present.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -216,3 +217,27 @@ def test_write_parquet_rejects_int_path(tmp_path):
     frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
     with pytest.raises(TypeError, match="path must be a string"):
         ar.write_parquet(frame, 42)
+
+
+class _BytesPathLike:
+    def __init__(self, path: bytes) -> None:
+        self._path = path
+
+    def __fspath__(self) -> bytes:
+        return self._path
+
+
+@skip_without_pyarrow
+def test_write_parquet_accepts_bytes_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    out = tmp_path / "out.parquet"
+    ar.write_parquet(frame, os.fsencode(out))
+    assert out.exists()
+
+
+@skip_without_pyarrow
+def test_write_parquet_accepts_pathlike_bytes_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    out = tmp_path / "out.parquet"
+    ar.write_parquet(frame, _BytesPathLike(os.fsencode(out)))
+    assert out.exists()

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -216,14 +216,3 @@ def test_write_parquet_rejects_int_path(tmp_path):
     frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
     with pytest.raises(TypeError, match="path must be a string"):
         ar.write_parquet(frame, 42)
-
-def test_write_parquet_rejects_bool_path(tmp_path):
-    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
-    with pytest.raises(TypeError, match="path must be a string"):
-        ar.write_parquet(frame, True)
-
-
-def test_write_parquet_rejects_int_path(tmp_path):
-    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
-    with pytest.raises(TypeError, match="path must be a string"):
-        ar.write_parquet(frame, 42)

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -316,3 +316,26 @@ class TestWriteCsvControlCharValidation:
             ValueError, match="delimiter must not be a control character"
         ):
             ar.write_csv(frame, str(tmp_path / "out.csv"), delimiter=delimiter)
+
+
+def test_write_csv_rejects_bool_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_csv(frame, True)
+
+
+def test_write_csv_rejects_int_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_csv(frame, 42)
+
+def test_write_csv_rejects_bool_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_csv(frame, True)
+
+
+def test_write_csv_rejects_int_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    with pytest.raises(TypeError, match="path must be a string"):
+        ar.write_csv(frame, 42)

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -328,14 +328,3 @@ def test_write_csv_rejects_int_path(tmp_path):
     frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
     with pytest.raises(TypeError, match="path must be a string"):
         ar.write_csv(frame, 42)
-
-def test_write_csv_rejects_bool_path(tmp_path):
-    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
-    with pytest.raises(TypeError, match="path must be a string"):
-        ar.write_csv(frame, True)
-
-
-def test_write_csv_rejects_int_path(tmp_path):
-    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
-    with pytest.raises(TypeError, match="path must be a string"):
-        ar.write_csv(frame, 42)

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -1,5 +1,6 @@
 """Tests for write_csv functionality."""
 
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -328,3 +329,25 @@ def test_write_csv_rejects_int_path(tmp_path):
     frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
     with pytest.raises(TypeError, match="path must be a string"):
         ar.write_csv(frame, 42)
+
+
+class _BytesPathLike:
+    def __init__(self, path: bytes) -> None:
+        self._path = path
+
+    def __fspath__(self) -> bytes:
+        return self._path
+
+
+def test_write_csv_accepts_bytes_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    out = tmp_path / "out.csv"
+    ar.write_csv(frame, os.fsencode(out))
+    assert out.exists()
+
+
+def test_write_csv_accepts_pathlike_bytes_path(tmp_path):
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    out = tmp_path / "out.csv"
+    ar.write_csv(frame, _BytesPathLike(os.fsencode(out)))
+    assert out.exists()


### PR DESCRIPTION
…arquet

## Summary
Added a type check before calling `os.fspath(path)` in both `write_csv()` and `write_parquet()`. Earlier, passing values like `bool` or `int` caused an unclear error from `os.fspath()`. With this change, invalid path inputs now raise a more understandable `TypeError` that clearly points to the `path` argument.

<!-- What changed and why? Keep this short but specific. -->

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #1689

<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging


## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `python -m pytest tests/test_write_csv.py tests/test_parquet.py -v` — 4 new tests pass
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
N/A
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
None — validation runs before any I/O.
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels

<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
