### PR TITLE
fix: make code block copy buttons visible on keyboard focus

### DIFF
--- a/website/css/components.css
+++ b/website/css/components.css
@@ -445,6 +445,12 @@ pre:hover .copy-btn {
   opacity: 1;
 }
 
+.copy-btn:focus-visible {
+  opacity: 1;
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
 .copy-btn:hover {
   background: var(--color-accent);
   color: #ffffff;


### PR DESCRIPTION
## Summary

This PR improves keyboard accessibility for generated code-block copy buttons by making them visible when focused via keyboard navigation. A clear focus indicator has also been added to ensure users can easily identify the focused control without relying on mouse hover.

Fixes #1925

## Changes

* Added `.copy-btn:focus-visible` styling.
* Made copy buttons visible on keyboard focus.
* Added a visible focus outline for accessibility.

## Manual Testing

1. Open a page containing code blocks.
2. Navigate using the `Tab` key.
3. Verify the copy button becomes visible when focused.
4. Verify a clear focus indicator is displayed.
5. Confirm existing hover and copy functionality remain unchanged.
