### PR TITLE
feat: include boolean columns in describe

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -661,7 +661,12 @@ class ArFrame:
         return self.select_columns(matched)
 
     def describe(self) -> dict[str, dict[str, float]]:
-        """Generate summary statistics for all numeric and string columns.
+        """Generate summary statistics for numeric, string, and boolean columns.
+
+        Numeric columns include ``count``, ``nulls``, ``mean``, ``min``, and
+        ``max``. String columns include ``count``, ``nulls``, and ``unique``.
+        Boolean columns include ``count``, ``nulls``, ``true``, ``false``, and
+        ``true_ratio``.
 
         Returns
         -------

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -233,6 +233,33 @@ std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>>
             }
 
             summary.push_back({col_name, stats});
+        } else if (col.dtype() == DType::BOOL) {
+            size_t true_count = 0;
+            size_t false_count = 0;
+            const auto& values = std::get<std::vector<bool>>(col.data());
+
+            for (size_t i = 0; i < total_rows; ++i) {
+                if (col.is_null(i)) {
+                    null_count++;
+                    continue;
+                }
+                valid_count++;
+                if (values[i]) {
+                    true_count++;
+                } else {
+                    false_count++;
+                }
+            }
+
+            stats.push_back({"count", static_cast<double>(valid_count)});
+            stats.push_back({"nulls", static_cast<double>(null_count)});
+            stats.push_back({"true", static_cast<double>(true_count)});
+            stats.push_back({"false", static_cast<double>(false_count)});
+            stats.push_back({"true_ratio", valid_count > 0 ? static_cast<double>(true_count) /
+                                                                 static_cast<double>(valid_count)
+                                                           : 0.0});
+
+            summary.push_back({col_name, stats});
         } else if (type_str == "string") {
             std::unordered_set<std::string> unique_values;
 

--- a/cpp/tests/test_frame.cpp
+++ b/cpp/tests/test_frame.cpp
@@ -93,3 +93,45 @@ TEST_CASE("Frame::add_column succeeds for distinct column names", "[frame]") {
     REQUIRE(f.has_column("price") == true);
     REQUIRE(f.has_column("quantity") == true);
 }
+
+TEST_CASE("Frame::describe includes boolean column metrics", "[frame][describe]") {
+    Column flags("flag", DType::BOOL);
+    flags.push_back(true);
+    flags.push_back(false);
+    flags.push_null();
+    flags.push_back(true);
+
+    Frame f;
+    f.add_column(std::move(flags));
+
+    auto summary = f.describe();
+    REQUIRE(summary.size() == 1);
+    REQUIRE(summary[0].first == "flag");
+
+    const auto& stats = summary[0].second;
+    REQUIRE(stats.size() == 5);
+    REQUIRE(stats[0] == std::make_pair(std::string("count"), 3.0));
+    REQUIRE(stats[1] == std::make_pair(std::string("nulls"), 1.0));
+    REQUIRE(stats[2] == std::make_pair(std::string("true"), 2.0));
+    REQUIRE(stats[3] == std::make_pair(std::string("false"), 1.0));
+    REQUIRE(stats[4].first == "true_ratio");
+    REQUIRE(stats[4].second == 2.0 / 3.0);
+}
+
+TEST_CASE("Frame::describe reports empty boolean summaries deterministically",
+          "[frame][describe]") {
+    Column flags("flag", DType::BOOL);
+
+    Frame f;
+    f.add_column(std::move(flags));
+
+    auto summary = f.describe();
+    REQUIRE(summary.size() == 1);
+
+    const auto& stats = summary[0].second;
+    REQUIRE(stats[0] == std::make_pair(std::string("count"), 0.0));
+    REQUIRE(stats[1] == std::make_pair(std::string("nulls"), 0.0));
+    REQUIRE(stats[2] == std::make_pair(std::string("true"), 0.0));
+    REQUIRE(stats[3] == std::make_pair(std::string("false"), 0.0));
+    REQUIRE(stats[4] == std::make_pair(std::string("true_ratio"), 0.0));
+}

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -890,6 +890,46 @@ def test_describe_all_string_columns(csv_with_whitespace):
         assert metric_keys == ["count", "nulls", "unique"]
 
 
+def test_describe_includes_boolean_columns():
+    frame = ar.ArFrame.from_records(
+        [
+            {"flag": True, "name": "a"},
+            {"flag": False, "name": "b"},
+            {"flag": True, "name": "c"},
+        ]
+    )
+
+    stats = frame.describe()
+
+    assert list(stats.keys()) == ["flag", "name"]
+    assert list(stats["flag"].keys()) == [
+        "count",
+        "nulls",
+        "true",
+        "false",
+        "true_ratio",
+    ]
+    assert stats["flag"]["count"] == 3.0
+    assert stats["flag"]["nulls"] == 0.0
+    assert stats["flag"]["true"] == 2.0
+    assert stats["flag"]["false"] == 1.0
+    assert stats["flag"]["true_ratio"] == pytest.approx(2.0 / 3.0)
+
+
+def test_describe_boolean_columns_with_nulls():
+    frame = ar.from_pandas(
+        pd.DataFrame({"flag": pd.Series([True, None, False, True], dtype="boolean")})
+    )
+
+    stats = frame.describe()
+
+    assert stats["flag"]["count"] == 3.0
+    assert stats["flag"]["nulls"] == 1.0
+    assert stats["flag"]["true"] == 2.0
+    assert stats["flag"]["false"] == 1.0
+    assert stats["flag"]["true_ratio"] == pytest.approx(2.0 / 3.0)
+
+
 def test_astype_valid_single_type():
     from arnio.convert import to_pandas
     from arnio.frame import ArFrame


### PR DESCRIPTION
Fixes #1935

This adds boolean columns to the existing native `ArFrame.describe()` summary path.

I kept the change focused on the shape discussed in the issue and assignment comment. Numeric and string columns keep their existing metrics and order. Bool columns now get a native summary without going through pandas or `profile()`.

What changed:

- Added a `DType::BOOL` branch in `cpp/src/frame.cpp`.
- Reports deterministic bool metrics: `count`, `nulls`, `true`, `false`, and `true_ratio`.
- Preserves existing numeric/string describe output.
- Added native C++ tests for bool summaries with nulls and empty bool columns.
- Added Python tests for bool columns appearing next to existing string/numeric describe output.
- Updated the `ArFrame.describe()` docstring to mention bool metrics.

This PR is for GSSoC 2026 and stays scoped to the assigned describe/boolean support issue.

Validation:

- `cmake -S . -B /tmp/arnio-build-1935 -DARNIO_BUILD_CPP_TESTS=ON -Dpybind11_DIR=/home/kali/arnio/.venv-codex/lib/python3.13/site-packages/pybind11/share/cmake/pybind11`
- `cmake --build /tmp/arnio-build-1935`
- `ctest --test-dir /tmp/arnio-build-1935 --output-on-failure` — 4 passed
- `.venv-codex/bin/python -m pip install -e '.[dev]'`
- `.venv-codex/bin/python -m pytest tests/test_frame.py -q -k describe` — 8 passed
- `.venv-codex/bin/python -m pytest tests/test_frame.py -q` — 161 passed
- `.venv-codex/bin/python -m pytest -q` — 2480 passed, 46 skipped
- `.venv-codex/bin/python -m ruff check arnio/frame.py tests/test_frame.py`
- `.venv-codex/bin/clang-format --dry-run --Werror cpp/src/frame.cpp cpp/tests/test_frame.cpp`
- Black API check passed for `arnio/frame.py` and `tests/test_frame.py`
- `git diff --check`
