### PR TITLE
fix: skip empty chunked CSV frames after bad-row filtering

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -846,7 +846,12 @@ def read_csv_chunked(
                 if on_bad_lines == "warn" and bad_rows:
                     _warn_bad_rows(bad_rows)
 
-                yield ArFrame(cpp_frame)
+                frame = ArFrame(cpp_frame)
+
+                if frame.shape[0] == 0 and bad_rows:
+                    continue
+
+                yield frame
     except ValueError:
         raise
     except CsvReadError:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -837,6 +837,7 @@ def read_csv_chunked(
             path, effective_encoding, delimiter=delimiter
         ) as native_path:
             reader.open(native_path)
+            yielded_nonempty_chunk = False
             while True:
                 chunk = reader.next_chunk(chunksize, on_bad_lines)
                 if chunk is None:
@@ -845,11 +846,13 @@ def read_csv_chunked(
 
                 if on_bad_lines == "warn" and bad_rows:
                     _warn_bad_rows(bad_rows)
-
                 frame = ArFrame(cpp_frame)
 
                 if frame.shape[0] == 0 and bad_rows:
-                    continue
+                    if yielded_nonempty_chunk:
+                        continue
+
+                yielded_nonempty_chunk = yielded_nonempty_chunk or frame.shape[0] > 0
 
                 yield frame
     except ValueError:

--- a/tests/test_csv_chunked.py
+++ b/tests/test_csv_chunked.py
@@ -105,6 +105,36 @@ class TestReadCsvChunked:
         chunks = _chunked_rows(str(path), chunksize=10)
         assert chunks == []
 
+    def test_warn_mode_skips_empty_chunks_from_bad_rows(self, tmp_path):
+        path = tmp_path / "bad_warn.csv"
+
+        path.write_text("a,b\n" "1,2,3\n" "4,5\n" "6,7,8\n")
+
+        chunks = list(
+            ar.read_csv_chunked(
+                str(path),
+                chunksize=1,
+                on_bad_lines="warn",
+            )
+        )
+
+        assert [chunk.shape for chunk in chunks] == [(1, 2)]
+
+    def test_skip_mode_skips_empty_chunks_from_bad_rows(self, tmp_path):
+        path = tmp_path / "bad_skip.csv"
+
+        path.write_text("a,b\n" "1,2,3\n" "4,5\n" "6,7,8\n")
+
+        chunks = list(
+            ar.read_csv_chunked(
+                str(path),
+                chunksize=1,
+                on_bad_lines="skip",
+            )
+        )
+
+        assert [chunk.shape for chunk in chunks] == [(1, 2)]
+
 
 class TestReadCsvChunkedParity:
     """Chunked reads must match read_csv for parser options."""


### PR DESCRIPTION
## Summary
Prevent read_csv_chunked() from yielding zero-row chunks created only from skipped malformed rows when using on_bad_lines="warn" or "skip".

Adds focused regression coverage in tests/test_csv_chunked.py to verify chunked reads only yield valid data chunks while preserving warnings and EOF behavior.

## Linked issue
Fixes #1891

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [x] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:  `pytest tests/test_csv_chunked.py -k empty_chunks -v`

## Screenshots / Media
NA

## Performance Impact
NA

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The fix is intentionally minimal and implemented in the Python chunk generator layer to avoid yielding empty frames created only by skipped malformed rows.