### PR TITLE
Fix: validate steps argument in ArnioCleaner.__init__ and fit

### DIFF
--- a/arnio/integrations/sklearn.py
+++ b/arnio/integrations/sklearn.py
@@ -17,6 +17,24 @@ except ImportError:
 from arnio.convert import from_pandas, to_pandas
 from arnio.pipeline import pipeline as run_pipeline
 
+
+def _validate_steps(steps):
+    if isinstance(steps, str):
+        raise TypeError(
+            "ArnioCleaner steps must be a list of step tuples, not a bare string. "
+            f"Did you mean steps=[('{steps}',)]?"
+        )
+    if not isinstance(steps, (list, tuple)):
+        raise TypeError(
+            f"ArnioCleaner steps must be a list of step tuples, got {type(steps).__name__!r}"
+        )
+    for item in steps:
+        if not isinstance(item, tuple):
+            raise TypeError(
+                f"Each step must be a tuple, got {type(item).__name__!r}: {item!r}"
+            )
+
+
 _ROW_COUNT_CHANGING_STEPS = frozenset(
     {"drop_nulls", "drop_duplicates", "keep_rows_with_nulls", "filter_rows"}
 )
@@ -46,6 +64,7 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
         self.copy = copy
         self.allow_row_count_change = allow_row_count_change
         self.allow_schema_changes = allow_schema_changes
+        _validate_steps(self.steps)
 
     def _validate_params(self):
         if not isinstance(self.copy, bool):
@@ -83,6 +102,7 @@ class ArnioCleaner(BaseEstimator, TransformerMixin):
 
     def fit(self, X, y=None):
         self._validate_params()
+        _validate_steps(self.steps)
 
         if not isinstance(X, pd.DataFrame):
             raise TypeError(f"ArnioCleaner requires a pandas DataFrame, got {type(X)}")

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -390,3 +390,38 @@ def test_arniocleaner_rejects_invalid_params_at_transform():
     cleaner.copy = "bad"
     with pytest.raises(TypeError, match="copy must be a bool"):
         cleaner.transform(df)
+
+
+def test_arniocleaner_rejects_bare_string_steps():
+    with pytest.raises(TypeError, match="steps must be a list of step tuples"):
+        ArnioCleaner(steps="strip_whitespace")
+
+
+def test_arniocleaner_rejects_dict_steps():
+    with pytest.raises(TypeError, match="steps must be a list of step tuples"):
+        ArnioCleaner(steps={"strip_whitespace": {}})
+
+
+def test_arniocleaner_rejects_non_tuple_items_in_steps():
+    with pytest.raises(TypeError, match="Each step must be a tuple"):
+        ArnioCleaner(steps=["strip_whitespace"])
+
+
+def test_arniocleaner_valid_steps_still_work():
+    df = pd.DataFrame({"a": [" x ", " y "]})
+    cleaner = ArnioCleaner(steps=[("strip_whitespace",)])
+    result = cleaner.fit_transform(df)
+    assert result["a"].tolist() == ["x", "y"]
+
+
+def test_arniocleaner_rejects_scalar_steps():
+    with pytest.raises(TypeError, match="steps must be a list of step tuples"):
+        ArnioCleaner(steps=1)
+
+
+def test_arniocleaner_validates_steps_set_via_set_params():
+    cleaner = ArnioCleaner(steps=[("strip_whitespace",)])
+    cleaner.set_params(steps="strip_whitespace")
+    df = pd.DataFrame({"a": [" x "]})
+    with pytest.raises(TypeError, match="steps must be a list of step tuples"):
+        cleaner.fit(df)


### PR DESCRIPTION
## Summary
Add `_validate_steps()` helper in `arnio/integrations/sklearn.py` that rejects invalid `steps` values at the estimator boundary - bare strings, dicts, scalars, and lists containing non-tuple items - with a clear `TypeError`. Called from both `__init__()` and `fit()` so `set_params(steps=...)` is also validated before the pipeline runs.

## Linked issue
Fixes #1679

## Type of change
- [x] Bug fix

## Area
- [x] Python API / ArFrame

## Testing
- [x] Other: `python3 -m pytest tests/test_sklearn.py -v` - 37 passed, 3 pre-existing failures unrelated to this change

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix:`).