### PR TITLE
fix(io): validate parquet compression argument type

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1417,7 +1417,7 @@ def write_parquet(
 
     if not isinstance(compression, str):
         raise TypeError("compression must be a string")
-    
+
     if compression not in _VALID_COMPRESSIONS:
         raise ValueError(
             f"Unknown compression codec: {compression!r}. "

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1415,6 +1415,9 @@ def write_parquet(
             "write_parquet only supports .parquet and .pq files."
         )
 
+    if not isinstance(compression, str):
+        raise TypeError("compression must be a string")
+    
     if compression not in _VALID_COMPRESSIONS:
         raise ValueError(
             f"Unknown compression codec: {compression!r}. "

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -198,6 +198,18 @@ class TestWriteParquetErrors:
         with pytest.raises(ValueError, match="Unknown compression codec"):
             ar.write_parquet(frame, tmp_path / "out.parquet", compression="lz4")
 
+    @pytest.mark.parametrize("compression", [None, 123, True, ["snappy"]])
+    def test_non_string_compression_raises_type_error(self, tmp_path, compression):
+        # Compression type validation happens before codec validation and pyarrow import.
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+        with pytest.raises(TypeError, match="compression must be a string"):
+            ar.write_parquet(
+                frame,
+                tmp_path / "out.parquet",
+                compression=compression,
+            )
+
     def test_missing_pyarrow_raises_import_error(self, tmp_path):
         # This test mocks pyarrow away and must run even without pyarrow.
         frame = ar.from_pandas(pd.DataFrame({"a": [1]}))


### PR DESCRIPTION
### Fixes #1812 

## Summary

Adds explicit type validation for the `compression` argument in `write_parquet()` before codec membership validation.

## Problem

`write_parquet()` previously checked:

```python
if compression not in _VALID_COMPRESSIONS:
```

without first validating that `compression` was a string.

This caused invalid non-string values such as:

```python
None
123
True
["snappy"]
```

to raise inconsistent or raw Python errors like:

```txt
TypeError: unhashable type: 'list'
```

instead of a clear Arnio-facing validation error.

## Changes made

- Added explicit type validation for the `compression` argument
- Non-string compression values now raise:
  ```python
  TypeError("compression must be a string")
  ```
- Preserved existing behavior for unsupported string codecs:
  ```python
  compression="lz4"
  ```
  still raises:
  ```python
  ValueError("Unknown compression codec")
  ```
- Added parametrized regression tests covering:
  - `None`
  - `123`
  - `True`
  - `["snappy"]`

## Result

`write_parquet()` now produces clearer and more consistent validation errors for invalid compression argument types while preserving existing codec validation behavior.
