### PR TITLE
fix: validate URL allowed_schemes case-insensitively

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1881,7 +1881,7 @@ def URL(
                     "allowed_schemes must contain URL scheme names such as 'http' or 'https'"
                 )
 
-            normalized_schemes.add(scheme)
+            normalized_schemes.add(scheme.lower())
 
         if len(normalized_schemes) == 0:
             raise ValueError("allowed_schemes must be a non-empty sequence")
@@ -2404,7 +2404,8 @@ def _validate_column(
             pattern = _SEMANTIC_PATTERNS.get(field_def.semantic)
             if pattern is None and field_def.semantic.startswith("url:"):
                 schemes = field_def.semantic[len("url:") :]
-                pattern = rf"({schemes})://[^\s]+"
+                pattern = rf"(?i)({schemes})://[^\s]+"
+
             if pattern is None:
                 issues.append(
                     ValidationIssue(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3551,3 +3551,38 @@ def test_validate_max_errors_zero_valid_data():
 
     with pytest.raises(ValueError, match="max_errors must be >= 1"):
         ar.validate(frame, schema, max_errors=0)
+
+
+def test_url_uppercase_scheme_accepted_with_lowercase_allowed(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nHTTPS://example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["https"])})
+    assert result.passed
+
+
+def test_url_mixed_case_scheme_accepted(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nHttps://example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["https"])})
+    assert result.passed
+
+
+def test_url_uppercase_allowed_scheme_matches_lowercase_url(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nhttps://example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["HTTPS"])})
+    assert result.passed
+
+
+def test_url_uppercase_scheme_rejected_when_not_in_allowed(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nFTP://files.example.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["https"])})
+    assert not result.passed
+
+
+def test_url_mixed_case_allowed_scheme_and_mixed_case_url(tmp_path):
+    path = tmp_path / "urls.csv"
+    path.write_text("url\nHTTPS://example.com\nHttps://test.org\nhttps://lower.com\n")
+    result = ar.validate(ar.read_csv(path), {"url": ar.URL(allowed_schemes=["HTTPS"])})
+    assert result.passed


### PR DESCRIPTION
## Summary
`URL(allowed_schemes=...)` treated URL schemes case-sensitively, causing `HTTPS://example.com` to fail validation when `allowed_schemes=["https"]` was set. This fix normalises both the allowed schemes and the incoming URL scheme to lowercase before matching, making validation RFC 3986 compliant. Rebased cleanly on latest main.

## Linked issue
Fixes #1699

## Type of change
- [x] Bug fix

## Area
- [x] Schema validation

## Testing
- [x] Other:
  - `git diff --check origin/main...HEAD` → clean ✅
  - `python -m black --check arnio/schema.py tests/test_schema.py` → unchanged ✅
  - `python -m ruff check arnio/schema.py tests/test_schema.py` → All checks passed ✅
  - `python -m pytest tests/test_schema.py -k "url_" -q` → 25 passed ✅
  - `python -m pytest tests/test_schema.py -q` → 274 passed ✅

## Screenshots / Media
NA

## Performance Impact
NA

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: validate URL allowed_schemes case-insensitively`).

## Maintainer notes
Two minimal changes in `arnio/schema.py`:
1. In `URL()` — added `.lower()` to `normalized_schemes.add(scheme.lower())` so allowed schemes are stored lowercase
2. In `_validate_column()` — added `(?i)` flag to the URL scheme regex for case-insensitive matching

Five new tests added covering: uppercase scheme in URL, mixed case scheme, uppercase allowed scheme, rejected unlisted uppercase scheme, and combined mixed case scenarios. All 274 tests passing.