### PR TITLE
fix: ArFrame string output is blank for zero-column frames

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -711,6 +711,14 @@ class ArFrame:
         if rows == 0:
             return f"{header}\nColumns: {truncated_names}\n(empty frame)"
 
+        if cols == 0:
+            dtypes_line = f"DTypes: {self.dtypes}"
+            memory_line = f"Memory: {self.memory_usage()} bytes"
+            return (
+                f"{header}\nColumns: {truncated_names}\n{dtypes_line}\n"
+                f"{memory_line}\n(no columns to display)"
+            )
+
         actual_n = min(5, rows)
         col_data = [
             [self._frame.column_by_index(i).at(r) for r in range(actual_n)]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -723,6 +723,17 @@ def test_str_keeps_normal_column_names():
     assert "..." not in result
 
 
+def test_str_zero_columns_non_empty_rows_has_explicit_message():
+    frame = ar.from_pandas(pd.DataFrame(index=range(2)))
+
+    result = str(frame)
+
+    assert "ArFrame: 2 rows × 0 columns" in result
+    assert "Columns: []" in result
+    assert "DTypes: {}" in result
+    assert "(no columns to display)" in result
+
+
 def test_add_column_accepts_matching_lengths():
     from arnio._arnio_cpp import Column, DType, Frame
 


### PR DESCRIPTION
Implemented the fix and regression test.

### Changes made
- Added a zero-column fast path in frame.py so non-empty frames with 0 columns no longer render blank table lines.
- The string output now includes an explicit terminal line, shown at frame.py: (no columns to display).
- Added regression test test_frame.py for a frame with 2 rows and 0 columns, asserting the shape line, columns, dtypes, and explicit no-columns message.

### Validation
- Ran targeted pytest for string tests in test_frame.
- Test run could not proceed because collection fails before tests execute: arnio._arnio_cpp is missing in this environment, so importing arnio fails.
- Error summary: ModuleNotFoundError for arnio._arnio_cpp, then ImportError from _core.py during test collection.

closes #1939