### PR TITLE
fix: avoid returning original frame from drop_empty_columns zero-row path

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -539,7 +539,15 @@ def drop_empty_columns(frame: ArFrame) -> ArFrame:
     from .convert import to_pandas
 
     if frame.shape[0] == 0:
-        return frame
+        attrs = copy.deepcopy(frame._attrs) if frame._attrs is not None else None
+        empty_columns_data: dict[str, list[object]] = {}
+        empty_dtype_hints: dict[str, _DType] = {}
+        for col_name in frame.columns:
+            empty_columns_data[col_name] = []
+            empty_dtype_hints[col_name] = frame._frame.column_by_name(col_name).dtype()
+        return ArFrame(
+            _Frame.from_dict(empty_columns_data, empty_dtype_hints, 0), attrs=attrs
+        )
 
     df = to_pandas(frame)
     empty_columns: list[str] = []

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -930,6 +930,20 @@ class TestDropEmptyColumns:
         assert result.shape[0] == 0
         assert result.shape[1] == 3
 
+    def test_drop_empty_columns_zero_row_metadata_isolation(self):
+        df = pd.DataFrame({"a": pd.Series(dtype="object")})
+        frame = ar.from_pandas(df)
+        frame._attrs = {"nested": {"x": 1}}
+
+        result = ar.drop_empty_columns(frame)
+
+        assert result is not frame
+        assert result.columns == ["a"]
+        assert result.shape == (0, 1)
+
+        result._attrs["nested"]["x"] = 2
+        assert frame._attrs["nested"]["x"] == 1
+
 
 class TestClipNumeric:
     def test_clip_numeric_lower_only(self):


### PR DESCRIPTION
Closes #1950. Preserves schema, shape, and deep copies _attrs on zero-row inputs to avoid wrapper and metadata aliasing.