### PR TITLE
ci: execute maintained example notebooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,14 +129,20 @@ jobs:
           pip install -e .[dev]
           pip install jupyter nbconvert ipykernel
 
-      - name: Execute notebook
+      - name: Execute notebooks
         run: |
           jupyter nbconvert \
             --to notebook \
             --execute \
             --ExecutePreprocessor.timeout=300 \
             examples/financial_csv_example.ipynb \
-            --output executed_notebook.ipynb
+            --output financial_csv_example.executed.ipynb
+          jupyter nbconvert \
+            --to notebook \
+            --execute \
+            --ExecutePreprocessor.timeout=300 \
+            examples/ignite_arnio_cleaning.ipynb \
+            --output ignite_arnio_cleaning.executed.ipynb
 
   sklearn_integration:
     name: scikit-learn Integration Tests


### PR DESCRIPTION
Fixes #1882

This PR keeps the notebook smoke coverage change scoped to the existing CI job.

What changed:

- Renamed the notebook smoke step from `Execute notebook` to `Execute notebooks`.
- Kept the existing dependency/setup flow unchanged.
- Added `examples/ignite_arnio_cleaning.ipynb` to the smoke execution path alongside `examples/financial_csv_example.ipynb`.
- Used separate output notebook names so the two executions do not collide.

Notebooks covered by the smoke job after this change:

- `examples/financial_csv_example.ipynb`
- `examples/ignite_arnio_cleaning.ipynb`

Validation:

- `.venv-codex/bin/jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=300 examples/financial_csv_example.ipynb --output-dir /tmp/arnio_nb_smoke --output financial_csv_example.executed.ipynb` -> passed
- `.venv-codex/bin/jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=300 examples/ignite_arnio_cleaning.ipynb --output-dir /tmp/arnio_nb_smoke --output ignite_arnio_cleaning.executed.ipynb` -> passed
- `git diff --check` -> passed

This is for GSSoC 2026 and stays limited to the assigned notebook smoke coverage issue.
