### PR TITLE
test: add required_if blank string regression coverage

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2987,6 +2987,41 @@ def test_empty_string_passes_when_nullable():
     assert result.issue_count == 0
 
 
+def test_required_if_treats_blank_strings_as_missing():
+    df = pd.DataFrame(
+        {
+            "user_type": [
+                "international",
+                "international",
+                "local",
+            ],
+            "country": [
+                "",
+                "   ",
+                "",
+            ],
+        }
+    )
+
+    schema = ar.Schema(
+        {
+            "user_type": ar.String(nullable=False),
+            "country": ar.String(
+                nullable=True,
+                required_if=("user_type", "international"),
+            ),
+        }
+    )
+
+    result = ar.validate(ar.from_pandas(df), schema)
+
+    assert result.issue_count == 2
+
+    for issue in result.issues:
+        assert issue.column == "country"
+        assert issue.rule == "required_if"
+
+
 def test_url_https_only_accepts_https(tmp_path):
     path = tmp_path / "urls.csv"
     path.write_text("url\nhttps://example.com\nhttps://test.org\n")


### PR DESCRIPTION
## Summary
Add regression coverage for required_if validation with blank strings and whitespace-only strings.

The new tests confirm that required_if already reuses Arnio's existing nullable semantics, where empty and whitespace-only string values are treated as missing values during validation.

## Linked issue
Refs #1750

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
            `pytest tests/test_schema.py` ->256 tests passed
            `ruff check arnio tests`  -> passed
            `black tests/test_schema.py` -> passed

## Screenshots / Media
NA

## Performance Impact
NA

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
This PR is intentionally limited to regression coverage/evidence only.
No runtime validation behavior was changed. The added tests confirm that required_if already treats blank strings and whitespace-only strings as missing values through the shared null-mask logic in schema validation.