### PR TITLE
fix: include schema rules in diff_schema

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import re
 import warnings
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable
@@ -1224,6 +1225,29 @@ class SchemaDiff:
         return "\n".join(lines)
 
 
+def _schema_rule_name(rule: Callable[[pd.DataFrame], list[ValidationIssue]]) -> str:
+    """Return a stable best-effort display name for a schema rule callable."""
+    qualname = getattr(rule, "__qualname__", None)
+    if isinstance(qualname, str) and qualname:
+        return qualname
+
+    name = getattr(rule, "__name__", None)
+    if isinstance(name, str) and name:
+        return name
+
+    rule_type = type(rule)
+    return getattr(rule_type, "__qualname__", rule_type.__name__)
+
+
+def _normalize_schema_rules(
+    rules: Sequence[Callable[[pd.DataFrame], list[ValidationIssue]]] | None,
+) -> tuple[str, ...] | None:
+    """Summarize schema rules by visible callable identity for diff output."""
+    if not rules:
+        return None
+    return tuple(_schema_rule_name(rule) for rule in rules)
+
+
 def diff_schema(
     expected: Schema | dict[str, Field],
     observed: Schema | dict[str, Field],
@@ -1241,7 +1265,10 @@ def diff_schema(
     -------
     SchemaDiff
         Structured differences covering missing columns, extra columns,
-        changed field attributes, and schema-level options.
+        changed field attributes, and schema-level options. Cross-field
+        ``Schema.rules`` are compared by best-effort callable identity using
+        visible callable names and rule count; exact callable equivalence is
+        intentionally not inferred.
     """
     expected_schema = expected if isinstance(expected, Schema) else Schema(expected)
     observed_schema = observed if isinstance(observed, Schema) else Schema(observed)
@@ -1306,6 +1333,19 @@ def diff_schema(
                 attribute="unique",
                 expected=_normalize_unique(expected_schema.unique),
                 observed=_normalize_unique(observed_schema.unique),
+            )
+        )
+
+    expected_rules = _normalize_schema_rules(expected_schema.rules)
+    observed_rules = _normalize_schema_rules(observed_schema.rules)
+    if expected_rules != observed_rules:
+        differences.append(
+            SchemaDiffEntry(
+                column=None,
+                change="changed_schema",
+                attribute="rules",
+                expected=expected_rules,
+                observed=observed_rules,
             )
         )
 

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -3,6 +3,31 @@
 from arnio.schema import Field, Schema, diff_schema
 
 
+def _rule_alpha(df):
+    return []
+
+
+def _rule_beta(df):
+    return []
+
+
+def _make_same_named_rule():
+    def same_rule_name(df):
+        return []
+
+    return same_rule_name
+
+
+class _CallableRule:
+    def __call__(self, df):
+        return []
+
+
+class _OtherCallableRule:
+    def __call__(self, df):
+        return []
+
+
 class TestDiffSchema:
     """Test suite for diff_schema function."""
 
@@ -91,6 +116,106 @@ class TestDiffSchema:
         assert len(changed) == 1
         assert changed[0].expected == ("name",)
         assert changed[0].observed is None
+
+    def test_detects_rules_present_vs_absent(self):
+        """diff_schema detects schema-level rules added or removed."""
+        expected = Schema(fields={"name": Field(dtype="string")}, rules=[_rule_alpha])
+        observed = Schema(fields={"name": Field(dtype="string")})
+
+        diff = diff_schema(expected, observed)
+        changed = [
+            d
+            for d in diff.differences
+            if d.change == "changed_schema" and d.attribute == "rules"
+        ]
+
+        assert len(changed) == 1
+        assert changed[0].column is None
+        assert changed[0].expected == ("_rule_alpha",)
+        assert changed[0].observed is None
+
+    def test_same_named_rules_are_unchanged(self):
+        """diff_schema treats rules with the same visible name as unchanged."""
+        expected = Schema(
+            fields={"name": Field(dtype="string")},
+            rules=[_make_same_named_rule()],
+        )
+        observed = Schema(
+            fields={"name": Field(dtype="string")},
+            rules=[_make_same_named_rule()],
+        )
+
+        diff = diff_schema(expected, observed)
+
+        assert diff.changed is False
+        assert diff.difference_count == 0
+
+    def test_detects_different_rule_names(self):
+        """diff_schema detects changed visible rule identities."""
+        expected = Schema(fields={"name": Field(dtype="string")}, rules=[_rule_alpha])
+        observed = Schema(fields={"name": Field(dtype="string")}, rules=[_rule_beta])
+
+        diff = diff_schema(expected, observed)
+        changed = [
+            d
+            for d in diff.differences
+            if d.change == "changed_schema" and d.attribute == "rules"
+        ]
+
+        assert len(changed) == 1
+        assert changed[0].expected == ("_rule_alpha",)
+        assert changed[0].observed == ("_rule_beta",)
+
+    def test_detects_rule_count_changes(self):
+        """diff_schema detects rule list length changes."""
+        expected = Schema(
+            fields={"name": Field(dtype="string")},
+            rules=[_rule_alpha, _rule_beta],
+        )
+        observed = Schema(fields={"name": Field(dtype="string")}, rules=[_rule_alpha])
+
+        diff = diff_schema(expected, observed)
+        changed = [
+            d
+            for d in diff.differences
+            if d.change == "changed_schema" and d.attribute == "rules"
+        ]
+
+        assert len(changed) == 1
+        assert changed[0].expected == ("_rule_alpha", "_rule_beta")
+        assert changed[0].observed == ("_rule_alpha",)
+
+    def test_rule_callable_object_fallback_uses_type_name(self):
+        """diff_schema names callable rule objects by their callable type."""
+        expected = Schema(
+            fields={"name": Field(dtype="string")},
+            rules=[_CallableRule()],
+        )
+        observed = Schema(
+            fields={"name": Field(dtype="string")},
+            rules=[_OtherCallableRule()],
+        )
+
+        diff = diff_schema(expected, observed)
+        changed = [
+            d
+            for d in diff.differences
+            if d.change == "changed_schema" and d.attribute == "rules"
+        ]
+
+        assert len(changed) == 1
+        assert changed[0].expected == ("_CallableRule",)
+        assert changed[0].observed == ("_OtherCallableRule",)
+
+    def test_rules_difference_renders_in_markdown(self):
+        """diff_schema markdown includes schema-level rules differences."""
+        expected = Schema(fields={"name": Field(dtype="string")}, rules=[_rule_alpha])
+        observed = Schema(fields={"name": Field(dtype="string")})
+
+        markdown = diff_schema(expected, observed).to_markdown()
+
+        assert "|  | changed_schema | rules |" in markdown
+        assert "_rule_alpha" in markdown
 
     def test_accepts_dict_input_for_expected(self):
         """diff_schema accepts dict form of expected schema."""


### PR DESCRIPTION
Summary
- Fixes #1665
- Adds a stable best-effort summary for `Schema.rules` so `diff_schema()` reports cross-field rule drift.
- Emits one schema-level `changed_schema` diff entry with `attribute="rules"` when rule presence, count, or visible callable names differ.
- Documents that rule comparison is by visible callable identity and does not try to infer exact semantic equivalence.
- Adds focused tests for present/absent rules, same named rules, different rule names, rule count changes, callable-object fallback, and markdown rendering.

This is for GSSoC 2026 and stays scoped to the assigned schema diff bug.

Validation
- `.venv-codex/bin/python -m pytest tests/test_diff_schema.py -q` - 21 passed
- `.venv-codex/bin/python -m pytest tests/test_diff_schema.py tests/test_schema.py -q` - 306 passed
- `.venv-codex/bin/python -m pytest -q` - 2591 passed, 46 skipped
- `.venv-codex/bin/python -m ruff check . --extend-exclude "*.ipynb"`
- `.venv-codex/bin/python -m mypy --config-file mypy.ini`
- `.venv-codex/bin/python scripts/check_docs_utf8.py`
- `git diff --check`