### PR TITLE
fix: return zero-column ArFrame when select_dtypes matches no columns

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -649,9 +649,7 @@ class ArFrame:
             matched.append(col)
 
         if not matched:
-            raise ValueError(
-                f"No columns match the dtype selection. Frame dtypes: {col_dtypes}."
-            )
+            return ArFrame(_Frame(len(self)), attrs=self._attrs.copy())
 
         return self.select_columns(matched)
 

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -581,8 +581,8 @@ class ArFrame:
         ------
         ValueError
             If neither *include* nor *exclude* is provided, if *include*
-            and *exclude* overlap, if an unrecognised dtype string is
-            passed, or if no columns match the filter.
+            and *exclude* overlap, or if an unrecognised dtype string is
+            passed.
         TypeError
             If *include* or *exclude* is not a string, list, or tuple of
             strings.

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1314,3 +1314,35 @@ class TestFilterRows:
             match="cannot compare column 'name' with value 18 using operator '>'",
         ):
             ar.filter_rows(frame, column="name", op=">", value=18)
+
+
+# ── select_dtypes zero-column ─────────────────────────────────────────────────
+
+
+def test_select_dtypes_include_absent_dtype_returns_zero_col_frame():
+    frame = ar.from_pandas(pd.DataFrame({"age": [1, 2], "score": [3.5, 4.0]}))
+    result = frame.select_dtypes(include="string")
+    assert result.shape == (2, 0)
+    assert result.columns == []
+
+
+def test_select_dtypes_exclude_all_columns_returns_zero_col_frame():
+    frame = ar.from_pandas(pd.DataFrame({"age": [1, 2], "score": [3.5, 4.0]}))
+    result = frame.select_dtypes(exclude=["int64", "float64"])
+    assert result.shape == (2, 0)
+    assert result.columns == []
+
+
+def test_select_dtypes_zero_col_preserves_row_count():
+    frame = ar.from_pandas(pd.DataFrame({"age": [1, 2, 3, 4, 5]}))
+    result = frame.select_dtypes(include="string")
+    assert result.shape[0] == 5
+    assert result.shape[1] == 0
+
+
+def test_select_dtypes_zero_col_preserves_attrs():
+    frame = ar.from_pandas(pd.DataFrame({"age": [1, 2]}))
+    frame._attrs["source"] = "test"
+    result = frame.select_dtypes(include="string")
+    assert result._attrs == {"source": "test"}
+    assert result._attrs is not frame._attrs

--- a/tests/test_select_dtypes.py
+++ b/tests/test_select_dtypes.py
@@ -157,8 +157,9 @@ def test_select_dtypes_single_column_frame(single_col_csv):
 def test_select_dtypes_null_dtype_is_valid(mixed_csv):
     # "null" is a recognised dtype — no TypeError, but no null columns here
     frame = ar.read_csv(mixed_csv)
-    with pytest.raises(ValueError, match="No columns match"):
-        frame.select_dtypes(include="null")
+    result = frame.select_dtypes(include="null")
+    assert result.shape == (3, 0)
+    assert result.columns == []
 
 
 # ---------------------------------------------------------------------------
@@ -168,14 +169,15 @@ def test_select_dtypes_null_dtype_is_valid(mixed_csv):
 
 def test_select_dtypes_no_match_raises_value_error(string_only_csv):
     frame = ar.read_csv(string_only_csv)
-    with pytest.raises(ValueError, match="No columns match"):
-        frame.select_dtypes(include="int64")
-
+    result = frame.select_dtypes(include="int64")
+    assert result.shape == (2, 0)
+    assert result.columns == []
 
 def test_select_dtypes_exclude_all_raises_value_error(mixed_csv):
     frame = ar.read_csv(mixed_csv)
-    with pytest.raises(ValueError, match="No columns match"):
-        frame.select_dtypes(exclude=["int64", "float64", "string", "bool"])
+    result = frame.select_dtypes(exclude=["int64", "float64", "string", "bool"])
+    assert result.shape == (3, 0)
+    assert result.columns == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_select_dtypes.py
+++ b/tests/test_select_dtypes.py
@@ -173,6 +173,7 @@ def test_select_dtypes_no_match_raises_value_error(string_only_csv):
     assert result.shape == (2, 0)
     assert result.columns == []
 
+
 def test_select_dtypes_exclude_all_raises_value_error(mixed_csv):
     frame = ar.read_csv(mixed_csv)
     result = frame.select_dtypes(exclude=["int64", "float64", "string", "bool"])


### PR DESCRIPTION
Fixes #1954

## What changed
- `select_dtypes()` no longer raises `ValueError` when a valid dtype filter matches no columns
- Returns a zero-column `ArFrame` preserving the original row count instead

## Tests added
- `include` with an absent dtype
- `exclude` removing all columns
- row count preservation
- `attrs` metadata copied but not shared