### PR TITLE
chore: run manylinux wheel smoke on binding changes

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -8,6 +8,7 @@ on:
       - 'setup.py'
       - 'CMakeLists.txt'
       - 'cpp/**'
+      - 'bindings/**'
   schedule:
     - cron: '0 4 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
## Summary
Adds `bindings/**` to the manylinux wheel smoke workflow `pull_request.paths` filter so binding-only PRs run the wheel smoke test.

Cross-checked the related wheel smoke path filters:
- `.github/workflows/wheel-smoke.yml`: now watches `bindings/**` for pull requests.
- `.github/workflows/macos-arm64-wheel-smoke.yml`: already watches `bindings/**` for pull requests.
- `.github/workflows/windows-msvc-wheel-smoke.yml`: already watches `bindings/**` for push and pull requests.

## Linked issue
Fixes #1896

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [x] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
  ```bash
  rg -n "bindings/\*\*" .github/workflows/wheel-smoke.yml
  rg -n "bindings/\*\*" .github/workflows/wheel-smoke.yml .github/workflows/macos-arm64-wheel-smoke.yml .github/workflows/windows-msvc-wheel-smoke.yml
  git diff --check
  python3 - <<'PY'
  from pathlib import Path

  checks = {
      '.github/workflows/wheel-smoke.yml': 1,
      '.github/workflows/macos-arm64-wheel-smoke.yml': 1,
      '.github/workflows/windows-msvc-wheel-smoke.yml': 2,
  }
  for file_name, expected_count in checks.items():
      text = Path(file_name).read_text()
      count = text.count('bindings/**')
      if count != expected_count:
          raise SystemExit(f'{file_name}: expected {expected_count} bindings/** entries, found {count}')
  print('binding path filters aligned for manylinux, macOS arm64, and Windows MSVC workflows')
  PY
  python3 - <<'PY'
  import yaml

  for file_name in [
      '.github/workflows/wheel-smoke.yml',
      '.github/workflows/macos-arm64-wheel-smoke.yml',
      '.github/workflows/windows-msvc-wheel-smoke.yml',
  ]:
      with open(file_name, 'r', encoding='utf-8') as fh:
          yaml.safe_load(fh)
  print('workflow YAML parsed successfully')
  PY
  ```

`make test` was not run because this PR only changes a GitHub Actions path filter and does not touch package/runtime code.

## Screenshots / Media
N/A

## Performance Impact
N/A

## GSSoC labels
N/A

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes. N/A: no public API or docs behavior changed.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Kept this scoped to the requested CI path-filter fix. No packaging or workflow logic changes beyond adding `bindings/**` to the manylinux PR trigger.
