### PR TITLE
fix: reject unsupported object scalars in from_pandas

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -105,8 +105,6 @@ def _normalize_scalar(value: object) -> object:
             )
     if isinstance(value, float):
         return _to_binding_safe(value)
-    if not isinstance(value, (bool, int, str)):
-        return str(value)
     return value
 
 
@@ -123,6 +121,8 @@ def _scalar_kind(value: object) -> str:
 def _series_to_python_values(series: pd.Series, col_name: object) -> list[object]:
     values: list[object] = []
     kinds: set[str] = set()
+
+    _ALLOWED_SCALAR_TYPES = (str, int, float, bool, decimal.Decimal)
 
     for raw in series.tolist():
         if _is_nested(raw):
@@ -154,6 +154,17 @@ def _series_to_python_values(series: pd.Series, col_name: object) -> list[object
                 f'Fix: split df["{col_name}"] into real/imag columns or '
                 "convert it to strings before from_pandas()"
             )
+
+        unpacked_raw = raw.item() if isinstance(raw, np.generic) else raw
+
+        if unpacked_raw is not None and not pd.isna(unpacked_raw):
+            if not isinstance(unpacked_raw, _ALLOWED_SCALAR_TYPES):
+                raise TypeError(
+                    f"Column '{col_name}' contains unsupported scalar value "
+                    f"of type '{type(raw).__name__}' at value {raw!r}. "
+                    f'Fix: convert df["{col_name}"] to strings or supported primitives '
+                    "before running from_pandas()"
+                )
 
         value = _normalize_scalar(raw)
         values.append(value)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -367,6 +367,49 @@ class TestFromPandas:
 
         assert "Fix:" in str(exc_info.value)
 
+    def test_from_pandas_object_custom_class_raises_clear_error(self):
+        class Token:
+            def __str__(self):
+                return "TOKEN"
+
+        df = pd.DataFrame({"x": pd.Series([Token()], dtype=object)})
+        with pytest.raises(
+            TypeError, match="Column 'x' contains unsupported scalar value"
+        ) as exc_info:
+            ar.from_pandas(df)
+        assert "Fix:" in str(exc_info.value)
+
+    def test_from_pandas_object_bytes_raises_clear_error(self):
+        df = pd.DataFrame({"x": pd.Series([b"abc"], dtype=object)})
+        with pytest.raises(
+            TypeError, match="Column 'x' contains unsupported scalar value"
+        ) as exc_info:
+            ar.from_pandas(df)
+        assert "Fix:" in str(exc_info.value)
+
+    def test_from_pandas_object_datetime_date_and_time_raise_clear_error(self):
+        import datetime as dt
+
+        df_date = pd.DataFrame({"x": pd.Series([dt.date(2026, 5, 29)], dtype=object)})
+        with pytest.raises(
+            TypeError, match="Column 'x' contains unsupported scalar value"
+        ):
+            ar.from_pandas(df_date)
+
+        df_time = pd.DataFrame({"x": pd.Series([dt.time(12, 30)], dtype=object)})
+        with pytest.raises(
+            TypeError, match="Column 'x' contains unsupported scalar value"
+        ):
+            ar.from_pandas(df_time)
+
+    def test_from_pandas_object_pandas_period_raises_clear_error(self):
+        df = pd.DataFrame({"x": pd.Series([pd.Period("2026-05")], dtype=object)})
+        with pytest.raises(
+            TypeError, match="Column 'x' contains unsupported scalar value"
+        ) as exc_info:
+            ar.from_pandas(df)
+        assert "Fix:" in str(exc_info.value)
+
     def test_from_pandas_native_datetime64_raises_clear_error(self):
         """Native datetime64 columns should raise a clear TypeError with a fix hint."""
         df = pd.DataFrame({"timestamp": pd.date_range("2026-05-20", periods=3)})


### PR DESCRIPTION
## Summary
Replaced the overly broad `str(value)` fallback mechanism in `from_pandas` scalar normalization with a strict primitive type allowlist. Now, instead of silently stringifying and potentially corrupting unsupported object-dtype scalars (like arbitrary custom objects, `bytes`, `datetime.date`, `datetime.time`, or `pd.Period`), arnio safely raises a descriptive `TypeError` containing the column name, the invalid type, and a suggestion path for the user.

## Linked issue
Fixes #1903

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (2429 passed including:
  - `test_from_pandas_object_custom_class_raises_clear_error`
  - `test_from_pandas_object_bytes_raises_clear_error`
  - `test_from_pandas_object_datetime_date_and_time_raise_clear_error`
  - `test_from_pandas_object_pandas_period_raises_clear_error`)
- [x] `make lint`

## Screenshots / Media

## Performance Impact

## GSSoC labels

- `level:intermediate`
- `type:bug`
-  `area:pandas-interop`

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes