### PR TITLE
fix(schema): reject bare strings in CurrencyCode allowed values

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2017,6 +2017,36 @@ def TimeZone(
     )
 
 
+# def CurrencyCode(
+#     *,
+#     nullable: bool = True,
+#     unique: bool = False,
+#     severity: str = "error",
+#     required_if: tuple[str, Any] | None = None,
+#     allowed: set[Any] | list[Any] | tuple[Any, ...] | None = None,
+# ) -> Field:
+#     """Create a currency-code schema field.
+
+#     Args:
+#         nullable: Whether null values are allowed.
+#         unique: Whether non-null values must be unique.
+#         severity: Severity level for validation issues.
+#         required_if: Conditional requirement as a column/value pair.
+#         allowed: Allowed currency codes, overriding the default active ISO 4217 set.
+
+#     Returns:
+#         Field: Configured 3-letter uppercase currency-code schema field.
+#     """
+#     allowed_set = set(allowed) if allowed is not None else None
+#     return Field(
+#         dtype="string",
+#         nullable=nullable,
+#         semantic="currency_code",
+#         unique=unique,
+#         severity=severity,
+#         required_if=required_if,
+#         allowed=allowed_set,
+#     )
 def CurrencyCode(
     *,
     nullable: bool = True,
@@ -2037,7 +2067,21 @@ def CurrencyCode(
     Returns:
         Field: Configured 3-letter uppercase currency-code schema field.
     """
+
+    if isinstance(allowed, (str, bytes)):
+        raise TypeError(
+            "allowed must be a sequence of currency codes, not a bare string"
+        )
+
+    if allowed is not None:
+        for value in allowed:
+            if not isinstance(value, str):
+                raise TypeError(
+                    "all allowed currency codes must be strings"
+                )
+
     allowed_set = set(allowed) if allowed is not None else None
+
     return Field(
         dtype="string",
         nullable=nullable,
@@ -2047,7 +2091,6 @@ def CurrencyCode(
         required_if=required_if,
         allowed=allowed_set,
     )
-
 
 def Date(
     *,

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2017,36 +2017,6 @@ def TimeZone(
     )
 
 
-# def CurrencyCode(
-#     *,
-#     nullable: bool = True,
-#     unique: bool = False,
-#     severity: str = "error",
-#     required_if: tuple[str, Any] | None = None,
-#     allowed: set[Any] | list[Any] | tuple[Any, ...] | None = None,
-# ) -> Field:
-#     """Create a currency-code schema field.
-
-#     Args:
-#         nullable: Whether null values are allowed.
-#         unique: Whether non-null values must be unique.
-#         severity: Severity level for validation issues.
-#         required_if: Conditional requirement as a column/value pair.
-#         allowed: Allowed currency codes, overriding the default active ISO 4217 set.
-
-#     Returns:
-#         Field: Configured 3-letter uppercase currency-code schema field.
-#     """
-#     allowed_set = set(allowed) if allowed is not None else None
-#     return Field(
-#         dtype="string",
-#         nullable=nullable,
-#         semantic="currency_code",
-#         unique=unique,
-#         severity=severity,
-#         required_if=required_if,
-#         allowed=allowed_set,
-#     )
 def CurrencyCode(
     *,
     nullable: bool = True,
@@ -2076,9 +2046,7 @@ def CurrencyCode(
     if allowed is not None:
         for value in allowed:
             if not isinstance(value, str):
-                raise TypeError(
-                    "all allowed currency codes must be strings"
-                )
+                raise TypeError("all allowed currency codes must be strings")
 
     allowed_set = set(allowed) if allowed is not None else None
 
@@ -2091,6 +2059,7 @@ def CurrencyCode(
         required_if=required_if,
         allowed=allowed_set,
     )
+
 
 def Date(
     *,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2735,6 +2735,7 @@ def test_currency_code_override(tmp_path):
     assert result_default.issue_count == 1
     assert result_default.issues[0].value == "ZZZ"
 
+
 def test_currency_code_rejects_bare_string_allowed():
     with pytest.raises(TypeError):
         ar.CurrencyCode(allowed="USD")
@@ -2750,7 +2751,7 @@ def test_currency_code_rejects_non_string_allowed_values():
     with pytest.raises(TypeError):
         ar.CurrencyCode(allowed=["USD", 123])
 
-        
+
 def test_currency_code_validation_respects_case_insensitive_field(tmp_path):
     path = tmp_path / "mixed_case_currencies.csv"
     path.write_text("currency\nusd\nEur\ninr\n")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2735,7 +2735,22 @@ def test_currency_code_override(tmp_path):
     assert result_default.issue_count == 1
     assert result_default.issues[0].value == "ZZZ"
 
+def test_currency_code_rejects_bare_string_allowed():
+    with pytest.raises(TypeError):
+        ar.CurrencyCode(allowed="USD")
 
+
+def test_currency_code_accepts_valid_allowed_sequence():
+    field = ar.CurrencyCode(allowed=["USD", "EUR"])
+
+    assert field.allowed == {"USD", "EUR"}
+
+
+def test_currency_code_rejects_non_string_allowed_values():
+    with pytest.raises(TypeError):
+        ar.CurrencyCode(allowed=["USD", 123])
+
+        
 def test_currency_code_validation_respects_case_insensitive_field(tmp_path):
     path = tmp_path / "mixed_case_currencies.csv"
     path.write_text("currency\nusd\nEur\ninr\n")


### PR DESCRIPTION
## Summary

Fixes `CurrencyCode(allowed=...)` incorrectly accepting bare strings and bytes, which previously caused values like `"USD"` to be converted into `{"U", "S", "D"}`.

## Linked issue

Fixes #1636

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [x] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [ ] `make lint`
* [ ] optionally `python -m pytest tests -v --tb=short -x`
* [x] Other:

Verified modified files using:

```powershell
python -m compileall arnio tests
```

Note: I could not run the full test suite locally because the project requires the `_arnio_cpp` extension and my current Windows environment is missing the required C++ build toolchain (`nmake` / MSVC).

## Screenshots / Media

N/A

## Performance Impact

No performance impact.

## GSSoC labels

Maintainers only.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behaviour changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that the generated files, logs, and local build artifacts are not committed.
* [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

The implementation mirrors the existing validation pattern used in similar schema field APIs and keeps the change focused strictly on `CurrencyCode(..., allowed=...)` validation behavior.