### PR TITLE
docs: refresh roadmap status text

### DIFF
--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -59,11 +59,13 @@ df = ar.to_pandas(clean)
 |-----------|--------|
 | CSV parsing and cleaning | 🔨 Current |
 | Data quality and schema validation | 🔨 Current |
-| Chunked and streaming processing | 📋 Near Term |
-| Native CSV writers | 📋 Near Term |
+| Chunked CSV reading via `read_csv_chunked()` | ✅ Available |
+| Native CSV export via `write_csv()` | ✅ Available |
+| JSON Lines import via `read_jsonl()` | ✅ Available |
+| Parquet export via `write_parquet()` | ✅ Available |
+| Broader streaming workflows and file-format polish | 📋 Near Term |
 | Parallel column processing | 💭 Long Term |
 | SIMD string operations | 💭 Long Term |
-| JSON Lines and Parquet support | 💭 Long Term |
 
 > Full roadmap: [ROADMAP.md](ROADMAP.md)
 

--- a/README.md
+++ b/README.md
@@ -1715,18 +1715,21 @@ null values were observed during profiling.
 
 ## 🗺️ Roadmap
 
-| Version | Focus | Status |
-|:---:|:---|:---:|
-| **v1.0** | Stable release · cross-platform wheels · CI/CD · PyPI publishing · Google Colab support | ✅ Shipped |
-| **v1.1** | Production readiness · release hardening · docs/tooling | ✅ Shipped |
-| **v1.2** | C++ pipeline optimization · speed parity with pandas · hash-based deduplication | 🔨 Active |
-| **v1.3** | Chunked / streaming processing · Parquet & JSON readers | 📋 Planned |
-| **v1.4** | Parallel column processing · SIMD string operations | 💭 Exploring |
+| Phase | Focus | Status |
+|:---|:---|:---:|
+| Stable foundations | Cross-platform wheels · CI/CD · PyPI publishing · Google Colab support · release hardening | ✅ Shipped |
+| Current focus | Reliability · contributor workflow · data-stack integrations · public API stability · benchmark baselines | 🔨 Active |
+| Next focus | Broader streaming workflows · richer file-format coverage · reproducible performance comparisons | 📋 Planned |
+| Later focus | Parallel column processing · SIMD string operations · lower-copy native cleaning paths | 💭 Exploring |
 
 Before expanding the backlog again, maintainers should complete the
 **[Core Stability Sprint](CORE_STABILITY_SPRINT.md)**: install reliability,
 correctness hardening, public API stability, benchmark baselines, and PR queue
 hygiene.
+
+The current release line is tracked in `pyproject.toml` and `CHANGELOG.md`.
+Feature status in this roadmap is phase-based so it does not drift behind the
+package version.
 
 > For CLI command reference and examples, see [CLI_REFERENCE.md](CLI_REFERENCE.md).
 <br>


### PR DESCRIPTION
## Summary
- Replace the stale README minor-version roadmap rows (`v1.2` active, `v1.3` planned, `v1.4` exploring) with phase-based roadmap status so it does not drift behind the package version.
- Update the CLI roadmap so `read_csv_chunked()`, `write_csv()`, `read_jsonl()`, and `write_parquet()` are marked as available instead of future work.
- Keep the change docs-only and limited to the roadmap/status text requested in #1872.

Fixes #1872

## Testing
- `git diff --check`
- `rg -n "v1\\.2|v1\\.3|v1\\.4|Chunked and streaming processing|Native CSV writers|JSON Lines and Parquet support" README.md CLI_REFERENCE.md` -> no matches