### PR TITLE
fix: validate public quality report dataclass invariants

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -121,6 +121,64 @@ class ColumnProfile:
     top_values_sample_ratio: float | None = None
     histogram: list[tuple[float, float, int, float]] | None = None
 
+    def __post_init__(self) -> None:
+        """Validate structural field invariants for ColumnProfile."""
+        counts = {
+            "row_count": self.row_count,
+            "null_count": self.null_count,
+            "empty_string_count": self.empty_string_count,
+            "whitespace_count": self.whitespace_count,
+        }
+        for field_name, value in counts.items():
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(
+                    f"{field_name} must be an integer, got {type(value).__name__}"
+                )
+            if value < 0:
+                raise ValueError(f"{field_name} cannot be negative: {value}")
+
+        if self.top_values_sample_count is not None:
+            if not isinstance(self.top_values_sample_count, int) or isinstance(
+                self.top_values_sample_count, bool
+            ):
+                raise TypeError(
+                    f"top_values_sample_count must be an integer, got {type(self.top_values_sample_count).__name__}"
+                )
+            if self.top_values_sample_count < 0:
+                raise ValueError(
+                    f"top_values_sample_count cannot be negative: {self.top_values_sample_count}"
+                )
+
+        ratios = {
+            "null_ratio": self.null_ratio,
+            "unique_ratio": self.unique_ratio,
+        }
+        for field_name, value in ratios.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(
+                    f"{field_name} must be a number, got {type(value).__name__}"
+                )
+            if not math.isfinite(value) or value < 0.0 or value > 1.0:
+                raise ValueError(
+                    f"{field_name} must be a finite ratio between 0.0 and 1.0: {value}"
+                )
+
+        optional_ratios = {
+            "email_validity_ratio": self.email_validity_ratio,
+            "url_validity_ratio": self.url_validity_ratio,
+            "top_values_sample_ratio": self.top_values_sample_ratio,
+        }
+        for field_name, value in optional_ratios.items():
+            if value is not None:
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    raise TypeError(
+                        f"{field_name} must be a number, got {type(value).__name__}"
+                    )
+                if not math.isfinite(value) or value < 0.0 or value > 1.0:
+                    raise ValueError(
+                        f"{field_name} must be a finite ratio between 0.0 and 1.0: {value}"
+                    )
+
     def to_dict(self, *, redact_sample_values: bool = False) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
         redact_sample_values = _validate_bool_option(
@@ -209,6 +267,52 @@ class DataQualityReport:
     quality_score: float = 100.0
     score_components: dict[str, float] = field(default_factory=dict)
     suggestions: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate structural field invariants for DataQualityReport."""
+        counts = {
+            "row_count": self.row_count,
+            "column_count": self.column_count,
+            "memory_usage": self.memory_usage,
+            "duplicate_rows": self.duplicate_rows,
+        }
+        for field_name, value in counts.items():
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(
+                    f"{field_name} must be an integer, got {type(value).__name__}"
+                )
+            if value < 0:
+                raise ValueError(f"{field_name} cannot be negative: {value}")
+
+        if isinstance(self.duplicate_ratio, bool) or not isinstance(
+            self.duplicate_ratio, (int, float)
+        ):
+            raise TypeError(
+                f"duplicate_ratio must be a number, got {type(self.duplicate_ratio).__name__}"
+            )
+        if (
+            not math.isfinite(self.duplicate_ratio)
+            or self.duplicate_ratio < 0.0
+            or self.duplicate_ratio > 1.0
+        ):
+            raise ValueError(
+                f"duplicate_ratio must be a finite ratio between 0.0 and 1.0: {self.duplicate_ratio}"
+            )
+
+        if isinstance(self.quality_score, bool) or not isinstance(
+            self.quality_score, (int, float)
+        ):
+            raise TypeError(
+                f"quality_score must be a number, got {type(self.quality_score).__name__}"
+            )
+        if (
+            not math.isfinite(self.quality_score)
+            or self.quality_score < 0.0
+            or self.quality_score > 100.0
+        ):
+            raise ValueError(
+                f"quality_score must be a finite value between 0.0 and 100.0: {self.quality_score}"
+            )
 
     def to_dict(
         self,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -126,6 +126,7 @@ class ColumnProfile:
         counts = {
             "row_count": self.row_count,
             "null_count": self.null_count,
+            "unique_count": self.unique_count,
             "empty_string_count": self.empty_string_count,
             "whitespace_count": self.whitespace_count,
         }

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -3108,3 +3108,97 @@ def test_profile_comparison_constructor_validation():
             drift_report={},
             status_counts={"missing_values": "should_be_an_int"},
         )
+
+
+def test_column_profile_invariant_valid_initialization():
+    from arnio.quality import ColumnProfile
+
+    cp = ColumnProfile(
+        name="score",
+        dtype="float64",
+        semantic_type="numeric",
+        row_count=100,
+        null_count=5,
+        null_ratio=0.05,
+        unique_count=90,
+        unique_ratio=0.9,
+    )
+    assert cp.name == "score"
+    assert cp.row_count == 100
+
+
+def test_column_profile_invariant_invalid_counts():
+    from arnio.quality import ColumnProfile
+
+    with pytest.raises(ValueError, match="row_count cannot be negative"):
+        ColumnProfile("x", "int64", "numeric", -1, 0, 0.0, 0, 0.0)
+
+    with pytest.raises(ValueError, match="null_count cannot be negative"):
+        ColumnProfile("x", "int64", "numeric", 10, -5, 0.0, 0, 0.0)
+
+    with pytest.raises(ValueError, match="top_values_sample_count cannot be negative"):
+        ColumnProfile(
+            "x", "int64", "numeric", 10, 0, 0.0, 0, 0.0, top_values_sample_count=-10
+        )
+
+    with pytest.raises(TypeError, match="row_count must be an integer"):
+        ColumnProfile("x", "int64", "numeric", True, 0, 0.0, 0, 0.0)
+
+    with pytest.raises(TypeError, match="null_count must be an integer"):
+        ColumnProfile("x", "int64", "numeric", 10, "0", 0.0, 0, 0.0)
+
+
+def test_column_profile_invariant_invalid_ratios():
+    from arnio.quality import ColumnProfile
+
+    with pytest.raises(ValueError, match="null_ratio must be a finite ratio"):
+        ColumnProfile("x", "int64", "numeric", 10, 0, 1.05, 0, 0.0)
+
+    with pytest.raises(ValueError, match="unique_ratio must be a finite ratio"):
+        ColumnProfile("x", "int64", "numeric", 10, 0, 0.1, 0, -0.01)
+
+    with pytest.raises(ValueError, match="email_validity_ratio must be a finite ratio"):
+        ColumnProfile(
+            "x", "string", "email", 10, 0, 0.0, 0, 0.0, email_validity_ratio=2.0
+        )
+
+    with pytest.raises(ValueError, match="null_ratio must be a finite ratio"):
+        ColumnProfile("x", "int64", "numeric", 10, 0, float("nan"), 0, 0.0)
+
+    with pytest.raises(ValueError, match="unique_ratio must be a finite ratio"):
+        ColumnProfile("x", "int64", "numeric", 10, 0, 0.0, 0, float("inf"))
+
+
+def test_data_quality_report_invariant_valid_initialization():
+    from arnio.quality import DataQualityReport
+
+    report = DataQualityReport(
+        row_count=200,
+        column_count=5,
+        memory_usage=4096,
+        duplicate_rows=10,
+        duplicate_ratio=0.05,
+        columns={},
+        quality_score=95.5,
+    )
+    assert report.row_count == 200
+    assert report.quality_score == 95.5
+
+
+def test_data_quality_report_invariant_invalid_metrics():
+    from arnio.quality import DataQualityReport
+
+    with pytest.raises(ValueError, match="memory_usage cannot be negative"):
+        DataQualityReport(10, 2, -1024, 0, 0.0, {})
+
+    with pytest.raises(ValueError, match="quality_score must be a finite value"):
+        DataQualityReport(10, 2, 512, 0, 0.0, {}, quality_score=100.5)
+
+    with pytest.raises(ValueError, match="quality_score must be a finite value"):
+        DataQualityReport(10, 2, 512, 0, 0.0, {}, quality_score=-1.0)
+
+    with pytest.raises(TypeError, match="quality_score must be a number"):
+        DataQualityReport(10, 2, 512, 0, 0.0, {}, quality_score=False)
+
+    with pytest.raises(ValueError, match="quality_score must be a finite value"):
+        DataQualityReport(10, 2, 512, 0, 0.0, {}, quality_score=float("nan"))

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -3147,6 +3147,12 @@ def test_column_profile_invariant_invalid_counts():
     with pytest.raises(TypeError, match="null_count must be an integer"):
         ColumnProfile("x", "int64", "numeric", 10, "0", 0.0, 0, 0.0)
 
+    with pytest.raises(ValueError, match="unique_count cannot be negative"):
+        ColumnProfile("x", "int64", "numeric", 10, 0, 0.0, -1, 0.0)
+
+    with pytest.raises(TypeError, match="unique_count must be an integer"):
+        ColumnProfile("x", "int64", "numeric", 10, 0, 0.0, True, 0.0)
+
 
 def test_column_profile_invariant_invalid_ratios():
     from arnio.quality import ColumnProfile


### PR DESCRIPTION
## Summary

Added robust validation logic inside the post-init hooks of both the ColumnProfile and DataQualityReport frozen dataclasses. This enforces crucial structural data invariants by ensuring row and null counts are strictly non-negative, non-boolean integers, ratios are bounded finite values between 0.0 and 1.0 inclusive, and quality scores sit within the 0.0 to 100.0 range. These safeguards prevent impossible or corrupt report states from failing silently and leaking down into downstream export formats, dashboards, or CI quality-gate integrations.

## Linked issue

Closes #1784

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [x] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [x] `make lint` 

## Screenshots / Media

N/A

## Performance Impact

Minimal to none. The checks run instantly upon dataclass initialization via simple, optimized type and value comparisons, adding negligible overhead to the profiling pipeline.

## GSSoC labels
- `level:intermediate`
- `type:bug`
- `area:quality`

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits.

## Maintainer notes

N/A