### PR TITLE
fix: require auto_clean cast confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,10 +1368,24 @@ clean = ar.pipeline(frame, suggestions)
 For low-risk automatic cleanup in one call:
 
 ```python
-clean, report = ar.auto_clean(frame, mode="strict", return_report=True)
+clean, report = ar.auto_clean(frame, return_report=True)
 ```
 
-This is the layer pandas does not try to own: profiling, data contracts, row-level validation issues, and safe cleaning suggestions for messy incoming datasets.
+For strict automatic cleanup, inspect type casts before applying them:
+
+```python
+report = ar.auto_clean(frame, mode="strict", dry_run=True)
+cast_mapping = dict(report.suggestions).get("cast_types")
+
+clean = ar.auto_clean(
+    frame,
+    mode="strict",
+    allow_lossy_casts=True,
+    confirmed_casts=cast_mapping,
+)
+```
+
+This is the layer pandas does not try to own: profiling, data contracts, row-level validation issues, and preview-gated cleaning suggestions for messy incoming datasets.
 
 <br>
 
@@ -1424,7 +1438,7 @@ Expected cleaned output with `mode="strict"`:
 | 1003 | Pranay | New York |
 | 1004 | Dhruv | Tokyo |
 
-`mode="safe"` only trims whitespace. Use `mode="strict"` when you also want deterministic built-in cleanup such as exact duplicate removal.
+`mode="safe"` only trims whitespace. Use `mode="strict"` when you also want deterministic built-in cleanup such as exact duplicate removal. If strict mode proposes type casts, run `dry_run=True` first and pass the exact proposed mapping as `confirmed_casts` with `allow_lossy_casts=True`.
 
 See [examples/auto_clean_tutorial.py](examples/auto_clean_tutorial.py) for a runnable version of this walkthrough, and [examples/schema_validation.py](examples/schema_validation.py) for a focused validation tutorial.
 

--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -92,6 +92,7 @@ class ArnioPandasAccessor:
         return_report: bool = False,
         dry_run: bool = False,
         allow_lossy_casts: bool = False,
+        confirmed_casts: dict[str, str] | None = None,
         explain: bool = False,
     ) -> (
         pd.DataFrame
@@ -107,6 +108,9 @@ class ArnioPandasAccessor:
         explain : bool, default False
             When ``True``, also return a :class:`~arnio.quality.CleanExplanation`
             audit trail describing which steps ran and why.
+        confirmed_casts : dict[str, str] or None, default None
+            Exact strict-mode ``cast_types`` mapping to confirm after previewing
+            proposed casts with ``dry_run=True`` or ``suggest_cleaning()``.
         """
         result = auto_clean(
             self.to_arframe(),
@@ -114,6 +118,7 @@ class ArnioPandasAccessor:
             return_report=return_report,
             dry_run=dry_run,
             allow_lossy_casts=allow_lossy_casts,
+            confirmed_casts=confirmed_casts,
             explain=explain,
         )
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -2219,6 +2219,31 @@ class CleanExplanation:
         return "\n".join(lines)
 
 
+def _validate_confirmed_casts(
+    confirmed_casts: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Validate and copy an explicit auto_clean cast confirmation mapping."""
+    if confirmed_casts is None:
+        return None
+    if not isinstance(confirmed_casts, dict):
+        raise TypeError("confirmed_casts must be a dict[str, str] or None")
+
+    normalized: dict[str, str] = {}
+    for column, dtype in confirmed_casts.items():
+        if not isinstance(column, str):
+            raise TypeError(
+                "confirmed_casts keys must be str column names, "
+                f"got {type(column).__name__}"
+            )
+        if not isinstance(dtype, str):
+            raise TypeError(
+                "confirmed_casts values must be str dtype names, "
+                f"got {type(dtype).__name__}"
+            )
+        normalized[column] = dtype
+    return normalized
+
+
 def auto_clean(
     frame: ArFrame,
     *,
@@ -2226,6 +2251,7 @@ def auto_clean(
     return_report: bool = False,
     dry_run: bool = False,
     allow_lossy_casts: bool = False,
+    confirmed_casts: dict[str, str] | None = None,
     explain: bool = False,
 ) -> (
     ArFrame
@@ -2248,7 +2274,13 @@ def auto_clean(
     dry_run : bool, default False
         Return the proposed pre-cleaning report without mutating the frame.
     allow_lossy_casts : bool, default False
-        Required before strict mode applies suggested type casts.
+        Required before strict mode applies suggested type casts. Type casts
+        also require *confirmed_casts* so callers explicitly confirm the exact
+        mapping they previewed.
+    confirmed_casts : dict[str, str] or None, default None
+        Exact cast mapping to apply in strict mode. Use ``dry_run=True`` or
+        ``suggest_cleaning()`` to inspect the proposed ``cast_types`` mapping,
+        then pass the same mapping here with ``allow_lossy_casts=True``.
     explain : bool, default False
         When ``True``, return a :class:`CleanExplanation` object that records
         which steps ran, before/after row counts for each step, and why each
@@ -2272,7 +2304,8 @@ def auto_clean(
     --------
     >>> clean = ar.auto_clean(frame)
     >>> report = ar.auto_clean(frame, mode="strict", dry_run=True)
-    >>> clean = ar.auto_clean(frame, mode="strict", allow_lossy_casts=True)
+    >>> casts = dict(report.suggestions)["cast_types"]
+    >>> clean = ar.auto_clean(frame, mode="strict", allow_lossy_casts=True, confirmed_casts=casts)
     >>> clean, report = ar.auto_clean(frame, mode="strict", return_report=True)
     >>> clean, explanation = ar.auto_clean(frame, explain=True)
     >>> print(explanation)
@@ -2291,6 +2324,7 @@ def auto_clean(
         raise TypeError("dry_run must be a bool")
     if not isinstance(allow_lossy_casts, bool):
         raise TypeError("allow_lossy_casts must be a bool")
+    confirmed_casts_map = _validate_confirmed_casts(confirmed_casts)
     if not isinstance(explain, bool):
         raise TypeError("explain must be a bool")
 
@@ -2328,7 +2362,20 @@ def auto_clean(
                 raise ValueError(
                     "auto_clean(mode='strict') would apply type casts. "
                     f"Proposed mapping: {kwargs}. Run with dry_run=True to inspect "
-                    "the report, or pass allow_lossy_casts=True to apply them."
+                    "the report, then pass allow_lossy_casts=True and "
+                    "confirmed_casts=<proposed mapping> to apply them."
+                )
+            if confirmed_casts_map is None:
+                raise ValueError(
+                    "auto_clean(mode='strict') requires confirmed_casts before "
+                    "applying type casts. Run with dry_run=True to inspect the "
+                    f"proposed mapping, then pass confirmed_casts={kwargs!r}."
+                )
+            if confirmed_casts_map != kwargs:
+                raise ValueError(
+                    "confirmed_casts must match the proposed cast mapping exactly. "
+                    f"Proposed mapping: {kwargs}. Confirmed mapping: "
+                    f"{confirmed_casts_map}."
                 )
             result = cast_types(result, kwargs)
         elif step == "drop_duplicates":

--- a/benchmarks/benchmark_auto_clean_memory.py
+++ b/benchmarks/benchmark_auto_clean_memory.py
@@ -202,6 +202,21 @@ def benchmark_auto_clean(
 
     frame = ar.read_csv(csv_path)
 
+    if mode == "strict":
+        report = ar.auto_clean(
+            frame,
+            mode="strict",
+            dry_run=True,
+        )
+        cast_mapping = dict(report.suggestions).get("cast_types")
+        if cast_mapping:
+            return ar.auto_clean(
+                frame,
+                mode="strict",
+                allow_lossy_casts=True,
+                confirmed_casts=cast_mapping,
+            )
+
     return ar.auto_clean(
         frame,
         mode=mode,

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -100,6 +100,29 @@ def test_pandas_accessor_auto_clean_dry_run_safe_mode():
     assert list(df["score"]) == ["10", "20", "30"]
 
 
+def test_pandas_accessor_auto_clean_strict_requires_confirmed_casts():
+    df = pd.DataFrame({"active": ["true", "false"]})
+
+    with pytest.raises(ValueError, match="requires confirmed_casts"):
+        df.arnio.auto_clean(mode="strict", allow_lossy_casts=True)
+
+
+def test_pandas_accessor_auto_clean_strict_accepts_confirmed_casts():
+    df = pd.DataFrame({"active": ["true", "false"]})
+    report = df.arnio.auto_clean(mode="strict", dry_run=True)
+    confirmed_casts = dict(report.suggestions)["cast_types"]
+
+    result = df.arnio.auto_clean(
+        mode="strict",
+        allow_lossy_casts=True,
+        confirmed_casts=confirmed_casts,
+    )
+
+    assert list(result["active"]) == [True, False]
+    assert pd.api.types.is_bool_dtype(result["active"])
+    assert list(df["active"]) == ["true", "false"]
+
+
 def test_pandas_accessor_validates_dataframe():
     df = pd.DataFrame({"email": ["alice@example.com", "bad"]})
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -592,6 +592,41 @@ def test_auto_clean_strict_casts_require_explicit_opt_in():
         ar.auto_clean(frame, mode="strict")
 
 
+def test_auto_clean_strict_casts_require_preview_confirmation():
+    frame = ar.from_pandas(pd.DataFrame({"active": ["true", "false"]}))
+
+    with pytest.raises(ValueError, match="requires confirmed_casts"):
+        ar.auto_clean(frame, mode="strict", allow_lossy_casts=True)
+
+
+def test_auto_clean_strict_rejects_mismatched_cast_confirmation():
+    frame = ar.from_pandas(pd.DataFrame({"active": ["true", "false"]}))
+
+    with pytest.raises(ValueError, match="must match the proposed cast mapping"):
+        ar.auto_clean(
+            frame,
+            mode="strict",
+            allow_lossy_casts=True,
+            confirmed_casts={"active": "int64"},
+        )
+
+
+@pytest.mark.parametrize(
+    "confirmed_casts",
+    [
+        [("active", "bool")],
+        {1: "bool"},
+        {"active": 1},
+    ],
+    ids=["list", "non-string-key", "non-string-value"],
+)
+def test_auto_clean_rejects_invalid_confirmed_casts(confirmed_casts):
+    frame = ar.from_pandas(pd.DataFrame({"active": ["true", "false"]}))
+
+    with pytest.raises(TypeError, match="confirmed_casts"):
+        ar.auto_clean(frame, mode="strict", confirmed_casts=confirmed_casts)
+
+
 def test_exclude_columns_prevents_leakage_in_json():
     import json
 
@@ -612,6 +647,23 @@ def test_auto_clean_dry_run_returns_report_without_mutating():
     assert isinstance(report, ar.DataQualityReport)
     assert ("cast_types", {"active": "bool"}) in report.suggestions
     assert frame.dtypes["active"] == "string"
+
+
+def test_auto_clean_strict_casts_after_explicit_preview_confirmation():
+    frame = ar.from_pandas(pd.DataFrame({"active": ["true", "false"]}))
+    report = ar.auto_clean(frame, mode="strict", dry_run=True)
+    confirmed_casts = dict(report.suggestions)["cast_types"]
+
+    clean = ar.auto_clean(
+        frame,
+        mode="strict",
+        allow_lossy_casts=True,
+        confirmed_casts=confirmed_casts,
+    )
+    result = ar.to_pandas(clean)
+
+    assert list(result["active"]) == [True, False]
+    assert pd.api.types.is_bool_dtype(result["active"])
 
 
 def test_auto_clean_dry_run_with_return_report_raises():
@@ -678,8 +730,14 @@ def test_auto_clean_strict_casts_ambiguous_numeric_strings():
     with pytest.raises(ValueError, match="would apply type casts"):
         ar.auto_clean(frame, mode="strict")
 
-    # Apply strict mode with allow_lossy_casts
-    clean = ar.auto_clean(frame, mode="strict", allow_lossy_casts=True)
+    # Apply strict mode after explicitly confirming the previewed cast mapping.
+    report = ar.auto_clean(frame, mode="strict", dry_run=True)
+    clean = ar.auto_clean(
+        frame,
+        mode="strict",
+        allow_lossy_casts=True,
+        confirmed_casts=dict(report.suggestions)["cast_types"],
+    )
     result = ar.to_pandas(clean)
 
     # "code" is cast to int64, losing leading zeros
@@ -1066,7 +1124,13 @@ def test_identifier_numeric_cast_prevention():
     assert "customer_id" not in suggestions
     assert "zip_code" not in suggestions
 
-    cleaned = ar.auto_clean(frame, mode="strict", allow_lossy_casts=True)
+    report = ar.auto_clean(frame, mode="strict", dry_run=True)
+    cleaned = ar.auto_clean(
+        frame,
+        mode="strict",
+        allow_lossy_casts=True,
+        confirmed_casts=dict(report.suggestions)["cast_types"],
+    )
     result = ar.to_pandas(cleaned)
     assert list(result["id"]) == ["001", "002", "003"]
     assert list(result["customer_id"]) == ["00123", "00456", "00789"]
@@ -1336,11 +1400,13 @@ def test_non_finite_numeric_strings_do_not_suggest_float64(values):
 
 def test_auto_clean_strict_float64_suggestions_are_executable():
     frame = ar.from_pandas(pd.DataFrame({"x": ["1.5", "2.0"]}))
+    report = ar.auto_clean(frame, mode="strict", dry_run=True)
 
     clean = ar.auto_clean(
         frame,
         mode="strict",
         allow_lossy_casts=True,
+        confirmed_casts=dict(report.suggestions)["cast_types"],
     )
 
     result = ar.to_pandas(clean)


### PR DESCRIPTION
## Summary
- require strict `auto_clean` type casts to pass an exact `confirmed_casts` mapping after preview
- expose the same confirmation gate through the pandas accessor
- update README and the auto-clean benchmark for the new strict-mode contract

## Verification
- `py -3.13 -m pytest tests\test_quality.py tests\test_pandas_accessor.py tests\test_benchmarks_smoke.py -q`
- `py -3.13 -m black --check arnio tests benchmarks`
- `py -3.13 -m ruff check arnio tests benchmarks`
- `git diff --check`

## Notes
- Full local `py -3.13 -m pytest tests -q` currently has unrelated failures in CSV/native-extension/frame/write paths on this Windows workspace; the focused issue coverage and static checks pass locally, and GitHub CI should be the merge gate.

Fixes #601