### PR TITLE
fix: validate ProfileComparison status_counts values

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -925,6 +925,22 @@ class ProfileComparison:
     status_counts: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        if not isinstance(self.left_profile, DataQualityReport):
+            raise TypeError("left_profile must be an instance of DataQualityReport")
+
+        if not isinstance(self.right_profile, DataQualityReport):
+            raise TypeError("right_profile must be an instance of DataQualityReport")
+
+        if not isinstance(self.drift_report, dict):
+            raise TypeError("drift_report must be a nested dictionary of dict")
+
+        for key, value in self.drift_report.items():
+            if not isinstance(key, str):
+                raise TypeError("drift_report keys must be strings")
+
+            if not isinstance(value, dict):
+                raise TypeError("drift_report must be a nested dictionary of dict")
+
         if not isinstance(self.status_counts, dict):
             raise TypeError("status_counts must be a dict")
 
@@ -932,15 +948,14 @@ class ProfileComparison:
             if not isinstance(key, str):
                 raise TypeError("status_counts keys must be strings")
 
-            if isinstance(value, bool) or not isinstance(value, int):
-                raise TypeError(
-                    "status_counts values must be non-negative integers"
-                )
+            if isinstance(value, bool):
+                raise TypeError("status_counts values must not be booleans")
+
+            if not isinstance(value, int):
+                raise TypeError("status_counts values must be integers")
 
             if value < 0:
-                raise ValueError(
-                    "status_counts values must be non-negative integers"
-                )
+                raise ValueError("status_counts values must be non-negative integers")
 
     def to_dict(
         self,
@@ -973,7 +988,6 @@ class ProfileComparison:
                 for name, entry in self.drift_report.items()
             },
         }
-
 
     def to_json(
         self,

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -925,26 +925,22 @@ class ProfileComparison:
     status_counts: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.left_profile, DataQualityReport):
-            raise TypeError("left_profile must be an instance of DataQualityReport")
-        if not isinstance(self.right_profile, DataQualityReport):
-            raise TypeError("right_profile must be an instance of DataQualityReport")
-
-        if not isinstance(self.drift_report, dict):
-            raise TypeError("drift_report must be a dictionary")
-        for key, val in self.drift_report.items():
-            if not isinstance(key, str):
-                raise TypeError("drift_report keys must be strings")
-            if not isinstance(val, dict):
-                raise TypeError("drift_report must be a nested dictionary of dict")
-
         if not isinstance(self.status_counts, dict):
-            raise TypeError("status_counts must be a dictionary")
-        for key, val in self.status_counts.items():
+            raise TypeError("status_counts must be a dict")
+
+        for key, value in self.status_counts.items():
             if not isinstance(key, str):
                 raise TypeError("status_counts keys must be strings")
-            if not isinstance(val, int):
-                raise TypeError("status_counts values must be integers")
+
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(
+                    "status_counts values must be non-negative integers"
+                )
+
+            if value < 0:
+                raise ValueError(
+                    "status_counts values must be non-negative integers"
+                )
 
     def to_dict(
         self,
@@ -977,6 +973,7 @@ class ProfileComparison:
                 for name, entry in self.drift_report.items()
             },
         }
+
 
     def to_json(
         self,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -304,6 +304,53 @@ def test_compare_profiles_handles_single_column_profiles():
     assert comparison.status_counts == {"ok": 1, "warning": 0, "changed": 0}
 
 
+def test_profile_comparison_accepts_valid_status_counts():
+    base = ar.DataQualityReport(0, 0, 0, 0, 0.0, {})
+
+    comparison = ar.ProfileComparison(
+        base,
+        base,
+        {},
+        {"ok": 1, "warning": 2, "changed": 0},
+    )
+
+    assert comparison.status_counts == {
+        "ok": 1,
+        "warning": 2,
+        "changed": 0,
+    }
+
+
+def test_profile_comparison_rejects_bool_status_counts():
+    base = ar.DataQualityReport(0, 0, 0, 0, 0.0, {})
+
+    with pytest.raises(
+        TypeError,
+        match="status_counts values must be non-negative integers",
+    ):
+        ar.ProfileComparison(
+            base,
+            base,
+            {},
+            {"passed": True},
+        )
+
+
+def test_profile_comparison_rejects_negative_status_counts():
+    base = ar.DataQualityReport(0, 0, 0, 0, 0.0, {})
+
+    with pytest.raises(
+        ValueError,
+        match="status_counts values must be non-negative integers",
+    ):
+        ar.ProfileComparison(
+            base,
+            base,
+            {},
+            {"failed": -1},
+        )
+
+
 def test_check_quality_gates_passes_identical_profiles():
     frame = ar.from_pandas(
         pd.DataFrame({"score": [10.0, 11.0, 12.0], "city": ["a", "b", "a"]})

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -326,7 +326,7 @@ def test_profile_comparison_rejects_bool_status_counts():
 
     with pytest.raises(
         TypeError,
-        match="status_counts values must be non-negative integers",
+        match="status_counts values must not be booleans",
     ):
         ar.ProfileComparison(
             base,


### PR DESCRIPTION
Adds validation for ProfileComparison.status_counts.

Previously, boolean values and negative integers were accepted as status counts because bool is a subclass of int in Python and negative integers were not explicitly rejected.

This change ensures that status count values must be non-negative integers.

Fixes #1941

Changes
Added validation in ProfileComparison.__post_init__()
Reject boolean values in status_counts
Reject negative integer values in status_counts
Added regression tests for:
valid status counts
boolean values
negative values
Tests
pytest tests/test_quality.py -v