### PR TITLE
build: exclude local virtual environments from sdist

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,6 +23,13 @@ jobs:
           ref: ${{ inputs.tag_name || github.ref }}
       - name: Build sdist
         run: pipx run build --sdist
+      - name: Verify sdist exclusions
+        run: |
+          if tar -tf dist/*.tar.gz | grep -E '\.venv|venv/|\.tox|\.pytest_cache|\.mypy_cache|site-packages'; then
+            echo "❌ sdist contains excluded directories!"
+            exit 1
+          fi
+          echo "✅ sdist exclusion check passed"
       - name: Install package from sdist
         run: pip install dist/*.tar.gz
       - name: Smoke test import

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
+      - name: Verify sdist exclusions
+        run: |
+          if tar -tf dist/*.tar.gz | grep -E '\.venv|venv/|\.tox|\.pytest_cache|\.mypy_cache|site-packages'; then
+            echo "❌ sdist contains excluded directories!"
+            exit 1
+          fi
+          echo "✅ sdist exclusion check passed"
+
       - name: Twine check sdist
         run: |
           pip install twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,14 @@ arnio = ["py.typed"]
 wheel.packages = ["arnio"]
 cmake.build-type = "Release"
 wheel.expand-macos-universal-tags = false
+sdist.exclude = [
+    ".venv*",
+    "venv",
+    ".tox",
+    ".pytest_cache",
+    ".mypy_cache",
+    "dist",
+]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Fixes #1672. Added \sdist.exclude\ to \pyproject.toml\ to prevent local virtual environments and caches from being included in the source distribution. Also added a release safety check to the GitHub Action workflows (\uild_wheels.yml\ and \elease-dry-run.yml\) to inspect the generated sdist.