### PR TITLE
docs: update NumPy example to use clip_numeric

### DIFF
--- a/examples/arnio_with_numpy.py
+++ b/examples/arnio_with_numpy.py
@@ -51,12 +51,14 @@ def main():
 
     clean_df = ar.to_pandas(cleaned)
 
-    # cast_types cannot handle non-numeric strings — coerce them to NaN first
+    # Convert values to numeric and drop invalid entries
     clean_df["values"] = pd.to_numeric(clean_df["values"], errors="coerce")
     clean_df = clean_df.dropna()
 
-    # clip is a pandas/NumPy operation, not an Arnio pipeline step
-    clean_df["values"] = clean_df["values"].clip(0, 100)
+    # Use Arnio's built-in clip_numeric helper
+    frame = ar.from_pandas(clean_df)
+    frame = ar.clip_numeric(frame, lower=0, upper=100)
+    clean_df = ar.to_pandas(frame)
 
     print("Cleaned Data:\n", clean_df)
     print("-" * 40)


### PR DESCRIPTION
## Summary

Updated `examples/arnio_with_numpy.py` to use Arnio's built-in `clip_numeric` helper instead of pandas/NumPy clipping.

This removes outdated guidance that stated clipping is not an Arnio pipeline step and ensures the example reflects the current Arnio API while still demonstrating NumPy interoperability.

## Linked issue

Fixes #1893

## Type of change

* [ ] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [x] Documentation
* [ ] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [ ] `make lint`
* [ ] optionally `python -m pytest tests -v --tb=short -x`
* [x] Other:

```powershell
python examples/arnio_with_numpy.py
```

Verified that:

* The example executes successfully.
* Values are clipped using `ar.clip_numeric(...)`.
* The clipped data is passed to NumPy for computation.
* NumPy mean and standard deviation calculations still work as expected.

## Screenshots / Media

N/A

## Performance Impact

None. This change only updates an example file.

## GSSoC labels

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [ ] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR updates the NumPy interoperability example to use Arnio's documented `clip_numeric` helper and removes outdated comments indicating clipping is not an Arnio pipeline step.
