### PR TITLE
fix: reject impossible numeric bounds in Field

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -724,6 +724,9 @@ class Field:
             if self.max is not None:
                 if isinstance(self.max, bool) or not isinstance(self.max, (int, float)):
                     raise TypeError("max must be numeric or None")
+            if self.min is not None and self.max is not None:
+                if self.min > self.max:
+                    raise ValueError("min must be less than or equal to max")
         if self.dtype is not None and not isinstance(self.dtype, str):
             raise TypeError(
                 f"dtype must be a str or None, got {type(self.dtype).__name__}"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1688,6 +1688,30 @@ def test_float64_rejects_impossible_bounds():
         raise AssertionError("Expected invalid Float64 bounds to raise")
 
 
+def test_field_rejects_invalid_int_bounds():
+    with pytest.raises(ValueError, match="min must be less than or equal to max"):
+        ar.Field(dtype="int64", min=10, max=1)
+
+
+def test_field_rejects_invalid_float_bounds():
+    with pytest.raises(ValueError, match="min must be less than or equal to max"):
+        ar.Field(dtype="float64", min=10.0, max=1.0)
+
+
+def test_field_allows_equal_bounds():
+    field = ar.Field(dtype="int64", min=5, max=5)
+
+    assert field.min == 5
+    assert field.max == 5
+
+
+def test_field_allows_valid_increasing_bounds():
+    field = ar.Field(dtype="float64", min=1.0, max=10.0)
+
+    assert field.min == 1.0
+    assert field.max == 10.0
+
+
 def test_string_rejects_impossible_length_bounds():
     try:
         ar.String(min_length=5, max_length=2)


### PR DESCRIPTION
## Summary
Reject impossible numeric bounds during direct `Field(...)` construction when `min > max` for numeric dtypes.

Adds validation parity with `Int64()` and `Float64()` helper constructors and preserves valid equal-bound behavior.

## Linked issue
Fixes #1930 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `pytest tests/test_schema.py -v`
- [x] `pytest tests/test_schema.py -k "impossible_bounds" -v`
- [x] `ruff check arnio/schema.py tests/test_schema.py`
- [x] `black arnio/schema.py tests/test_schema.py`


## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).