### PR TITLE
Test: add README snippet smoke tests

### DIFF
--- a/tests/test_readme_snippets.py
+++ b/tests/test_readme_snippets.py
@@ -1,0 +1,105 @@
+import os
+import tempfile
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+
+
+@pytest.fixture
+def csv_file():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        f.write("name,age,revenue\n")
+        f.write("Alice,30,1000.0\n")
+        f.write("  Bob  ,25,2000.0\n")
+        f.write("Alice,30,1000.0\n")
+        f.write("Charlie,,3000.0\n")
+        tmp = f.name
+    yield tmp
+    os.unlink(tmp)
+
+
+def test_readme_read_csv(csv_file):
+    frame = ar.read_csv(csv_file)
+    assert frame.shape[0] == 4
+    assert "name" in frame.columns
+
+
+def test_readme_pipeline(csv_file):
+    frame = ar.read_csv(csv_file)
+    clean = ar.pipeline(
+        frame,
+        [
+            ("strip_whitespace",),
+            ("normalize_case", {"case_type": "lower"}),
+            ("drop_nulls",),
+            ("drop_duplicates",),
+        ],
+    )
+    df = ar.to_pandas(clean)
+    assert df["name"].iloc[0] == "alice"
+    assert df.shape[0] == 2
+
+
+def test_readme_from_dict():
+    data = {"name": ["Alice", "Bob"], "age": [25, 30]}
+    frame = ar.from_dict(data)
+    assert frame.shape == (2, 2)
+    assert "name" in frame.columns
+
+
+def test_readme_select_columns(csv_file):
+    frame = ar.read_csv(csv_file)
+    selected = ar.select_columns(frame, ["name", "revenue"])
+    assert selected.columns == ["name", "revenue"]
+
+
+def test_readme_scan_csv(csv_file):
+    schema = ar.scan_csv(csv_file)
+    assert "name" in schema
+
+
+def test_readme_profile(csv_file):
+    frame = ar.read_csv(csv_file)
+    result = ar.profile(frame)
+    assert result is not None
+
+
+def test_readme_to_pandas_roundtrip(csv_file):
+    frame = ar.read_csv(csv_file)
+    df = ar.to_pandas(frame)
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape[0] == 4
+
+
+def test_readme_pipeline_dry_run(csv_file):
+    frame = ar.read_csv(csv_file)
+    ar.pipeline(frame, [("drop_nulls",)], dry_run=True)
+
+
+def test_readme_pipeline_metadata(csv_file):
+    frame = ar.read_csv(csv_file)
+    clean, metadata = ar.pipeline(
+        frame,
+        [("strip_whitespace",), ("drop_duplicates",)],
+        return_metadata=True,
+    )
+    assert "step_timings" in metadata
+    assert "applied_steps" in metadata
+    assert "row_counts" in metadata
+
+
+def test_readme_validate(csv_file):
+    schema = ar.Schema(
+        {
+            "name": ar.String(),
+            "age": ar.String(),
+            "revenue": ar.String(),
+        }
+    )
+    frame = ar.read_csv(csv_file)
+    result = ar.validate(frame, schema)
+    assert result is not None
+    assert hasattr(result, "passed")
+    assert hasattr(result, "issues")


### PR DESCRIPTION
## Summary
Add `tests/test_readme_snippets.py` with 10 focused tests that exercise high-value README examples against the live API. CI picks this up automatically via the existing pytest run - no workflow changes needed.

## Linked issue
Fixes #1888

## Type of change
- [x] Tests

## Area
- [x] Docs / website
- [x] Developer tooling

## Testing
- [x] Other: `python3 -m pytest tests/test_readme_snippets.py -v` - 10 passed in 1.22s

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`test:`).