### PR TITLE
ci: expand Arrow and Parquet workflow path filters

### DIFF
--- a/.github/workflows/arrow-extra-test.yml
+++ b/.github/workflows/arrow-extra-test.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths:
       - ".github/workflows/arrow-extra-test.yml"
+      - "cpp/**"
+      - "bindings/**"
+      - "arnio/_core.py"
+      - "arnio/_arnio_cpp.pyi"
       - "arnio/convert.py"
       - "tests/test_to_arrow_edge_cases.py"
       - "tests/test_convert.py"

--- a/.github/workflows/parquet-extra-test.yml
+++ b/.github/workflows/parquet-extra-test.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     paths:
       - ".github/workflows/parquet-extra-test.yml"
+      - "cpp/**"
+      - "bindings/**"
+      - "arnio/_core.py"
+      - "arnio/_arnio_cpp.pyi"
+      - "arnio/convert.py"
       - "arnio/io.py"
       - "tests/test_parquet.py"
       - "pyproject.toml"


### PR DESCRIPTION
Summary

This PR expands the pull_request.paths filters for the Arrow and Parquet extra-test workflows to ensure that conversion-sensitive native and binding changes trigger the appropriate optional integration tests.

Changes

Arrow workflow
Added:

cpp/**
bindings/**
arnio/_core.py
arnio/_arnio_cpp.pyi

Parquet workflow
Added:

cpp/**
bindings/**
arnio/_core.py
arnio/_arnio_cpp.pyi
arnio/convert.py
Why

Arrow and Parquet functionality depends on the native C++ frame implementation, pybind11 bindings, and shared conversion paths. Previously, changes in these components could bypass the dedicated Arrow and Parquet extra-test workflows because the path filters only monitored a narrow set of Python wrapper and test files.

These updates keep the workflows focused while ensuring that relevant native, binding, and conversion changes trigger the appropriate optional integration checks.