### PR TITLE
fix: clone clean column names noop

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -2090,7 +2090,7 @@ def clean_column_names(
         if original != updated
     }
     if not mapping:
-        return frame
+        return copy.deepcopy(frame)
 
     result = _rename_columns(frame._frame, mapping)
     return ArFrame(result)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4020,6 +4020,26 @@ class TestCleanColumnNames:
         result = ar.clean_column_names(frame)
         assert to_pandas(result).columns.tolist() == ["my_name", "age"]
 
+    def test_clean_column_names_noop_returns_fresh_frame(self):
+        df = pd.DataFrame({"name": [1], "age": [2]})
+        frame = from_pandas(df)
+
+        result = ar.clean_column_names(frame)
+
+        assert result is not frame
+        assert to_pandas(result).equals(to_pandas(frame))
+
+    def test_clean_column_names_noop_attrs_are_isolated(self):
+        df = pd.DataFrame({"name": [1], "age": [2]})
+        frame = from_pandas(df)
+        frame._attrs = {"source": {"name": "original"}}
+
+        result = ar.clean_column_names(frame)
+
+        result._attrs["source"]["name"] = "mutated"
+
+        assert frame._attrs["source"]["name"] == "original"
+
     def test_clean_column_names_consecutive_and_boundary_underscores(self):
         df = pd.DataFrame({"__col__name__": [1], "-another--col-": [2]})
         frame = from_pandas(df)


### PR DESCRIPTION
## Summary

Fixed `clean_column_names()` no-op behavior so it no longer returns the original `ArFrame` when column names are already clean.

The no-op path now returns a fresh `ArFrame` and copies attrs/metadata so mutating the returned frame metadata does not mutate the input frame metadata. Existing dirty-name cleaning behavior remains unchanged.

## Linked issue

Fixes #1938

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [ ] `make lint`
* [x] optionally `python -m pytest tests/test_cleaning.py -v --tb=short -x`
* [ ] Other:

## Screenshots / Media

Not applicable — this PR does not change UI, README visuals, or terminal output.

## Performance Impact

Not applicable — this is a small no-op branch behavior fix and regression test update.

## GSSoC labels

Maintainers only.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Focused regression coverage verifies:

* `ar.clean_column_names(frame) is not frame` when column names are already clean
* mutating output `_attrs` does not mutate input `_attrs`
* existing dirty-name renaming behavior still works
