### PR TITLE
Ci/cpp tests cross platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,41 @@ jobs:
             | xargs clang-format-17 --dry-run --Werror
 
   cpp_tests:
-    name: C++ Native Tests (CMake + Catch2)
-    runs-on: ubuntu-latest
+    name: C++ Native Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: 
+          - os: ubuntu-latest
+            shell: bash
+          - os: windows-latest
+            shell: bash
+          - os: macos-latest
+            shell: bash
+    defaults:
+      run: 
+        shell: ${{ matrix.shell }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq cmake ninja-build python3-dev
-          pip install pybind11
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install native build dependencies
+        run: | 
+          python -m pip install --upgrade pip
+          pip install pybind11 ninja
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Configure CMake
         run: |
-          cmake -S . -B build \
+          cmake -S . -B build -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DARNIO_BUILD_CPP_TESTS=ON \
             -DCMAKE_PREFIX_PATH=$(python3 -c "import pybind11; print(pybind11.get_cmake_dir())")

--- a/.github/workflows/cpp-tests-baseline-phase0.yml
+++ b/.github/workflows/cpp-tests-baseline-phase0.yml
@@ -1,0 +1,78 @@
+# Temporary Phase 0 baseline: direct CMake + Catch2 cpp_tests on Windows/macOS.
+# workflow_dispatch only — not wired into main CI until Phase 1 unification.
+name: C++ Tests Baseline (Phase 0)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cpp_tests_baseline:
+    name: cpp_tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            shell: bash
+          - os: windows-latest
+            shell: bash
+          - os: macos-latest
+            shell: bash
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: MSVC environment (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install system build tools (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq cmake ninja-build python3-dev
+
+      - name: Install pybind11 and Ninja (pip)
+        run: python -m pip install pybind11 ninja
+
+      - name: Verify toolchain
+        run: |
+          python --version
+          cmake --version
+          ninja --version
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            command -v cl && cl 2>&1 | head -n 3 || echo "cl not on PATH"
+          elif [ "${{ runner.os }}" = "Linux" ]; then
+            c++ --version | head -n 1
+          else
+            c++ --version | head -n 1
+          fi
+
+      - name: Configure CMake (Ninja, Debug, cpp_tests)
+        run: |
+          PYBIND11_CMAKE_DIR=$(python -c "import pybind11; print(pybind11.get_cmake_dir())")
+          echo "CMAKE_PREFIX_PATH=${PYBIND11_CMAKE_DIR}"
+          cmake -S . -B build \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DARNIO_BUILD_CPP_TESTS=ON \
+            -DCMAKE_PREFIX_PATH="${PYBIND11_CMAKE_DIR}"
+          echo "--- Cache (generator / build type) ---"
+          grep -E 'CMAKE_GENERATOR:|CMAKE_BUILD_TYPE:' build/CMakeCache.txt || true
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Run C++ tests
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/cpp-tests-baseline-phase0.yml
+++ b/.github/workflows/cpp-tests-baseline-phase0.yml
@@ -4,8 +4,6 @@ name: C++ Tests Baseline (Phase 0)
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ci/cpp-tests-cross-platform]
 
 jobs:
   cpp_tests_baseline:

--- a/.github/workflows/cpp-tests-baseline-phase0.yml
+++ b/.github/workflows/cpp-tests-baseline-phase0.yml
@@ -4,6 +4,8 @@ name: C++ Tests Baseline (Phase 0)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ci/cpp-tests-cross-platform]
 
 jobs:
   cpp_tests_baseline:

--- a/docs/cpp-tests-phase0-baseline.md
+++ b/docs/cpp-tests-phase0-baseline.md
@@ -1,0 +1,41 @@
+# C++ native tests — Phase 0 cross-platform baseline
+
+Temporary baseline from `.github/workflows/cpp-tests-baseline-phase0.yml` (workflow_dispatch).
+Drives Phase 1 unification of `ci.yml` `cpp_tests`.
+
+Commands (all platforms):
+
+```bash
+pip install pybind11 ninja
+cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug \
+  -DARNIO_BUILD_CPP_TESTS=ON \
+  -DCMAKE_PREFIX_PATH="$(python -c "import pybind11; print(pybind11.get_cmake_dir())")"
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure
+```
+
+Windows additionally needs MSVC on `PATH` (`ilammy/msvc-dev-cmd` in CI; x64 Developer Command Prompt locally).
+
+## Results
+
+| Platform | Result | First failing step | Notes |
+|----------|--------|-------------------|-------|
+| Ubuntu (ubuntu-latest) | _pending CI_ | — | Local WSL: **pass** (4/4 ctest, Ninja single-config, no `--config`) |
+| Windows (windows-latest) | _pending CI_ | — | Uses `ilammy/msvc-dev-cmd@v1` before configure |
+| macOS (macos-latest) | _pending CI_ | — | Clang; FetchContent Catch2 |
+
+### Generator / `CMAKE_BUILD_TYPE`
+
+| Platform | Generator | `-DCMAKE_BUILD_TYPE=Debug` honored? | `ctest` needs `--config Debug`? |
+|----------|-----------|-------------------------------------|----------------------------------|
+| Ubuntu | _pending CI_ | — | — |
+| Windows | _pending CI_ | — | — |
+| macOS | _pending CI_ | — | — |
+
+### MSVC / compile errors (Phase 1 fixes)
+
+_Will fill from failed Windows logs if any._
+
+---
+
+_Last updated: workflow run pending._

--- a/docs/cpp-tests-phase0-baseline.md
+++ b/docs/cpp-tests-phase0-baseline.md
@@ -20,22 +20,33 @@ Windows additionally needs MSVC on `PATH` (`ilammy/msvc-dev-cmd` in CI; x64 Deve
 
 | Platform | Result | First failing step | Notes |
 |----------|--------|-------------------|-------|
-| Ubuntu (ubuntu-latest) | _pending CI_ | — | Local WSL: **pass** (4/4 ctest, Ninja single-config, no `--config`) |
-| Windows (windows-latest) | _pending CI_ | — | Uses `ilammy/msvc-dev-cmd@v1` before configure |
-| macOS (macos-latest) | _pending CI_ | — | Clang; FetchContent Catch2 |
+| Ubuntu (ubuntu-latest) | **pass** | — | 4/4 ctest; [run 26637563979](https://github.com/shreyansh-tech21/arnio/actions/runs/26637563979) |
+| Windows (windows-latest) | **pass** | — | Requires `ilammy/msvc-dev-cmd@v1` before configure; no `/WX` failures |
+| macOS (macos-latest) | **pass** | — | FetchContent Catch2 OK; Clang; 4/4 ctest |
+
+Local WSL (Ubuntu): **pass** — same cmake/ctest sequence, Ninja single-config.
 
 ### Generator / `CMAKE_BUILD_TYPE`
 
 | Platform | Generator | `-DCMAKE_BUILD_TYPE=Debug` honored? | `ctest` needs `--config Debug`? |
 |----------|-----------|-------------------------------------|----------------------------------|
-| Ubuntu | _pending CI_ | — | — |
-| Windows | _pending CI_ | — | — |
-| macOS | _pending CI_ | — | — |
+| Ubuntu | Ninja | Yes (`CMAKE_BUILD_TYPE:STRING=Debug`) | **No** |
+| Windows | Ninja | Yes | **No** |
+| macOS | Ninja | Yes | **No** |
 
 ### MSVC / compile errors (Phase 1 fixes)
 
-_Will fill from failed Windows logs if any._
+None on current `main` baseline — no code changes required for green cpp_tests on Windows with MSVC + Ninja.
+
+## Phase 1 YAML checklist (from Phase 0)
+
+1. **Matrix** `cpp_tests` on `ubuntu-latest`, `windows-latest`, `macos-latest` (or start with Windows/macOS only if Ubuntu job already exists).
+2. **All runners:** `actions/setup-python@v6` with `3.12`, `pip install pybind11 ninja`, explicit `-GNinja`.
+3. **Windows only:** `ilammy/msvc-dev-cmd@v1` (or `microsoft/setup-msvc` + dev cmd) **before** configure — without it, CMake may pick GCC or `cl` is missing.
+4. **Ubuntu only:** keep `apt` `cmake` / `ninja-build` / `python3-dev` **or** rely on pip Ninja + setup-python (Phase 0 used both apt and pip).
+5. **Do not** use Visual Studio multi-config generator in CI; if you ever do, add `--config Debug` to `cmake --build` and `ctest`.
+6. **No** `--config` needed with Ninja + `-DCMAKE_BUILD_TYPE=Debug` on any of the three GHA images (verified).
 
 ---
 
-_Last updated: workflow run pending._
+_CI run: https://github.com/shreyansh-tech21/arnio/actions/runs/26637563979 — branch `ci/cpp-tests-cross-platform`._


### PR DESCRIPTION
## Summary
<!-- What changed and why? Keep this short but specific. -->

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [ ] I read the contributing guide.
- [ ] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
