### PR TITLE
ci: run compatibility matrix for runtime source changes

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -2,6 +2,7 @@ name: Compatibility Matrix
 
 on:
   pull_request:
+    # Run compatibility checks for runtime and test changes.
     paths:
     - '.github/workflows/compat-matrix.yml'
     - 'pyproject.toml'

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -3,9 +3,10 @@ name: Compatibility Matrix
 on:
   pull_request:
     paths:
-      - '.github/workflows/compat-matrix.yml'
-      - 'tests/test_compat_matrix.py'
-      - 'pyproject.toml'
+    - '.github/workflows/compat-matrix.yml'
+    - 'pyproject.toml'
+    - 'arnio/**'
+    - 'tests/**'
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
### Fixes #1894 

## Summary

Expands the compatibility matrix workflow trigger paths so that compatibility checks run for relevant runtime source and test changes.

## Problem

The compatibility matrix workflow currently runs only when the following files are modified:

- `.github/workflows/compat-matrix.yml`
- `tests/test_compat_matrix.py`
- `pyproject.toml`

As a result, changes to runtime modules such as:

- `arnio/convert.py`
- `arnio/io.py`
- `arnio/frame.py`
- `arnio/cleaning.py`
- `arnio/quality.py`

do not trigger the compatibility matrix, even though such changes can affect pandas and NumPy compatibility.

## Changes Made

Updated the `pull_request.paths` filter in `.github/workflows/compat-matrix.yml` to include:

- `arnio/**`
- `tests/**`

while keeping the existing workflow and dependency configuration unchanged.

## Result

The compatibility matrix will now run for:

- Runtime source code changes
- Test changes
- Compatibility workflow changes
- Dependency metadata changes

This improves the likelihood of catching pandas/NumPy compatibility regressions before merge while still avoiding unnecessary runs for unrelated documentation-only changes.

