### PR TITLE
fix: preserve arrow rows for zero-column frames

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -301,6 +301,10 @@ def to_arrow(frame: ArFrame) -> pa.Table:
     arrays: list[pa.Array] = []
     names: list[str] = []
 
+    if cpp_frame.num_cols() == 0:
+        empty = pd.DataFrame(index=pd.RangeIndex(cpp_frame.num_rows()))
+        return pa.Table.from_pandas(empty)
+
     for i in range(cpp_frame.num_cols()):
         col = cpp_frame.column_by_index(i)
         name = col.name()

--- a/tests/test_to_arrow_edge_cases.py
+++ b/tests/test_to_arrow_edge_cases.py
@@ -17,6 +17,19 @@ class TestToArrowEdgeCases:
         frame = ar.from_pandas(pd.DataFrame())
         table = to_arrow(frame)
         assert table.num_columns == 0
+        assert table.num_rows == 0
+
+    def test_zero_column_frame_preserves_row_count(self):
+        """to_arrow preserves rows when all columns are dropped."""
+        frame = ar.from_pandas(pd.DataFrame({"a": [None, None], "b": ["", ""]}))
+        zero_column_frame = ar.drop_empty_columns(frame)
+
+        assert zero_column_frame.shape == (2, 0)
+
+        table = to_arrow(zero_column_frame)
+
+        assert table.num_columns == 0
+        assert table.num_rows == 2
 
     def test_all_null_column(self):
         """to_arrow handles column with all null values."""


### PR DESCRIPTION
Summary
- Fixes #1648
- Preserves row count when `to_arrow()` exports an ArFrame with zero columns.
- Adds regression coverage for both `(0, 0)` and `(n, 0)` zero-column frames.

Context
This came up through the GSSoC 2026 issue for zero-column Arrow exports. `to_pandas()` already preserves the row count for zero-column frames by constructing a `RangeIndex`, but `to_arrow()` was calling `pa.Table.from_arrays([], names=[])`, which leaves PyArrow with no column length to infer from and collapses the table to zero rows.

What changed
- Added a narrow zero-column branch in `arnio/convert.py`.
- Reuses PyArrow's pandas conversion path with a RangeIndex-backed empty DataFrame so row count is kept in the Arrow table metadata.
- Leaves the normal typed-column conversion path untouched.
- Extended `tests/test_to_arrow_edge_cases.py` to assert the existing `(0, 0)` behavior and cover the dropped-columns `(2, 0)` workflow.

Validation
- `.venv-codex/bin/python -m pytest tests/test_to_arrow_edge_cases.py -q` - 13 passed
- `.venv-codex/bin/python -m pytest tests/test_convert.py tests/test_to_arrow_edge_cases.py tests/test_parquet.py -q` - 174 passed
- `.venv-codex/bin/python -m pytest -q` - 2667 passed, 3 skipped
- `.venv-codex/bin/python -m ruff check arnio/convert.py tests/test_to_arrow_edge_cases.py`
- `git diff --check`
