### PR TITLE
fix(quality): validate QualityGateIssue and QualityGateResult constructor fields

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -1154,6 +1154,25 @@ class QualityGateIssue:
     threshold: Any = None
     delta: float | None = None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.metric, str):
+            raise TypeError(f"metric must be a str, got {type(self.metric).__name__}")
+        if not self.metric.strip():
+            raise ValueError("metric must be a non-empty string")
+        if not isinstance(self.message, str):
+            raise TypeError(f"message must be a str, got {type(self.message).__name__}")
+        if not self.message.strip():
+            raise ValueError("message must be a non-empty string")
+        if self.column is not None and not isinstance(self.column, str):
+            raise TypeError(
+                f"column must be a str or None, got {type(self.column).__name__}"
+            )
+        if self.delta is not None:
+            if isinstance(self.delta, bool) or not isinstance(self.delta, (int, float)):
+                raise TypeError(
+                    f"delta must be a float, integer, or None, got {type(self.delta).__name__}"
+                )
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly dictionary representation."""
         return {
@@ -1175,6 +1194,29 @@ class QualityGateResult:
     current_profile: DataQualityReport
     issues: list[QualityGateIssue]
     thresholds: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.baseline_profile, DataQualityReport):
+            raise TypeError(
+                f"baseline_profile must be a DataQualityReport instance, got {type(self.baseline_profile).__name__}"
+            )
+        if not isinstance(self.current_profile, DataQualityReport):
+            raise TypeError(
+                f"current_profile must be a DataQualityReport instance, got {type(self.current_profile).__name__}"
+            )
+        if not isinstance(self.issues, list):
+            raise TypeError(
+                f"issues must be a list of QualityGateIssue instances, got {type(self.issues).__name__}"
+            )
+        for i, issue in enumerate(self.issues):
+            if not isinstance(issue, QualityGateIssue):
+                raise TypeError(
+                    f"issues[{i}] must be a QualityGateIssue instance, got {type(issue).__name__}"
+                )
+        if not isinstance(self.thresholds, dict):
+            raise TypeError(
+                f"thresholds must be a dict, got {type(self.thresholds).__name__}"
+            )
 
     @property
     def passed(self) -> bool:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -3908,3 +3908,107 @@ class TestCleanExplanationValidation:
         exp = self._valid_explanation()
         text = str(exp)
         assert "(none)" in text
+
+
+class TestQualityGateResultConstructorValidation:
+    """Tests for QualityGateIssue and QualityGateResult constructor field validation."""
+
+    def test_quality_gate_issue_valid(self):
+        issue = ar.QualityGateIssue(
+            metric="null_ratio",
+            message="Column has too many nulls",
+            column="age",
+            baseline=0.05,
+            current=0.10,
+            threshold=0.08,
+            delta=0.05,
+        )
+        assert issue.metric == "null_ratio"
+        assert issue.message == "Column has too many nulls"
+        assert issue.column == "age"
+        assert issue.delta == 0.05
+        assert issue.to_dict()["metric"] == "null_ratio"
+
+    def test_quality_gate_issue_invalid_metric(self):
+        with pytest.raises(TypeError, match="metric must be a str"):
+            ar.QualityGateIssue(metric=123, message="msg")
+        with pytest.raises(ValueError, match="metric must be a non-empty string"):
+            ar.QualityGateIssue(metric="   ", message="msg")
+
+    def test_quality_gate_issue_invalid_message(self):
+        with pytest.raises(TypeError, match="message must be a str"):
+            ar.QualityGateIssue(metric="null_ratio", message=42)
+        with pytest.raises(ValueError, match="message must be a non-empty string"):
+            ar.QualityGateIssue(metric="null_ratio", message="")
+
+    def test_quality_gate_issue_invalid_column(self):
+        with pytest.raises(TypeError, match="column must be a str or None"):
+            ar.QualityGateIssue(metric="null_ratio", message="msg", column=123)
+
+    def test_quality_gate_issue_invalid_delta(self):
+        with pytest.raises(TypeError, match="delta must be a float, integer, or None"):
+            ar.QualityGateIssue(metric="null_ratio", message="msg", delta="0.5")
+        with pytest.raises(TypeError, match="delta must be a float, integer, or None"):
+            ar.QualityGateIssue(metric="null_ratio", message="msg", delta=True)
+
+    def test_quality_gate_result_valid(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        report = ar.profile(ar.from_pandas(df))
+
+        issue = ar.QualityGateIssue(metric="null_ratio", message="msg")
+        res = ar.QualityGateResult(
+            baseline_profile=report,
+            current_profile=report,
+            issues=[issue],
+            thresholds={"null_ratio": 0.05},
+        )
+        assert res.passed is False
+        assert len(res.issues) == 1
+        assert res.thresholds == {"null_ratio": 0.05}
+
+    def test_quality_gate_result_invalid_profiles(self):
+        issue = ar.QualityGateIssue(metric="null_ratio", message="msg")
+        with pytest.raises(
+            TypeError, match="baseline_profile must be a DataQualityReport instance"
+        ):
+            ar.QualityGateResult(
+                baseline_profile="not a report",
+                current_profile="not a report",
+                issues=[issue],
+                thresholds={},
+            )
+
+    def test_quality_gate_result_invalid_issues(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        report = ar.profile(ar.from_pandas(df))
+
+        with pytest.raises(TypeError, match="issues must be a list"):
+            ar.QualityGateResult(
+                baseline_profile=report,
+                current_profile=report,
+                issues="not a list",
+                thresholds={},
+            )
+
+        with pytest.raises(
+            TypeError, match="issues\\[0\\] must be a QualityGateIssue instance"
+        ):
+            ar.QualityGateResult(
+                baseline_profile=report,
+                current_profile=report,
+                issues=["not an issue"],
+                thresholds={},
+            )
+
+    def test_quality_gate_result_invalid_thresholds(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        report = ar.profile(ar.from_pandas(df))
+        issue = ar.QualityGateIssue(metric="null_ratio", message="msg")
+
+        with pytest.raises(TypeError, match="thresholds must be a dict"):
+            ar.QualityGateResult(
+                baseline_profile=report,
+                current_profile=report,
+                issues=[issue],
+                thresholds="not a dict",
+            )


### PR DESCRIPTION
Closes #1686. Adds __post_init__ validation methods to ensure the constructor fields of QualityGateIssue and QualityGateResult are type-safe, non-empty, and correct. Also added extensive regression unit tests.