### PR TITLE
perf: skip csv inference when dtypes cover selected columns

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -334,6 +334,70 @@ void validate_row_width(size_t row_number, size_t expected, size_t actual) {
                              std::to_string(expected));
 }
 
+void generate_synthetic_header(std::vector<std::string>& header, size_t column_count) {
+    header.clear();
+    header.reserve(column_count);
+    for (size_t i = 0; i < column_count; ++i) header.push_back("col_" + std::to_string(i));
+    validate_header(header);
+}
+
+std::vector<size_t> resolve_col_indices(const std::vector<std::string>& header,
+                                        const CsvConfig& config) {
+    std::vector<size_t> col_indices;
+    if (config.usecols.has_value()) {
+        for (const auto& name : config.usecols.value()) {
+            auto it = std::find(header.begin(), header.end(), name);
+            if (it == header.end()) throw std::runtime_error("Column not found: " + name);
+            col_indices.push_back(static_cast<size_t>(std::distance(header.begin(), it)));
+        }
+    } else {
+        for (size_t i = 0; i < header.size(); ++i) col_indices.push_back(i);
+    }
+    return col_indices;
+}
+
+struct ExplicitDTypeResult {
+    std::vector<bool> explicit_columns;
+    bool covers_selected_columns = false;
+};
+
+ExplicitDTypeResult apply_explicit_dtypes(const CsvConfig& config,
+                                          const std::vector<std::string>& header,
+                                          const std::vector<size_t>& col_indices,
+                                          std::vector<DType>& col_types) {
+    ExplicitDTypeResult result{std::vector<bool>(col_types.size(), false), false};
+
+    if (!config.dtype.has_value()) {
+        return result;
+    }
+
+    const auto& dtype = config.dtype.value();
+    for (const auto& [column_name, dtype_name] : dtype) {
+        auto header_it = std::find(header.begin(), header.end(), column_name);
+        if (header_it == header.end()) {
+            throw std::runtime_error("Column not found in dtype mapping: " + column_name);
+        }
+        size_t column_index = static_cast<size_t>(std::distance(header.begin(), header_it));
+        bool selected =
+            std::find(col_indices.begin(), col_indices.end(), column_index) != col_indices.end();
+        if (!selected) {
+            throw std::runtime_error("dtype specified for non-selected column: " + column_name);
+        }
+        col_types[column_index] = string_to_dtype(dtype_name);
+        result.explicit_columns[column_index] = true;
+    }
+
+    result.covers_selected_columns = !col_indices.empty();
+    for (size_t ci : col_indices) {
+        if (ci >= result.explicit_columns.size() || !result.explicit_columns[ci]) {
+            result.covers_selected_columns = false;
+            break;
+        }
+    }
+
+    return result;
+}
+
 // Detect if a numeric string has leading zeros that indicate it's likely an
 // identifier (ZIP code, account ID, product code, etc.) rather than a true
 // numeric value. Identifiers with leading zeros should be preserved as strings.
@@ -703,12 +767,16 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
     std::string line;
     std::vector<std::string> header;
     std::vector<DType> col_types;
+    std::vector<size_t> col_indices;
+    std::vector<bool> explicit_dtype_columns;
     std::optional<size_t> expected_cols;
+    bool inference_pass_ran = true;
 
     // =================================================================
-    // PASS 1: Infer column types from ALL data rows (nothing stored).
-    // This preserves the original full-read type-inference contract.
-    // We also collect bad_rows here using the new on_bad_lines logic.
+    // PASS 1: Infer column types from data rows when needed (nothing stored).
+    // Fully explicit dtype mappings can skip value type inference once
+    // header/usecols resolution proves every selected output column is typed.
+    // When this pass is skipped, pass 2 owns bad-row collection.
     // =================================================================
     {
         std::ifstream file;
@@ -746,6 +814,12 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
 
         if (config.has_header && !header.empty()) {
             col_types.assign(header.size(), DType::NULL_TYPE);
+            col_indices = resolve_col_indices(header, config);
+            auto dtype_result = apply_explicit_dtypes(config, header, col_indices, col_types);
+            explicit_dtype_columns = std::move(dtype_result.explicit_columns);
+            if (dtype_result.covers_selected_columns) {
+                inference_pass_ran = false;
+            }
         }
 
         size_t row_count = 0;
@@ -754,7 +828,7 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
             reusable_fields.reserve(expected_cols.value());
         }
 
-        while (record_reader.read(line, line_number)) {
+        while (inference_pass_ran && record_reader.read(line, line_number)) {
             ++record_number;
 
             if (config.nrows.has_value() && (row_count + bad_rows.size()) >= config.nrows.value()) {
@@ -789,10 +863,22 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
 
             if (col_types.empty()) {
                 col_types.assign(reusable_fields.size(), DType::NULL_TYPE);
+                if (!config.has_header) {
+                    generate_synthetic_header(header, col_types.size());
+                    col_indices = resolve_col_indices(header, config);
+                    auto dtype_result =
+                        apply_explicit_dtypes(config, header, col_indices, col_types);
+                    explicit_dtype_columns = std::move(dtype_result.explicit_columns);
+                    if (dtype_result.covers_selected_columns) {
+                        inference_pass_ran = false;
+                        break;
+                    }
+                }
             }
 
             for (size_t ci = 0; ci < col_types.size(); ++ci) {
                 if (ci < reusable_fields.size()) {
+                    if (ci < explicit_dtype_columns.size() && explicit_dtype_columns[ci]) continue;
                     col_types[ci] = CsvParser::promote_type(
                         col_types[ci], parser_.infer_type(reusable_fields[ci]));
                 }
@@ -808,8 +894,9 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
 
     // For headerless CSVs generate synthetic column names.
     if (!config.has_header && !col_types.empty()) {
-        for (size_t i = 0; i < col_types.size(); ++i) header.push_back("col_" + std::to_string(i));
-        validate_header(header);
+        if (header.empty()) {
+            generate_synthetic_header(header, col_types.size());
+        }
     }
 
     // Zero-data-row edge case (headerless empty body).
@@ -817,32 +904,13 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
         return CsvParseResult{Frame(std::vector<Column>{}), std::move(bad_rows)};
     }
 
-    size_t num_cols = header.size();
-    std::vector<size_t> col_indices;
-    if (config.usecols.has_value()) {
-        for (const auto& name : config.usecols.value()) {
-            auto it = std::find(header.begin(), header.end(), name);
-            if (it == header.end()) throw std::runtime_error("Column not found: " + name);
-            col_indices.push_back(static_cast<size_t>(std::distance(header.begin(), it)));
-        }
-    } else {
-        for (size_t i = 0; i < num_cols; ++i) col_indices.push_back(i);
+    if (col_indices.empty()) {
+        col_indices = resolve_col_indices(header, config);
     }
 
-    if (config.dtype.has_value()) {
-        for (const auto& [column_name, dtype_name] : config.dtype.value()) {
-            auto header_it = std::find(header.begin(), header.end(), column_name);
-            if (header_it == header.end()) {
-                throw std::runtime_error("Column not found in dtype mapping: " + column_name);
-            }
-            size_t column_index = static_cast<size_t>(std::distance(header.begin(), header_it));
-            bool selected = std::find(col_indices.begin(), col_indices.end(), column_index) !=
-                            col_indices.end();
-            if (!selected) {
-                throw std::runtime_error("dtype specified for non-selected column: " + column_name);
-            }
-            col_types[column_index] = string_to_dtype(dtype_name);
-        }
+    if (explicit_dtype_columns.empty()) {
+        auto dtype_result = apply_explicit_dtypes(config, header, col_indices, col_types);
+        explicit_dtype_columns = std::move(dtype_result.explicit_columns);
     }
 
     // Initialise output columns with the statically-known types.
@@ -903,7 +971,14 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
                 const size_t expected = expected_cols2.value();
                 const size_t actual = reusable_fields2.size();
                 if (actual > expected || config.mode == "strict") {
-                    // Already recorded in pass 1, just count to skip and enforce nrows properly.
+                    if (!inference_pass_ran) {
+                        if (on_bad_lines == "error") {
+                            validate_row_width(record_number2, expected, actual);
+                        }
+                        bad_rows.push_back(BadRow{record_number2, expected, actual});
+                    }
+                    // Already recorded in pass 1 when it ran; either way count to
+                    // skip and enforce nrows properly.
                     ++bad_row_count2;
                     continue;
                 }

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -96,6 +96,50 @@ class TestReadCsv:
         assert frame.dtypes["price"] == "float64"
         assert pdf["zip"].tolist() == ["07001", "08002"]
 
+    def test_read_csv_fully_explicit_dtype_with_usecols(self, tmp_path):
+        path = tmp_path / "usecols_full_dtype.csv"
+        path.write_text("zip,quantity,price\n07001,5,12.5\n08002,10,20.0\n")
+
+        frame = ar.read_csv(
+            path,
+            usecols=["zip", "price"],
+            dtype={"zip": "string", "price": "float64"},
+        )
+
+        pdf = ar.to_pandas(frame)
+
+        assert list(pdf.columns) == ["zip", "price"]
+        assert frame.dtypes == {"zip": "string", "price": "float64"}
+        assert pdf["zip"].tolist() == ["07001", "08002"]
+        assert pdf["price"].tolist() == [12.5, 20.0]
+
+    def test_read_csv_fully_explicit_dtype_preserves_bad_line_errors(self, tmp_path):
+        path = tmp_path / "full_dtype_bad_line_error.csv"
+        path.write_text("id,name\n1,Alice\n2,Bob,extra\n")
+
+        with pytest.raises(ar.CsvReadError, match="CSV row 3 has 3 fields; expected 2"):
+            ar.read_csv(
+                path,
+                dtype={"id": "int64", "name": "string"},
+            )
+
+    def test_read_csv_fully_explicit_dtype_preserves_bad_line_warnings(self, tmp_path):
+        path = tmp_path / "full_dtype_bad_line_warn.csv"
+        path.write_text("id,name\n1,Alice\n2,Bob,extra\n3,Cara\n")
+
+        with pytest.warns(UserWarning, match="CSV row 3 has 3 fields; expected 2"):
+            frame = ar.read_csv(
+                path,
+                dtype={"id": "int64", "name": "string"},
+                on_bad_lines="warn",
+            )
+
+        pdf = ar.to_pandas(frame)
+
+        assert frame.dtypes == {"id": "int64", "name": "string"}
+        assert pdf["id"].tolist() == [1, 3]
+        assert pdf["name"].tolist() == ["Alice", "Cara"]
+
     def test_read_csv_dtype_parse_failure_becomes_null(self, tmp_path):
         path = tmp_path / "parse_failure.csv"
         path.write_text("quantity\nabc\n")


### PR DESCRIPTION
## Summary

Fixes #1710

This PR skips the full CSV type-inference scan when `dtype` fully covers the selected output columns. The reader still resolves the header/usecols first, validates the dtype mapping, and then goes directly to the streaming parse path with the explicit column types.

This is for GSSoC 2026 and stays scoped to the assigned CSV parser performance issue.

## What changed

- Added shared helpers for resolving selected CSV columns and applying explicit dtype mappings.
- Detects the fully-covered dtype case after header/usecols resolution.
- Skips value type inference only when every selected output column has an explicit dtype.
- Keeps partial dtype mappings on the existing inference path for unspecified columns.
- Preserves `on_bad_lines` behavior by collecting/raising bad rows in the streaming pass when the inference pass is skipped.
- Added regression coverage for fully explicit dtype + `usecols`, bad-line errors, and bad-line warnings.

## Validation

- `.venv-codex/bin/python -m pip install -e '.[dev]'`
- `.venv-codex/bin/python -m pytest tests/test_csv.py -q -k "dtype or bad_line or on_bad_lines or nrows or usecols"` - 21 passed
- `.venv-codex/bin/python -m pytest tests/test_csv.py -q` - 333 passed
- `.venv-codex/bin/python -m pytest -q` - 2340 passed, 47 skipped
- `.venv-codex/bin/ruff check tests/test_csv.py`
- `.venv-codex/bin/black --check tests/test_csv.py`
- `.venv-codex/bin/clang-format --dry-run --Werror cpp/src/csv_reader.cpp`
- `git diff --check`
