### PR TITLE
fix: preserve attrs in frame head and tail

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -400,7 +400,9 @@ class ArFrame:
 
         actual_n = min(n, len(self))
 
-        return ArFrame(self._frame.select_rows(0, actual_n))
+        return ArFrame(
+            self._frame.select_rows(0, actual_n), attrs=copy.deepcopy(self._attrs)
+        )
 
     def tail(self, n: int = 5) -> ArFrame:
         """Return the last n rows as an ArFrame.
@@ -421,7 +423,9 @@ class ArFrame:
         actual_n = min(n, len(self))
         start = max(0, len(self) - actual_n)
 
-        return ArFrame(self._frame.select_rows(start, actual_n))
+        return ArFrame(
+            self._frame.select_rows(start, actual_n), attrs=copy.deepcopy(self._attrs)
+        )
 
     def to_dict(self) -> dict[str, list]:
         """Export the frame as a Python dictionary.

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -420,6 +420,30 @@ def test_tail_native_path_avoids_pandas_roundtrip(monkeypatch):
     assert result.columns == ["name", "salary"]
 
 
+@pytest.mark.parametrize("method_name", ["head", "tail"])
+def test_head_tail_preserve_attrs_roundtrip(method_name):
+    df = pd.DataFrame({"name": ["alice", "bob"], "score": [10, 20]})
+    df.attrs = {"source": "qa", "metadata": {"tags": ["sample"]}}
+    frame = ar.from_pandas(df)
+
+    subset = getattr(frame, method_name)(1)
+    result = ar.to_pandas(subset)
+
+    assert result.attrs == {"source": "qa", "metadata": {"tags": ["sample"]}}
+
+
+@pytest.mark.parametrize("method_name", ["head", "tail"])
+def test_head_tail_attrs_are_deep_copied(method_name):
+    df = pd.DataFrame({"name": ["alice", "bob"], "score": [10, 20]})
+    df.attrs = {"metadata": {"tags": ["sample"]}}
+    frame = ar.from_pandas(df)
+
+    subset = getattr(frame, method_name)(1)
+    subset._attrs["metadata"]["tags"].append("subset")
+
+    assert frame._attrs == {"metadata": {"tags": ["sample"]}}
+
+
 def test_head_default_n():
     frame = ar.from_pandas(
         pd.DataFrame(


### PR DESCRIPTION
## Summary
- Preserve `ArFrame._attrs` when `head()` and `tail()` return row subsets.
- Use `copy.deepcopy(self._attrs)` so subset metadata cannot mutate the source frame metadata.
- Add regression tests for pandas attrs round-tripping and nested attrs isolation through both methods.

## Linked issue
Fixes #1911

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `python3 -m pytest tests/test_frame.py tests/test_convert.py -v` - 279 passed, 12 skipped
- [x] `make lint` - ruff and black checks passed
- [x] `python3 -m pytest tests/ -v` - 2604 passed, 43 skipped, 12 warnings
- [ ] Other:

## Screenshots / Media
N/A

## Performance Impact
N/A - metadata copy only on `head()` / `tail()` result construction.

## GSSoC labels
Maintainers only: issue is labeled `gssoc`, `level:beginner`, and `type:bug`.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Docs/examples are unchanged because this is scoped to restoring the metadata-preservation behavior requested in #1911. Optional `pyarrow` is not installed locally, so arrow/parquet optional tests were skipped as expected.
