### PR TITLE
fix: add Escape key support and sync aria-label for mobile menu

### DIFF
--- a/website/js/main.js
+++ b/website/js/main.js
@@ -31,22 +31,40 @@
     const mobileMenu = document.querySelector('.mobile-menu');
 
     if (hamburger && mobileMenu) {
+
+      function closeMobileMenu() {
+        mobileMenu.classList.remove('open');
+        hamburger.setAttribute('aria-expanded', 'false');
+        hamburger.setAttribute('aria-label', 'Open menu');
+        hamburger.innerHTML = '☰';
+        document.body.style.overflow = '';
+      }
+
       hamburger.addEventListener('click', function () {
         const isOpen = mobileMenu.classList.contains('open');
-        mobileMenu.classList.toggle('open');
-        hamburger.setAttribute('aria-expanded', !isOpen);
-        hamburger.innerHTML = isOpen ? '☰' : '✕';
-        document.body.style.overflow = isOpen ? '' : 'hidden';
+        if (isOpen) {
+          closeMobileMenu();
+        } else {
+          mobileMenu.classList.add('open');
+          hamburger.setAttribute('aria-expanded', 'true');
+          hamburger.setAttribute('aria-label', 'Close menu');
+          hamburger.innerHTML = '✕';
+          document.body.style.overflow = 'hidden';
+        }
       });
 
       // Close menu when clicking a link
       mobileMenu.querySelectorAll('a').forEach(function (link) {
         link.addEventListener('click', function () {
-          mobileMenu.classList.remove('open');
-          hamburger.setAttribute('aria-expanded', 'false');
-          hamburger.innerHTML = '☰';
-          document.body.style.overflow = '';
+          closeMobileMenu();
         });
+      });
+
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && mobileMenu.classList.contains('open')) {
+          closeMobileMenu();
+          hamburger.focus();
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
Mobile navigation menu was not fully accessible to keyboard and assistive-technology users. This fix adds a shared `closeMobileMenu()` helper, syncs the hamburger button `aria-label` between open/closed states, and adds an Escape key listener that closes the menu and returns focus to the hamburger button. No visual changes.

## Linked issue
Fixes #1770

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [x] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
- Opened website/api.html and website/docs.html at mobile viewport (375px) in Chrome DevTools
- Clicked hamburger button → menu opened, aria-label changed to "Close menu", aria-expanded="true"
- Pressed Escape → menu closed, focus returned to hamburger, aria-label changed back to "Open menu"
- Clicked a menu link → menu closed correctly via shared closeMobileMenu() helper
- Verified body scroll was locked while menu open and restored on close
- No existing behavior broken

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
-This PR only modifies website/js/main.js 
Python test suite, ruff, and black are not applicable.
