### PR TITLE
feat: accept tuple subsets in round_numeric_columns

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1416,7 +1416,7 @@ def round_numeric_columns(
     frame : ArFrame or pd.DataFrame
         Input data frame.
     subset : sequence of str, optional
-    Column names to round. If None, applies to all numeric columns.
+        Column names to round. If None, applies to all numeric columns.
     decimals : int, default 0
         Number of decimal places to round to.
 

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1404,7 +1404,7 @@ def filter_rows(
 def round_numeric_columns(
     frame,
     *,
-    subset: list[str] | None = None,
+    subset: Sequence[str] | None = None,
     decimals: int = 0,
 ):
     """Round numeric columns to specified decimal places.
@@ -1415,8 +1415,8 @@ def round_numeric_columns(
     ----------
     frame : ArFrame or pd.DataFrame
         Input data frame.
-    subset : list[str], optional
-        Column names to round. If None, applies to all numeric columns.
+    subset : sequence of str, optional
+    Column names to round. If None, applies to all numeric columns.
     decimals : int, default 0
         Number of decimal places to round to.
 
@@ -1433,8 +1433,7 @@ def round_numeric_columns(
     from .convert import from_pandas, to_pandas
 
     frame, is_arframe = _validate_frame(frame, allow_pandas=True)
-    if subset is not None and not isinstance(subset, list):
-        raise TypeError("subset must be a list of column names")
+    
     if isinstance(decimals, bool) or not isinstance(decimals, int):
         raise TypeError("decimals must be an integer")
 

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1433,7 +1433,7 @@ def round_numeric_columns(
     from .convert import from_pandas, to_pandas
 
     frame, is_arframe = _validate_frame(frame, allow_pandas=True)
-    
+
     if isinstance(decimals, bool) or not isinstance(decimals, int):
         raise TypeError("decimals must be an integer")
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2902,7 +2902,9 @@ class TestRoundNumericColumns:
 
         df = pd.DataFrame({"a": [1.123]})
         frame = ar.from_pandas(df)
-        with pytest.raises(TypeError, match="subset must be a sequence of column names"):
+        with pytest.raises(
+            TypeError, match="subset must be a sequence of column names"
+        ):
             ar.round_numeric_columns(frame, subset="a")
 
     def test_invalid_decimals_type(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2902,7 +2902,7 @@ class TestRoundNumericColumns:
 
         df = pd.DataFrame({"a": [1.123]})
         frame = ar.from_pandas(df)
-        with pytest.raises(TypeError, match="subset must be a list"):
+        with pytest.raises(TypeError, match="subset must be a sequence of column names"):
             ar.round_numeric_columns(frame, subset="a")
 
     def test_invalid_decimals_type(self):
@@ -2932,6 +2932,41 @@ class TestRoundNumericColumns:
         assert result["a"].tolist() == [1.2, 5.7]
         assert result["label"].tolist() == ["x", "y"]
         assert df["a"].tolist() == [1.234, 5.678]
+
+    def test_round_tuple_subset(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123, 2.456], "b": [3.789, 4.0]})
+
+        frame = ar.from_pandas(df)
+
+        result = ar.round_numeric_columns(
+            frame,
+            subset=("a",),
+            decimals=1,
+        )
+
+        result_df = ar.to_pandas(result)
+
+        assert list(result_df["a"]) == [1.1, 2.5]
+        assert list(result_df["b"]) == [3.789, 4.0]
+
+    def test_round_tuple_subset_non_string_member(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"a": [1.123]})
+
+        frame = ar.from_pandas(df)
+
+        with pytest.raises(
+            TypeError,
+            match="string column names",
+        ):
+            ar.round_numeric_columns(
+                frame,
+                subset=("a", 123),
+                decimals=1,
+            )
 
 
 class TestCombineColumns:


### PR DESCRIPTION
## Summary

Updated `round_numeric_columns()` to accept tuple-based subsets in addition to lists, making its behavior consistent with other Arnio cleaning helpers that already support sequence-based column selections.

## Linked issue

Fixes #1918

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [ ] optionally `python -m pytest tests -v --tb=short -x`
* [x] Other:

```bash
pytest tests/test_cleaning.py
```

Result:

```text
415 passed
```

## Screenshots / Media

N/A

## Performance Impact

None. This change only updates subset validation and adds test coverage.

## GSSoC labels

Maintainers only.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR updates `round_numeric_columns()` to accept tuple-based subsets by using the existing shared sequence validation helper. Existing validation behavior for bare strings, invalid members, and unknown columns is preserved. Additional tests were added for tuple support and invalid tuple members.
