### PR TITLE
fix: support cast_types ignore errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,7 +964,7 @@ Most operations below run natively in C++. Currently, `filter_rows`, `replace_va
 | `standardize_missing_tokens` | Replace common missing-value strings with NaN | `ar.standardize_missing_tokens(frame)` |
 | `normalize_case` | Force lower/upper/title case | `ar.normalize_case(frame, case_type="title")` |
 | `rename_columns` | Rename columns via mapping | `ar.rename_columns(frame, {"old": "new"})` |
-| `cast_types` | Cast column types | `ar.cast_types(frame, {"age": "int64"})` |
+| `cast_types` | Cast column types with `errors="raise"`, `"coerce"`, or `"ignore"` | `ar.cast_types(frame, {"age": "int64"}, errors="raise")` |
 | `round_numeric_columns` | Round numeric columns (non-numeric columns in subset ignored safely) | `ar.round_numeric_columns(frame, decimals=2)` |
 | `replace_values` | Replace values using a mapping (column or whole-frame). Handles `None`/`NaN`. | `ar.replace_values(frame, {"active": "A", "inactive": "I"}, column="status")` |
 | `clean` | Convenience shorthand | `ar.clean(frame, drop_nulls=True)` |

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1257,8 +1257,9 @@ def cast_types(
         Input data frame.
     mapping : dict[str, str]
         Dictionary mapping column names to target type strings (e.g., "int64", "float64", "bool", "string").
-    errors : {"raise", "coerce"}, default "raise"
-        Whether invalid casts raise ``TypeCastError`` or become null values.
+    errors : {"raise", "coerce", "ignore"}, default "raise"
+        Whether invalid casts raise ``TypeCastError``, become null values, or
+        leave the affected column unchanged.
 
     Returns
     -------
@@ -1271,8 +1272,8 @@ def cast_types(
     >>> casted = ar.cast_types(frame, {"age": "int64", "score": "float64"})
     """
     frame, _ = _validate_frame(frame)
-    if errors not in {"raise", "coerce"}:
-        raise ValueError("errors must be either 'raise' or 'coerce'")
+    if errors not in {"raise", "coerce", "ignore"}:
+        raise ValueError("errors must be one of 'raise', 'coerce', or 'ignore'")
 
     mapping = _validate_string_mapping(mapping, argument_name="mapping")
     validate_columns_exist(
@@ -1281,11 +1282,20 @@ def cast_types(
         operation="cast_types",
     )
     try:
-        result = _cast_types(
-            frame._frame,
-            mapping,
-            errors == "coerce",
-        )
+        if errors == "ignore":
+            result = frame._frame
+            for column, dtype in mapping.items():
+                try:
+                    result = _cast_types(result, {column: dtype}, False)
+                except ValueError as e:
+                    if not str(e).startswith("Cannot cast column "):
+                        raise
+        else:
+            result = _cast_types(
+                frame._frame,
+                mapping,
+                errors == "coerce",
+            )
     except ValueError as e:
         raise TypeCastError(str(e)) from e
     return ArFrame(result)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2503,8 +2503,8 @@ class TestCastTypes:
     def test_cast_rejects_invalid_errors_policy(self, sample_csv):
         frame = ar.read_csv(sample_csv)
 
-        with pytest.raises(ValueError, match="errors must be either"):
-            ar.cast_types(frame, {"age": "int64"}, errors="ignore")
+        with pytest.raises(ValueError, match="errors must be one of"):
+            ar.cast_types(frame, {"age": "int64"}, errors="warn")
 
     @pytest.mark.parametrize(
         "mapping",
@@ -2628,6 +2628,15 @@ class TestCastTypes:
         assert df["score"].iloc[0] == 1.5
         assert pd.isna(df["score"].iloc[1])
 
+    def test_cast_string_to_float_unparseable_ignores_column(self):
+        frame = ar.from_pandas(pd.DataFrame({"score": ["1.5", "abc"]}))
+
+        result = ar.cast_types(frame, {"score": "float64"}, errors="ignore")
+        df = ar.to_pandas(result)
+
+        assert result.dtypes["score"] == "string"
+        assert list(df["score"]) == ["1.5", "abc"]
+
     def test_cast_string_to_int_unparseable_raises(self):
         # "hello" cannot be parsed as int64, raises TypeCastError by default
         frame = ar.from_pandas(pd.DataFrame({"age": ["10", "hello"]}))
@@ -2642,6 +2651,34 @@ class TestCastTypes:
         assert result.dtypes["age"] == "int64"
         assert df["age"].iloc[0] == 10
         assert pd.isna(df["age"].iloc[1])
+
+    def test_cast_ignore_casts_valid_columns_and_preserves_invalid_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "age": ["10", "hello"],
+                    "score": ["1.5", "2.25"],
+                }
+            )
+        )
+
+        result = ar.cast_types(
+            frame,
+            {"age": "int64", "score": "float64"},
+            errors="ignore",
+        )
+        df = ar.to_pandas(result)
+
+        assert result.dtypes["age"] == "string"
+        assert result.dtypes["score"] == "float64"
+        assert list(df["age"]) == ["10", "hello"]
+        assert list(df["score"]) == [1.5, 2.25]
+
+    def test_cast_ignore_still_rejects_unknown_target_dtype(self):
+        frame = ar.from_pandas(pd.DataFrame({"age": ["10", "20"]}))
+
+        with pytest.raises(ar.TypeCastError, match="Unknown target dtype"):
+            ar.cast_types(frame, {"age": "datetime"}, errors="ignore")
 
     def test_cast_invalid_dtype_string_raises(self):
         # "datetime" is not a supported type, raises TypeCastError


### PR DESCRIPTION
## Summary
- add `errors="ignore"` support to `ar.cast_types()`
- preserve columns that fail value conversion while still casting valid requested columns
- keep unknown target dtypes as hard `TypeCastError`s
- document the available `cast_types` error modes in the README

## Verification
- `py -3.13 -m pytest tests\test_cleaning.py::TestCastTypes -q`
- `py -3.13 -m pytest tests\test_cleaning.py tests\test_pipeline.py -q` *(2 unrelated existing native validation failures; cast_types and pipeline coverage pass)*
- `py -3.13 -m black --check arnio tests`
- `py -3.13 -m ruff check arnio tests`
- `git diff --check`

Fixes #85