### PR TITLE
ci: run benchmark workflow for bindings

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - "arnio/**"
+      - "bindings/**"
       - "cpp/**"
       - "benchmarks/**"
       - ".github/workflows/benchmark.yml"


### PR DESCRIPTION
## Summary
- add `bindings/**` to the benchmark workflow PR path filters
- keep the existing benchmark jobs and commands unchanged
- ensure binding-only changes trigger benchmark coverage alongside `arnio/**`, `cpp/**`, and `benchmarks/**`

## Validation
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/benchmark.yml').read_text()); print('benchmark workflow yaml ok')"`
- `git diff --check`

Closes #1898