### PR TITLE
fix: guard unsafe float-to-int64 conversions

### DIFF
--- a/cpp/src/cleaning.cpp
+++ b/cpp/src/cleaning.cpp
@@ -174,6 +174,18 @@ static uint64_t hash_row(const Frame& frame, size_t row, const std::vector<size_
     return h;
 }
 
+static int64_t checked_double_to_int64(double value, const char* context) {
+    constexpr double int64_min = static_cast<double>(std::numeric_limits<int64_t>::min());
+    constexpr double int64_max_exclusive = 9223372036854775808.0;  // 2^63
+
+    if (!std::isfinite(value) || value != std::floor(value) || value < int64_min ||
+        value >= int64_max_exclusive) {
+        throw std::invalid_argument(std::string(context) +
+                                    " must be a finite integral value within int64 range.");
+    }
+    return static_cast<int64_t>(value);
+}
+
 static CellValue coerce_value(const CellValue& value, DType target) {
     if (std::holds_alternative<std::monostate>(value)) {
         return std::monostate{};
@@ -190,12 +202,13 @@ static CellValue coerce_value(const CellValue& value, DType target) {
         }
         if (std::holds_alternative<double>(value)) {
             double d = std::get<double>(value);
-            if (std::isnan(d) || std::isinf(d) || d != std::floor(d)) {
+            try {
+                return checked_double_to_int64(d, "Numeric fill value");
+            } catch (const std::invalid_argument&) {
                 throw std::invalid_argument(
                     "Lossy or non-finite numeric fill values are not permitted for integer "
                     "columns.");
             }
-            return static_cast<int64_t>(d);
         }
         if (std::holds_alternative<std::string>(value)) {
             const auto& s = std::get<std::string>(value);
@@ -752,9 +765,9 @@ Frame clip_numeric(const Frame& frame, std::optional<double> lower, std::optiona
         if (src.dtype() == DType::INT64) {
             const auto& vec = std::get<std::vector<int64_t>>(src.data());
             Column col(src.name(), DType::INT64);
-            const int64_t lo = lower.has_value() ? static_cast<int64_t>(lower.value())
+            const int64_t lo = lower.has_value() ? checked_double_to_int64(lower.value(), "lower")
                                                  : std::numeric_limits<int64_t>::min();
-            const int64_t hi = upper.has_value() ? static_cast<int64_t>(upper.value())
+            const int64_t hi = upper.has_value() ? checked_double_to_int64(upper.value(), "upper")
                                                  : std::numeric_limits<int64_t>::max();
             for (size_t r = 0; r < src.size(); ++r) {
                 if (src.is_null(r)) {

--- a/cpp/tests/test_cleaning.cpp
+++ b/cpp/tests/test_cleaning.cpp
@@ -2,6 +2,7 @@
 #include <cmath>    // std::isnan
 #include <cstdint>  // uint64_t
 #include <cstring>  // std::memcpy
+#include <limits>
 
 #include "arnio/cleaning.h"
 
@@ -105,6 +106,88 @@ TEST_CASE("fill_nulls replaces nulls in int column", "[cleaning]") {
 
     REQUIRE(result.column("val").is_null(1) == false);
     REQUIRE(result.column("val").at(1) == CellValue(int64_t(99)));
+}
+
+TEST_CASE("fill_nulls rejects double values outside int64 range", "[cleaning][numeric-safety]") {
+    Frame f = make_null_frame();
+
+    REQUIRE_THROWS_AS(fill_nulls(f, CellValue(1e20), std::vector<std::string>{"val"}),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(fill_nulls(f, CellValue(-1e20), std::vector<std::string>{"val"}),
+                      std::invalid_argument);
+}
+
+TEST_CASE("fill_nulls rejects non-finite double values for int columns",
+          "[cleaning][numeric-safety]") {
+    Frame f = make_null_frame();
+
+    REQUIRE_THROWS_AS(fill_nulls(f, CellValue(std::numeric_limits<double>::infinity()),
+                                 std::vector<std::string>{"val"}),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(fill_nulls(f, CellValue(-std::numeric_limits<double>::infinity()),
+                                 std::vector<std::string>{"val"}),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(fill_nulls(f, CellValue(std::numeric_limits<double>::quiet_NaN()),
+                                 std::vector<std::string>{"val"}),
+                      std::invalid_argument);
+}
+
+TEST_CASE("fill_nulls preserves int64 boundary fill values", "[cleaning][numeric-safety]") {
+    Column min_col("v", DType::INT64);
+    min_col.push_null();
+    Frame min_frame;
+    min_frame.add_column(std::move(min_col));
+
+    Frame min_result = fill_nulls(min_frame, CellValue(std::numeric_limits<int64_t>::min()),
+                                  std::vector<std::string>{"v"});
+    REQUIRE(min_result.column("v").at(0) == CellValue(std::numeric_limits<int64_t>::min()));
+
+    Column max_col("v", DType::INT64);
+    max_col.push_null();
+    Frame max_frame;
+    max_frame.add_column(std::move(max_col));
+
+    Frame max_result = fill_nulls(max_frame, CellValue(std::numeric_limits<int64_t>::max()),
+                                  std::vector<std::string>{"v"});
+    REQUIRE(max_result.column("v").at(0) == CellValue(std::numeric_limits<int64_t>::max()));
+}
+
+TEST_CASE("clip_numeric rejects unsafe int64 double bounds", "[cleaning][numeric-safety]") {
+    Column c("v", DType::INT64);
+    c.push_back(int64_t(-5));
+    c.push_back(int64_t(0));
+    c.push_back(int64_t(5));
+
+    Frame f;
+    f.add_column(std::move(c));
+
+    REQUIRE_THROWS_AS(clip_numeric(f, -1e20, std::nullopt, std::vector<std::string>{"v"}),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(clip_numeric(f, std::nullopt, 1e20, std::vector<std::string>{"v"}),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(clip_numeric(f, std::numeric_limits<double>::quiet_NaN(), std::nullopt,
+                                   std::vector<std::string>{"v"}),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(clip_numeric(f, std::nullopt, std::numeric_limits<double>::infinity(),
+                                   std::vector<std::string>{"v"}),
+                      std::invalid_argument);
+}
+
+TEST_CASE("clip_numeric accepts valid int64 boundary bounds", "[cleaning][numeric-safety]") {
+    Column c("v", DType::INT64);
+    c.push_back(std::numeric_limits<int64_t>::min());
+    c.push_back(int64_t(0));
+    c.push_back(int64_t(5));
+
+    Frame f;
+    f.add_column(std::move(c));
+
+    Frame result = clip_numeric(f, static_cast<double>(std::numeric_limits<int64_t>::min()), 5.0,
+                                std::vector<std::string>{"v"});
+
+    REQUIRE(result.column("v").at(0) == CellValue(std::numeric_limits<int64_t>::min()));
+    REQUIRE(result.column("v").at(1) == CellValue(int64_t(0)));
+    REQUIRE(result.column("v").at(2) == CellValue(int64_t(5)));
 }
 
 TEST_CASE("drop_duplicates removes repeated rows", "[cleaning]") {

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1117,6 +1117,15 @@ class TestClipNumeric:
 
         assert list(df["x"]) == [0, 2, 5]
 
+    def test_clip_numeric_out_of_range_bound_on_int64_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [-1, 2, 10]}))
+
+        with pytest.raises(ValueError, match="within int64 range"):
+            ar.clip_numeric(frame, upper=1e20)
+
+        with pytest.raises(ValueError, match="within int64 range"):
+            ar.clip_numeric(frame, lower=-1e20)
+
     def test_clip_numeric_non_integral_bound_on_float64_accepted(self):
         # Non-integral bounds are valid for float64 columns.
         frame = ar.from_pandas(pd.DataFrame({"v": [-1.0, 2.5, 9.9]}))
@@ -3690,6 +3699,12 @@ def test_fill_nulls_validation_lossy_and_non_finite():
         match="Lossy or non-finite numeric fill values are not permitted for integer columns.",
     ):
         ar.fill_nulls(int_frame, float("nan"), subset=["x"])
+
+    with pytest.raises(
+        ValueError,
+        match="Lossy or non-finite numeric fill values are not permitted for integer columns.",
+    ):
+        ar.fill_nulls(int_frame, 1e20, subset=["x"])
 
     float_frame = ar.from_pandas(pd.DataFrame({"x": [1.0, None]}))
 


### PR DESCRIPTION
Fixes #1591

This keeps the numeric-safety fix scoped to the two native paths called out in the issue: `coerce_value()` and the int64 branch of `clip_numeric()`.

The problem was that both paths validated part of the input shape, then still reached `static_cast<int64_t>` with doubles that could be outside the representable int64 range. That is the unsafe part: non-finite values, huge integral-looking doubles like `1e20`, and values at/above `2^63` should never reach the cast.

What changed:

- Added a small local `checked_double_to_int64()` helper in `cpp/src/cleaning.cpp`.
- Requires double values to be finite, integral, and inside the safe int64 conversion range before casting.
- Reused the helper from `coerce_value()` and from int64 `clip_numeric()` bounds.
- Preserved existing valid int64 fill behavior and ordinary valid clip bounds.
- Added native C++ regression coverage for out-of-range doubles, `inf`, `-inf`, `NaN`, and int64 boundary fill values.
- Added Python API regression coverage for out-of-range `fill_nulls()` and `clip_numeric()` inputs.

This PR is for GSSoC 2026 and stays focused on the assigned numeric-safety bug.

Validation:

- `cmake -S . -B /tmp/arnio-build-1591 -DARNIO_BUILD_CPP_TESTS=ON -Dpybind11_DIR=/home/kali/arnio/.venv-codex/lib/python3.13/site-packages/pybind11/share/cmake/pybind11`
- `cmake --build /tmp/arnio-build-1591`
- `ctest --test-dir /tmp/arnio-build-1591 --output-on-failure` — 4 passed
- `.venv-codex/bin/python -m pip install -e '.[dev]'`
- `.venv-codex/bin/python -m pytest tests/test_cleaning.py -q -k "clip_numeric or fill_nulls_validation_lossy"` — 23 passed
- `.venv-codex/bin/python -m pytest tests/test_cleaning.py -q` — 410 passed
- `.venv-codex/bin/python -m pytest -q` — 2466 passed, 43 skipped
- `.venv-codex/bin/python -m black --check tests/test_cleaning.py`
- `.venv-codex/bin/python -m ruff check tests/test_cleaning.py`
- `git diff --check`
