### PR TITLE
fix: deterministic sort for mixed-type allowed values

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2665,11 +2665,15 @@ def _normalize_unique(
 def _normalize_sequence(value: Any) -> Any:
     """Convert sets and tuples to lists for JSON-serializable output.
 
-    Sets are sorted with a type-safe key so mixed scalar types (e.g. ``{1, "1"}``)
-    do not raise ``TypeError``.
+    Sets are sorted naturally when possible. If the set contains mixed
+    incomparable types (e.g. int and str), falls back to a type-safe key
+    so serialization never raises TypeError.
     """
     if isinstance(value, set):
-        return sorted(value, key=lambda x: (type(x).__name__, repr(x)))
+        try:
+            return sorted(value)
+        except TypeError:
+            return sorted(value, key=lambda x: (type(x).__name__, repr(x)))
 
     if isinstance(value, tuple):
         return list(value)

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2663,9 +2663,14 @@ def _normalize_unique(
 
 
 def _normalize_sequence(value: Any) -> Any:
-    """Convert sets and tuples to lists for JSON-serializable output."""
+    """Convert sets and tuples to lists for JSON-serializable output.
+
+    Sets are sorted with a type-safe key so mixed scalar types (e.g. ``{1, "1"}``)
+    do not raise ``TypeError``.
+    """
     if isinstance(value, set):
-        return sorted(value)
+        return sorted(value, key=lambda x: (type(x).__name__, repr(x)))
+
     if isinstance(value, tuple):
         return list(value)
     return value

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3586,3 +3586,37 @@ def test_validate_max_errors_zero_valid_data():
 
     with pytest.raises(ValueError, match="max_errors must be >= 1"):
         ar.validate(frame, schema, max_errors=0)
+
+
+def test_normalize_sequence_homogeneous_strings():
+    schema = ar.Schema({"status": ar.String(allowed={"active", "inactive", "pending"})})
+    payload = json.loads(schema.to_json())
+    assert payload["fields"]["status"]["allowed"] == ["active", "inactive", "pending"]
+
+
+def test_normalize_sequence_homogeneous_numerics():
+    schema = ar.Schema({"code": ar.Field(allowed={3, 1, 2})})
+    payload = json.loads(schema.to_json())
+    assert payload["fields"]["code"]["allowed"] == ["1", "2", "3"] or payload["fields"][
+        "code"
+    ]["allowed"] == [1, 2, 3]
+    assert json.loads(schema.to_json()) == json.loads(schema.to_json())
+
+
+def test_normalize_sequence_mixed_scalar_allowed_does_not_raise():
+    schema = ar.Schema({"code": ar.String(allowed={1, "1"})})
+    result = schema.to_json()
+    assert result is not None
+
+
+def test_normalize_sequence_mixed_scalar_allowed_is_deterministic():
+    schema = ar.Schema({"code": ar.String(allowed={1, "1", 2, "two"})})
+    assert schema.to_json() == schema.to_json()
+
+
+def test_mixed_scalar_allowed_roundtrip():
+    """Mixed-type allowed values survive a to_json() / from_json() round-trip."""
+    schema = ar.Schema({"code": ar.String(allowed={1, "1"})})
+    restored = ar.Schema.from_json(schema.to_json())
+    assert restored.fields["code"].allowed is not None
+    assert len(restored.fields["code"].allowed) == len(schema.fields["code"].allowed)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3595,12 +3595,9 @@ def test_normalize_sequence_homogeneous_strings():
 
 
 def test_normalize_sequence_homogeneous_numerics():
-    schema = ar.Schema({"code": ar.Field(allowed={3, 1, 2})})
+    schema = ar.Schema({"code": ar.Field(allowed={1, 2, 10})})
     payload = json.loads(schema.to_json())
-    assert payload["fields"]["code"]["allowed"] == ["1", "2", "3"] or payload["fields"][
-        "code"
-    ]["allowed"] == [1, 2, 3]
-    assert json.loads(schema.to_json()) == json.loads(schema.to_json())
+    assert payload["fields"]["code"]["allowed"] == [1, 2, 10]
 
 
 def test_normalize_sequence_mixed_scalar_allowed_does_not_raise():
@@ -3618,5 +3615,4 @@ def test_mixed_scalar_allowed_roundtrip():
     """Mixed-type allowed values survive a to_json() / from_json() round-trip."""
     schema = ar.Schema({"code": ar.String(allowed={1, "1"})})
     restored = ar.Schema.from_json(schema.to_json())
-    assert restored.fields["code"].allowed is not None
-    assert len(restored.fields["code"].allowed) == len(schema.fields["code"].allowed)
+    assert restored.fields["code"].allowed == {1, "1"}


### PR DESCRIPTION
Fixes #1682

`_normalize_sequence()` called `sorted(value)` directly on sets, which raises `TypeError` when the set contains mixed scalar types like `{1, "1"}` since Python can't compare `int` and `str` with `<`.

Replaced with a type-safe key:

```python
sorted(value, key=lambda x: (type(x).__name__, repr(x)))
```

Tests added for homogeneous strings, homogeneous numerics, mixed scalars, and `to_json()` / `from_json()` round-trip.