### PR TITLE
Fix: write_csv uses atomic write via temp file then rename

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -945,10 +945,22 @@ def write_csv(
     config.line_terminator = line_terminator
 
     writer = _CsvWriter(config)
+    dir_path = os.path.dirname(os.path.abspath(path))
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        dir=dir_path,
+        suffix=".csv",
+        prefix=f".{os.path.basename(path)}.",
+    )
+    os.close(tmp_fd)
     try:
-        writer.write(frame._frame, path)
-    except RuntimeError as e:
-        raise RuntimeError(str(e)) from e
+        writer.write(frame._frame, tmp_path)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def scan_csv(

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import arnio as ar
+import arnio.io
 
 
 @pytest.mark.parametrize(
@@ -23,6 +24,45 @@ def test_write_csv_invalid_frame(bad_input, tmp_path):
 
 
 class TestWriteCsv:
+    def test_atomic_write_success(self, tmp_path, sample_csv):
+        frame = ar.read_csv(sample_csv)
+        out = str(tmp_path / "out.csv")
+        ar.write_csv(frame, out)
+        assert Path(out).exists()
+        frame2 = ar.read_csv(out)
+        pd.testing.assert_frame_equal(ar.to_pandas(frame), ar.to_pandas(frame2))
+
+    def test_atomic_write_preserves_dest_on_failure(self, tmp_path, monkeypatch):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+        out = str(tmp_path / "out.csv")
+        ar.write_csv(frame, out)
+        original_content = Path(out).read_text()
+
+        orig_write = arnio.io._CsvWriter.write
+        def failing_write(self_, f, p):
+            raise RuntimeError("Writer failed")
+
+        monkeypatch.setattr(arnio.io._CsvWriter, "write", failing_write)
+
+        with pytest.raises(RuntimeError, match="Writer failed"):
+            ar.write_csv(frame, out)
+        assert Path(out).read_text() == original_content
+
+    def test_atomic_write_cleans_up_temp_on_failure(self, tmp_path, monkeypatch):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+        out = str(tmp_path / "out.csv")
+
+        orig_write = arnio.io._CsvWriter.write
+        def failing_write(self_, f, p):
+            raise RuntimeError("Writer failed")
+
+        monkeypatch.setattr(arnio.io._CsvWriter, "write", failing_write)
+
+        with pytest.raises(RuntimeError, match="Writer failed"):
+            ar.write_csv(frame, out)
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".out.csv")]
+        assert len(leftovers) == 0
+
     def test_basic_write(self, tmp_path, sample_csv):
         frame = ar.read_csv(sample_csv)
         out = str(tmp_path / "out.csv")


### PR DESCRIPTION
### Description
write_csv writes directly to the destination path. If the write is interrupted (crash, disk full), a corrupted partial file is left at the destination. This fix writes to a temporary file in the same directory first, then atomically renames it to the destination path. On failure, the temp file is cleaned up.

### Related Issue
Fixes #2069

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

program: gssoc