### PR TITLE
fix(schema): normalize timestamps and arrays in validation exports

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2766,15 +2766,25 @@ def _normalize_sequence(value: Any) -> Any:
 
 
 def _clean_scalar(value: Any) -> Any:
-    """Recursively convert numpy scalars and NaN values to JSON-safe Python types."""
+    """Recursively convert numpy/pandas values to JSON-safe Python types."""
     if isinstance(value, dict):
         return {key: _clean_scalar(val) for key, val in value.items()}
+
+    if isinstance(value, np.ndarray):
+        return [_clean_scalar(item) for item in value.tolist()]
+
     if isinstance(value, (list, tuple, set)):
         return [_clean_scalar(item) for item in value]
+
+    if isinstance(value, pd.Timestamp):
+        return value.isoformat()
+
     if pd.isna(value):
         return None
+
     if hasattr(value, "item"):
         return value.item()
+
     return value
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,6 +4,7 @@ import io
 import json
 import warnings
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -3431,6 +3432,72 @@ def test_validation_issue_rejects_invalid_severity_typo():
         ar.ValidationIssue(
             column="score", rule="custom", message="bad", severity="erorr"
         )
+
+
+def test_validation_issue_to_dict_serializes_timestamp():
+    issue = ar.ValidationIssue(
+        column="created_at",
+        rule="custom",
+        message="bad timestamp",
+        value=pd.Timestamp("2026-01-01"),
+    )
+
+    payload = issue.to_dict()
+
+    assert payload["value"] == "2026-01-01T00:00:00"
+
+
+def test_validation_issue_to_dict_serializes_numpy_array():
+    issue = ar.ValidationIssue(
+        column="scores",
+        rule="custom",
+        message="bad array",
+        value=np.array([1, 2]),
+    )
+
+    payload = issue.to_dict()
+
+    assert payload["value"] == [1, 2]
+
+
+def test_validation_issue_to_dict_is_json_serializable():
+    issue = ar.ValidationIssue(
+        column="created_at",
+        rule="custom",
+        message="bad value",
+        value=pd.Timestamp("2026-01-01"),
+    )
+
+    json.dumps(issue.to_dict())
+
+
+def test_validation_result_to_dict_serializes_timestamp_and_array_values():
+    result = ar.ValidationResult(
+        row_count=1,
+        issue_count=2,
+        issues=[
+            ar.ValidationIssue(
+                column="created_at",
+                rule="custom",
+                message="bad timestamp",
+                value=pd.Timestamp("2026-01-01"),
+            ),
+            ar.ValidationIssue(
+                column="scores",
+                rule="custom",
+                message="bad array",
+                value=np.array([1, 2]),
+            ),
+        ],
+        bad_rows=[],
+    )
+
+    payload = result.to_dict()
+
+    assert payload["issues"][0]["value"] == "2026-01-01T00:00:00"
+    assert payload["issues"][1]["value"] == [1, 2]
+
+    json.dumps(payload)
 
 
 def test_custom_rule_with_invalid_severity_fails_validation_execution():


### PR DESCRIPTION
### Fixes #1901 

## Summary

Improves JSON serialization support for validation exports by normalizing timestamp and NumPy array values in `_clean_scalar()`.

## Problem

`ValidationIssue.to_dict()` and `ValidationResult.to_dict()` are documented as JSON-friendly, but certain common value types were not normalized correctly.

Examples:

- `pd.Timestamp` values remained as `Timestamp` objects and could not be serialized with `json.dumps()`
- `numpy.ndarray` values could raise errors during normalization because `pd.isna()` returns an array for NumPy arrays

This could cause validation results produced by custom validation rules to fail when exported to APIs, CI logs, dashboards, or JSON artifacts.

## Changes Made

- Added explicit handling for `pd.Timestamp` values using `isoformat()`
- Added explicit handling for `numpy.ndarray` values by converting them to recursively cleaned Python lists
- Preserved existing behavior for:
  - dictionaries
  - lists / tuples / sets
  - NumPy scalar `.item()` conversions
  - NaN values

## Tests Added

Added regression tests covering:

- `ValidationIssue.to_dict()` with `pd.Timestamp`
- `ValidationIssue.to_dict()` with `numpy.ndarray`
- JSON serialization via `json.dumps()`
- `ValidationResult.to_dict()` containing timestamp and array values

## Result

Validation export payloads are now consistently JSON-serializable for common timestamp and NumPy container values while preserving existing behavior for existing supported types.

