### PR TITLE
fix: defer ArnioCleaner param validation to fit/transform

### DIFF
--- a/arnio/integrations/sklearn.py
+++ b/arnio/integrations/sklearn.py
@@ -33,15 +33,18 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, steps=None, copy=True, allow_row_count_change=False):
-        if not isinstance(copy, bool):
-            raise TypeError("copy must be a bool")
-        if not isinstance(allow_row_count_change, bool):
-            raise TypeError("allow_row_count_change must be a bool")
         self.steps = steps if steps is not None else []
         self.copy = copy
         self.allow_row_count_change = allow_row_count_change
 
+    def _validate_params(self):
+        if not isinstance(self.copy, bool):
+            raise TypeError("copy must be a bool")
+        if not isinstance(self.allow_row_count_change, bool):
+            raise TypeError("allow_row_count_change must be a bool")
+
     def fit(self, X, y=None):
+        self._validate_params()
         if not isinstance(X, pd.DataFrame):
             raise TypeError(f"ArnioCleaner requires a pandas DataFrame, got {type(X)}")
 
@@ -59,6 +62,7 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
 
     def transform(self, X, y=None):
         # Scikit-learn expectation: ensure the estimator was fitted
+        self._validate_params()
         check_is_fitted(self, "n_features_in_")
 
         if not isinstance(X, pd.DataFrame):

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -279,10 +279,28 @@ def test_arniocleaner_warns_for_multiple_dtype_changes():
 
 
 def test_arniocleaner_rejects_non_boolean_options():
-    """Ensure constructor explicitly blocks truthy/falsy non-boolean values."""
+    """Ensure non-boolean values are rejected at fit/transform, not construction."""
+    df = pd.DataFrame({"A": [1, 2, 3]})
     invalid_values = ["false", "True", 1, 0, None, [], {}]
     for value in invalid_values:
         with pytest.raises(TypeError, match="copy must be a bool"):
-            ArnioCleaner(copy=value)
+            ArnioCleaner(copy=value).fit(df)
         with pytest.raises(TypeError, match="allow_row_count_change must be a bool"):
-            ArnioCleaner(allow_row_count_change=value)
+            ArnioCleaner(allow_row_count_change=value).fit(df)
+
+
+def test_arniocleaner_construction_with_invalid_params_does_not_raise():
+    # Construction must succeed even with invalid types (sklearn convention)
+    cleaner = ArnioCleaner(copy="yes")
+    assert cleaner.copy == "yes"
+    cleaner2 = ArnioCleaner(allow_row_count_change=1)
+    assert cleaner2.allow_row_count_change == 1
+
+
+def test_arniocleaner_clone_with_invalid_params_does_not_raise():
+    # sklearn clone() must work without triggering validation
+    from sklearn.base import clone
+
+    cleaner = ArnioCleaner(copy="yes")
+    cloned = clone(cleaner)
+    assert cloned.copy == "yes"


### PR DESCRIPTION
Closes #1734

Moved `copy` and `allow_row_count_change` validation out of `__init__` into a `_validate_params()` helper, called at the start of `fit()` and `transform()`. This follows scikit-learn estimator conventions — constructors should only store parameters, keeping cloning and parameter search compatible.

Changes:
- `arnio/integrations/sklearn.py`: removed validation from `__init__`, added `_validate_params()`
- `tests/test_sklearn.py`: updated existing test to expect errors at `fit()`, added two regression tests for construction and `clone()` compatibility