### PR TITLE
fix: validate ArnioCleaner parameters after set_params updates

### DIFF
--- a/arnio/integrations/sklearn.py
+++ b/arnio/integrations/sklearn.py
@@ -55,6 +55,19 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
         if not isinstance(self.allow_schema_changes, bool):
             raise TypeError("allow_schema_changes must be a bool")
 
+    def set_params(self, **params):
+        snapshot = self.get_params(deep=False)
+
+        try:
+            super().set_params(**params)
+            self._validate_params()
+        except Exception:
+            for key, value in snapshot.items():
+                setattr(self, key, value)
+            raise
+
+        return self
+
     def _validate_steps_contract(self):
         for step in self.steps:
             name = step[0] if isinstance(step, tuple) else step

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -276,6 +276,44 @@ def test_arniocleaner_rejects_non_boolean_options():
             ArnioCleaner(allow_row_count_change=value).fit(df)
 
 
+def test_arniocleaner_set_params_rejects_invalid_runtime_updates_and_rolls_back():
+    cleaner = ArnioCleaner(copy=True, allow_row_count_change=False, allow_schema_changes=False)
+
+    with pytest.raises(TypeError, match="copy must be a bool"):
+        cleaner.set_params(copy="not-a-bool")
+    assert cleaner.copy is True
+
+    with pytest.raises(TypeError, match="allow_row_count_change must be a bool"):
+        cleaner.set_params(allow_row_count_change="not-a-bool")
+    assert cleaner.allow_row_count_change is False
+
+    with pytest.raises(TypeError, match="allow_schema_changes must be a bool"):
+        cleaner.set_params(allow_schema_changes="not-a-bool")
+    assert cleaner.allow_schema_changes is False
+
+
+def test_arniocleaner_set_params_supports_valid_updates():
+    cleaner = ArnioCleaner()
+
+    returned = cleaner.set_params(copy=False, allow_row_count_change=True)
+
+    assert returned is cleaner
+    assert cleaner.copy is False
+    assert cleaner.allow_row_count_change is True
+
+
+def test_arniocleaner_pipeline_set_params_rejects_invalid_updates():
+    df = pd.DataFrame({"A": [1, 2]})
+    pipe = Pipeline([("arnio_prep", ArnioCleaner())])
+
+    with pytest.raises(TypeError, match="copy must be a bool"):
+        pipe.set_params(arnio_prep__copy="bad")
+
+    result = pipe.fit_transform(df)
+
+    assert isinstance(result, pd.DataFrame)
+
+
 def test_arniocleaner_construction_with_invalid_params_does_not_raise():
     cleaner = ArnioCleaner(copy="yes")
     assert cleaner.copy == "yes"

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -277,7 +277,9 @@ def test_arniocleaner_rejects_non_boolean_options():
 
 
 def test_arniocleaner_set_params_rejects_invalid_runtime_updates_and_rolls_back():
-    cleaner = ArnioCleaner(copy=True, allow_row_count_change=False, allow_schema_changes=False)
+    cleaner = ArnioCleaner(
+        copy=True, allow_row_count_change=False, allow_schema_changes=False
+    )
 
     with pytest.raises(TypeError, match="copy must be a bool"):
         cleaner.set_params(copy="not-a-bool")


### PR DESCRIPTION
I added a `set_params()` override in sklearn.py that snapshots the current top-level parameters, applies the update, revalidates the runtime booleans, and rolls back to the previous state if validation or sklearn’s own parameter handling fails.

I also added regression coverage in test_sklearn.py, test_sklearn.py, and test_sklearn.py for invalid runtime updates, rollback after failure, valid updates returning self, and Pipeline delegation.

closes #1660

