### PR TITLE
fix(cleaning): return a new ArFrame from winsorize_outliers when no target columns exist

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -773,7 +773,7 @@ def winsorize_outliers(
         target_columns = numeric_columns
 
     if not target_columns:
-        return frame
+        return from_pandas(to_pandas(frame))
 
     df = to_pandas(frame).copy(deep=False)
 

--- a/tests/test_winsorize_outliers.py
+++ b/tests/test_winsorize_outliers.py
@@ -135,7 +135,9 @@ class TestWinsorizeOutliersBoundary:
         assert list(result_df.columns) == list(original_df.columns)
         assert list(result_df["name"]) == list(original_df["name"])
 
-    def test_no_numeric_columns_with_subset_empty_after_filter_returns_distinct_frame(self):
+    def test_no_numeric_columns_with_subset_empty_after_filter_returns_distinct_frame(
+        self,
+    ):
         """winsorize_outliers returns a new ArFrame when the frame has no numeric columns at all."""
         frame = ar.from_pandas(
             pd.DataFrame({"label": ["x", "y"], "category": ["a", "b"]})

--- a/tests/test_winsorize_outliers.py
+++ b/tests/test_winsorize_outliers.py
@@ -116,3 +116,33 @@ class TestWinsorizeOutliersBoundary:
         assert pd.isna(df["val"].iloc[1]) is True
         assert df["val"].iloc[0] == pytest.approx(1.6)
         assert df["val"].iloc[4] == pytest.approx(71.2)
+
+    def test_no_numeric_columns_returns_distinct_frame(self):
+        """winsorize_outliers returns a new distinct ArFrame when no numeric columns exist.
+
+        Regression test for: the early-return path returned the original frame
+        object unchanged, violating the documented 'New frame' return contract.
+        """
+        frame = ar.from_pandas(pd.DataFrame({"name": ["alice", "bob", "carol"]}))
+        result = winsorize_outliers(frame)
+
+        # Must be a distinct object, not the same reference
+        assert result is not frame
+
+        # Data must be identical (no transformation should occur)
+        original_df = ar.to_pandas(frame)
+        result_df = ar.to_pandas(result)
+        assert list(result_df.columns) == list(original_df.columns)
+        assert list(result_df["name"]) == list(original_df["name"])
+
+    def test_no_numeric_columns_with_subset_empty_after_filter_returns_distinct_frame(self):
+        """winsorize_outliers returns a new ArFrame when the frame has no numeric columns at all."""
+        frame = ar.from_pandas(
+            pd.DataFrame({"label": ["x", "y"], "category": ["a", "b"]})
+        )
+        result = winsorize_outliers(frame)
+
+        assert result is not frame
+        result_df = ar.to_pandas(result)
+        assert list(result_df.columns) == ["label", "category"]
+        assert list(result_df["label"]) == ["x", "y"]


### PR DESCRIPTION
## Summary

Fixes #2071

When `winsorize_outliers` found no numeric columns to process, the early-return path returned the **original `frame` object** rather than a new `ArFrame`. The documented return type states:

> Returns: ArFrame — **New frame** with winsorized numeric values.

Returning the same reference violates this contract. Pipeline steps that track frame identity, tests that check `result is not frame`, or code that mutates the returned frame expecting isolation all received unexpected behavior.

## What changed

**`arnio/cleaning.py`** (one line)

```python
# Before
if not target_columns:
    return frame

# After
if not target_columns:
    return from_pandas(to_pandas(frame))
```

The `from_pandas(to_pandas(frame))` round-trip is the established pattern used throughout `cleaning.py`. It:
- Returns a distinct `ArFrame` object (satisfies the return contract)
- Preserves all data and column structure unchanged (no winsorization applied, as expected)
- Preserves attrs/metadata: `to_pandas` restores `frame._attrs` into `df.attrs`; `from_pandas` deep-copies `df.attrs` into the new `ArFrame`

No other cleaning helpers are modified.

## Tests added

Two regression tests added to `TestWinsorizeOutliersBoundary` in `tests/test_winsorize_outliers.py`:

| Test | What it verifies |
|---|---|
| `test_no_numeric_columns_returns_distinct_frame` | String-only frame: `result is not frame`, data and columns identical |
| `test_no_numeric_columns_with_subset_empty_after_filter_returns_distinct_frame` | Two string columns: distinct object, column structure preserved |

All 15 tests pass. Black and ruff pass on all touched files.

## Checklist

- [x] Fix is scoped to `winsorize_outliers` no-target behavior only
- [x] Distinct `ArFrame` returned
- [x] Data, column structure, and attrs/metadata preserved
- [x] Regression tests added
- [x] No unrelated cleaning helpers modified
- [x] All existing tests still pass
- [x] Black formatting applied (`black --check` passes)
- [x] Ruff passes