### PR TITLE
fix: reject zero-column Parquet export that drops row count

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1456,8 +1456,6 @@ def write_parquet(
             f"Cannot write a zero-column ArFrame with {rows} rows to Parquet: the current export path cannot preserve row count without columns."
         )
 
-    """ If the frame has zero columns and a positive row count. """
-
     df = to_pandas(frame)
 
     kwargs: dict = {

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1450,6 +1450,14 @@ def write_parquet(
             "Install it with: pip install arnio[parquet]"
         ) from exc
 
+    rows, cols = frame.shape
+    if cols == 0 and rows > 0:
+        raise ValueError(
+            f"Cannot write a zero-column ArFrame with {rows} rows to Parquet: the current export path cannot preserve row count without columns."
+        )
+
+    """ If the frame has zero columns and a positive row count. """
+
     df = to_pandas(frame)
 
     kwargs: dict = {

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -150,6 +150,46 @@ class TestWriteParquetCompression:
 
 
 @skip_without_pyarrow
+class TestWriteParquetZeroColumn:
+    def test_zero_by_zero_frame_round_trips_empty(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame())
+        assert frame.shape == (0, 0)
+
+        out = tmp_path / "empty.parquet"
+
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+
+        assert df.shape == (0, 0)
+        assert out.exists()
+
+    def test_zero_column_with_row_raises(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame(index=range(3)))
+        assert frame.shape == (3, 0)
+
+        out = tmp_path / "zero_cols.parquet"
+        with pytest.raises(
+            ValueError,
+            match="Cannot write a zero-column ArFrame with 3 rows to Parquet: the current export path cannot preserve row count without columns.",
+        ):
+            ar.write_parquet(frame, out)
+
+        assert not out.exists()
+
+    def test_normal_frame_still_round_trips(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+        assert frame.shape == (3, 2)
+
+        out = tmp_path / "normal.parquet"
+        ar.write_parquet(frame, out)
+        df = pd.read_parquet(out, engine="pyarrow")
+        assert df.shape == (3, 2)
+        assert df["a"].tolist() == [1, 2, 3]
+        assert df["b"].tolist() == ["x", "y", "z"]
+        assert out.exists()
+
+
+@skip_without_pyarrow
 class TestWriteParquetRowGroupSize:
     def test_row_group_size_accepted(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"v": list(range(100))}))


### PR DESCRIPTION

Fixes #1942

## Summary
- Add a guard in `write_parquet()` for `(n, 0)` frames where `n > 0`
- Keep `(0, 0)` export behavior unchanged
- Add regression tests for `(0, 0)`, `(n, 0)`, and normal frames

## Test plan
- [x] `pytest tests/test_parquet.py -v`
- [x] `make test`
- [x] `make lint`