### PR TITLE
feat(integrations): expose ArnioCleaner from arnio.integrations names…

### DIFF
--- a/arnio/integrations/__init__.py
+++ b/arnio/integrations/__init__.py
@@ -1,6 +1,28 @@
 """Integration helpers for the Python data ecosystem."""
 
+import importlib
+
 from .duckdb import register_duckdb
 from .pandas import ArnioPandasAccessor
 
-__all__ = ["ArnioPandasAccessor", "register_duckdb"]
+__all__ = ["ArnioPandasAccessor", "register_duckdb", "ArnioCleaner"]
+
+# Lazy import: ArnioCleaner is only available when scikit-learn is installed.
+# This keeps the base `arnio` import free of any sklearn dependency.
+_LAZY_IMPORTS = {
+    "ArnioCleaner": ("arnio.integrations.sklearn", "ArnioCleaner"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        try:
+            module = importlib.import_module(module_path)
+            return getattr(module, attr)
+        except ImportError:
+            raise ImportError(
+                f"'{name}' requires scikit-learn. "
+                "Install it with: pip install arnio[sklearn]"
+            ) from None
+    raise AttributeError(f"module 'arnio.integrations' has no attribute {name!r}")

--- a/examples/sklearn_pipeline.py
+++ b/examples/sklearn_pipeline.py
@@ -12,7 +12,7 @@ except ImportError:
     )
     exit(1)
 
-from arnio.integrations.sklearn import ArnioCleaner
+from arnio.integrations import ArnioCleaner  # requires: pip install arnio[sklearn]
 
 
 def main():

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1,3 +1,4 @@
+import importlib
 import warnings
 
 import numpy as np
@@ -9,6 +10,47 @@ pytest.importorskip("sklearn")
 from sklearn.pipeline import Pipeline  # noqa: E402
 
 from arnio.integrations.sklearn import ArnioCleaner  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Namespace discoverability tests (issue: from arnio.integrations import
+# ArnioCleaner should work when sklearn is installed)
+# ---------------------------------------------------------------------------
+
+
+def test_arniocleaner_importable_from_integrations_namespace():
+    """ArnioCleaner must be importable from arnio.integrations when sklearn is installed."""
+    from arnio.integrations import ArnioCleaner as AC  # noqa: PLC0415
+
+    assert AC is ArnioCleaner
+
+
+def test_arniocleaner_in_integrations_all():
+    """ArnioCleaner must be listed in arnio.integrations.__all__."""
+    import arnio.integrations as integrations  # noqa: PLC0415
+
+    assert "ArnioCleaner" in integrations.__all__
+
+
+def test_arniocleaner_missing_sklearn_raises_clear_import_error():
+    """When sklearn is absent, importing ArnioCleaner from arnio.integrations
+    must raise ImportError with a message directing users to install arnio[sklearn].
+    """
+    from unittest.mock import patch  # noqa: PLC0415
+
+    import arnio.integrations as integrations  # noqa: PLC0415
+
+    # Patch importlib.import_module inside the integrations __getattr__ so that
+    # importing "arnio.integrations.sklearn" behaves as if sklearn is not installed.
+    def _raise_import_error(name, *args, **kwargs):
+        if name == "arnio.integrations.sklearn":
+            raise ImportError("No module named 'sklearn'")
+        return importlib.import_module(name, *args, **kwargs)
+
+    with patch(
+        "arnio.integrations.importlib.import_module", side_effect=_raise_import_error
+    ):
+        with pytest.raises(ImportError, match="arnio\\[sklearn\\]"):
+            _ = integrations.__getattr__("ArnioCleaner")
 
 
 def test_arniocleaner_non_dataframe_input():


### PR DESCRIPTION
## Summary

Add a lazy `__getattr__` export for `ArnioCleaner` in `arnio/integrations/__init__.py`
so that `from arnio.integrations import ArnioCleaner` works when scikit-learn is
installed. Previously this raised `ImportError` even with `arnio[sklearn]` installed.
The base `arnio` import remains free of any sklearn dependency (lazy-loaded on first
access). A clear `ImportError` with a `pip install arnio[sklearn]` hint is raised when
sklearn is absent.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue

Fixes #1807 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing

- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [x] `python -m pytest tests/test_sklearn.py -v --tb=short -x`

Results:
```
============================= 31 passed in 1.32s ==============================
```
black and ruff both passed via pre-commit hooks on commit.

## Screenshots / Media

N/A — no UI, README, or terminal output changes.

## Performance Impact

No performance impact. `importlib.import_module` is called only on the first access
of `ArnioCleaner`; the base `arnio` import path is completely unchanged.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

- `arnio.integrations.sklearn` direct import still works unchanged — fully backward compatible.
- `__all__` updated so IDEs and `dir(arnio.integrations)` surface `ArnioCleaner`.
- `importlib` is imported at module level (not inside the function) so `unittest.mock.patch`
  can target it cleanly in tests.
- 3 new tests added: successful namespace import, `__all__` membership, and the
  missing-sklearn clear error path.
```