### PR TITLE
fix: return fresh object for zero-row drop_constant_columns

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -507,7 +507,17 @@ def drop_constant_columns(
     frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     df = to_pandas(frame) if is_arframe else frame
     if len(df.index) == 0:
-        return frame
+        result_df = df.copy(deep=True)
+
+        if is_arframe:
+            result = from_pandas(result_df)
+
+            if getattr(frame, "_attrs", None) is not None:
+                result._attrs = copy.deepcopy(frame._attrs)
+
+            return result
+
+        return result_df
 
     nunique_counts = df.nunique(dropna=False)
     constant_columns = nunique_counts[nunique_counts == 1].index.tolist()

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -888,22 +888,18 @@ class TestDropConstantColumns:
         result = ar.drop_constant_columns(df)
 
         assert result is not df
-        assert result.shape == (0, 1)        
+        assert result.shape == (0, 1)
 
     def test_drop_constant_columns_zero_row_arframe_returns_new_object(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"a": pd.Series(dtype="int64")})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"a": pd.Series(dtype="int64")}))
 
         result = ar.drop_constant_columns(frame)
 
         assert result is not frame
-        assert result.shape == (0, 1)    
+        assert result.shape == (0, 1)
 
     def test_drop_constant_columns_zero_row_attrs_not_shared(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"a": pd.Series(dtype="int64")})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"a": pd.Series(dtype="int64")}))
 
         frame._attrs = {"nested": {"x": 1}}
 
@@ -911,7 +907,7 @@ class TestDropConstantColumns:
 
         result._attrs["nested"]["x"] = 2
 
-        assert frame._attrs["nested"]["x"] == 1    
+        assert frame._attrs["nested"]["x"] == 1
 
 
 class TestDropEmptyColumns:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -882,6 +882,37 @@ class TestDropConstantColumns:
         ):
             ar.drop_constant_columns([1, 2, 3])
 
+    def test_drop_constant_columns_zero_row_pandas_returns_new_object(self):
+        df = pd.DataFrame({"a": pd.Series(dtype="int64")})
+
+        result = ar.drop_constant_columns(df)
+
+        assert result is not df
+        assert result.shape == (0, 1)        
+
+    def test_drop_constant_columns_zero_row_arframe_returns_new_object(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": pd.Series(dtype="int64")})
+        )
+
+        result = ar.drop_constant_columns(frame)
+
+        assert result is not frame
+        assert result.shape == (0, 1)    
+
+    def test_drop_constant_columns_zero_row_attrs_not_shared(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"a": pd.Series(dtype="int64")})
+        )
+
+        frame._attrs = {"nested": {"x": 1}}
+
+        result = ar.drop_constant_columns(frame)
+
+        result._attrs["nested"]["x"] = 2
+
+        assert frame._attrs["nested"]["x"] == 1    
+
 
 class TestDropEmptyColumns:
     def test_drop_empty_columns_removes_fully_empty_columns(self, tmp_path):


### PR DESCRIPTION
Fixes #1949

### Changes

- Return a fresh result object for zero-row pandas inputs
- Return a fresh ArFrame wrapper for zero-row ArFrame inputs
- Deep copy `_attrs` metadata to prevent aliasing
- Added regression tests for:
  - pandas object identity
  - ArFrame object identity
  - `_attrs` metadata isolation