### PR TITLE
fix(csv): preserve mid-field quotes

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -44,16 +44,34 @@ inline void strip_utf8_bom(std::string& s) {
     }
 }
 
-inline bool record_complete(const std::string& record) {
+inline bool record_complete(const std::string& record, char delimiter) {
     bool in_quotes = false;
+    bool at_field_start = true;
 
     for (size_t i = 0; i < record.size(); ++i) {
-        if (record[i] != '"') continue;
+        const char c = record[i];
 
-        if (in_quotes && i + 1 < record.size() && record[i + 1] == '"') {
-            ++i;
-        } else {
-            in_quotes = !in_quotes;
+        if (in_quotes) {
+            if (c == '"') {
+                if (i + 1 < record.size() && record[i + 1] == '"') {
+                    ++i;
+                } else {
+                    in_quotes = false;
+                    at_field_start = false;
+                }
+            }
+            continue;
+        }
+
+        if (c == '"') {
+            if (at_field_start) {
+                in_quotes = true;
+                at_field_start = false;
+            }
+        } else if (c == delimiter) {
+            at_field_start = true;
+        } else if (c != '\r') {
+            at_field_start = false;
         }
     }
 
@@ -137,7 +155,8 @@ class BufferedStreamReader {
 
 class RecordReader {
    public:
-    explicit RecordReader(std::istream& stream) : reader_(stream) {
+    explicit RecordReader(std::istream& stream, char delimiter)
+        : reader_(stream), delimiter_(delimiter) {
         record_.reserve(1024);
         line_.reserve(1024);
     }
@@ -161,13 +180,13 @@ class RecordReader {
             prev_line_ending_ = line_ending_;
             first = false;
 
-            if (record_complete(record_)) {
+            if (record_complete(record_, delimiter_)) {
                 out_record = record_;
                 return true;
             }
         }
 
-        if (!record_.empty() && !record_complete(record_)) {
+        if (!record_.empty() && !record_complete(record_, delimiter_)) {
             throw std::runtime_error("Unterminated quoted field starting at line " +
                                      std::to_string(record_start_line));
         }
@@ -185,6 +204,7 @@ class RecordReader {
     std::string line_;
     std::string line_ending_;
     std::string prev_line_ending_;
+    char delimiter_;
 };
 
 namespace {
@@ -586,6 +606,7 @@ void CsvParser::parse_line(const std::string& line, std::vector<std::string>& fi
     std::string field;
     field.reserve(line.size() / 4 + 1);  // heuristic for average field length
     bool in_quotes = false;
+    bool at_field_start = true;
 
     for (size_t i = 0; i < line.size(); ++i) {
         char c = line[i];
@@ -596,16 +617,23 @@ void CsvParser::parse_line(const std::string& line, std::vector<std::string>& fi
                     ++i;
                 } else {
                     in_quotes = false;
+                    at_field_start = false;
                 }
             } else {
                 field += c;
             }
         } else {
             if (c == '"') {
-                in_quotes = true;
+                if (at_field_start) {
+                    in_quotes = true;
+                    at_field_start = false;
+                } else {
+                    field += c;
+                }
             } else if (c == config_.delimiter) {
                 add_field(field);
                 field.clear();
+                at_field_start = true;
             } else if (c == '\r') {
                 continue;
             } else {
@@ -623,6 +651,7 @@ void CsvParser::parse_line(const std::string& line, std::vector<std::string>& fi
                 // After loop's ++i, i will point at the first stop char (or
                 // one past end), so subtract 1 to compensate.
                 i = static_cast<size_t>(scan - line.data()) - 1;
+                at_field_start = false;
             }
         }
     }
@@ -782,7 +811,7 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
         std::ifstream file;
         open_binary_input(file, path);
         if (!file.is_open()) throw std::runtime_error("Cannot open file: " + path);
-        RecordReader record_reader(file);
+        RecordReader record_reader(file, config.delimiter);
 
         size_t record_number = 0;
         size_t line_number = 0;
@@ -924,7 +953,7 @@ CsvParseResult CsvReader::read(const std::string& path, const std::string& on_ba
     {
         std::ifstream file2;
         open_binary_input(file2, path);
-        RecordReader record_reader2(file2);
+        RecordReader record_reader2(file2, config.delimiter);
 
         size_t record_number2 = 0;
         size_t line_number2 = 0;
@@ -1014,7 +1043,7 @@ CsvReader::scan_schema(const std::string& path, const std::string& on_bad_lines)
         throw std::runtime_error("Cannot open file: " + path);
     }
 
-    RecordReader record_reader(file);
+    RecordReader record_reader(file, config.delimiter);
 
     std::string line;
     std::vector<std::string> header;
@@ -1239,7 +1268,7 @@ void CsvChunkReader::open(const std::string& path) {
         throw std::runtime_error("Cannot open file: " + path);
     }
 
-    record_reader_ = std::make_unique<RecordReader>(file_);
+    record_reader_ = std::make_unique<RecordReader>(file_, config.delimiter);
 
     opened_ = true;
     record_number_ = 0;

--- a/cpp/tests/test_csv_parser.cpp
+++ b/cpp/tests/test_csv_parser.cpp
@@ -28,6 +28,35 @@ TEST_CASE("parse_line handles escaped quotes inside quoted field", "[csv_parser]
     REQUIRE(fields[0] == "she said \"hello\"");
 }
 
+TEST_CASE("parse_line preserves mid-field quotes as literal data", "[csv_parser]") {
+    CsvParser parser;
+    auto fields = parser.parse_line("ab\"cd,2");
+    REQUIRE(fields.size() == 2);
+    REQUIRE(fields[0] == "ab\"cd");
+    REQUIRE(fields[1] == "2");
+}
+
+TEST_CASE("parse_line preserves mid-field quotes in non-first columns", "[csv_parser]") {
+    CsvParser parser;
+    auto fields = parser.parse_line("a,ab\"cd,z");
+    REQUIRE(fields.size() == 3);
+    REQUIRE(fields[1] == "ab\"cd");
+}
+
+TEST_CASE("parse_line keeps escaped quotes in proper quoted fields", "[csv_parser]") {
+    CsvParser parser;
+    auto fields = parser.parse_line("\"ab\"\"cd\",2");
+    REQUIRE(fields.size() == 2);
+    REQUIRE(fields[0] == "ab\"cd");
+}
+
+TEST_CASE("parse_line keeps trailing text after a quoted field", "[csv_parser]") {
+    CsvParser parser;
+    auto fields = parser.parse_line("\"ab\"cd,2");
+    REQUIRE(fields.size() == 2);
+    REQUIRE(fields[0] == "abcd");
+}
+
 TEST_CASE("parse_line handles empty fields", "[csv_parser]") {
     CsvParser parser;
     auto fields = parser.parse_line("a,,c");

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1028,6 +1028,44 @@ class TestReadCsv:
 
         assert exc.value.__cause__ is None
 
+    def test_preserves_mid_field_quote_characters(self, tmp_path):
+        csv_path = tmp_path / "mid_field_quotes.csv"
+        csv_path.write_text('id,value\n1,ab"cd"\n2,x"y"z\n')
+
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+
+        assert df["value"].tolist() == ['ab"cd"', 'x"y"z']
+
+    def test_preserves_leading_quoted_field_with_trailing_text(self, tmp_path):
+        csv_path = tmp_path / "quoted_trailing_text.csv"
+        csv_path.write_text('id,value\n1,"ab"cd\n')
+
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+
+        assert df["value"].iloc[0] == "abcd"
+
+    def test_preserves_escaped_quotes_in_quoted_fields(self, tmp_path):
+        csv_path = tmp_path / "escaped_quotes.csv"
+        csv_path.write_text('id,value\n1,"ab""cd"\n')
+
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+
+        assert df["value"].iloc[0] == 'ab"cd'
+
+    def test_parses_delimiter_adjacent_quoted_fields(self, tmp_path):
+        csv_path = tmp_path / "delimiter_adjacent_quotes.csv"
+        csv_path.write_text('left,value,right\nA,"b,c",D\n')
+
+        frame = ar.read_csv(csv_path)
+        df = ar.to_pandas(frame)
+
+        assert df.loc[0, "left"] == "A"
+        assert df.loc[0, "value"] == "b,c"
+        assert df.loc[0, "right"] == "D"
+
     def test_empty_file_raises(self, tmp_path):
         csv_path = tmp_path / "empty.csv"
         csv_path.write_text("")

--- a/tests/test_csv_fuzz.py
+++ b/tests/test_csv_fuzz.py
@@ -22,14 +22,13 @@ def test_malformed_unclosed_quotes(tmp_path):
 
 
 def test_malformed_mid_field_quotes(tmp_path):
-    """Test mid-field quotes parses safely or raises defined exception."""
+    """Test mid-field quotes are preserved instead of silently dropped."""
     csv_path = tmp_path / "test.csv"
     csv_path.write_text('id,text\n1,hel"lo\n2,ok')
 
-    try:
-        ar.read_csv(csv_path)
-    except ar.CsvReadError:
-        pass  # If it rejects, that's fine too
+    frame = ar.read_csv(csv_path)
+    df = ar.to_pandas(frame)
+    assert df.loc[0, "text"] == 'hel"lo'
 
 
 def test_malformed_double_quotes_inside_field(tmp_path):
@@ -62,6 +61,18 @@ def test_malformed_quote_followed_by_non_delimiter(tmp_path):
         ar.read_csv(csv_path)
     except ar.CsvReadError:
         pass
+
+
+def test_mid_field_quote_regression_preserves_data(tmp_path):
+    """Issue #1890: mid-field quote characters must not disappear."""
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text('a,b\nab"cd,2\n')
+
+    frame = ar.read_csv(csv_path)
+    df = ar.to_pandas(frame)
+
+    assert df.loc[0, "a"] == 'ab"cd'
+    assert df.loc[0, "b"] == 2
 
 
 def test_random_delim_tab_separated(tmp_path):


### PR DESCRIPTION
## Summary
- make CSV quote handling context-aware so quotes only enter quoted mode at field start
- preserve mid-field quote characters as literal CSV data instead of silently dropping them
- add C++ parser and Python regression coverage for mid-field quotes, escaped quotes, delimiter-adjacent quoted fields, and quoted fields followed by trailing text

## Verification
- `clang++ -std=c++17 -Icpp/include -c cpp/src/csv_reader.cpp -o /private/tmp/arnio_csv_reader.o`
- `clang++ -std=c++17 -Icpp/include /private/tmp/arnio_parser_smoke.cpp cpp/src/csv_reader.cpp cpp/src/frame.cpp cpp/src/column.cpp -o /private/tmp/arnio_parser_smoke`
- `/private/tmp/arnio_parser_smoke`
- `PYTHONPYCACHEPREFIX=/private/tmp/arnio-1890-pycache python3 -m compileall -q tests/test_csv.py tests/test_csv_fuzz.py`
- `git diff --check`

Could not run the CMake/Catch2 target locally because `cmake` is not installed in this environment. Could not run the Python regression tests locally because the editable extension is not built here and `pip install -e . --no-build-isolation` failed with missing `scikit_build_core`.

Closes #1890
