### PR TITLE
fix: validate Custom validator names before registry lookup

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2795,8 +2795,10 @@ def Custom(
     >>> schema = ar.Schema({"score": ar.Custom("positive", nullable=False)})
     """
 
-    if not isinstance(name, str) or not name:
-        raise ValueError("name must be a non-empty string")
+    if not isinstance(name, str):
+        raise TypeError("The validator name must be a string.")
+    if not name.strip():
+        raise ValueError("The validator name cannot be an empty string.")
 
     if name not in _CUSTOM_VALIDATORS:
         raise ValueError(

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2794,12 +2794,10 @@ def Custom(
     >>> ar.register_validator("positive", lambda v: v > 0)
     >>> schema = ar.Schema({"score": ar.Custom("positive", nullable=False)})
     """
-
     if not isinstance(name, str):
         raise TypeError("The validator name must be a string.")
     if not name.strip():
         raise ValueError("The validator name cannot be an empty string.")
-
     if name not in _CUSTOM_VALIDATORS:
         raise ValueError(
             f"No validator registered under {name!r}. "

--- a/fix_whitespace.py
+++ b/fix_whitespace.py
@@ -1,0 +1,8 @@
+import re
+for f in ['tests/test_register_validator.py', 'arnio/schema.py']:
+    with open(f, 'r') as file:
+        content = file.read()
+    cleaned = re.sub(r'[ \t]+\n', '\n', content)
+    with open(f, 'w') as file:
+        file.write(cleaned)
+print('Done!') 

--- a/fix_whitespace.py
+++ b/fix_whitespace.py
@@ -1,0 +1,8 @@
+import re
+for f in ['tests/test_register_validator.py', 'arnio/schema.py']:
+    with open(f, 'r') as file:
+        content = file.read()
+    cleaned = re.sub(r'[ \t]+\n', '\n', content)
+    with open(f, 'w') as file:
+        file.write(cleaned)
+print('Done!')

--- a/fix_whitespace.py
+++ b/fix_whitespace.py
@@ -1,8 +1,0 @@
-import re
-for f in ['tests/test_register_validator.py', 'arnio/schema.py']:
-    with open(f, 'r') as file:
-        content = file.read()
-    cleaned = re.sub(r'[ \t]+\n', '\n', content)
-    with open(f, 'w') as file:
-        file.write(cleaned)
-print('Done!')

--- a/fix_whitespace.py
+++ b/fix_whitespace.py
@@ -1,8 +1,0 @@
-import re
-for f in ['tests/test_register_validator.py', 'arnio/schema.py']:
-    with open(f, 'r') as file:
-        content = file.read()
-    cleaned = re.sub(r'[ \t]+\n', '\n', content)
-    with open(f, 'w') as file:
-        file.write(cleaned)
-print('Done!') 

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -50,8 +50,8 @@ class TestRegisterValidator:
             register_validator("none_fn", None)
 
     def test_raises_value_error_when_name_is_empty_string(self):
-        """register_validator raises typeerror when name is empty string."""
-        with pytest.raises(typeerror, match="non-empty string"):
+        """register_validator raises ValueError when name is empty string."""
+        with pytest.raises(ValueError, match="non-empty string"):
             register_validator("", lambda x: True)
 
     def test_raises_value_error_when_name_is_not_string(self):
@@ -166,7 +166,7 @@ class TestCustomValidator:
 
     def test_custom_raises_when_validator_not_registered(self):
         """Custom raises typeerror when validator name not registered."""
-        with pytest.raises(typeerror, match="No validator registered"):
+        with pytest.raises(TypeError, match="No validator registered"):
             Custom("nonexistent_validator_name_xyz")
 
     def test_custom_repr_contains_name(self):
@@ -227,14 +227,10 @@ class TestCustomValidator:
         with pytest.raises(TypeError, match="The validator name must be a string."):
             ar.Custom(None)
 
-        """Test empty string raises typeerror"""
-        with pytest.raises(
-            typeerror, match="The validator name cannot be an empty string."
-        ):
+        """Test empty string raises ValueError"""
+        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
             ar.Custom("")
-        with pytest.raises(
-            typeerror, match="The validator name cannot be an empty string."
-        ):
+        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
             ar.Custom("   ")
 
 
@@ -342,22 +338,22 @@ class TestCustomValidatorNameValidation:
         schema._CUSTOM_VALIDATORS.clear()
         schema._CUSTOM_VALIDATORS.update(self._original_validators)
 
-    def test_raises_value_error_when_name_is_empty_string(self):
+    def test_raises_type_error_when_name_is_empty_string(self):
         """Custom raises typeerror when name is an empty string."""
         with pytest.raises(typeerror, match="non-empty string"):
             Custom("")
 
-    def test_raises_value_error_when_name_is_integer(self):
+    def test_raises_type_error_when_name_is_integer(self):
         """Custom raises typeerror when name is an integer."""
         with pytest.raises(typeerror, match="non-empty string"):
             Custom(123)
 
-    def test_raises_value_error_when_name_is_none(self):
+    def test_raises_type_error_when_name_is_none(self):
         """Custom raises typeerror when name is None."""
         with pytest.raises(typeerror, match="non-empty string"):
             Custom(None)
 
-    def test_raises_value_error_when_name_is_list(self):
+    def test_raises_type_error_when_name_is_list(self):
         """Custom raises typeerror when name is a list."""
         with pytest.raises(typeerror, match="non-empty string"):
             Custom(["my_validator"])

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -50,13 +50,13 @@ class TestRegisterValidator:
             register_validator("none_fn", None)
 
     def test_raises_value_error_when_name_is_empty_string(self):
-        """register_validator raises ValueError when name is empty string."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        """register_validator raises typeerror when name is empty string."""
+        with pytest.raises(typeerror, match="non-empty string"):
             register_validator("", lambda x: True)
 
     def test_raises_value_error_when_name_is_not_string(self):
-        """register_validator raises ValueError when name is not a string."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        """register_validator raises typeerror when name is not a string."""
+        with pytest.raises(typeerror, match="non-empty string"):
             register_validator(123, lambda x: True)
 
     def test_overwrites_existing_validator(self):
@@ -165,8 +165,8 @@ class TestCustomValidator:
         assert field.severity == "warning"
 
     def test_custom_raises_when_validator_not_registered(self):
-        """Custom raises ValueError when validator name not registered."""
-        with pytest.raises(ValueError, match="No validator registered"):
+        """Custom raises typeerror when validator name not registered."""
+        with pytest.raises(typeerror, match="No validator registered"):
             Custom("nonexistent_validator_name_xyz")
 
     def test_custom_repr_contains_name(self):
@@ -227,13 +227,13 @@ class TestCustomValidator:
         with pytest.raises(TypeError, match="The validator name must be a string."):
             ar.Custom(None)
 
-        """Test empty string raises ValueError"""
+        """Test empty string raises typeerror"""
         with pytest.raises(
-            ValueError, match="The validator name cannot be an empty string."
+            typeerror, match="The validator name cannot be an empty string."
         ):
             ar.Custom("")
         with pytest.raises(
-            ValueError, match="The validator name cannot be an empty string."
+            typeerror, match="The validator name cannot be an empty string."
         ):
             ar.Custom("   ")
 
@@ -343,26 +343,26 @@ class TestCustomValidatorNameValidation:
         schema._CUSTOM_VALIDATORS.update(self._original_validators)
 
     def test_raises_value_error_when_name_is_empty_string(self):
-        """Custom raises ValueError when name is an empty string."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        """Custom raises typeerror when name is an empty string."""
+        with pytest.raises(typeerror, match="non-empty string"):
             Custom("")
 
     def test_raises_value_error_when_name_is_integer(self):
-        """Custom raises ValueError when name is an integer."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        """Custom raises typeerror when name is an integer."""
+        with pytest.raises(typeerror, match="non-empty string"):
             Custom(123)
 
     def test_raises_value_error_when_name_is_none(self):
-        """Custom raises ValueError when name is None."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        """Custom raises typeerror when name is None."""
+        with pytest.raises(typeerror, match="non-empty string"):
             Custom(None)
 
     def test_raises_value_error_when_name_is_list(self):
-        """Custom raises ValueError when name is a list."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        """Custom raises typeerror when name is a list."""
+        with pytest.raises(typeerror, match="non-empty string"):
             Custom(["my_validator"])
 
     def test_valid_name_still_raises_when_unregistered(self):
         """A valid string name that isn't registered raises the registry error, not the name error."""
-        with pytest.raises(ValueError, match="No validator registered"):
+        with pytest.raises(typeerror, match="No validator registered"):
             Custom("unregistered_name_xyz")

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -210,6 +210,28 @@ class TestCustomValidator:
         assert f1.semantic == "custom:positive"
         assert f2.semantic == "custom:email"
 
+    def test_custom_validator_name_validation(self):
+        import pytest
+        import arnio as ar
+
+        """Test unhashable type raises TypeError"""
+        with pytest.raises(TypeError, match="The validator name must be a string."):
+            ar.Custom(["validator"])
+
+        """Test invalid scalar type raises TypeError"""
+        with pytest.raises(TypeError, match="The validator name must be a string."):
+            ar.Custom(123)
+
+        """Test None type raises TypeError"""
+        with pytest.raises(TypeError, match="The validator name must be a string."):
+            ar.Custom(None)
+
+        """Test empty string raises ValueError"""
+        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
+            ar.Custom("")
+        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
+            ar.Custom("   ")
+
 
 class TestCustomValidatorReturnNormalization:
     """Regression tests for issue #1469.

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -228,9 +228,13 @@ class TestCustomValidator:
             ar.Custom(None)
 
         """Test empty string raises ValueError"""
-        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
+        with pytest.raises(
+            ValueError, match="The validator name cannot be an empty string."
+        ):
             ar.Custom("")
-        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
+        with pytest.raises(
+            ValueError, match="The validator name cannot be an empty string."
+        ):
             ar.Custom("   ")
 
 

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -165,8 +165,8 @@ class TestCustomValidator:
         assert field.severity == "warning"
 
     def test_custom_raises_when_validator_not_registered(self):
-        """Custom raises typeerror when validator name not registered."""
-        with pytest.raises(TypeError, match="No validator registered"):
+        """Custom raises ValueError when validator name not registered."""
+        with pytest.raises(ValueError, match="No validator registered"):
             Custom("nonexistent_validator_name_xyz")
 
     def test_custom_repr_contains_name(self):

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -210,33 +210,6 @@ class TestCustomValidator:
         assert f1.semantic == "custom:positive"
         assert f2.semantic == "custom:email"
 
-    def test_custom_validator_name_validation(self):
-        import pytest
-
-        import arnio as ar
-
-        """Test unhashable type raises TypeError"""
-        with pytest.raises(TypeError, match="The validator name must be a string."):
-            ar.Custom(["validator"])
-
-        """Test invalid scalar type raises TypeError"""
-        with pytest.raises(TypeError, match="The validator name must be a string."):
-            ar.Custom(123)
-
-        """Test None type raises TypeError"""
-        with pytest.raises(TypeError, match="The validator name must be a string."):
-            ar.Custom(None)
-
-        """Test empty string raises ValueError"""
-        with pytest.raises(
-            ValueError, match="The validator name cannot be an empty string."
-        ):
-            ar.Custom("")
-        with pytest.raises(
-            ValueError, match="The validator name cannot be an empty string."
-        ):
-            ar.Custom("   ")
-
 
 class TestCustomValidatorReturnNormalization:
     """Regression tests for issue #1469.

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -55,8 +55,8 @@ class TestRegisterValidator:
             register_validator("", lambda x: True)
 
     def test_raises_value_error_when_name_is_not_string(self):
-        """register_validator raises typeerror when name is not a string."""
-        with pytest.raises(typeerror, match="non-empty string"):
+        """register_validator raises ValueError when name is not a string."""
+        with pytest.raises(ValueError, match="non-empty string"):
             register_validator(123, lambda x: True)
 
     def test_overwrites_existing_validator(self):
@@ -344,25 +344,25 @@ class TestCustomValidatorNameValidation:
 
     def test_raises_type_error_when_name_is_empty_string(self):
         """Custom raises typeerror when name is an empty string."""
-        with pytest.raises(typeerror, match="non-empty string"):
+        with pytest.raises(TypeError, match="non-empty string"):
             Custom("")
 
     def test_raises_type_error_when_name_is_integer(self):
         """Custom raises typeerror when name is an integer."""
-        with pytest.raises(typeerror, match="non-empty string"):
+        with pytest.raises(TypeError, match="non-empty string"):
             Custom(123)
 
     def test_raises_type_error_when_name_is_none(self):
         """Custom raises typeerror when name is None."""
-        with pytest.raises(typeerror, match="non-empty string"):
+        with pytest.raises(TypeError, match="non-empty string"):
             Custom(None)
 
     def test_raises_type_error_when_name_is_list(self):
         """Custom raises typeerror when name is a list."""
-        with pytest.raises(typeerror, match="non-empty string"):
+        with pytest.raises(TypeError, match="non-empty string"):
             Custom(["my_validator"])
 
     def test_valid_name_still_raises_when_unregistered(self):
         """A valid string name that isn't registered raises the registry error, not the name error."""
-        with pytest.raises(typeerror, match="No validator registered"):
+        with pytest.raises(TypeError, match="No validator registered"):
             Custom("unregistered_name_xyz")

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -212,6 +212,7 @@ class TestCustomValidator:
 
     def test_custom_validator_name_validation(self):
         import pytest
+
         import arnio as ar
 
         """Test unhashable type raises TypeError"""
@@ -227,9 +228,13 @@ class TestCustomValidator:
             ar.Custom(None)
 
         """Test empty string raises ValueError"""
-        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
+        with pytest.raises(
+            ValueError, match="The validator name cannot be an empty string."
+        ):
             ar.Custom("")
-        with pytest.raises(ValueError, match="The validator name cannot be an empty string."):
+        with pytest.raises(
+            ValueError, match="The validator name cannot be an empty string."
+        ):
             ar.Custom("   ")
 
 

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -343,26 +343,28 @@ class TestCustomValidatorNameValidation:
         schema._CUSTOM_VALIDATORS.update(self._original_validators)
 
     def test_raises_type_error_when_name_is_empty_string(self):
-        """Custom raises typeerror when name is an empty string."""
-        with pytest.raises(TypeError, match="non-empty string"):
+        """Custom raises ValueError when name is an empty string."""
+        with pytest.raises(
+            ValueError, match="The validator name cannot be an empty string."
+        ):
             Custom("")
 
     def test_raises_type_error_when_name_is_integer(self):
-        """Custom raises typeerror when name is an integer."""
-        with pytest.raises(TypeError, match="non-empty string"):
+        """Custom raises TypeError when name is an integer."""
+        with pytest.raises(TypeError, match="The validator name must be a string."):
             Custom(123)
 
     def test_raises_type_error_when_name_is_none(self):
-        """Custom raises typeerror when name is None."""
-        with pytest.raises(TypeError, match="non-empty string"):
+        """Custom raises TypeError when name is None."""
+        with pytest.raises(TypeError, match="The validator name must be a string."):
             Custom(None)
 
     def test_raises_type_error_when_name_is_list(self):
-        """Custom raises typeerror when name is a list."""
-        with pytest.raises(TypeError, match="non-empty string"):
+        """Custom raises TypeError when name is a list."""
+        with pytest.raises(TypeError, match="The validator name must be a string."):
             Custom(["my_validator"])
 
     def test_valid_name_still_raises_when_unregistered(self):
         """A valid string name that isn't registered raises the registry error, not the name error."""
-        with pytest.raises(TypeError, match="No validator registered"):
+        with pytest.raises(ValueError, match="No validator registered"):
             Custom("unregistered_name_xyz")


### PR DESCRIPTION
## Summary
validate the `Custom()` validator name parameter before making dictionary registry lookups. This prevents lists, integers, and None values from throwing raw Python errors, and treats empty/whitespace strings as a validation error instead of a missing registered validator.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #1801 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
NA

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
None