### PR TITLE
ci: run scikit-learn integration tests with the sklearn extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,31 @@ jobs:
             --ExecutePreprocessor.timeout=300 \
             examples/financial_csv_example.ipynb \
             --output executed_notebook.ipynb
+
+  sklearn_integration:
+    name: scikit-learn Integration Tests
+    needs: build_and_test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install dev + sklearn extras
+        run: pip install -e ".[dev,sklearn]"
+
+      - name: Run sklearn integration tests
+        run: pytest tests/test_sklearn.py -v --cov=arnio --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes #1741 

Adds a focused `sklearn_integration` job to `ci.yml` that:
- Installs `pip install -e ".[dev,sklearn]"` so scikit-learn is available
- Runs only `pytest tests/test_sklearn.py` (previously skipped in main matrix)
- Uploads coverage to Codecov
- Runs after `build_and_test` via `needs:` so it doesn't block the main matrix

<img width="933" height="604" alt="image" src="https://github.com/user-attachments/assets/a7bcb073-ec1d-4213-8f54-2ce0fc31f10f" />


No changes to `pyproject.toml` or any source files.