### PR TITLE
Fix: remove redundant inline pandas import in _normalize_validator_result

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2893,14 +2893,8 @@ def _normalize_validator_result(result: object, validator_name: str) -> bool:
         return True
     if result is False or result is None:
         return False
-    # Check for pd.NA without importing pandas at module level
-    try:
-        import pandas as _pd
-
-        if result is _pd.NA:
-            return False
-    except ImportError:
-        pass
+    if result is pd.NA:
+        return False
     raise TypeError(
         f"Custom validator {validator_name!r} returned "
         f"{type(result).__name__!r} ({result!r}); "


### PR DESCRIPTION
### Description
The _normalize_validator_result function has a redundant inline import pandas as _pd inside a try/except block. Since pandas is already imported at module level on line 18 (import pandas as pd), this inline import is dead code. Replaced with a direct reference to pd.NA.

### Related Issue
Fixes #2067

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

program: gssoc