### PR TITLE
Add CI type-checking dependencies to dev extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ dev = [
     "PyYAML>=6.0",
     "duckdb>=1.0",
     "tomli; python_version < '3.11'",
+    "mypy>=1.0",
+    "pandas-stubs",
+    "types-setuptools",
 ]
 sklearn = [
     "scikit-learn>=1.0",


### PR DESCRIPTION
## Summary

This PR adds the CI type-checking dependencies to the `dev` extra in `pyproject.toml`.

### Added

* `mypy>=1.0`
* `pandas-stubs`
* `types-setuptools`

### Why

The CI workflow installs these dependencies before running:

`mypy --config-file mypy.ini`

However, they were not included in the `dev` extra, which prevented contributors using:

`pip install -e ".[dev]"`

from reproducing the same type-checking workflow locally.

Closes #1886

