### PR TITLE
fix: prevent float64 suggestions for non-finite numeric strings

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -2473,10 +2473,13 @@ def _suggest_column_dtype(series: pd.Series, dtype: str) -> str | None:
         return "bool"
 
     numeric = pd.to_numeric(values, errors="coerce")
+
     if numeric.notna().all():
         if values.str.fullmatch(r"[+-]?\d+").all():
             return "int64"
-        return "float64"
+
+        if np.isfinite(numeric).all():
+            return "float64"
     return None
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1262,6 +1262,46 @@ def test_decimal_looking_strings_suggest_float64_not_int64():
 
     assert suggestions["price"] == "float64"
 
+def test_finite_numeric_strings_suggest_float64():
+    frame = ar.from_pandas(
+        pd.DataFrame({"x": ["1.5", "2.0", "3.14"]})
+    )
+
+    report = ar.profile(frame)
+
+    assert report.columns["x"].suggested_dtype == "float64"
+    
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        ["inf", "2.0"],
+        ["-inf", "2.0"],
+        ["Infinity", "2.0"],
+    ],
+)
+def test_non_finite_numeric_strings_do_not_suggest_float64(values):
+    frame = ar.from_pandas(pd.DataFrame({"x": values}))
+
+    report = ar.profile(frame)
+
+    assert report.columns["x"].suggested_dtype is None
+     
+def test_auto_clean_strict_float64_suggestions_are_executable():
+    frame = ar.from_pandas(
+        pd.DataFrame({"x": ["1.5", "2.0"]})
+    )
+
+    clean = ar.auto_clean(
+        frame,
+        mode="strict",
+        allow_lossy_casts=True,
+    )
+
+    result = ar.to_pandas(clean)
+
+    assert pd.api.types.is_float_dtype(result["x"])
+    assert list(result["x"]) == [1.5, 2.0]
 
 def test_profile_string_metrics():
     df = pd.DataFrame({"text": ["a", "abc", "abcde", "", "  ", None]})

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1262,15 +1262,14 @@ def test_decimal_looking_strings_suggest_float64_not_int64():
 
     assert suggestions["price"] == "float64"
 
+
 def test_finite_numeric_strings_suggest_float64():
-    frame = ar.from_pandas(
-        pd.DataFrame({"x": ["1.5", "2.0", "3.14"]})
-    )
+    frame = ar.from_pandas(pd.DataFrame({"x": ["1.5", "2.0", "3.14"]}))
 
     report = ar.profile(frame)
 
     assert report.columns["x"].suggested_dtype == "float64"
-    
+
 
 @pytest.mark.parametrize(
     "values",
@@ -1286,11 +1285,10 @@ def test_non_finite_numeric_strings_do_not_suggest_float64(values):
     report = ar.profile(frame)
 
     assert report.columns["x"].suggested_dtype is None
-     
+
+
 def test_auto_clean_strict_float64_suggestions_are_executable():
-    frame = ar.from_pandas(
-        pd.DataFrame({"x": ["1.5", "2.0"]})
-    )
+    frame = ar.from_pandas(pd.DataFrame({"x": ["1.5", "2.0"]}))
 
     clean = ar.auto_clean(
         frame,
@@ -1302,6 +1300,7 @@ def test_auto_clean_strict_float64_suggestions_are_executable():
 
     assert pd.api.types.is_float_dtype(result["x"])
     assert list(result["x"]) == [1.5, 2.0]
+
 
 def test_profile_string_metrics():
     df = pd.DataFrame({"text": ["a", "abc", "abcde", "", "  ", None]})


### PR DESCRIPTION
* **Summary**

  * Align dtype suggestions with Arnio's actual casting behavior.
  * Prevent `float64` suggestions for non-finite numeric strings such as `"inf"`, `"-inf"`, and `"Infinity"`.
  * Ensure generated suggestions remain executable through `auto_clean(mode="strict", allow_lossy_casts=True)`.

* **Linked Issue**

    Fixes #1899


* **Type of Change**

  * [x] Bug fix
  * [x] Tests
  * [ ] Feature
  * [ ] Performance improvement
  * [ ] Documentation
  * [ ] Refactor
  * [ ] CI / packaging

* **Area**

  * [x] Data quality / profiling
  * [ ] CSV parser / I/O
  * [ ] C++ cleaning engine
  * [ ] Python API / ArFrame
  * [ ] Pipeline / custom steps
  * [ ] Schema validation
  * [ ] pandas interoperability
  * [ ] Docs / website
  * [ ] Developer tooling

* **Testing**

  * [x] `python -m pytest tests/test_quality.py -v`
  * [x] `python -m pytest`
  * [x] `python -m ruff check arnio/quality.py tests/test_quality.py`
  * [x] `python -m black arnio/quality.py tests/test_quality.py`

  **Results**

  * Added test coverage for finite numeric strings that should still suggest `float64`.
  * Added test coverage for `"inf"`, `"-inf"`, and `"Infinity"` values that should not suggest `float64`.
  * Added a strict `auto_clean()` path test proving generated suggestions remain executable.
  * Full test suite passed locally (`2453 passed, 43 skipped`).

* **Screenshots / Media**

  * N/A

* **Performance Impact**

  * No expected performance impact.
  * Change only adds a finite-value validation check during dtype suggestion generation.

* **Contributor Checklist**

  * [x] I read the contributing guide.
  * [x] I kept the PR focused on one issue or one logical change.
  * [x] I added or updated tests for behavior changes.
  * [ ] I added or updated docs/examples for public API changes (not applicable).
  * [x] I checked that generated files, logs, and local build artifacts are not committed.
  * [x] My PR title uses Conventional Commits (`fix:`).

* **Maintainer Notes**

  * `_suggest_column_dtype()` now aligns with Arnio's casting contract by requiring finite numeric values before suggesting `float64`.
  * This prevents runtime failures caused by self-generated cleaning suggestions.
