### PR TITLE
fix: allow unregistering custom aliases of built-in cleaning steps

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -175,9 +175,13 @@ def unregister_step(name: str) -> None:
         if name not in _PYTHON_STEP_REGISTRY:
             available_steps = sorted(set(_STEP_REGISTRY) | set(_PYTHON_STEP_REGISTRY))
             raise UnknownStepError(name, available_steps)
-        fn = _PYTHON_STEP_REGISTRY[name]
 
-        if _is_builtin_python_step(name, fn):
+        # Protect only names that were registered as built-ins at module load
+        # time (i.e. present in _BUILTIN_PYTHON_STEP_REGISTRY).  Do NOT use
+        # _is_builtin_python_step here: that helper checks the function's
+        # __module__, which would wrongly block user-defined aliases whose
+        # underlying callable happens to live in arnio.cleaning.
+        if name in _BUILTIN_PYTHON_STEP_REGISTRY:
             available_steps = sorted(set(_STEP_REGISTRY) | set(_PYTHON_STEP_REGISTRY))
             raise UnknownStepError(name, available_steps)
         del _PYTHON_STEP_REGISTRY[name]

--- a/tests/test_register_step_safety.py
+++ b/tests/test_register_step_safety.py
@@ -5,8 +5,10 @@ import pytest  # noqa: E402
 from arnio.pipeline import (  # noqa: E402
     _BUILTIN_PYTHON_STEP_REGISTRY,
     _PYTHON_STEP_REGISTRY,
+    list_steps,
     register_step,
     reset_steps,
+    unregister_step,
 )
 
 
@@ -107,3 +109,52 @@ class TestRegisterStepSafety:
         assert step_name not in _PYTHON_STEP_REGISTRY
         for step in _BUILTIN_PYTHON_STEP_REGISTRY:
             assert step in _PYTHON_STEP_REGISTRY
+
+
+class TestUnregisterStepBuiltinAlias:
+    """Regression tests for the custom-alias-of-builtin-function unregister bug.
+
+    Previously, unregister_step() used _is_builtin_python_step() which checked
+    the function's __module__ attribute.  This incorrectly blocked removal of
+    user-registered aliases whose callable originated in arnio.cleaning.
+    The fix switches the guard to a membership check against
+    _BUILTIN_PYTHON_STEP_REGISTRY (keyed by *registered name*).
+    """
+
+    def test_custom_alias_of_builtin_function_can_be_unregistered(self):
+        """A user-defined alias for a built-in cleaning function is removable.
+
+        Regression: unregister_step() previously raised UnknownStepError for
+        any alias whose underlying function originated in arnio.cleaning.
+        """
+        import arnio.cleaning as cleaning
+
+        alias = "tmp_strip_alias_safety_test"
+
+        # Precondition: alias must not already exist
+        assert alias not in _PYTHON_STEP_REGISTRY
+
+        # 1. Register a custom alias pointing to a built-in cleaning function
+        register_step(alias, cleaning.normalize_whitespace)
+
+        # 2. The alias should appear in list_steps()
+        assert alias in list_steps()
+
+        # 3. Unregistering the alias must succeed (this was the bug)
+        unregister_step(alias)
+
+        # 4. The alias must no longer appear in list_steps()
+        assert alias not in list_steps()
+        assert alias not in _PYTHON_STEP_REGISTRY
+
+    def test_builtin_python_step_names_remain_protected(self):
+        """Actual built-in Python step names cannot be unregistered.
+
+        Ensures the fix does not weaken protection for real built-in names
+        such as 'filter_rows', 'normalize_whitespace', 'coalesce_columns'.
+        """
+        from arnio.exceptions import UnknownStepError
+
+        for step_name in list(_BUILTIN_PYTHON_STEP_REGISTRY):
+            with pytest.raises(UnknownStepError):
+                unregister_step(step_name)


### PR DESCRIPTION
## Summary

Fixes #1921

Custom aliases registered using built-in `arnio.cleaning` functions were incorrectly treated as protected built-in steps during `unregister_step()`. As a result, user-defined aliases could not be removed even though they appeared in the step registry.

## Root Cause

Built-in step detection relied on the underlying function's module origin (`arnio.cleaning`) rather than the registered step name. This caused custom aliases pointing to built-in cleaning functions to be mistakenly identified as built-in steps.

## Changes

- Updated built-in step detection logic to distinguish actual built-in step names from user-defined aliases.
- Preserved protection for genuine built-in steps.
- Added regression tests covering:
  - Registration of a custom alias for a built-in cleaning function.
  - Successful unregistration of the alias.
  - Continued protection of actual built-in step names.

## Result

User-defined aliases of built-in cleaning steps can now be unregistered correctly, while built-in steps remain protected from removal.