### PR TITLE
Fix: preserve empty pandas int64 dtype in from_pandas

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -339,6 +339,8 @@ def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
         return _DType.FLOAT64
     if dtype == pd.BooleanDtype() or str(dtype) == "bool":
         return _DType.BOOL
+    if str(dtype) == "int64":
+        return _DType.INT64
     return None
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -279,6 +279,21 @@ class TestFromPandas:
 
         pd.testing.assert_series_equal(result["id"], df["id"])
 
+    def test_from_pandas_empty_int64_preserves_dtype(self):
+        df = pd.DataFrame({"a": pd.Series(dtype="int64")})
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert result.shape == (0, 1)
+        assert str(result["a"].dtype) == "Int64"
+
+    def test_from_pandas_mixed_empty_frame_preserves_dtypes(self):
+        df = pd.DataFrame({"a": pd.Series(dtype="int64"), "b": pd.Series(dtype="float64")})
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert result.shape == (0, 2)
+        assert str(result["a"].dtype) == "Int64"
+        assert str(result["b"].dtype) == "Float64"
+
     def test_roundtrip_values(self):
         df = pd.DataFrame(
             {


### PR DESCRIPTION
Closes #1960