### PR TITLE
fix: validate required_if scalar values

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -718,6 +718,8 @@ class Field:
                 )
             if not isinstance(self.required_if[0], str):
                 raise TypeError("required_if column name must be a string")
+            if not pd.api.types.is_scalar(self.required_if[1]):
+                raise TypeError("required_if expected value must be a scalar")
         if self.dtype in {"int64", "float64"}:
             if self.min is not None:
                 if isinstance(self.min, bool) or not isinstance(self.min, (int, float)):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2032,6 +2032,26 @@ def test_required_if_rejects_non_string_column_name():
         ar.String(required_if=(123, "active"))  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["yes"],
+        ("yes",),
+        {"value": "yes"},
+    ],
+)
+def test_required_if_rejects_non_scalar_expected_value(value):
+    with pytest.raises(TypeError, match="required_if expected value must be a scalar"):
+        ar.String(required_if=("flag", value))
+
+
+@pytest.mark.parametrize("value", ["yes", 1, 1.5, True, None])
+def test_required_if_accepts_scalar_expected_value(value):
+    field = ar.String(required_if=("flag", value))
+
+    assert field.required_if == ("flag", value)
+
+
 def test_required_if_valid_conditional_validation(tmp_path):
     path = tmp_path / "conditional_req.csv"
     path.write_text("status,notes\n" "active,has notes\n" "inactive,\n" "active,\n")


### PR DESCRIPTION
## Summary

Added schema-level validation for `required_if` expected values.

`required_if` now rejects non-scalar expected values such as lists, tuples, and dictionaries during field/schema construction instead of allowing them to fail later during pandas comparison logic. Valid scalar expected values continue to work unchanged.

## Linked issue

Fixes #1698

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint`
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
  - `pytest tests/test_schema.py -k "required_if" -v` — 25 passed
  - `git diff --check` — passed

## Screenshots / Media

Not applicable — this PR does not change UI, README visuals, or terminal output.

## Performance Impact

Not applicable — this is a small schema construction validation fix.

## GSSoC labels

Maintainers only.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Focused regression coverage verifies:
- list expected values are rejected
- tuple expected values are rejected
- dict expected values are rejected
- valid scalar expected values are preserved
- existing valid `required_if` validation behavior remains unchanged