### PR TITLE
fix: allow tuple input in ArFrame.drop_columns

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -518,7 +518,7 @@ class ArFrame:
         >>> frame = ar.read_csv("data.csv")
         >>> smaller = frame.drop_columns(["col1", "col2"])
         """
-        if not isinstance(cols, list):
+        if not isinstance(cols, (list, tuple)):
             raise TypeError(
                 f"cols must be a list of column names, got {type(cols).__name__!r}"
             )

--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -491,12 +491,12 @@ class ArFrame:
             self._frame.select_columns(columns), attrs=copy.deepcopy(self._attrs)
         )
 
-    def drop_columns(self, cols: list[str]) -> ArFrame:
+    def drop_columns(self, cols: list[str] | tuple[str, ...]) -> ArFrame:
         """Return a new ArFrame with the specified columns removed.
 
         Parameters
         ----------
-        cols : list[str]
+        cols : list[str] | tuple[str, ...]
             Column names to drop. Duplicates are silently ignored.
             An empty list returns a copy of the frame unchanged.
 
@@ -517,10 +517,11 @@ class ArFrame:
         --------
         >>> frame = ar.read_csv("data.csv")
         >>> smaller = frame.drop_columns(["col1", "col2"])
+        >>> smaller = frame.drop_columns(("col1", "col2"))
         """
         if not isinstance(cols, (list, tuple)):
             raise TypeError(
-                f"cols must be a list of column names, got {type(cols).__name__!r}"
+                f"cols must be a list or tuple of column names, got {type(cols).__name__!r}"
             )
 
         if any(not isinstance(col, str) for col in cols):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -680,6 +680,22 @@ class TestDropColumns:
         assert list(df.columns) == ["id", "name"]
         assert list(df["name"]) == ["Alice", "Bob"]
 
+    def test_drop_columns_accepts_tuple_input(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [1],
+                    "b": [2],
+                    "c": [3],
+                }
+            )
+        )
+
+        result = ar.drop_columns(frame, ("a",))
+        df = ar.to_pandas(result)
+
+        assert list(df.columns) == ["b", "c"]
+
     def test_drop_columns_allows_empty_input_as_no_op(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -984,6 +984,21 @@ class TestDropColumns:
         assert result.columns == ["a", "c"]
         assert result.shape == (2, 2)
 
+    def test_accepts_tuple_of_column_names(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [1],
+                    "b": [2],
+                    "c": [3],
+                }
+            )
+        )
+
+        result = frame.drop_columns(("a",))
+
+        assert result.columns == ["b", "c"]
+
     def test_drop_multiple_columns(self):
         df = pd.DataFrame({"a": [1], "b": [2], "c": [3], "d": [4]})
         frame = ar.from_pandas(df)


### PR DESCRIPTION
## Summary

Aligned `ArFrame.drop_columns()` behavior with `ar.drop_columns()` by allowing tuple inputs in addition to lists.

Added regression tests to verify tuple input is accepted through both the `ArFrame.drop_columns()` method and the top-level `ar.drop_columns()` helper while preserving existing invalid-input validation behavior.

## Linked issue

Fixes #1914

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [ ] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [x] Python API / ArFrame
* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [ ] `make lint`
* [x] Other:

```powershell
python -m pytest tests/test_frame.py -k drop
python -m pytest tests/test_cleaning.py -k drop_columns
```

Results:

* Added `test_accepts_tuple_of_column_names` for `ArFrame.drop_columns()`
* Added `test_drop_columns_accepts_tuple_input` for `ar.drop_columns()`
* All selected tests passed successfully.

## Screenshots / Media

N/A

## Performance Impact

No performance impact. This change only expands accepted input types for column sequences and adds regression tests.

## GSSoC labels

Maintainers only.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR keeps existing validation behavior intact and only aligns tuple/list column-sequence handling between `ArFrame.drop_columns()` and `ar.drop_columns()`.
