### PR TITLE
fix(frame): handle non-finite float values in ArFrame.describe()

### DIFF
--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -1,5 +1,6 @@
 #include "arnio/frame.h"
 
+#include <cmath>
 #include <stdexcept>
 
 namespace arnio {
@@ -199,6 +200,8 @@ std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>>
             double sum = 0.0;
             double min_val = std::numeric_limits<double>::infinity();
             double max_val = -std::numeric_limits<double>::infinity();
+            size_t finite_count = 0;
+            size_t non_finite_count = 0;
 
             for (size_t i = 0; i < total_rows; ++i) {
                 if (col.is_null(i)) {
@@ -214,16 +217,22 @@ std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>>
                     val = std::get<double>(col.at(i));
                 }
 
+                if (!std::isfinite(val)) {
+                    non_finite_count++;
+                    continue;
+                }
+
+                finite_count++;
                 sum += val;
                 if (val < min_val) min_val = val;
                 if (val > max_val) max_val = val;
             }
 
-            // Push metrics in the exact forward order requested by the maintainer
             stats.push_back({"count", static_cast<double>(valid_count)});
             stats.push_back({"nulls", static_cast<double>(null_count)});
-            if (valid_count > 0) {
-                stats.push_back({"mean", sum / valid_count});
+            stats.push_back({"non_finite", static_cast<double>(non_finite_count)});
+            if (finite_count > 0) {
+                stats.push_back({"mean", sum / finite_count});
                 stats.push_back({"min", min_val});
                 stats.push_back({"max", max_val});
             } else {

--- a/cpp/tests/test_frame.cpp
+++ b/cpp/tests/test_frame.cpp
@@ -138,10 +138,8 @@ TEST_CASE("Frame::describe reports empty boolean summaries deterministically",
 
 // ── non-finite describe tests ─────────────────────────────────────────────────
 
-static double find_stat(
-    const std::vector<std::pair<std::string, double>>& stats,
-    const std::string& key)
-{
+static double find_stat(const std::vector<std::pair<std::string, double>>& stats,
+                        const std::string& key) {
     for (const auto& kv : stats) {
         if (kv.first == key) return kv.second;
     }
@@ -163,12 +161,12 @@ TEST_CASE("Frame::describe excludes non-finite floats and exposes non_finite cou
     REQUIRE(summary.size() == 1);
 
     const auto& stats = summary[0].second;
-    REQUIRE(find_stat(stats, "count")      == 4.0);
-    REQUIRE(find_stat(stats, "nulls")      == 0.0);
+    REQUIRE(find_stat(stats, "count") == 4.0);
+    REQUIRE(find_stat(stats, "nulls") == 0.0);
     REQUIRE(find_stat(stats, "non_finite") == 2.0);
-    REQUIRE(find_stat(stats, "mean")       == 2.0);
-    REQUIRE(find_stat(stats, "min")        == 1.0);
-    REQUIRE(find_stat(stats, "max")        == 3.0);
+    REQUIRE(find_stat(stats, "mean") == 2.0);
+    REQUIRE(find_stat(stats, "min") == 1.0);
+    REQUIRE(find_stat(stats, "max") == 3.0);
 }
 
 TEST_CASE("Frame::describe all-non-finite column returns zero fallback",
@@ -182,11 +180,11 @@ TEST_CASE("Frame::describe all-non-finite column returns zero fallback",
 
     auto summary = f.describe();
     const auto& stats = summary[0].second;
-    REQUIRE(find_stat(stats, "count")      == 2.0);
+    REQUIRE(find_stat(stats, "count") == 2.0);
     REQUIRE(find_stat(stats, "non_finite") == 2.0);
-    REQUIRE(find_stat(stats, "mean")       == 0.0);
-    REQUIRE(find_stat(stats, "min")        == 0.0);
-    REQUIRE(find_stat(stats, "max")        == 0.0);
+    REQUIRE(find_stat(stats, "mean") == 0.0);
+    REQUIRE(find_stat(stats, "min") == 0.0);
+    REQUIRE(find_stat(stats, "max") == 0.0);
 }
 
 TEST_CASE("Frame::describe negative-infinity only column is non-finite",
@@ -201,9 +199,9 @@ TEST_CASE("Frame::describe negative-infinity only column is non-finite",
     auto summary = f.describe();
     const auto& stats = summary[0].second;
     REQUIRE(find_stat(stats, "non_finite") == 2.0);
-    REQUIRE(find_stat(stats, "mean")       == 0.0);
-    REQUIRE(find_stat(stats, "min")        == 0.0);
-    REQUIRE(find_stat(stats, "max")        == 0.0);
+    REQUIRE(find_stat(stats, "mean") == 0.0);
+    REQUIRE(find_stat(stats, "min") == 0.0);
+    REQUIRE(find_stat(stats, "max") == 0.0);
 }
 
 TEST_CASE("Frame::describe int64 column non_finite is always zero",
@@ -219,8 +217,8 @@ TEST_CASE("Frame::describe int64 column non_finite is always zero",
     auto summary = f.describe();
     const auto& stats = summary[0].second;
     REQUIRE(find_stat(stats, "non_finite") == 0.0);
-    REQUIRE(find_stat(stats, "count")      == 3.0);
-    REQUIRE(find_stat(stats, "mean")       == 20.0);
-    REQUIRE(find_stat(stats, "min")        == 10.0);
-    REQUIRE(find_stat(stats, "max")        == 30.0);
+    REQUIRE(find_stat(stats, "count") == 3.0);
+    REQUIRE(find_stat(stats, "mean") == 20.0);
+    REQUIRE(find_stat(stats, "min") == 10.0);
+    REQUIRE(find_stat(stats, "max") == 30.0);
 }

--- a/cpp/tests/test_frame.cpp
+++ b/cpp/tests/test_frame.cpp
@@ -135,3 +135,92 @@ TEST_CASE("Frame::describe reports empty boolean summaries deterministically",
     REQUIRE(stats[3] == std::make_pair(std::string("false"), 0.0));
     REQUIRE(stats[4] == std::make_pair(std::string("true_ratio"), 0.0));
 }
+
+// ── non-finite describe tests ─────────────────────────────────────────────────
+
+static double find_stat(
+    const std::vector<std::pair<std::string, double>>& stats,
+    const std::string& key)
+{
+    for (const auto& kv : stats) {
+        if (kv.first == key) return kv.second;
+    }
+    return -999.0;  // sentinel: key not found
+}
+
+TEST_CASE("Frame::describe excludes non-finite floats and exposes non_finite count",
+          "[frame][describe][non_finite]") {
+    Column x("x", DType::FLOAT64);
+    x.push_back(CellValue(1.0));
+    x.push_back(CellValue(std::numeric_limits<double>::infinity()));
+    x.push_back(CellValue(-std::numeric_limits<double>::infinity()));
+    x.push_back(CellValue(3.0));
+
+    Frame f;
+    f.add_column(std::move(x));
+
+    auto summary = f.describe();
+    REQUIRE(summary.size() == 1);
+
+    const auto& stats = summary[0].second;
+    REQUIRE(find_stat(stats, "count")      == 4.0);
+    REQUIRE(find_stat(stats, "nulls")      == 0.0);
+    REQUIRE(find_stat(stats, "non_finite") == 2.0);
+    REQUIRE(find_stat(stats, "mean")       == 2.0);
+    REQUIRE(find_stat(stats, "min")        == 1.0);
+    REQUIRE(find_stat(stats, "max")        == 3.0);
+}
+
+TEST_CASE("Frame::describe all-non-finite column returns zero fallback",
+          "[frame][describe][non_finite]") {
+    Column x("x", DType::FLOAT64);
+    x.push_back(CellValue(std::numeric_limits<double>::infinity()));
+    x.push_back(CellValue(-std::numeric_limits<double>::infinity()));
+
+    Frame f;
+    f.add_column(std::move(x));
+
+    auto summary = f.describe();
+    const auto& stats = summary[0].second;
+    REQUIRE(find_stat(stats, "count")      == 2.0);
+    REQUIRE(find_stat(stats, "non_finite") == 2.0);
+    REQUIRE(find_stat(stats, "mean")       == 0.0);
+    REQUIRE(find_stat(stats, "min")        == 0.0);
+    REQUIRE(find_stat(stats, "max")        == 0.0);
+}
+
+TEST_CASE("Frame::describe negative-infinity only column is non-finite",
+          "[frame][describe][non_finite]") {
+    Column x("x", DType::FLOAT64);
+    x.push_back(CellValue(-std::numeric_limits<double>::infinity()));
+    x.push_back(CellValue(-std::numeric_limits<double>::infinity()));
+
+    Frame f;
+    f.add_column(std::move(x));
+
+    auto summary = f.describe();
+    const auto& stats = summary[0].second;
+    REQUIRE(find_stat(stats, "non_finite") == 2.0);
+    REQUIRE(find_stat(stats, "mean")       == 0.0);
+    REQUIRE(find_stat(stats, "min")        == 0.0);
+    REQUIRE(find_stat(stats, "max")        == 0.0);
+}
+
+TEST_CASE("Frame::describe int64 column non_finite is always zero",
+          "[frame][describe][non_finite]") {
+    Column x("x", DType::INT64);
+    x.push_back(CellValue(int64_t(10)));
+    x.push_back(CellValue(int64_t(20)));
+    x.push_back(CellValue(int64_t(30)));
+
+    Frame f;
+    f.add_column(std::move(x));
+
+    auto summary = f.describe();
+    const auto& stats = summary[0].second;
+    REQUIRE(find_stat(stats, "non_finite") == 0.0);
+    REQUIRE(find_stat(stats, "count")      == 3.0);
+    REQUIRE(find_stat(stats, "mean")       == 20.0);
+    REQUIRE(find_stat(stats, "min")        == 10.0);
+    REQUIRE(find_stat(stats, "max")        == 30.0);
+}

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -965,9 +965,7 @@ def test_describe_non_finite_all_non_finite_column():
     """All-non-finite column: mean/min/max fall back to 0.0 deterministically."""
     import math
 
-    frame = ar.from_pandas(
-        pd.DataFrame({"x": [math.inf, -math.inf]})
-    )
+    frame = ar.from_pandas(pd.DataFrame({"x": [math.inf, -math.inf]}))
     stats = frame.describe()
 
     assert stats["x"]["count"] == 2.0
@@ -981,9 +979,7 @@ def test_describe_non_finite_negative_inf_only():
     """-inf only column is fully non-finite; fallback values are 0.0."""
     import math
 
-    frame = ar.from_pandas(
-        pd.DataFrame({"x": [-math.inf, -math.inf]})
-    )
+    frame = ar.from_pandas(pd.DataFrame({"x": [-math.inf, -math.inf]}))
     stats = frame.describe()
 
     assert stats["x"]["non_finite"] == 2.0

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -963,9 +963,9 @@ def test_describe_non_finite_all_finite_column():
 
 def test_describe_non_finite_all_non_finite_column():
     """All-non-finite column: mean/min/max fall back to 0.0 deterministically."""
-    import math
+    import io
 
-    frame = ar.from_pandas(pd.DataFrame({"x": [math.inf, -math.inf]}))
+    frame = ar.read_csv(io.StringIO("x\ninf\n-inf\n"))
     stats = frame.describe()
 
     assert stats["x"]["count"] == 2.0
@@ -977,9 +977,9 @@ def test_describe_non_finite_all_non_finite_column():
 
 def test_describe_non_finite_negative_inf_only():
     """-inf only column is fully non-finite; fallback values are 0.0."""
-    import math
+    import io
 
-    frame = ar.from_pandas(pd.DataFrame({"x": [-math.inf, -math.inf]}))
+    frame = ar.read_csv(io.StringIO("x\n-inf\n-inf\n"))
     stats = frame.describe()
 
     assert stats["x"]["non_finite"] == 2.0

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -876,7 +876,7 @@ def test_describe_all_numeric_columns(large_csv):
 
     for col in ["id", "value"]:
         metric_keys = list(stats[col].keys())
-        assert metric_keys == ["count", "nulls", "mean", "min", "max"]
+        assert metric_keys == ["count", "nulls", "non_finite", "mean", "min", "max"]
 
 
 def test_describe_all_string_columns(csv_with_whitespace):
@@ -928,6 +928,78 @@ def test_describe_boolean_columns_with_nulls():
     assert stats["flag"]["true"] == 2.0
     assert stats["flag"]["false"] == 1.0
     assert stats["flag"]["true_ratio"] == pytest.approx(2.0 / 3.0)
+
+
+# ── non-finite describe regression tests ─────────────────────────────────────
+
+
+def test_describe_non_finite_mixed_float_column():
+    """inf and -inf are excluded from sum/min/max; non_finite count is reported."""
+    import io
+
+    frame = ar.read_csv(io.StringIO("x\n1.0\ninf\n-inf\n3.0\n"))
+    stats = frame.describe()
+
+    assert stats["x"]["count"] == 4.0
+    assert stats["x"]["nulls"] == 0.0
+    assert stats["x"]["non_finite"] == 2.0
+    assert stats["x"]["mean"] == pytest.approx(2.0)
+    assert stats["x"]["min"] == pytest.approx(1.0)
+    assert stats["x"]["max"] == pytest.approx(3.0)
+
+
+def test_describe_non_finite_all_finite_column():
+    """All-finite column: non_finite == 0, mean/min/max computed normally."""
+    import io
+
+    frame = ar.read_csv(io.StringIO("x\n2.0\n4.0\n6.0\n"))
+    stats = frame.describe()
+
+    assert stats["x"]["non_finite"] == 0.0
+    assert stats["x"]["mean"] == pytest.approx(4.0)
+    assert stats["x"]["min"] == pytest.approx(2.0)
+    assert stats["x"]["max"] == pytest.approx(6.0)
+
+
+def test_describe_non_finite_all_non_finite_column():
+    """All-non-finite column: mean/min/max fall back to 0.0 deterministically."""
+    import math
+
+    frame = ar.from_pandas(
+        pd.DataFrame({"x": [math.inf, -math.inf]})
+    )
+    stats = frame.describe()
+
+    assert stats["x"]["count"] == 2.0
+    assert stats["x"]["non_finite"] == 2.0
+    assert stats["x"]["mean"] == 0.0
+    assert stats["x"]["min"] == 0.0
+    assert stats["x"]["max"] == 0.0
+
+
+def test_describe_non_finite_negative_inf_only():
+    """-inf only column is fully non-finite; fallback values are 0.0."""
+    import math
+
+    frame = ar.from_pandas(
+        pd.DataFrame({"x": [-math.inf, -math.inf]})
+    )
+    stats = frame.describe()
+
+    assert stats["x"]["non_finite"] == 2.0
+    assert stats["x"]["mean"] == 0.0
+    assert stats["x"]["min"] == 0.0
+    assert stats["x"]["max"] == 0.0
+
+
+def test_describe_non_finite_int64_no_regression():
+    """int64 columns cannot hold inf; non_finite must always be 0."""
+    frame = ar.from_pandas(pd.DataFrame({"x": [10, 20, 30]}))
+    stats = frame.describe()
+
+    assert stats["x"]["non_finite"] == 0.0
+    assert stats["x"]["count"] == 3.0
+    assert stats["x"]["mean"] == pytest.approx(20.0)
 
 
 def test_astype_valid_single_type():


### PR DESCRIPTION
## What this PR does

Fixes silent corruption in `ArFrame.describe()` when a float column contains
`inf` or `-inf` values. Previously, non-finite values propagated into `sum`,
`min`, and `max`, producing `NaN`, `Infinity`, and `-Infinity` in the output.

### Changes

**`cpp/src/frame.cpp`**
- Added `#include <cmath>` for `std::isfinite`
- In the numeric branch of `Frame::describe()`: tracks `finite_count` and
  `non_finite_count` separately; non-finite values are excluded from
  `sum`/`min`/`max`; mean is computed from `finite_count` only
- New `"non_finite"` stat key exposed in output so callers can see the count
  of `±inf`/`NaN` values explicitly
- All-non-finite columns emit `mean/min/max = 0.0` — deterministic fallback
  matching the existing all-null behaviour

**`tests/test_frame.py`**
- Updated `test_describe_all_numeric_columns` to include `"non_finite"` in
  the expected key order (necessary follow-on from adding the new stat)
- Added 5 regression tests covering: all-finite, mixed finite/`±inf`,
  all-non-finite, `-inf` only, and int64 no-regression

**`cpp/tests/test_frame.cpp`**
- Added 4 C++ unit tests covering the same cases at the native layer

---

## Before / after

```python
import io, arnio as ar

frame = ar.read_csv(io.StringIO("x\n1.0\ninf\n-inf\n3.0\n"))
print(frame.describe())
```

**Before:**
{'x': {'count': 4.0, 'nulls': 0.0, 'mean': NaN, 'min': -Infinity, 'max': Infinity}}

**After:**
{'x': {'count': 4.0, 'nulls': 0.0, 'non_finite': 2.0, 'mean': 2.0, 'min': 1.0, 'max': 3.0}}

---

## Checklist

- [x] All existing tests pass (`make test`)
- [x] New C++ unit tests added (`cpp/tests/test_frame.cpp`)
- [x] New Python regression tests added (`tests/test_frame.py`)
- [x] No changes to `profile()`, pipeline, schema, or unrelated API
- [x] Behaviour is deterministic for all-non-finite columns

Closes #1936