### PR TITLE
fix: prevent benchmark scripts from deleting user files

### DIFF
--- a/benchmarks/benchmark_auto_clean_memory.py
+++ b/benchmarks/benchmark_auto_clean_memory.py
@@ -259,6 +259,12 @@ def main() -> None:
         help="Keep the generated CSV file after benchmark",
     )
 
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite an existing --file path",
+    )
+
     args = parser.parse_args()
 
     csv_path = (
@@ -269,13 +275,21 @@ def main() -> None:
 
     warmup = not args.no_warmup
 
+    csv_existed_before = os.path.exists(csv_path)
     generated = False
 
-    if os.path.exists(csv_path) and args.reuse_file:
+    if csv_existed_before and args.reuse_file:
         print(f"Using existing dataset: {csv_path}")
 
+    elif csv_existed_before and not args.overwrite:
+        raise FileExistsError(
+            f"{csv_path} already exists. "
+            "Use --reuse-file to use it as-is or "
+            "--overwrite to replace it."
+        )
+
     else:
-        if os.path.exists(csv_path):
+        if csv_existed_before:
             print(f"Overwriting existing dataset: {csv_path}")
 
         generate_synthetic_data(

--- a/benchmarks/benchmark_csv.py
+++ b/benchmarks/benchmark_csv.py
@@ -1,14 +1,16 @@
 import csv
-import os
+import tempfile
 import time
+from pathlib import Path
 
 import arnio
 
 
 def generate_test_csv(filename, num_rows=200000, num_cols=10):
-    if not os.path.exists(filename):
+    filename = Path(filename)
+    if not filename.exists():
         print(f"Generating test CSV with {num_rows} rows...")
-        with open(filename, "w", newline="", encoding="utf-8") as f:
+        with filename.open("w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
             header = [f"col_{i}" for i in range(num_cols)]
             writer.writerow(header)
@@ -33,10 +35,7 @@ def run_benchmark(filename):
 
 
 if __name__ == "__main__":
-    test_file = "large_benchmark.csv"
-    try:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "large_benchmark.csv"
         generate_test_csv(test_file)
         run_benchmark(test_file)
-    finally:
-        if os.path.exists(test_file):
-            os.remove(test_file)


### PR DESCRIPTION
## Summary

Prevent benchmark scripts from overwriting or deleting pre-existing CSV files unless the current benchmark run explicitly owns or creates them.

Fixes #1933

## Changes

* Updated `benchmark_csv.py` to generate benchmark data in a temporary directory instead of using a fixed repository-root filename.
* Added explicit file ownership tracking in `benchmark_auto_clean_memory.py`.
* Added a new `--overwrite` flag for intentionally replacing an existing user-provided file.
* Prevented cleanup logic from deleting files that existed before the benchmark started.
* Preserved existing `--reuse-file` and `--keep-file` behavior.

## Verification

Verified the following scenarios manually:

### benchmark_csv.py

* Confirmed a pre-existing `large_benchmark.csv` is no longer deleted after running the benchmark.
* Confirmed benchmark data is generated and used from a temporary directory.

### benchmark_auto_clean_memory.py

* Confirmed a pre-existing file without `--reuse-file` or `--overwrite` raises `FileExistsError`.
* Confirmed a pre-existing file with `--reuse-file` is reused and preserved.
* Confirmed a pre-existing file with `--overwrite` is explicitly replaced.
* Confirmed cleanup only removes files created during the current benchmark run.

## Quality Checks

* `black` passed
* `ruff` passed
* `pre-commit` checks passed
