### PR TITLE
fix: restrict write_csv line_terminator to standard newline values

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -923,8 +923,10 @@ def write_csv(
         )
     if not isinstance(line_terminator, str):
         raise TypeError("line_terminator must be a string")
-    if line_terminator == "":
-        raise ValueError("line_terminator must not be empty")
+    if line_terminator not in {"\n", "\r\n", "\r"}:
+        raise ValueError(
+            f"line_terminator must be one of '\\n', '\\r\\n', or '\\r', got {line_terminator!r}"
+        )
 
     config = _CsvWriteConfig()
     config.delimiter = delimiter

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -130,16 +130,30 @@ class TestWriteCsvLineTerminatorBytes:
         assert b"\r\r" not in raw
 
     def test_custom_terminator_writes_exact_bytes(self, tmp_path):
-        # An arbitrary terminator (e.g. "|") must be written verbatim.
+        # Arbitrary/custom terminators (e.g. "|") must be rejected.
         frame = ar.from_pandas(pd.DataFrame({"x": [7]}))
         out = tmp_path / "out.csv"
-        ar.write_csv(frame, out, line_terminator="|")
+        with pytest.raises(ValueError, match="line_terminator must be one of"):
+            ar.write_csv(frame, out, line_terminator="|")
+
+    def test_r_terminator_writes_exact_r_bytes(self, tmp_path):
+        # line_terminator="\r" must produce CR bytes verbatim.
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        out = tmp_path / "out.csv"
+        ar.write_csv(frame, out, line_terminator="\r")
         raw = out.read_bytes()
-        assert raw == b"x|7|"
+        assert raw == b"a\r1\r2\r"
+
+    def test_arbitrary_strings_rejected(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+        out = tmp_path / "out.csv"
+        for term in ["END", "\n\0", "\0", "\r\r\n"]:
+            with pytest.raises(ValueError, match="line_terminator must be one of"):
+                ar.write_csv(frame, out, line_terminator=term)
 
     def test_empty_line_terminator_rejected(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
-        with pytest.raises(ValueError, match="line_terminator must not be empty"):
+        with pytest.raises(ValueError, match="line_terminator must be one of"):
             ar.write_csv(frame, tmp_path / "out.csv", line_terminator="")
 
     def test_non_string_line_terminator_rejected(self, tmp_path):


### PR DESCRIPTION
Closes #1707. Restricts write_csv() line_terminator to standard newline values (\n, \r\n, and \r) and rejects arbitrary strings or NUL-containing terminators.