### PR TITLE
fix: reject invalid tokens for forced numeric CSV dtypes

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -648,6 +648,7 @@ def read_csv_chunked(
     path: str | os.PathLike[str] | io.TextIOBase,
     *,
     chunksize: int = 10_000,
+    dtype: dict[str, str] | None = None,
     delimiter: str | None = None,
     has_header: bool = True,
     usecols: list[str] | None = None,
@@ -815,6 +816,9 @@ def read_csv_chunked(
 
         if null_values is not None:
             config.null_values = _validate_null_values(null_values)
+
+        if dtype is not None:
+            config.dtype = _validate_dtype_mapping(dtype)
 
         if usecols is not None:
             config.usecols = _validate_usecols(usecols)

--- a/cpp/include/arnio/csv_reader.h
+++ b/cpp/include/arnio/csv_reader.h
@@ -53,7 +53,7 @@ class CsvParser {
     bool is_null_sentinel(const std::string& value) const;
     DType infer_type(const std::string& value) const;
     static DType promote_type(DType current, DType incoming);
-    CellValue parse_value(const std::string& raw, DType dtype) const;
+    CellValue parse_value(const std::string& raw, DType dtype, bool is_forced = false) const;
 
    private:
     CsvConfig config_;
@@ -94,6 +94,7 @@ class CsvChunkReader {
     std::vector<std::string> header_;
     std::vector<size_t> col_indices_;
     std::vector<DType> col_types_;
+    std::vector<bool> explicit_dtype_columns_;
     std::optional<size_t> expected_cols_;
     size_t record_number_ = 0;
     size_t rows_read_total_ = 0;

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -745,9 +745,8 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype, bool is_fo
             int64_t value = 0;
             if (!try_parse_int64(cleaned, value)) {
                 if (is_forced) {
-                    throw std::runtime_error(
-                        "CsvReadError: Invalid token '" + raw +
-                        "' for forced int64 column");
+                    throw std::runtime_error("CsvReadError: Invalid token '" + raw +
+                                             "' for forced int64 column");
                 }
                 return std::monostate{};
             }
@@ -758,9 +757,8 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype, bool is_fo
             double value = 0.0;
             if (!try_parse_float64(cleaned, value)) {
                 if (is_forced) {
-                    throw std::runtime_error(
-                        "CsvReadError: Invalid token '" + raw +
-                        "' for forced float64 column");
+                    throw std::runtime_error("CsvReadError: Invalid token '" + raw +
+                                             "' for forced float64 column");
                 }
                 return std::monostate{};
             }
@@ -1007,8 +1005,11 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
             for (size_t i = 0; i < col_indices.size(); ++i) {
                 size_t ci = col_indices[i];
                 if (ci < reusable_fields2.size()) {
-                    bool is_forced = (ci < explicit_dtype_columns.size() && explicit_dtype_columns[ci]);
-                    columns[i].push_back(parser_.parse_value(reusable_fields2[ci], col_types[ci], is_forced));
+                    bool is_forced =
+                        ci < explicit_dtype_columns.size() && explicit_dtype_columns[ci];
+                    CellValue parsed =
+                        parser_.parse_value(reusable_fields2[ci], col_types[ci], is_forced);
+                    columns[i].push_back(parsed);
                 } else {
                     columns[i].push_null();
                 }
@@ -1203,7 +1204,7 @@ Frame CsvChunkReader::build_frame(const std::vector<std::vector<std::string>>& r
         for (const auto& row : raw_data) {
             if (ci < row.size()) {
                 const std::string& raw_value = row[ci];
-                bool is_forced = (ci < explicit_dtype_columns_.size() && explicit_dtype_columns_[ci]);
+                bool is_forced = ci < explicit_dtype_columns_.size() && explicit_dtype_columns_[ci];
                 CellValue parsed = parser_.parse_value(raw_value, effective_type, is_forced);
 
                 // Fail-fast validation for locked schema in subsequent chunks
@@ -1354,6 +1355,9 @@ std::optional<CsvParseResult> CsvChunkReader::next_chunk(size_t chunksize,
         for (const auto& row : raw_data) {
             for (size_t ci : col_indices_) {
                 if (ci < row.size()) {
+                    if (ci < explicit_dtype_columns_.size() && explicit_dtype_columns_[ci]) {
+                        continue;
+                    }
                     DType inferred = parser_.infer_type(row[ci]);
                     col_types_[ci] = CsvParser::promote_type(col_types_[ci], inferred);
                 }

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -729,7 +729,7 @@ DType CsvParser::promote_type(DType current, DType incoming) {
     return DType::STRING;
 }
 
-CellValue CsvParser::parse_value(const std::string& raw, DType dtype) const {
+CellValue CsvParser::parse_value(const std::string& raw, DType dtype, bool is_forced) const {
     const std::string sanitized = handle_utf8_errors(raw, config_.encoding_errors);
     if (is_null_sentinel(sanitized)) return std::monostate{};
 
@@ -743,13 +743,23 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype) const {
         case DType::INT64: {
             std::string cleaned = normalize_numeric(sanitized, config_);
             int64_t value = 0;
-            if (!try_parse_int64(cleaned, value)) return std::monostate{};
+            if (!try_parse_int64(cleaned, value)) {
+                if (is_forced) {
+                    throw std::runtime_error("CsvReadError: Invalid token '" + raw + "' for forced int64 column");
+                }
+                return std::monostate{};
+            }
             return value;
         }
         case DType::FLOAT64: {
             std::string cleaned = normalize_numeric(sanitized, config_);
             double value = 0.0;
-            if (!try_parse_float64(cleaned, value)) return std::monostate{};
+            if (!try_parse_float64(cleaned, value)) {
+                if (is_forced) {
+                    throw std::runtime_error("CsvReadError: Invalid token '" + raw + "' for forced float64 column");
+                }
+                return std::monostate{};
+            }
             return value;
         }
         case DType::STRING: {
@@ -993,7 +1003,8 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
             for (size_t i = 0; i < col_indices.size(); ++i) {
                 size_t ci = col_indices[i];
                 if (ci < reusable_fields2.size()) {
-                    columns[i].push_back(parser_.parse_value(reusable_fields2[ci], col_types[ci]));
+                    bool is_forced = (ci < explicit_dtype_columns.size() && explicit_dtype_columns[ci]);
+                    columns[i].push_back(parser_.parse_value(reusable_fields2[ci], col_types[ci], is_forced));
                 } else {
                     columns[i].push_null();
                 }
@@ -1188,7 +1199,8 @@ Frame CsvChunkReader::build_frame(const std::vector<std::vector<std::string>>& r
         for (const auto& row : raw_data) {
             if (ci < row.size()) {
                 const std::string& raw_value = row[ci];
-                CellValue parsed = parser_.parse_value(raw_value, effective_type);
+                bool is_forced = (ci < explicit_dtype_columns_.size() && explicit_dtype_columns_[ci]);
+                CellValue parsed = parser_.parse_value(raw_value, effective_type, is_forced);
 
                 // Fail-fast validation for locked schema in subsequent chunks
                 if (validate_locked_schema && std::holds_alternative<std::monostate>(parsed)) {
@@ -1263,6 +1275,8 @@ void CsvChunkReader::open(const std::string& path) {
         expected_cols_ = header_.size();
         resolve_col_indices();
         col_types_.assign(header_.size(), DType::NULL_TYPE);
+        auto dtype_result = apply_explicit_dtypes(config, header_, col_indices_, col_types_);
+        explicit_dtype_columns_ = std::move(dtype_result.explicit_columns);
     }
 
     const size_t skip_target = config.skip_rows.value_or(0);
@@ -1328,6 +1342,8 @@ std::optional<CsvParseResult> CsvChunkReader::next_chunk(size_t chunksize,
         expected_cols_ = header_.size();
         resolve_col_indices();
         col_types_.assign(header_.size(), DType::NULL_TYPE);
+        auto dtype_result = apply_explicit_dtypes(config, header_, col_indices_, col_types_);
+        explicit_dtype_columns_ = std::move(dtype_result.explicit_columns);
     }
 
     if (!schema_locked_) {

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -745,7 +745,9 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype, bool is_fo
             int64_t value = 0;
             if (!try_parse_int64(cleaned, value)) {
                 if (is_forced) {
-                    throw std::runtime_error("CsvReadError: Invalid token '" + raw + "' for forced int64 column");
+                    throw std::runtime_error(
+                        "CsvReadError: Invalid token '" + raw +
+                        "' for forced int64 column");
                 }
                 return std::monostate{};
             }
@@ -756,7 +758,9 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype, bool is_fo
             double value = 0.0;
             if (!try_parse_float64(cleaned, value)) {
                 if (is_forced) {
-                    throw std::runtime_error("CsvReadError: Invalid token '" + raw + "' for forced float64 column");
+                    throw std::runtime_error(
+                        "CsvReadError: Invalid token '" + raw +
+                        "' for forced float64 column");
                 }
                 return std::monostate{};
             }

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -140,19 +140,18 @@ class TestReadCsv:
         assert pdf["id"].tolist() == [1, 3]
         assert pdf["name"].tolist() == ["Alice", "Cara"]
 
-    def test_read_csv_dtype_parse_failure_becomes_null(self, tmp_path):
+    def test_read_csv_dtype_parse_failure_raises(self, tmp_path):
         path = tmp_path / "parse_failure.csv"
         path.write_text("quantity\nabc\n")
 
-        frame = ar.read_csv(
-            path,
-            dtype={"quantity": "int64"},
-        )
-
-        pdf = ar.to_pandas(frame)
-
-        assert frame.dtypes["quantity"] == "int64"
-        assert pdf["quantity"].isna().tolist() == [True]
+        with pytest.raises(
+            ar.CsvReadError,
+            match="Invalid token 'abc' for forced int64 column",
+        ):
+            ar.read_csv(
+                path,
+                dtype={"quantity": "int64"},
+            )
 
     def test_read_csv_dtype_non_selected_usecols_column(self, tmp_path):
         path = tmp_path / "dtype_usecols_error.csv"

--- a/tests/test_csv_numeric_parsing.py
+++ b/tests/test_csv_numeric_parsing.py
@@ -140,20 +140,24 @@ def test_hex_int_is_string(tmp_path):
 def test_forced_int_invalid_token_raises(tmp_path):
     import pytest
     from arnio.exceptions import CsvReadError
-    
+
     csv_file = tmp_path / "bad_int.csv"
     csv_file.write_text("a,b\n1,2\nabc,4\n")
 
-    with pytest.raises(CsvReadError, match="Invalid token 'abc' for forced int64 column"):
+    with pytest.raises(
+        CsvReadError, match="Invalid token 'abc' for forced int64 column"
+    ):
         read_csv(str(csv_file), dtype={"a": "int64", "b": "int64"})
 
 
 def test_forced_float_invalid_token_raises(tmp_path):
     import pytest
     from arnio.exceptions import CsvReadError
-    
+
     csv_file = tmp_path / "bad_float.csv"
     csv_file.write_text("a,b\n1.5,2.0\n3.14,bad\n")
 
-    with pytest.raises(CsvReadError, match="Invalid token 'bad' for forced float64 column"):
+    with pytest.raises(
+        CsvReadError, match="Invalid token 'bad' for forced float64 column"
+    ):
         read_csv(str(csv_file), dtype={"a": "float64", "b": "float64"})

--- a/tests/test_csv_numeric_parsing.py
+++ b/tests/test_csv_numeric_parsing.py
@@ -135,3 +135,25 @@ def test_hex_int_is_string(tmp_path):
     df = read_csv(str(csv_file))
 
     assert df.dtypes["a"] == "string"
+
+
+def test_forced_int_invalid_token_raises(tmp_path):
+    import pytest
+    from arnio.exceptions import CsvReadError
+    
+    csv_file = tmp_path / "bad_int.csv"
+    csv_file.write_text("a,b\n1,2\nabc,4\n")
+
+    with pytest.raises(CsvReadError, match="Invalid token 'abc' for forced int64 column"):
+        read_csv(str(csv_file), dtype={"a": "int64", "b": "int64"})
+
+
+def test_forced_float_invalid_token_raises(tmp_path):
+    import pytest
+    from arnio.exceptions import CsvReadError
+    
+    csv_file = tmp_path / "bad_float.csv"
+    csv_file.write_text("a,b\n1.5,2.0\n3.14,bad\n")
+
+    with pytest.raises(CsvReadError, match="Invalid token 'bad' for forced float64 column"):
+        read_csv(str(csv_file), dtype={"a": "float64", "b": "float64"})

--- a/tests/test_csv_numeric_parsing.py
+++ b/tests/test_csv_numeric_parsing.py
@@ -1,4 +1,7 @@
+import pytest
+
 from arnio import read_csv
+from arnio.exceptions import CsvReadError
 
 
 def test_int_inference_valid(tmp_path):
@@ -138,10 +141,6 @@ def test_hex_int_is_string(tmp_path):
 
 
 def test_forced_int_invalid_token_raises(tmp_path):
-    import pytest
-
-    from arnio.exceptions import CsvReadError
-
     csv_file = tmp_path / "bad_int.csv"
     csv_file.write_text("a,b\n1,2\nabc,4\n")
 
@@ -152,10 +151,6 @@ def test_forced_int_invalid_token_raises(tmp_path):
 
 
 def test_forced_float_invalid_token_raises(tmp_path):
-    import pytest
-
-    from arnio.exceptions import CsvReadError
-
     csv_file = tmp_path / "bad_float.csv"
     csv_file.write_text("a,b\n1.5,2.0\n3.14,bad\n")
 

--- a/tests/test_csv_numeric_parsing.py
+++ b/tests/test_csv_numeric_parsing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from arnio import read_csv
+from arnio import read_csv, read_csv_chunked
 from arnio.exceptions import CsvReadError
 
 
@@ -158,3 +158,23 @@ def test_forced_float_invalid_token_raises(tmp_path):
         CsvReadError, match="Invalid token 'bad' for forced float64 column"
     ):
         read_csv(str(csv_file), dtype={"a": "float64", "b": "float64"})
+
+
+def test_partial_dtype_invalid_token_raises(tmp_path):
+    csv_file = tmp_path / "partial_bad.csv"
+    csv_file.write_text("a,b\n1,foo\nabc,bar\n")
+
+    with pytest.raises(
+        CsvReadError, match="Invalid token 'abc' for forced int64 column"
+    ):
+        read_csv(str(csv_file), dtype={"a": "int64"})
+
+
+def test_forced_int_invalid_token_raises_chunked(tmp_path):
+    csv_file = tmp_path / "bad_int_chunked.csv"
+    csv_file.write_text("a,b\n1,2\nabc,4\n")
+
+    with pytest.raises(
+        CsvReadError, match="Invalid token 'abc' for forced int64 column"
+    ):
+        list(read_csv_chunked(str(csv_file), chunksize=1, dtype={"a": "int64"}))

--- a/tests/test_csv_numeric_parsing.py
+++ b/tests/test_csv_numeric_parsing.py
@@ -139,6 +139,7 @@ def test_hex_int_is_string(tmp_path):
 
 def test_forced_int_invalid_token_raises(tmp_path):
     import pytest
+
     from arnio.exceptions import CsvReadError
 
     csv_file = tmp_path / "bad_int.csv"
@@ -152,6 +153,7 @@ def test_forced_int_invalid_token_raises(tmp_path):
 
 def test_forced_float_invalid_token_raises(tmp_path):
     import pytest
+
     from arnio.exceptions import CsvReadError
 
     csv_file = tmp_path / "bad_float.csv"


### PR DESCRIPTION
Resolves #1923

### Description
This PR modifies `CsvParser::parse_value` to reject invalid non-null tokens (like `"abc"`) when a column is explicitly forced to `int64` or `float64`. Rather than silently converting these tokens to nulls (`std::monostate{}`), the parser now throws a `CsvReadError`. This aligns forced dtype behavior with user expectations for fail-fast validation.

- Updated `CsvReader` and `CsvChunkReader` to resolve explicit columns and pass the `is_forced` flag to `parse_value`.
- Added regression tests in `tests/test_csv_numeric_parsing.py` for `int64` and `float64` forced types.

### Related issue
Fixes #1923
