### PR TITLE
fix: validate parse_bool_strings token container types

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -900,7 +900,21 @@ def parse_bool_strings(
         raise TypeError(
             "false_values must be a set/list/tuple of strings, not a bare string"
         )
+    if true_values is not None and (
+        isinstance(true_values, Mapping)
+        or not isinstance(true_values, (set, list, tuple))
+    ):
+        raise TypeError(
+            "true_values must be a set, list, or tuple of strings"
+        )
 
+    if false_values is not None and (
+        isinstance(false_values, Mapping)
+        or not isinstance(false_values, (set, list, tuple))
+    ):
+        raise TypeError(
+            "false_values must be a set, list, or tuple of strings"
+        )
     df = to_pandas(frame).copy(deep=False)
     if true_values is None:
         true_values = {"true", "yes", "y", "1"}

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -904,17 +904,13 @@ def parse_bool_strings(
         isinstance(true_values, Mapping)
         or not isinstance(true_values, (set, list, tuple))
     ):
-        raise TypeError(
-            "true_values must be a set, list, or tuple of strings"
-        )
+        raise TypeError("true_values must be a set, list, or tuple of strings")
 
     if false_values is not None and (
         isinstance(false_values, Mapping)
         or not isinstance(false_values, (set, list, tuple))
     ):
-        raise TypeError(
-            "false_values must be a set, list, or tuple of strings"
-        )
+        raise TypeError("false_values must be a set, list, or tuple of strings")
     df = to_pandas(frame).copy(deep=False)
     if true_values is None:
         true_values = {"true", "yes", "y", "1"}

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2022,11 +2022,28 @@ class TestParseBoolStrings:
         df = pd.DataFrame({"active": ["yes", "no"]}, dtype=object)
         frame = ar.from_pandas(df)
 
-        with pytest.raises(TypeError, match="'int' object is not iterable"):
+        with pytest.raises(TypeError, match="true_values must be a set, list, or tuple of strings"):
             ar.parse_bool_strings(frame, true_values=123)
 
-        with pytest.raises(TypeError, match="'float' object is not iterable"):
+        with pytest.raises(TypeError, match="false_values must be a set, list, or tuple of strings",):
             ar.parse_bool_strings(frame, false_values=45.6)
+    def test_parse_bool_strings_rejects_mapping_containers(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"active": ["yes", "no"]}, dtype=object)
+        frame = ar.from_pandas(df)
+
+        with pytest.raises(
+            TypeError,
+            match="true_values must be a set, list, or tuple of strings",
+        ):
+            ar.parse_bool_strings(frame, true_values={"yes": 1})
+
+        with pytest.raises(
+            TypeError,
+            match="false_values must be a set, list, or tuple of strings",
+        ):
+            ar.parse_bool_strings(frame, false_values={"no": 1})
 
     def test_parse_bool_strings_overlap_whitespace_and_case_normalization(self):
         """Test that tokens that overlap after case folding and whitespace stripping are correctly rejected."""

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2022,11 +2022,17 @@ class TestParseBoolStrings:
         df = pd.DataFrame({"active": ["yes", "no"]}, dtype=object)
         frame = ar.from_pandas(df)
 
-        with pytest.raises(TypeError, match="true_values must be a set, list, or tuple of strings"):
+        with pytest.raises(
+            TypeError, match="true_values must be a set, list, or tuple of strings"
+        ):
             ar.parse_bool_strings(frame, true_values=123)
 
-        with pytest.raises(TypeError, match="false_values must be a set, list, or tuple of strings",):
+        with pytest.raises(
+            TypeError,
+            match="false_values must be a set, list, or tuple of strings",
+        ):
             ar.parse_bool_strings(frame, false_values=45.6)
+
     def test_parse_bool_strings_rejects_mapping_containers(self):
         import pandas as pd
 


### PR DESCRIPTION
## Summary

Validate container types for `true_values` and `false_values` in `parse_bool_strings()` before iteration.

This fixes cases where non-iterable values raised raw Python errors and mapping types (e.g. `dict`) were silently accepted. The change ensures only `set`, `list`, and `tuple` containers are accepted while preserving existing item-type and overlap validation.

## Linked issue

Fixes #1955

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [x] Python API / ArFrame
* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [x] `python -m pytest tests -v`
* [ ] `make lint`
* [ ] optionally `python -m pytest tests -v --tb=short -x`
* [x] Other:

```powershell
python -m pytest tests/test_cleaning.py::TestParseBoolStrings -v
python -m pytest
```

Result:

```text
2449 passed, 43 skipped
```

## Screenshots / Media

N/A

## Performance Impact

No performance impact. Validation is performed once before iterating over custom boolean token collections.

## GSSoC labels

Maintainers only.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Added validation to reject mappings and non-iterable values for `true_values` and `false_values` while continuing to accept documented container types (`set`, `list`, `tuple`).
