### PR TITLE
Fix missing input validation in write_csv and write_parquet

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -875,8 +875,6 @@ def write_csv(
     write_header: bool = True,
     line_terminator: str = "\n",
 ) -> None:
-    if not isinstance(frame, ArFrame):
-        raise TypeError("frame must be an ArFrame")
     """Write an ArFrame to a CSV file via C++ backend.
 
     Parameters
@@ -904,6 +902,9 @@ def write_csv(
     >>> ar.write_csv(frame, "output.csv")
     >>> ar.write_csv(frame, "output.tsv", delimiter="\\t")
     """
+    if not isinstance(frame, ArFrame):
+        raise TypeError("frame must be an ArFrame")
+
     if not isinstance(path, (str, bytes, os.PathLike)):
         raise TypeError(
             f"path must be a string, bytes, or os.PathLike object, got {type(path).__name__!r}"
@@ -1397,8 +1398,6 @@ def write_parquet(
     compression: str = "snappy",
     row_group_size: int | None = None,
 ) -> None:
-    if not isinstance(frame, ArFrame):
-        raise TypeError("frame must be an ArFrame")
     """Write an ArFrame to a Parquet file via pyarrow.
 
     Requires the ``pyarrow`` package.  Install it with::
@@ -1438,6 +1437,9 @@ def write_parquet(
     >>> ar.write_parquet(frame, "output.pq", compression="zstd")
     >>> ar.write_parquet(frame, "output.parquet", row_group_size=50_000)
     """
+    if not isinstance(frame, ArFrame):
+        raise TypeError("frame must be an ArFrame")
+
     from .convert import to_pandas
 
     if not isinstance(path, (str, bytes, os.PathLike)):

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -875,6 +875,8 @@ def write_csv(
     write_header: bool = True,
     line_terminator: str = "\n",
 ) -> None:
+    if not isinstance(frame, ArFrame):
+        raise TypeError("frame must be an ArFrame")
     """Write an ArFrame to a CSV file via C++ backend.
 
     Parameters
@@ -1395,6 +1397,8 @@ def write_parquet(
     compression: str = "snappy",
     row_group_size: int | None = None,
 ) -> None:
+    if not isinstance(frame, ArFrame):
+        raise TypeError("frame must be an ArFrame")
     """Write an ArFrame to a Parquet file via pyarrow.
 
     Requires the ``pyarrow`` package.  Install it with::

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -258,6 +258,15 @@ class TestWriteParquetErrors:
             with pytest.raises(ImportError, match="pip install arnio\\[parquet\\]"):
                 ar.write_parquet(frame, tmp_path / "out.parquet")
 
+    @pytest.mark.parametrize("bad_input", [
+        object(),
+        None,
+        pd.DataFrame({"a": [1, 2]}),
+    ])
+    def test_write_parquet_invalid_frame(self, tmp_path, bad_input):
+        with pytest.raises(TypeError, match="frame must be an ArFrame"):
+            ar.write_parquet(bad_input, tmp_path / "out.parquet")
+
 
 def test_write_parquet_rejects_bool_path(tmp_path):
     frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -258,11 +258,14 @@ class TestWriteParquetErrors:
             with pytest.raises(ImportError, match="pip install arnio\\[parquet\\]"):
                 ar.write_parquet(frame, tmp_path / "out.parquet")
 
-    @pytest.mark.parametrize("bad_input", [
-        object(),
-        None,
-        pd.DataFrame({"a": [1, 2]}),
-    ])
+    @pytest.mark.parametrize(
+        "bad_input",
+        [
+            object(),
+            None,
+            pd.DataFrame({"a": [1, 2]}),
+        ],
+    )
     def test_write_parquet_invalid_frame(self, tmp_path, bad_input):
         with pytest.raises(TypeError, match="frame must be an ArFrame"):
             ar.write_parquet(bad_input, tmp_path / "out.parquet")

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -8,14 +8,19 @@ import pytest
 
 import arnio as ar
 
-@pytest.mark.parametrize("bad_input", [
-    object(),
-    None,
-    pd.DataFrame({"a": [1, 2]}),
-])
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [
+        object(),
+        None,
+        pd.DataFrame({"a": [1, 2]}),
+    ],
+)
 def test_write_csv_invalid_frame(bad_input, tmp_path):
     with pytest.raises(TypeError, match="frame must be an ArFrame"):
         ar.write_csv(bad_input, tmp_path / "out.csv")
+
 
 class TestWriteCsv:
     def test_basic_write(self, tmp_path, sample_csv):

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -8,6 +8,14 @@ import pytest
 
 import arnio as ar
 
+@pytest.mark.parametrize("bad_input", [
+    object(),
+    None,
+    pd.DataFrame({"a": [1, 2]}),
+])
+def test_write_csv_invalid_frame(bad_input, tmp_path):
+    with pytest.raises(TypeError, match="frame must be an ArFrame"):
+        ar.write_csv(bad_input, tmp_path / "out.csv")
 
 class TestWriteCsv:
     def test_basic_write(self, tmp_path, sample_csv):


### PR DESCRIPTION
## Description
This PR fixes an issue where the `write_csv()` and `write_parquet()` export helpers were missing type validation for their `frame` arguments. Previously, passing a non-`ArFrame` object (like `None`, a base `object()`, or a pandas `DataFrame`) would bypass validation and crash deep within the C++ bindings or pyarrow conversion paths, resulting in a confusing internal `AttributeError: 'object' object has no attribute '_frame'`.

Because these export functions act as public API boundaries, it is critical that they fail early with clear, consistent messages. 

## Changes Made
- **Type Guard Added:** Inserted an `isinstance(frame, ArFrame)` check at the very beginning of both `arnio/io.py::write_csv` and `arnio/io.py::write_parquet`.
- **Clear Error Messaging:** The functions now explicitly raise `TypeError("frame must be an ArFrame")` when the guard fails, standardizing the error surface.
- **Valid Output Retained:** Behavior for valid `ArFrame` instances remains completely untouched and functions identically to before.
- **Comprehensive Testing:** Added parameterized unit tests (`test_write_csv_invalid_frame` and `test_write_parquet_invalid_frame`) to ensure the correct `TypeError` is raised across multiple invalid inputs including `object()`, `None`, and `pd.DataFrame`.

## Related Files
- `arnio/io.py`
- `tests/test_write_csv.py`
- `tests/test_parquet.py`