### PR TITLE
test: add comprehensive unit tests for frame filter_rows #1813

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1151,3 +1151,166 @@ def test_repr_html_does_not_convert_full_frame(large_csv, monkeypatch):
     assert (
         call_sizes == []
     ), f"_repr_html_() should not call to_pandas(), but got calls with {call_sizes} rows"
+
+
+# ── filter_rows() tests ───────────────────────────────────────────────────────
+
+
+class TestFilterRows:
+    """Tests for arnio.filter_rows function."""
+
+    def test_filter_rows_numeric_greater_than(self):
+        # We test '>' on a numeric column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "age": [25, 17, 30]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op=">", value=18)
+        assert filtered.columns == ["name", "age"]
+        assert filtered.shape == (2, 2)
+        assert filtered["name"] == ["Alice", "Charlie"]
+        assert filtered["age"] == [25, 30]
+
+    def test_filter_rows_numeric_less_than(self):
+        # We test '<' on a numeric column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "age": [25, 17, 30]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op="<", value=18)
+        assert filtered.shape == (1, 2)
+        assert filtered["name"] == ["Bob"]
+        assert filtered["age"] == [17]
+
+    def test_filter_rows_numeric_greater_equal(self):
+        # We test '>=' on a numeric column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "age": [25, 18, 30]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op=">=", value=18)
+        assert filtered.shape == (3, 2)
+        assert filtered["name"] == ["Alice", "Bob", "Charlie"]
+
+    def test_filter_rows_numeric_less_equal(self):
+        # We test '<=' on a numeric column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "age": [25, 18, 30]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op="<=", value=18)
+        assert filtered.shape == (1, 2)
+        assert filtered["name"] == ["Bob"]
+
+    def test_filter_rows_numeric_equal(self):
+        # We test '==' on a numeric column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "age": [25, 18, 30]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op="==", value=18)
+        assert filtered.shape == (1, 2)
+        assert filtered["name"] == ["Bob"]
+
+    def test_filter_rows_numeric_not_equal(self):
+        # We test '!=' on a numeric column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "age": [25, 18, 30]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op="!=", value=18)
+        assert filtered.shape == (2, 2)
+        assert filtered["name"] == ["Alice", "Charlie"]
+
+    def test_filter_rows_string_equal(self):
+        # We test '==' on a string column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "city": ["NYC", "Paris", "NYC"]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="city", op="==", value="NYC")
+        assert filtered.shape == (2, 2)
+        assert filtered["name"] == ["Alice", "Charlie"]
+
+    def test_filter_rows_string_not_equal(self):
+        # We test '!=' on a string column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "city": ["NYC", "Paris", "NYC"]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="city", op="!=", value="NYC")
+        assert filtered.shape == (1, 2)
+        assert filtered["name"] == ["Bob"]
+
+    def test_filter_rows_boolean_equal(self):
+        # We test '==' on a boolean column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "active": [True, False, True]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="active", op="==", value=True)
+        assert filtered.shape == (2, 2)
+        assert filtered["name"] == ["Alice", "Charlie"]
+
+    def test_filter_rows_boolean_not_equal(self):
+        # We test '!=' on a boolean column.
+        data = {"name": ["Alice", "Bob", "Charlie"], "active": [True, False, True]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="active", op="!=", value=True)
+        assert filtered.shape == (1, 2)
+        assert filtered["name"] == ["Bob"]
+
+    def test_filter_rows_with_null_values_filled_false(self):
+        # Null values inside a filtered column should be filled with False in the comparison mask
+        # and not raise errors or keep the null rows for operators like >.
+        data = {"name": ["Alice", "Bob", "Charlie", "David"], "age": [25, None, 30, 15]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op=">", value=18)
+        assert filtered.shape == (2, 2)
+        assert filtered["name"] == ["Alice", "Charlie"]
+
+    def test_filter_rows_accepts_and_returns_pandas_dataframe(self):
+        # When filter_rows gets a pd.DataFrame, it should return a pd.DataFrame.
+        data = {"name": ["Alice", "Bob"], "age": [25, 17]}
+        df = pd.DataFrame(data)
+        filtered = ar.filter_rows(df, column="age", op=">", value=18)
+        assert isinstance(filtered, pd.DataFrame)
+        assert len(filtered) == 1
+        assert list(filtered["name"]) == ["Alice"]
+
+    def test_filter_rows_empty_frame(self):
+        # Filtering an empty frame should return a brand new empty frame with the same columns.
+        data = {"name": [], "age": []}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op=">", value=18)
+        assert filtered.is_empty is True
+        assert filtered.columns == ["name", "age"]
+
+    def test_filter_rows_zero_matching_rows(self):
+        # If no rows match, we should get an empty frame.
+        data = {"name": ["Alice", "Bob"], "age": [25, 17]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op=">", value=100)
+        assert filtered.is_empty is True
+        assert filtered.columns == ["name", "age"]
+
+    def test_filter_rows_all_matching_rows(self):
+        # If all rows match, we should get all rows back.
+        data = {"name": ["Alice", "Bob"], "age": [25, 17]}
+        frame = ar.from_dict(data)
+        filtered = ar.filter_rows(frame, column="age", op=">", value=10)
+        assert filtered.shape == (2, 2)
+        assert filtered["name"] == ["Alice", "Bob"]
+
+    def test_filter_rows_invalid_operator(self):
+        # Passing an unsupported operator should raise ValueError.
+        data = {"name": ["Alice", "Bob"], "age": [25, 17]}
+        frame = ar.from_dict(data)
+        with pytest.raises(ValueError, match="Unsupported operator: %%"):
+            ar.filter_rows(frame, column="age", op="%%", value=18)
+
+    def test_filter_rows_missing_column(self):
+        # Passing a non-existent column name should raise ValueError.
+        data = {"name": ["Alice", "Bob"], "age": [25, 17]}
+        frame = ar.from_dict(data)
+        with pytest.raises(ValueError, match="Unknown column: salary"):
+            ar.filter_rows(frame, column="salary", op=">", value=18)
+
+    def test_filter_rows_non_scalar_value(self):
+        # Passing a non-scalar value (like a list) should raise TypeError.
+        data = {"name": ["Alice", "Bob"], "age": [25, 17]}
+        frame = ar.from_dict(data)
+        with pytest.raises(TypeError, match="filter_rows value must be a scalar"):
+            ar.filter_rows(frame, column="age", op=">", value=[18])
+
+    def test_filter_rows_incompatible_types_comparison(self):
+        # Comparing incompatible types (e.g. string vs number with '>') should raise TypeError.
+        data = {"name": ["Alice", "Bob"], "age": [25, 17]}
+        frame = ar.from_dict(data)
+        with pytest.raises(
+            TypeError,
+            match="cannot compare column 'name' with value 18 using operator '>'",
+        ):
+            ar.filter_rows(frame, column="name", op=">", value=18)


### PR DESCRIPTION
## Summary
Added comprehensive unit tests for the `arnio.frame.filter_rows` (and `arnio.cleaning.filter_rows`) function. The tests cover normal operations (numeric, string, boolean comparisons), edge cases (empty frames, null values inside filtered columns, all/zero matching rows), and error handling (unsupported operators, missing columns, non-scalar values, and incompatible type comparisons).

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #1813

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
  Ran the full test suite inside virtual environment: `.venv/bin/pytest tests/ -v` (2356 passed, 47 skipped, 7 warnings)
- [x] `make lint` (or run separately: ruff and black check)
  All checks passed successfully:
  - `.venv/bin/ruff check .` (Passed)
  - `.venv/bin/black --check .` (Passed)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
  - Ran specific `filter_rows` suite: `.venv/bin/pytest tests/test_frame.py -v -k filter_rows` (19/19 PASSED)

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
