### PR TITLE
fix: validate ColumnSummary constructor fields

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -41,6 +41,12 @@ class ColumnSummary:
     __slots__ = ("name", "dtype", "nullable")
 
     def __init__(self, name: str, dtype: str, nullable: bool) -> None:
+        if not isinstance(name, str):
+            raise TypeError("name must be a str")
+        if not isinstance(dtype, str):
+            raise TypeError("dtype must be a str")
+        if not isinstance(nullable, bool):
+            raise TypeError("nullable must be a bool")
         self.name = name
         self.dtype = dtype
         self.nullable = nullable

--- a/tests/test_schema_summary.py
+++ b/tests/test_schema_summary.py
@@ -3,6 +3,7 @@ Tests for ArFrame.schema_summary property.
 """
 
 import pandas as pd
+import pytest
 
 import arnio as ar
 from arnio.frame import ColumnSummary
@@ -13,6 +14,24 @@ from arnio.frame import ColumnSummary
 
 
 class TestColumnSummary:
+    def test_column_summary_invalid_name(self):
+        with pytest.raises(TypeError, match="name must be a str"):
+            ColumnSummary(name=1, dtype="int64", nullable=False)
+
+    def test_column_summary_invalid_dtype(self):
+        with pytest.raises(TypeError, match="dtype must be a str"):
+            ColumnSummary(name="id", dtype=2, nullable=False)
+
+    def test_column_summary_invalid_nullable(self):
+        with pytest.raises(TypeError, match="nullable must be a bool"):
+            ColumnSummary(name="id", dtype="int64", nullable="yes")
+
+    def test_column_summary_valid(self):
+        entry = ColumnSummary("id", "int64", True)
+        assert entry.name == "id"
+        assert entry.dtype == "int64"
+        assert entry.nullable is True
+
     def test_attributes(self):
         entry = ColumnSummary(name="age", dtype="int64", nullable=False)
         assert entry.name == "age"
@@ -166,6 +185,14 @@ class TestSchemaSummaryNormal:
         df = pd.DataFrame({"a": [1, None], "b": ["x", "y"]})
         frame = ar.from_pandas(df)
         assert frame.schema_summary == frame.schema_summary
+
+    def test_schema_summary_returns_valid_column_summaries(self):
+        df = pd.DataFrame({"id": [1, 2], "name": ["a", None]})
+        frame = ar.from_pandas(df)
+        for entry in frame.schema_summary:
+            assert isinstance(entry.name, str)
+            assert isinstance(entry.dtype, str)
+            assert isinstance(entry.nullable, bool)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Add type validation to ColumnSummary.__init__() so invalid field types (name, dtype, nullable) raise TypeError immediately instead of propagating silently into schema summaries and export helpers like schema_to_yaml.

Fixes #1735


## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [X] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [X] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [X] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Full pytest execution was not possible in this environment because the native arnio C++ extension is not built locally. Python syntax was verified on all edited files.
Tests added in tests/test_frame.py:

- test_column_summary_invalid_name — ColumnSummary(1, "int64", True) raises TypeError
- test_column_summary_invalid_dtype — ColumnSummary("id", 2, True) raises TypeError
- test_column_summary_invalid_nullable — ColumnSummary("id", "int64", "yes") raises TypeError
- test_column_summary_valid — ColumnSummary("id", "int64", True) constructs without error
- test_schema_summary_field_types — ArFrame.schema_summary returns objects with str name, str dtype, and bool nullable

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
None. Validation adds three isinstance checks at construction time only.

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [X] I read the contributing guide.
- [X] I kept the PR focused on one issue or one logical change.
- [X] I added or updated tests for behavior changes.
- [X] I added or updated docs/examples for public API changes.
- [X] I checked that generated files, logs, and local build artifacts are not committed.
- [X] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Change is strictly additive — only ColumnSummary.__init__() is touched. No schema export logic, ArFrame, or __init__.py exports were modified. All existing callers passing valid types are unaffected. If a dtype allowlist is added to ArFrame.dtypes in future, a follow-up can extend the dtype check to validate against it.