### PR TITLE
fix: validate and normalize structured metadata in schema_to_dict

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -142,9 +142,15 @@ def _normalize_serializable(value: Any) -> Any:
 
     - dict keys are sorted deterministically
     - sets are converted into sorted lists
+    - tuples are converted into lists
     - lists are normalized recursively
     - unsupported values raise TypeError
     """
+    # Normalize tuples to lists before validation so that tuple fields
+    # (e.g. required_if=("col", "val"), unique=("id",)) survive export.
+    if isinstance(value, tuple):
+        return [_normalize_serializable(v) for v in value]
+
     _validate_serializable(value)
 
     if isinstance(value, dict):
@@ -319,7 +325,15 @@ def schema_to_dict(schema: dict | Any) -> dict:
                 normalised[field_name] = _normalize_serializable(value)
 
         result = {"fields": normalised}
-        result.update(metadata)
+
+        # Validate and normalize structured metadata before merging.
+        # Keys must be strings; values must be serialization-safe.
+        for meta_key, meta_val in metadata.items():
+            if not isinstance(meta_key, str):
+                raise TypeError(
+                    f"schema metadata keys must be strings, got {type(meta_key)!r}"
+                )
+            result[meta_key] = _normalize_serializable(meta_val)
 
         return result
 

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -413,3 +413,59 @@ class TestDateLikeStringQuoting:
         raw = {"field": {"type": "string", "default": "2026-05-28T10:30:00+05:30"}}
         out = schema_to_yaml(raw)
         assert '"2026-05-28T10:30:00+05:30"' in out
+
+
+# ── Regression tests for issue #1797 ────────────────────────────────────────
+
+
+class TestStructuredMetadataValidation:
+    """schema_to_dict() must validate and normalize structured raw-dict metadata.
+
+    Covers the path where the input is {"fields": {...}, "strict": ..., ...}.
+    Previously, metadata was merged without any validation, which allowed
+    non-serializable values and non-string keys to leak into the result and
+    cause delayed failures in schema_to_yaml() or downstream serializers.
+    """
+
+    def test_non_string_metadata_key_raises(self):
+        """Integer metadata keys must be rejected immediately."""
+        with pytest.raises(TypeError, match="metadata keys must be strings"):
+            schema_to_dict({"fields": {"a": "int64"}, 123: "bad"})
+
+    def test_unsupported_metadata_value_raises(self):
+        """Non-serializable metadata values (e.g. object()) must be rejected."""
+        with pytest.raises(TypeError):
+            schema_to_dict({"fields": {"a": "int64"}, "strict": object()})
+
+    def test_tuple_metadata_value_normalized_to_list(self):
+        """Tuple metadata values (e.g. unique=('id',)) must be converted to list."""
+        result = schema_to_dict({"fields": {"a": "int64"}, "unique": ("id", "name")})
+        assert result["unique"] == ["id", "name"]
+        assert isinstance(result["unique"], list)
+
+    def test_valid_strict_metadata_preserved(self):
+        """strict=True metadata must survive schema_to_dict() unchanged."""
+        result = schema_to_dict({"fields": {"a": "int64"}, "strict": True})
+        assert result["strict"] is True
+
+    def test_valid_unique_list_metadata_preserved(self):
+        """unique=['id'] metadata must survive schema_to_dict() unchanged."""
+        result = schema_to_dict({"fields": {"a": "int64"}, "unique": ["id"]})
+        assert result["unique"] == ["id"]
+
+    def test_schema_to_yaml_end_to_end_valid_metadata(self):
+        """schema_to_yaml() must not raise for valid structured metadata."""
+        raw = {"fields": {"a": "int64"}, "strict": True, "unique": ["a"]}
+        out = schema_to_yaml(raw)
+        assert "strict: true" in out
+        assert "- a" in out
+
+    def test_schema_to_yaml_raises_for_non_string_key(self):
+        """schema_to_yaml() must surface the TypeError from non-string metadata keys."""
+        with pytest.raises(TypeError, match="metadata keys must be strings"):
+            schema_to_yaml({"fields": {"a": "int64"}, 123: "bad"})
+
+    def test_schema_to_yaml_raises_for_unsupported_metadata_value(self):
+        """schema_to_yaml() must surface the TypeError from object() metadata values."""
+        with pytest.raises(TypeError):
+            schema_to_yaml({"fields": {"a": "int64"}, "strict": object()})


### PR DESCRIPTION
## Summary
Fixes a gap in `schema_to_dict()` where structured metadata (keys/values alongside `"fields"`) was merged into the result via `result.update(metadata)` without any validation. This allowed non-string metadata keys (e.g. `123`) and non-serializable values (e.g. `object()`) to silently pass through and produce a delayed `TypeError` inside `schema_to_yaml()` or downstream serializers.

**Changes:**
- `_normalize_serializable()`: add tuple → list conversion so `unique=("id",)` normalizes instead of failing
- `schema_to_dict()` raw dict path: replace `result.update(metadata)` with a validation loop — rejects non-string keys immediately, normalizes values via `_normalize_serializable()`
- `tests/test_schema_export.py`: add `TestStructuredMetadataValidation` (8 new tests)

## Linked issue
Fixes #1797

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] Schema validation

## Testing
```
pytest tests/test_schema_export.py -v
# 59 passed in 1.33s
```
- [x] `python -m pytest tests -v --tb=short -x`

## Screenshots / Media
N/A — no UI or terminal output changes.

## Performance Impact
N/A — validation only runs on the metadata dict (typically 0–2 keys).

## GSSoC labels
<!-- Maintainers only -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: validate and normalize structured metadata in schema_to_dict`).

## Maintainer notes
No breaking changes. The new validation only affects the structured raw-dict path `{"fields": {...}, "strict": ..., ...}`. Valid inputs (string keys, serializable values) behave identically to before.