### PR TITLE
fix: reject duplicate subset columns

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -118,6 +118,7 @@ def _validate_existing_column_sequence(
     available_columns: Sequence[str],
     argument_name: str,
     allow_empty: bool = True,
+    reject_duplicates: bool = False,
     missing_error: type[Exception] = KeyError,
     missing_message: Callable[[list[str], str], str] | None = None,
 ) -> list[str]:
@@ -125,6 +126,18 @@ def _validate_existing_column_sequence(
 
     if not normalized and not allow_empty:
         raise ValueError(f"{argument_name} cannot be empty")
+
+    if reject_duplicates:
+        seen = set()
+        duplicates = []
+        for col in normalized:
+            if col in seen and col not in duplicates:
+                duplicates.append(col)
+            seen.add(col)
+        if duplicates:
+            raise ValueError(
+                f"{argument_name} contains duplicate column names: {duplicates}"
+            )
 
     missing = [column for column in normalized if column not in available_columns]
     if missing:
@@ -1526,6 +1539,7 @@ def combine_columns(
             subset,
             available_columns=column_names,
             argument_name="subset",
+            reject_duplicates=True,
             missing_message=lambda missing, available: (
                 f"Missing columns for combine_columns: {missing}. "
                 f"Available columns: {available}"
@@ -2015,6 +2029,7 @@ def coalesce_columns(
         subset,
         available_columns=column_names,
         argument_name="subset",
+        reject_duplicates=True,
         missing_message=lambda missing, available: (
             f"Missing columns for coalesce_columns: {missing}. "
             f"Available columns: {available}"

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -508,18 +508,67 @@ class TestSharedColumnSequenceValidation:
 
         assert list(df.columns) == ["id", "name"]
 
-    def test_combine_columns_preserves_duplicate_subset_entries(self):
+    def test_combine_columns_rejects_duplicate_subset_entries(self):
         frame = ar.from_pandas(pd.DataFrame({"word": ["go"], "suffix": ["!"]}))
 
-        result = ar.combine_columns(
-            frame,
-            subset=["word", "word", "suffix"],
-            separator="-",
-            output_column="combined",
-        )
-        df = ar.to_pandas(result)
+        with pytest.raises(ValueError, match="duplicate column names"):
+            ar.combine_columns(
+                frame,
+                subset=["word", "word", "suffix"],
+                separator="-",
+                output_column="combined",
+            )
 
-        assert df["combined"].tolist() == ["go-go-!"]
+    def test_combine_columns_rejects_duplicate_subset_direct(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": ["x"], "b": ["y"]}))
+
+        with pytest.raises(ValueError, match="duplicate column names"):
+            ar.combine_columns(frame, subset=["a", "a"], output_column="combined")
+
+    def test_combine_columns_pipeline_rejects_duplicate_subset(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": ["x"], "b": ["y"]}))
+
+        with pytest.raises(ValueError, match="duplicate column names"):
+            ar.pipeline(
+                frame,
+                [
+                    (
+                        "combine_columns",
+                        {"subset": ["a", "a"], "output_column": "combined"},
+                    )
+                ],
+            )
+
+    def test_coalesce_columns_rejects_duplicate_subset_entries(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"nickname": [None, "Bee"], "name": ["Alice", "Bob"]})
+        )
+
+        with pytest.raises(ValueError, match="duplicate column names"):
+            ar.coalesce_columns(
+                frame,
+                subset=["nickname", "nickname"],
+                output_column="display_name",
+            )
+
+    def test_coalesce_columns_pipeline_rejects_duplicate_subset(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"nickname": [None, "Bee"], "name": ["Alice", "Bob"]})
+        )
+
+        with pytest.raises(ValueError, match="duplicate column names"):
+            ar.pipeline(
+                frame,
+                [
+                    (
+                        "coalesce_columns",
+                        {
+                            "subset": ["nickname", "nickname"],
+                            "output_column": "display_name",
+                        },
+                    )
+                ],
+            )
 
 
 class TestDropDuplicates:


### PR DESCRIPTION
…columns

## Summary
combine_columns() and coalesce_columns() silently accepted duplicate column names in subset, causing incorrect output (e.g. subset=["a", "a"] in combine_columns would join the same column twice producing "x x"). This PR adds duplicate rejection to the shared _validate_existing_column_sequence validator via an opt-in reject_duplicates flag, and enables it in both helpers.

## Linked issue
Fixes #1704

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
pytest tests/test_cleaning.py -k "duplicate_subset"
# 5 passed
pytest tests/test_cleaning.py -q
# 422 passed, 2 pre-existing failures unrelated to this change


## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
## Notes

* Added duplicate subset validation for `combine_columns()` and `coalesce_columns()` via `_validate_existing_column_sequence(..., reject_duplicates=True)`.
* Added tests covering direct helper usage and pipeline usage.
* `arnio/frame.py` was not modified; it was referenced in the issue as prior art because `ArFrame.select_columns()` already rejects duplicate columns.
* There were 2 test failures already exist on `main` and are unrelated to this PR.