### PR TITLE
fix: respect encoding in delimiter sniffing

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1297,10 +1297,11 @@ def sniff_delimiter(
     except FileNotFoundError as e:
         raise FileNotFoundError(f"File not found: {path!r}") from e
 
-    try:
-        _reject_utf8_nul_bytes(path)
-    except FileNotFoundError:
-        pass
+    if _is_utf8_encoding(encoding):
+        try:
+            _reject_utf8_nul_bytes(path)
+        except FileNotFoundError:
+            pass
 
     # 3. Read Sample
     try:

--- a/tests/test_sniff_delimiter.py
+++ b/tests/test_sniff_delimiter.py
@@ -99,6 +99,24 @@ class TestSniffDelimiter:
         result = sniff_delimiter(path, encoding="latin-1")
         assert result == ","
 
+    def test_handles_utf16_comma_delimited_file(self, tmp_path):
+        """sniff_delimiter decodes UTF-16 CSV before binary checks."""
+        path = tmp_path / "utf16.csv"
+        path.write_text("name,age\nAlice,30\nBob,25\n", encoding="utf-16")
+
+        result = sniff_delimiter(path, encoding="utf-16")
+
+        assert result == ","
+
+    def test_handles_utf16_tab_delimited_file(self, tmp_path):
+        """sniff_delimiter decodes UTF-16 TSV before binary checks."""
+        path = tmp_path / "utf16.tsv"
+        path.write_text("name\tage\nAlice\t30\nBob\t25\n", encoding="utf-16")
+
+        result = sniff_delimiter(path, encoding="utf-16")
+
+        assert result == "\t"
+
     def test_handles_quoted_fields_with_delimiter(self, tmp_path):
         """sniff_delimiter correctly handles delimiters inside quoted fields."""
         path = tmp_path / "quoted.csv"


### PR DESCRIPTION
Summary
- Fixes #1664
- Makes `sniff_delimiter()` skip the raw UTF-8 NUL-byte scan for explicitly non-UTF-8 encodings.
- Adds UTF-16 comma and tab delimiter regression coverage.

Context
This is for the assigned GSSoC 2026 issue around UTF-16 CSV delimiter sniffing. The bug was that `sniff_delimiter()` always called `_reject_utf8_nul_bytes(path)` before decoding the sample. That guard is correct for raw UTF-8 input, but UTF-16 text naturally contains NUL bytes in its byte representation, so valid UTF-16 CSV files were rejected as binary before `open(..., encoding="utf-16")` could decode them.

What changed
- Reused the same `_is_utf8_encoding()` gate already used by the CSV validation path.
- Kept the existing binary/NUL-byte rejection behavior for UTF-8 input.
- Left the delimiter scoring and quote-aware scanner untouched.
- Added focused tests for UTF-16 comma-delimited and tab-delimited files.

Validation
- `.venv-codex/bin/python -m pytest tests/test_sniff_delimiter.py -q` - 22 passed
- `.venv-codex/bin/python -m pytest tests/test_csv.py tests/test_csv_validation_delimiter.py tests/test_sniff_delimiter.py -q` - 379 passed
- `.venv-codex/bin/python -m pytest -q` - 2700 passed, 3 skipped
- `.venv-codex/bin/python -m ruff check arnio/io.py tests/test_sniff_delimiter.py`
- `git diff --check`
