### PR TITLE
fix: preserve severity for unknown semantic validation issues

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2389,6 +2389,7 @@ def _validate_column(
                         column=name,
                         rule="custom",
                         message=f"Custom validator {validator_name!r} is not registered",
+                        severity=field_def.severity,
                     )
                 )
             else:
@@ -2420,6 +2421,7 @@ def _validate_column(
                         column=name,
                         rule="semantic",
                         message=f"Unknown semantic type: {field_def.semantic}",
+                        severity=field_def.severity,
                     )
                 )
             else:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3515,3 +3515,26 @@ def test_custom_field_json_roundtrip_preserves_required_if():
 
     restored = ar.Schema.from_json(schema.to_json())
     assert restored == schema
+
+
+def test_unknown_semantic_severity_preservation():
+    frame = ar.from_dict({"x": ["abc"]})
+    unknown_schema = ar.Schema({"x": ar.Field(semantic="unknown", severity="warning")})
+
+    result = ar.validate(frame, unknown_schema)
+    assert not result.issues[0].passed if hasattr(result.issues[0], "passed") else True
+    assert len(result.issues) == 1
+    assert result.issues[0].rule == "semantic"
+    assert result.issues[0].severity == "warning"
+
+
+def test_missing_custom_validator_severity_preservation():
+    frame = ar.from_dict({"x": ["abc"]})
+    missing_custom_schema = ar.Schema(
+        {"x": ar.Field(semantic="custom:missing", severity="warning")}
+    )
+
+    result = ar.validate(frame, missing_custom_schema)
+    for issue in result.issues:
+        if issue.rule == "custom":
+            assert issue.severity == "warning"


### PR DESCRIPTION
## Summary
Updated _validate_column() in arnio/schema.py to pass severity=field_def.severity inside the fallback branches for unknown semantic types and missing custom validators. Previously, these issues ignored the field configuration and always defaulted to "error". Added corresponding regression tests in tests/test_schema.py.

## Linked issue
Fixes #1804

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] make test
- [x] make lint

## Screenshots / Media
N/A

## Performance Impact
None.

## GSSoC labels
- `level:beginner;
- `type:bug`
- `area:schema`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits 

## Maintainer notes