### PR TITLE
fix: preserve row count in normalize_unicode for zero-column frames (…

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1112,7 +1112,7 @@ def normalize_unicode(
         else:
             new_columns[name] = col.to_python_list()
             dtype_hints[name] = dtype
-    new_cpp_frame = _Frame.from_dict(new_columns, dtype_hints)
+    new_cpp_frame = _Frame.from_dict(new_columns, dtype_hints, frame.shape[0])
     return ArFrame(
         new_cpp_frame,
         attrs=copy.deepcopy(frame._attrs) if frame._attrs is not None else None,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1735,7 +1735,6 @@ class TestNormalizeUnicode:
         assert frame_3_0_attrs._attrs["key"] == "value"
 
 
-
 class TestParseBoolStrings:
     def test_parse_basic_bool_strings(self):
         import pandas as pd

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1699,6 +1699,42 @@ class TestNormalizeUnicode:
         result._attrs["meta"]["key"] = "mutated"
         assert frame._attrs["meta"]["key"] == "value"
 
+    def test_normalize_unicode_zero_columns(self):
+        import pandas as pd
+
+        import arnio as ar
+
+        # Non-empty zero-column frame
+        frame_3_0 = ar.from_pandas(pd.DataFrame(index=range(3)))
+        assert frame_3_0.shape == (3, 0)
+        result_3_0 = ar.normalize_unicode(frame_3_0)
+        assert result_3_0.shape == (3, 0)
+
+        # Empty zero-column frame
+        frame_0_0 = ar.from_pandas(pd.DataFrame())
+        assert frame_0_0.shape == (0, 0)
+        result_0_0 = ar.normalize_unicode(frame_0_0)
+        assert result_0_0.shape == (0, 0)
+
+        # Normal string-column behavior
+        df_normal = pd.DataFrame({"text": ["cafe\u0301"], "other": [1]})
+        frame_normal = ar.from_pandas(df_normal)
+        result_normal = ar.normalize_unicode(frame_normal)
+        assert result_normal.shape == (1, 2)
+        assert ar.to_pandas(result_normal)["text"].iloc[0] == "café"
+
+        # attrs preservation on the zero-column path
+        frame_3_0_attrs = ar.from_pandas(pd.DataFrame(index=range(3)))
+        frame_3_0_attrs._attrs = {"key": "value"}
+        result_3_0_attrs = ar.normalize_unicode(frame_3_0_attrs)
+        assert result_3_0_attrs.shape == (3, 0)
+        assert result_3_0_attrs._attrs == {"key": "value"}
+
+        # attrs deepcopy check on zero-column path
+        result_3_0_attrs._attrs["key"] = "mutated"
+        assert frame_3_0_attrs._attrs["key"] == "value"
+
+
 
 class TestParseBoolStrings:
     def test_parse_basic_bool_strings(self):


### PR DESCRIPTION
Here is a concise and professional summary you can copy and paste directly into your Pull Request description on GitHub:

***

## Description

This PR resolves a data-integrity issue where `normalize_unicode()` loses the row count when called on an `ArFrame` with zero columns and one or more rows (for example, reducing a shape of `(3, 0)` down to `(0, 0)`). 

### Key Changes
- **Bug Fix (`arnio/cleaning.py`)**: Updated `normalize_unicode()` to explicitly pass the source frame's row count (`frame.shape[0]`) to `_Frame.from_dict()` when rebuilding the native C++ frame.
- **Testing (`tests/test_cleaning.py`)**: Added a dedicated test method `test_normalize_unicode_zero_columns` to thoroughly verify:
  - Non-empty zero-column frames (e.g., shape `(3, 0)`) preserve their row count.
  - Empty zero-column frames (shape `(0, 0)`) work correctly.
  - Existing non-empty string-column normalization behavior remains unchanged (no regressions).
  - Metadata `attrs` preservation and deep-copy isolation behave correctly on the zero-column path.

Closes #1956