### PR TITLE
Fix: use deep copy in combine_columns pandas fallback

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1568,7 +1568,7 @@ def combine_columns(
         return ArFrame(result)
 
     # Pandas fallback
-    df = frame.copy(deep=False)
+    df = frame.copy(deep=True)
     combined = (
         df[subset_columns].astype("string").fillna("").agg(separator.join, axis=1)
     )


### PR DESCRIPTION
### Description
The pandas fallback in combine_columns uses rame.copy(deep=False), creating a shallow copy that shares column data with the original DataFrame. When the combined column is assigned back, this can trigger SettingWithCopyWarning or silently corrupt the original DataFrame's internal state. Changed to deep=True for a safe independent copy.

### Related Issue
Fixes #2073

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

program: gssoc