### PR TITLE
feat: add permissive mode parity to scan_csv

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -950,6 +950,7 @@ def scan_csv(
     null_values: list[str] | None = None,
     has_header: bool = True,
     encoding_errors: str = "strict",
+    mode: str = "strict",
     on_bad_lines: str = "error",
 ) -> dict[str, str]:
     """Return schema (column names + inferred types) without loading data.
@@ -995,6 +996,11 @@ def scan_csv(
     encoding_errors : str, default "strict"
         How encoding errors are handled. One of ``"strict"``, ``"replace"``,
         or ``"ignore"``.
+
+    mode : {"strict", "permissive"}, default "strict"
+        Controls malformed row handling during schema inference. In
+        ``"permissive"`` mode, narrow rows are padded with nulls before type
+        inference so scanning matches ``read_csv(..., mode="permissive")``.
 
     on_bad_lines : str, default "error"
         What to do when a malformed row is encountered during schema inference.
@@ -1044,6 +1050,7 @@ def scan_csv(
     _validate_thousands_separator(thousands_separator, decimal_separator)
     delimiter = _validate_delimiter(delimiter)
     encoding_errors = _validate_encoding_errors(encoding_errors)
+    mode = _validate_parser_mode(mode)
     on_bad_lines = _validate_on_bad_lines(on_bad_lines)
     config = _CsvConfig()
     config.delimiter = delimiter
@@ -1053,6 +1060,7 @@ def scan_csv(
     config.thousands_separator = thousands_separator
     config.has_header = _validate_bool_option(has_header, "has_header")
     config.encoding_errors = encoding_errors
+    config.mode = mode
 
     if null_values is not None:
         config.null_values = _validate_null_values(null_values)

--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -1092,15 +1092,22 @@ CsvReader::scan_schema(const std::string& path, const std::string& on_bad_lines)
         if (line.empty()) continue;
         parser_.parse_line(line, reusable_fields);
         if (reusable_fields.size() != num_cols) {
-            if (on_bad_lines == "error") {
-                validate_row_width(record_number, num_cols, reusable_fields.size());
-            } else if (on_bad_lines == "warn") {
-                bad_rows.push_back("CSV row " + std::to_string(record_number) + " has " +
-                                   std::to_string(reusable_fields.size()) + " fields; expected " +
-                                   std::to_string(num_cols));
-                continue;
-            } else if (on_bad_lines == "skip") {
-                continue;
+            const size_t actual = reusable_fields.size();
+            if (actual > num_cols || config.mode == "strict") {
+                if (on_bad_lines == "error") {
+                    validate_row_width(record_number, num_cols, actual);
+                } else if (on_bad_lines == "warn") {
+                    bad_rows.push_back("CSV row " + std::to_string(record_number) + " has " +
+                                       std::to_string(actual) + " fields; expected " +
+                                       std::to_string(num_cols));
+                    continue;
+                } else if (on_bad_lines == "skip") {
+                    continue;
+                }
+            } else {
+                while (reusable_fields.size() < num_cols) {
+                    reusable_fields.push_back("");
+                }
             }
         }
         for (size_t i = 0; i < num_cols && i < reusable_fields.size(); ++i) {

--- a/tests/test_csv_on_bad_lines.py
+++ b/tests/test_csv_on_bad_lines.py
@@ -487,6 +487,12 @@ class TestScanCsvOnBadLines:
         with pytest.raises(ValueError):
             ar.scan_csv(csv_path, on_bad_lines="invalid")
 
+    def test_invalid_mode_raises(self, tmp_path):
+        csv_path = tmp_path / "good.csv"
+        csv_path.write_text("a,b\n1,2\n")
+        with pytest.raises(ValueError, match="mode must be either"):
+            ar.scan_csv(csv_path, mode="loose")
+
     def test_warn_emits_user_warning(self, tmp_path):
         csv_path = tmp_path / "bad.csv"
         csv_path.write_text("a,b\n1,2\nbad_row\n3,4\n")
@@ -562,3 +568,36 @@ class TestScanCsvOnBadLines:
         with pytest.warns(UserWarning) as caught:
             ar.scan_csv(csv_path, on_bad_lines="warn", has_header=False)
         assert "CSV row 2 has 1 fields; expected 2" in str(caught[0].message)
+
+    def test_permissive_mode_pads_narrow_rows(self, tmp_path):
+        csv_path = tmp_path / "narrow.csv"
+        csv_path.write_text("a,b,c\n1,2,3\n4,5\n6,7,8\n")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            schema = ar.scan_csv(csv_path, mode="permissive", on_bad_lines="warn")
+
+        assert schema == {"a": "int64", "b": "int64", "c": "int64"}
+        assert [w for w in caught if w.category is UserWarning] == []
+
+    def test_permissive_scan_matches_read_csv_dtypes_for_narrow_rows(self, tmp_path):
+        csv_path = tmp_path / "scan_read_parity.csv"
+        csv_path.write_text("id,name,score\n1,Alice,10\n2,Bob\n3,Cara,12\n")
+
+        schema = ar.scan_csv(csv_path, mode="permissive")
+        frame = ar.read_csv(csv_path, mode="permissive")
+
+        assert schema == frame.dtypes
+
+    def test_permissive_mode_keeps_wide_rows_on_bad_lines(self, tmp_path):
+        csv_path = tmp_path / "wide.csv"
+        csv_path.write_text("a,b\n1,2,extra\n3,4\n")
+
+        with pytest.warns(UserWarning, match="CSV row 2 has 3 fields; expected 2"):
+            schema = ar.scan_csv(
+                csv_path,
+                mode="permissive",
+                on_bad_lines="warn",
+            )
+
+        assert schema == {"a": "int64", "b": "int64"}


### PR DESCRIPTION
## Summary
Fixes #1924

This PR adds `mode` support to `scan_csv()` so schema inference can follow the same strict/permissive malformed-row policy as `read_csv()`. In permissive mode, narrow rows are padded before inference instead of being routed through `on_bad_lines`, while wide rows still remain governed by `on_bad_lines`.

Submitted as part of GSSoC 2026.

## What changed
- Added `mode: str = "strict"` to `scan_csv()` and documented it in the public API docstring.
- Reused `_validate_parser_mode()` and passed the value through `_CsvConfig`.
- Updated `CsvReader::scan_schema()` so narrow rows in permissive mode are padded like the load path.
- Added regression coverage for invalid scan mode, narrow-row permissive scanning, scan/read dtype parity, and wide-row warning behavior.

## Validation
- `.venv-codex/bin/python -m pip install -e '.[dev]'`
- `.venv-codex/bin/python -m pytest tests/test_csv_on_bad_lines.py -q` — 46 passed
- `.venv-codex/bin/python -m pytest tests/test_csv.py tests/test_csv_on_bad_lines.py -q` — 380 passed
- `.venv-codex/bin/python -m pytest -q` — 2452 passed, 43 skipped
- `.venv-codex/bin/ruff check arnio/io.py tests/test_csv_on_bad_lines.py`
- Black formatting verified through the Black API for `arnio/io.py` and `tests/test_csv_on_bad_lines.py` with the repo settings; the Black CLI completed formatting checks but did not exit cleanly in this local sandbox, so I did not rely on that process state.
- `.venv-codex/bin/clang-format --dry-run --Werror cpp/src/csv_reader.cpp`
- `git diff --check`
- `cmake -S . -B /tmp/arnio-root-build-1924 -DARNIO_BUILD_CPP_TESTS=ON -Dpybind11_DIR=/home/kali/arnio/.venv-codex/lib/python3.13/site-packages/pybind11/share/cmake/pybind11`
- `cmake --build /tmp/arnio-root-build-1924`
- `ctest --test-dir /tmp/arnio-root-build-1924 --output-on-failure` — 4/4 tests passed