### PR TITLE
ci: add explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/arrow-extra-test.yml
+++ b/.github/workflows/arrow-extra-test.yml
@@ -16,6 +16,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   arrow-extra-test:
     name: to_arrow() with pyarrow (${{ matrix.python-version }})

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,5 +1,8 @@
 name: Build & Publish Wheels
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint (Black, Ruff, clang-format)

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -10,6 +10,9 @@ on:
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   compat:
     name: pandas=${{ matrix.pandas-version }} numpy=${{ matrix.numpy-version }} (Python ${{ matrix.python-version }})

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   examples-core:
     name: Smoke – core examples

--- a/.github/workflows/macos-arm64-wheel-smoke.yml
+++ b/.github/workflows/macos-arm64-wheel-smoke.yml
@@ -18,6 +18,9 @@ on:
     - cron: "0 5 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   macos-arm64-wheel-smoke:
     name: Build arm64 wheel and smoke test (macOS)

--- a/.github/workflows/parquet-extra-test.yml
+++ b/.github/workflows/parquet-extra-test.yml
@@ -15,6 +15,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   parquet-extra-test:
     name: write_parquet with pyarrow (${{ matrix.python-version }})

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -3,6 +3,9 @@ name: Release Dry-Run Checklist
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # ── 1. Validate version in pyproject.toml ─────────────────────────────────
   validate-version:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -12,6 +12,9 @@ on:
     - cron: '0 4 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   wheel-smoke:
     name: Build manylinux wheel and smoke test

--- a/.github/workflows/windows-msvc-wheel-smoke.yml
+++ b/.github/workflows/windows-msvc-wheel-smoke.yml
@@ -20,6 +20,9 @@ on:
       - "cpp/**"
       - ".github/workflows/windows-msvc-wheel-smoke.yml"
 
+permissions:
+  contents: read
+
 jobs:
   windows_msvc_wheel_smoke:
     name: Windows MSVC Wheel Smoke Test


### PR DESCRIPTION
## Summary

Add explicit least-privilege `permissions` declarations to GitHub Actions workflows that currently rely on repository default token permissions.

## Changes

Added:

```yaml
permissions:
  contents: read
```

to read-only CI/smoke workflows:

* `.github/workflows/ci.yml`
* `.github/workflows/compat-matrix.yml`
* `.github/workflows/examples-smoke.yml`
* `.github/workflows/wheel-smoke.yml`
* `.github/workflows/parquet-extra-test.yml`
* `.github/workflows/arrow-extra-test.yml`
* `.github/workflows/macos-arm64-wheel-smoke.yml`
* `.github/workflows/windows-msvc-wheel-smoke.yml`
* `.github/workflows/release-dry-run.yml`

Also added workflow-level `contents: read` to:

* `.github/workflows/build_wheels.yml`

while preserving the existing publish-job `id-token: write` permission required for trusted PyPI publishing.

## Scope

This PR is intentionally limited to explicit workflow permission declarations only and avoids unrelated workflow changes.

Fixes #1875
