### PR TITLE
fix: forced bool dtype raises CsvReadError for invalid non-null tokens

### DIFF
--- a/cpp/src/csv_reader.cpp
+++ b/cpp/src/csv_reader.cpp
@@ -738,7 +738,13 @@ CellValue CsvParser::parse_value(const std::string& raw, DType dtype, bool is_fo
             std::string trimmed = sanitized;
             trim_in_place(trimmed);
             std::string lower = to_lower_copy(trimmed);
-            return (lower == "true");
+            if (lower == "true") return true;
+            if (lower == "false") return false;
+            if (is_forced) {
+                throw std::runtime_error("CsvReadError: Invalid token '" + raw +
+                                         "' for forced bool column");
+            }
+            return std::monostate{};
         }
         case DType::INT64: {
             std::string cleaned = normalize_numeric(sanitized, config_);

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1222,6 +1222,36 @@ class TestReadCsv:
                 encoding_errors="strict",
             )
 
+    def test_read_csv_bool_dtype_valid_values(self, tmp_path):
+        path = tmp_path / "bool_valid.csv"
+        path.write_text("flag\ntrue\nTrue\nTRUE\nfalse\nFalse\nFALSE\n")
+        frame = ar.read_csv(path, dtype={"flag": "bool"})
+        df = ar.to_pandas(frame)
+        assert frame.dtypes["flag"] == "bool"
+        assert df["flag"].tolist() == [True, True, True, False, False, False]
+
+    def test_read_csv_bool_dtype_invalid_token_raises(self, tmp_path):
+        path = tmp_path / "bool_invalid.csv"
+        path.write_text("flag\ntrue\nmaybe\nfalse\n")
+        with pytest.raises(
+            ar.CsvReadError, match="Invalid token 'maybe' for forced bool column"
+        ):
+            ar.read_csv(path, dtype={"flag": "bool"})
+
+    def test_read_csv_bool_dtype_yes_no_raises(self, tmp_path):
+        path = tmp_path / "bool_yes_no.csv"
+        path.write_text("flag\nyes\nno\n")
+        with pytest.raises(ar.CsvReadError, match="Invalid token"):
+            ar.read_csv(path, dtype={"flag": "bool"})
+
+    def test_read_csv_bool_dtype_null_sentinel_becomes_null(self, tmp_path):
+        path = tmp_path / "bool_nulls.csv"
+        path.write_text("flag\ntrue\nNA\nfalse\n")
+        frame = ar.read_csv(path, dtype={"flag": "bool"}, null_values=["NA"])
+        assert frame["flag"][0]
+        assert frame["flag"][1] is None
+        assert not frame["flag"][2]
+
 
 class TestScanCsv:
     def test_scan_schema(self, sample_csv):


### PR DESCRIPTION
Closes #1922

## Summary

When a user explicitly requests `dtype={"col": "bool"}`, any non-null value that wasn't `"true"` was silently coerced to `False`. This is a data-integrity bug — values like `"maybe"`, `"yes"`, or typos would change business meaning in production pipelines with no warning.

## Root cause

In `CsvParser::parse_value`, the `DType::BOOL` branch returned `lower == "true"` for every non-null value, making anything that isn't `"true"` become `False`. Unlike the `INT64` and `FLOAT64` branches, it had no error path for invalid tokens even when `is_forced` was `true`.

## Fix

Updated the `DType::BOOL` case in `cpp/src/csv_reader.cpp` to only accept explicit `true`/`false` tokens (case-insensitive) and throw a `CsvReadError` for anything else when the dtype is forced — matching the pattern already used for `INT64` and `FLOAT64`:

```cpp
// Before
return (lower == "true");

// After
if (lower == "true") return true;
if (lower == "false") return false;
if (is_forced) {
    throw std::runtime_error("CsvReadError: Invalid token '" + raw +
                             "' for forced bool column");
}
return std::monostate{};
```

Null sentinels are unaffected — they are caught by `is_null_sentinel` at the top of `parse_value` before the switch is reached.

## Tests added

All added inside `TestReadCsv`:

- `test_read_csv_bool_dtype_valid_values` — `true`/`false` in mixed case all parse correctly
- `test_read_csv_bool_dtype_invalid_token_raises` — `"maybe"` raises `CsvReadError` with a clear message
- `test_read_csv_bool_dtype_yes_no_raises` — `"yes"`/`"no"` raise instead of silently coercing
- `test_read_csv_bool_dtype_null_sentinel_becomes_null` — null sentinels produce `None`, not `False`

## Checklist

- [x] C++ change is limited to the `DType::BOOL` branch in `parse_value`
- [x] Existing 338 tests pass
- [x] 4 new tests added and passing
- [x] `ruff` and `clang-format` clean
- [x] `arnio/io.py` unchanged — no bool-specific logic there