### PR TITLE
fix: make custom pipeline step frames writable

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -5,6 +5,7 @@ Chained cleaning pipeline.
 
 from __future__ import annotations
 
+import copy as copylib
 import inspect
 import logging
 import warnings
@@ -68,6 +69,41 @@ class PipelineContext:
     step_index: int
     total_steps: int
     dry_run: bool
+
+
+class _WritablePipelineSeries(pd.Series):
+    @property
+    def _constructor(self):
+        return _WritablePipelineSeries
+
+    @property
+    def _constructor_expanddim(self):
+        return _WritablePipelineDataFrame
+
+    def to_numpy(self, *args, **kwargs):
+        values = super().to_numpy(*args, **kwargs)
+        try:
+            values.setflags(write=True)
+        except ValueError:
+            pass
+        return values
+
+
+class _WritablePipelineDataFrame(pd.DataFrame):
+    @property
+    def _constructor(self):
+        return _WritablePipelineDataFrame
+
+    @property
+    def _constructor_sliced(self):
+        return _WritablePipelineSeries
+
+
+def _to_writable_pipeline_dataframe(frame: ArFrame) -> pd.DataFrame:
+    base = to_pandas(frame, copy=True)
+    writable = _WritablePipelineDataFrame(base, copy=False)
+    writable.attrs = copylib.deepcopy(base.attrs)
+    return writable
 
 
 def _is_builtin_python_step(name: str, fn: Callable) -> bool:
@@ -473,10 +509,12 @@ def pipeline(
 
             fn = python_step_registry[name]
 
-            df = to_pandas(working_frame)
-
             # Isolate genuine custom steps from internal core library functions
             is_builtin = _is_builtin_python_step(name, fn)
+            if is_builtin:
+                df = to_pandas(working_frame)
+            else:
+                df = _to_writable_pipeline_dataframe(working_frame)
             signature = inspect.signature(fn)
             call_kwargs = dict(kwargs)
             if "context" in signature.parameters and "context" not in call_kwargs:

--- a/tests/test_pipeline_custom_step_return_type.py
+++ b/tests/test_pipeline_custom_step_return_type.py
@@ -245,6 +245,25 @@ def test_valid_step_with_kwargs_passes(small_frame):
     assert list(result_df["tag"]) == ["hello", "hello"]
 
 
+def test_custom_step_receives_writable_numeric_array():
+    frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+    writeable_flags = []
+
+    def mutate_numpy_in_place(df):
+        values = df["x"].to_numpy()
+        writeable_flags.append(values.flags.writeable)
+        values[0] = 99.0
+        return df
+
+    ar.register_step("mutate_numpy_in_place", mutate_numpy_in_place)
+
+    result = ar.pipeline(frame, [("mutate_numpy_in_place",)])
+    result_df = ar.to_pandas(result)
+
+    assert writeable_flags == [True]
+    assert list(result_df["x"]) == [99.0, 2.0]
+
+
 # ---------------------------------------------------------------------------
 # return_metadata=True compatibility
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1657

This PR keeps the custom pipeline step fix scoped to the handoff between Arnio and user-registered Python steps.

What changed:

- Custom user steps now receive a defensive pandas frame instead of the default zero-copy view.
- The writable frame path is only used for genuine custom steps; built-in Python-backed Arnio steps keep the existing handoff.
- The custom-step frame uses a small internal pandas subclass so `Series.to_numpy()` returns a writable view even under pandas 3 copy-on-write behavior.
- Added a regression test for a custom step that mutates a numeric column through `df["x"].to_numpy()[0] = ...`.

Why this shape:

I first tried the obvious `to_pandas(..., copy=True)` path, but under pandas 3 the resulting `Series.to_numpy()` view is still marked read-only because copy-on-write is always active. The internal wrapper keeps the public custom-step contract the same while making the frame users receive behave like a normal mutable working DataFrame.

Validation:

- `.venv-codex/bin/python -m pytest tests/test_pipeline_custom_step_return_type.py -q` -> 19 passed
- `.venv-codex/bin/python -m pytest tests/test_pipeline.py tests/test_pipeline_custom_step_return_type.py -q` -> 145 passed
- `.venv-codex/bin/ruff check arnio/pipeline.py tests/test_pipeline_custom_step_return_type.py` -> passed
- `.venv-codex/bin/python -m black --check --diff arnio/pipeline.py tests/test_pipeline_custom_step_return_type.py` -> passed
- `.venv-codex/bin/python -m pytest -q` -> 2712 passed, 3 skipped
- `git diff --check` -> passed

This is for GSSoC 2026 and stays limited to the assigned custom pipeline step writable-buffer bug.
