### PR TITLE
ci: run cpp_tests on ubuntu, windows, and macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
-
 jobs:
   lint:
     name: Lint (Black, Ruff, clang-format)
@@ -50,22 +47,44 @@ jobs:
             | xargs clang-format-17 --dry-run --Werror
 
   cpp_tests:
-    name: C++ Native Tests (CMake + Catch2)
-    runs-on: ubuntu-latest
+    name: C++ Native Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: 
+          - os: ubuntu-latest
+            shell: bash
+          - os: windows-latest
+            shell: bash
+          - os: macos-latest
+            shell: bash
+    defaults:
+      run: 
+        shell: ${{ matrix.shell }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq cmake ninja-build python3-dev
-          pip install pybind11
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install native build dependencies
+        run: | 
+          python -m pip install --upgrade pip
+          pip install pybind11 ninja
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Configure CMake
         run: |
-          cmake -S . -B build \
+          cmake -S . -B build -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DARNIO_BUILD_CPP_TESTS=ON \
-            -DCMAKE_PREFIX_PATH=$(python3 -c "import pybind11; print(pybind11.get_cmake_dir())")
+            -DCMAKE_PREFIX_PATH="$(python -c 'import pybind11; print(pybind11.get_cmake_dir())')"
       - name: Build
         run: cmake --build build --parallel
       - name: Run C++ tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: 
+        include:
           - os: ubuntu-latest
             shell: bash
           - os: windows-latest
@@ -63,7 +63,7 @@ jobs:
           - os: macos-latest
             shell: bash
     defaults:
-      run: 
+      run:
         shell: ${{ matrix.shell }}
     steps:
       - name: Checkout repository
@@ -74,7 +74,7 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install native build dependencies
-        run: | 
+        run: |
           python -m pip install --upgrade pip
           pip install pybind11 ninja
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint (Black, Ruff, clang-format)


### PR DESCRIPTION
## Summary

Run the standalone Catch2 C++ test job on ubuntu-latest, windows-latest,
and macos-latest instead of Ubuntu only. Windows uses ilammy/msvc-dev-cmd
and Ninja; the Python build_and_test matrix is unchanged.

## Type of change
- [x] CI / packaging

## Testing
Local WSL: cmake + ctest (4/4 pass). PR CI: three C++ Native Tests jobs.