### PR TITLE
fix: require explicit custom validator overwrite

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2738,10 +2738,15 @@ _SEMANTIC_PATTERNS = {
 }
 
 # Registry for custom validators registered via register_validator()
-_CUSTOM_VALIDATORS: dict[str, callable] = {}
+_CUSTOM_VALIDATORS: dict[str, Callable[[Any], object]] = {}
 
 
-def register_validator(name: str, fn: callable) -> None:
+def register_validator(
+    name: str,
+    fn: Callable[[Any], object],
+    *,
+    overwrite: bool = False,
+) -> None:
     """Register a custom validator function for use with Custom().
 
     Parameters
@@ -2751,17 +2756,32 @@ def register_validator(name: str, fn: callable) -> None:
     fn : callable
         A function that accepts a scalar value and returns True if valid,
         False otherwise.
+    overwrite : bool, default False
+        If True, allows replacing an existing custom validator with the same
+        name.
+
+    Raises
+    ------
+    ValueError
+        If the validator name is already registered and `overwrite` is False.
 
     Examples
     --------
     >>> def is_positive(value):
     ...     return value > 0
     >>> ar.register_validator("positive", is_positive)
+    # Overwriting an existing validator intentionally
+    >>> ar.register_validator("positive", lambda value: value >= 0, overwrite=True)
     """
     if not callable(fn):
         raise TypeError("fn must be callable")
     if not isinstance(name, str) or not name:
         raise ValueError("name must be a non-empty string")
+    if name in _CUSTOM_VALIDATORS and not overwrite:
+        raise ValueError(
+            f"Validator {name!r} is already registered. "
+            "To intentionally overwrite it, set 'overwrite=True'."
+        )
     _CUSTOM_VALIDATORS[name] = fn
 
 

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -59,8 +59,8 @@ class TestRegisterValidator:
         with pytest.raises(ValueError, match="non-empty string"):
             register_validator(123, lambda x: True)
 
-    def test_overwrites_existing_validator(self):
-        """register_validator allows overwriting an existing validator."""
+    def test_duplicate_validator_requires_explicit_overwrite(self):
+        """register_validator blocks accidental duplicate validator names."""
 
         def validator_a(value):
             return value > 0
@@ -71,8 +71,44 @@ class TestRegisterValidator:
         register_validator("my_validator", validator_a)
         assert schema._CUSTOM_VALIDATORS["my_validator"] is validator_a
 
-        register_validator("my_validator", validator_b)
+        with pytest.raises(ValueError, match="already registered"):
+            register_validator("my_validator", validator_b)
+
+        assert schema._CUSTOM_VALIDATORS["my_validator"] is validator_a
+
+    def test_overwrite_true_replaces_existing_validator(self):
+        """register_validator allows deliberate replacement with overwrite=True."""
+
+        def validator_a(value):
+            return value > 0
+
+        def validator_b(value):
+            return value < 0
+
+        register_validator("my_validator", validator_a)
+        register_validator("my_validator", validator_b, overwrite=True)
+
         assert schema._CUSTOM_VALIDATORS["my_validator"] is validator_b
+
+    def test_duplicate_registration_does_not_mutate_existing_custom_schema(self):
+        """A blocked duplicate registration leaves existing Custom schemas stable."""
+
+        def positive(value):
+            return value > 0
+
+        def negative(value):
+            return value < 0
+
+        register_validator("sign_check", positive)
+        custom_schema = {"score": Custom("sign_check")}
+        frame = ar.from_pandas(pd.DataFrame({"score": [1]}))
+
+        assert ar.validate(frame, custom_schema).passed
+
+        with pytest.raises(ValueError, match="already registered"):
+            register_validator("sign_check", negative)
+
+        assert ar.validate(frame, custom_schema).passed
 
 
 class TestCustomValidator:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2563,18 +2563,18 @@ def test_required_if_validation_handles_null_trigger_values(tmp_path):
 
 
 def test_register_validator_and_custom_field_passes(tmp_path):
-    ar.register_validator("positive", lambda v: v > 0)
+    ar.register_validator("positive_pass", lambda v: v > 0)
     path = tmp_path / "scores.csv"
     path.write_text("score\n1\n5\n100\n")
-    result = ar.validate(ar.read_csv(path), {"score": ar.Custom("positive")})
+    result = ar.validate(ar.read_csv(path), {"score": ar.Custom("positive_pass")})
     assert result.passed
 
 
 def test_register_validator_and_custom_field_fails(tmp_path):
-    ar.register_validator("positive", lambda v: v > 0)
+    ar.register_validator("positive_fail", lambda v: v > 0)
     path = tmp_path / "scores.csv"
     path.write_text("score\n1\n-5\n0\n")
-    result = ar.validate(ar.read_csv(path), {"score": ar.Custom("positive")})
+    result = ar.validate(ar.read_csv(path), {"score": ar.Custom("positive_fail")})
     assert not result.passed
     assert result.issues[0].rule == "custom"
     assert result.issues[0].row_index == 2
@@ -2583,10 +2583,12 @@ def test_register_validator_and_custom_field_fails(tmp_path):
 def test_custom_field_respects_nullable(tmp_path):
     import pandas as pd
 
-    ar.register_validator("positive", lambda v: v > 0)
+    ar.register_validator("positive_nullable", lambda v: v > 0)
     df = pd.DataFrame({"score": [1, None, 5]})
     frame = ar.from_pandas(df)
-    result = ar.validate(frame, {"score": ar.Custom("positive", nullable=False)})
+    result = ar.validate(
+        frame, {"score": ar.Custom("positive_nullable", nullable=False)}
+    )
     assert not result.passed
     assert any(i.rule == "nullable" for i in result.issues)
 
@@ -3512,7 +3514,7 @@ def test_field_allowed_rejects_bytes():
 
 
 def test_custom_field_required_if_validation_passes_when_condition_matches(tmp_path):
-    ar.register_validator("positive_req", lambda v: v > 0)
+    ar.register_validator("positive_req_pass", lambda v: v > 0)
 
     path = tmp_path / "custom_conditional_pass.csv"
     path.write_text("status,score\n" "active,10\n" "inactive,\n")
@@ -3522,7 +3524,7 @@ def test_custom_field_required_if_validation_passes_when_condition_matches(tmp_p
         {
             "status": ar.String(nullable=False),
             "score": ar.Custom(
-                "positive_req", nullable=True, required_if=("status", "active")
+                "positive_req_pass", nullable=True, required_if=("status", "active")
             ),
         }
     )
@@ -3533,7 +3535,7 @@ def test_custom_field_required_if_validation_passes_when_condition_matches(tmp_p
 
 
 def test_custom_field_required_if_validation_fails_when_condition_matches(tmp_path):
-    ar.register_validator("positive_req", lambda v: v > 0)
+    ar.register_validator("positive_req_required", lambda v: v > 0)
 
     path = tmp_path / "custom_conditional_fail.csv"
     path.write_text("status,score\n" "active,\n" "inactive,5\n")
@@ -3543,7 +3545,7 @@ def test_custom_field_required_if_validation_fails_when_condition_matches(tmp_pa
         {
             "status": ar.String(nullable=False),
             "score": ar.Custom(
-                "positive_req", nullable=True, required_if=("status", "active")
+                "positive_req_required", nullable=True, required_if=("status", "active")
             ),
         }
     )
@@ -3557,7 +3559,7 @@ def test_custom_field_required_if_validation_fails_when_condition_matches(tmp_pa
 
 
 def test_custom_field_required_if_validation_ignores_non_matching_conditions(tmp_path):
-    ar.register_validator("positive_req", lambda v: v > 0)
+    ar.register_validator("positive_req_ignore", lambda v: v > 0)
 
     path = tmp_path / "custom_conditional_ignore.csv"
     path.write_text("status,score\n" "pending,\n" "inactive,\n")
@@ -3567,7 +3569,7 @@ def test_custom_field_required_if_validation_ignores_non_matching_conditions(tmp
         {
             "status": ar.String(nullable=False),
             "score": ar.Custom(
-                "positive_req", nullable=True, required_if=("status", "active")
+                "positive_req_ignore", nullable=True, required_if=("status", "active")
             ),
         }
     )
@@ -3578,7 +3580,7 @@ def test_custom_field_required_if_validation_ignores_non_matching_conditions(tmp
 
 
 def test_custom_field_required_if_enforces_rule_logic_when_matched(tmp_path):
-    ar.register_validator("positive_req", lambda v: v > 0)
+    ar.register_validator("positive_req_rule", lambda v: v > 0)
 
     path = tmp_path / "custom_conditional_rule_fail.csv"
     path.write_text("status,score\n" "active,-5\n")
@@ -3588,7 +3590,7 @@ def test_custom_field_required_if_enforces_rule_logic_when_matched(tmp_path):
         {
             "status": ar.String(nullable=False),
             "score": ar.Custom(
-                "positive_req", nullable=True, required_if=("status", "active")
+                "positive_req_rule", nullable=True, required_if=("status", "active")
             ),
         }
     )


### PR DESCRIPTION
Summary
- Fixes #1666
- Adds an explicit `overwrite=False` default to `register_validator()` so duplicate custom validator names fail fast instead of silently changing global validation behavior.
- Allows intentional replacement with `overwrite=True`, matching the existing `register_step()` pattern.
- Adds regression coverage for blocked duplicate registration, original schema behavior remaining intact, and explicit overwrite behavior.
- Renames a few test-local validator names that previously relied on silent duplicate registration.

This is for GSSoC 2026 and stays scoped to the assigned schema registry bug.

Validation
- `.venv-codex/bin/python -m pip install -e '.[dev]'`
- `.venv-codex/bin/python -m pytest tests/test_register_validator.py tests/test_schema.py -q` - 317 passed
- `.venv-codex/bin/python -m pytest tests/test_frame.py -q` - 168 passed
- `.venv-codex/bin/python -m pytest -q` - 2572 passed, 46 skipped
- `.venv-codex/bin/python -m ruff check . --extend-exclude "*.ipynb"`
- `.venv-codex/bin/python -m mypy --config-file mypy.ini`
- `.venv-codex/bin/python scripts/check_docs_utf8.py`
- `git diff --check`