### PR TITLE
fix: preserve Float64 nullable dtype in from_pandas round-trip

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -318,6 +318,8 @@ def to_arrow(frame: ArFrame) -> pa.Table:
 def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
     if dtype == pd.Int64Dtype():
         return _DType.INT64
+    if dtype == pd.Float64Dtype():
+        return _DType.FLOAT64
     if str(dtype) == "float64":
         return _DType.FLOAT64
     if dtype == pd.BooleanDtype() or str(dtype) == "bool":

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -636,7 +636,15 @@ class TestFromPandas:
         result = ar.to_pandas(ar.from_pandas(df))
         assert len(result) == 3
         assert result["score"].isna().all()
-        assert str(result["score"].dtype) == "string"
+        assert str(result["score"].dtype) == "float64"
+
+    def test_from_pandas_mixed_null_float64_extension(self):
+        df = pd.DataFrame({"score": pd.Series([1.5, pd.NA, 3.7], dtype="Float64")})
+        result = ar.to_pandas(ar.from_pandas(df))
+        assert str(result["score"].dtype) == "float64"
+        assert result["score"].iloc[0] == 1.5
+        assert pd.isna(result["score"].iloc[1])
+        assert result["score"].iloc[2] == 3.7
 
     def test_from_pandas_all_null_boolean_extension(self):
         df = pd.DataFrame({"active": pd.Series([pd.NA, pd.NA, pd.NA], dtype="boolean")})


### PR DESCRIPTION
## Summary
Teach `_pandas_dtype_to_arnio()` to recognise `pd.Float64Dtype()`, mirroring the existing `Int64Dtype` and `BooleanDtype` handling. All-null nullable `Float64` columns now round-trip as `float64` instead of `string`.

## Linked issue
Fixes #1839

## Type of change
- [x] Bug fix

## Area
- [x] pandas interoperability

## Testing
- [x] Other: `python3 -m pytest tests/test_convert.py -v -k "float64"` - 2 passed, 1 skipped (pyarrow not installed)

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix:`).