### PR TITLE
chore(packaging): exclude virtual environments from sdist

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
           SDIST=$(ls dist/*.tar.gz | head -n 1)
           echo "Checking $SDIST for leaked environments..."
           tar -tf "$SDIST" > sdist_contents.txt
-          
+
           if grep -E -q '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt; then
             echo "::error::SDIST contains excluded virtual environment files!"
             grep -E '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,6 +23,18 @@ jobs:
           ref: ${{ inputs.tag_name || github.ref }}
       - name: Build sdist
         run: pipx run build --sdist
+      - name: Verify sdist safety
+        run: |
+          SDIST=$(ls dist/*.tar.gz | head -n 1)
+          echo "Checking $SDIST for leaked environments..."
+          tar -tf "$SDIST" > sdist_contents.txt
+          
+          if grep -E -q '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt; then
+            echo "::error::SDIST contains excluded virtual environment files!"
+            grep -E '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt
+            exit 1
+          fi
+          echo "SDIST is safe."
       - name: Install package from sdist
         run: pip install dist/*.tar.gz
       - name: Smoke test import

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -45,7 +45,7 @@ jobs:
           SDIST=$(ls dist/*.tar.gz | head -n 1)
           echo "Checking $SDIST for leaked environments..."
           tar -tf "$SDIST" > sdist_contents.txt
-          
+
           if grep -E -q '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt; then
             echo "::error::SDIST contains excluded virtual environment files!"
             grep -E '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -40,6 +40,19 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
+      - name: Verify sdist safety
+        run: |
+          SDIST=$(ls dist/*.tar.gz | head -n 1)
+          echo "Checking $SDIST for leaked environments..."
+          tar -tf "$SDIST" > sdist_contents.txt
+          
+          if grep -E -q '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt; then
+            echo "::error::SDIST contains excluded virtual environment files!"
+            grep -E '/(\.venv|venv|\.tox|site-packages)/' sdist_contents.txt
+            exit 1
+          fi
+          echo "✅ SDIST is safe."
+
       - name: Twine check sdist
         run: |
           pip install twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,14 @@ arnio = ["py.typed"]
 wheel.packages = ["arnio"]
 cmake.build-type = "Release"
 wheel.expand-macos-universal-tags = false
+sdist.exclude = [
+    ".venv*",
+    "venv/",
+    ".tox/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    "dist/",
+]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Fixes #1672

**Changes:**
- Added \sdist.exclude\ list to \pyproject.toml\ to block \.venv\, \.tox\, \.pytest_cache\, and \dist\ directories from source distributions.
- Added a safety step in \uild_wheels.yml\ and \elease-dry-run.yml\ to verify the generated tarball contents with \	ar -tf\ and fail the CI if virtual environments leak.

Tested manually locally.