### PR TITLE
fix: support non-ASCII write_csv output paths

### DIFF
--- a/cpp/src/csv_writer.cpp
+++ b/cpp/src/csv_writer.cpp
@@ -1,5 +1,8 @@
 #include "arnio/csv_writer.h"
 
+#ifdef _WIN32
+#include <filesystem>
+#endif
 #include <fstream>
 #include <iomanip>
 #include <limits>
@@ -10,6 +13,16 @@
 #include "arnio/frame.h"
 
 namespace arnio {
+
+namespace {
+inline void open_binary_output(std::ofstream& file, const std::string& path) {
+#ifdef _WIN32
+    file.open(std::filesystem::u8path(path), std::ios::binary);
+#else
+    file.open(path, std::ios::binary);
+#endif
+}
+}  // namespace
 
 CsvWriter::CsvWriter(const CsvWriteConfig& config) : config_(config) {}
 
@@ -63,7 +76,8 @@ void CsvWriter::write(const Frame& frame, const std::string& path) const {
     // text mode would silently expand every '\n' to '\r\n',
     // corrupting any line_terminator that already contains '\r'
     // (e.g. "\r\n" → "\r\r\n").
-    std::ofstream out(path, std::ios::binary);
+    std::ofstream out;
+    open_binary_output(out, path);
     if (!out.is_open()) {
         throw std::runtime_error("Could not open file for writing: " + path);
     }

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -66,6 +66,16 @@ class TestWriteCsv:
         ar.write_csv(frame, out)
         assert out.exists()
 
+    def test_non_ascii_output_path_round_trip(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"city": ["Łódź", "東京"], "sales": [10, 20]}))
+        out = tmp_path / "résumé_東京.csv"
+
+        ar.write_csv(frame, str(out))
+
+        assert out.exists()
+        round_tripped = ar.to_pandas(ar.read_csv(str(out)))
+        pd.testing.assert_frame_equal(round_tripped, ar.to_pandas(frame))
+
     def test_high_precision_float_round_trip(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"val": [1.23456789012345678]}))
         out = str(tmp_path / "float.csv")

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -67,7 +67,9 @@ class TestWriteCsv:
         assert out.exists()
 
     def test_non_ascii_output_path_round_trip(self, tmp_path):
-        frame = ar.from_pandas(pd.DataFrame({"city": ["Łódź", "東京"], "sales": [10, 20]}))
+        frame = ar.from_pandas(
+            pd.DataFrame({"city": ["Łódź", "東京"], "sales": [10, 20]})
+        )
         out = tmp_path / "résumé_東京.csv"
 
         ar.write_csv(frame, str(out))


### PR DESCRIPTION
## Summary
- mirror the reader's Windows UTF-8 path handling in `CsvWriter`
- keep non-Windows output behavior on the existing `std::ofstream` string path
- add a non-ASCII output path round-trip regression for `write_csv`

## Validation
- `/private/tmp/arnio-1913-venv/bin/python -m pytest tests/test_write_csv.py -q` -> 54 passed
- `git diff --check`

Closes #1913
