### PR TITLE
fix(schema): validate ValidationResult constructor fields

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1021,6 +1021,57 @@ class ValidationResult:
     issues: list[ValidationIssue]
     bad_rows: list[int] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        if isinstance(self.row_count, bool) or not isinstance(self.row_count, int):
+            raise TypeError(
+                f"ValidationResult 'row_count' must be a non-negative int, "
+                f"got {type(self.row_count).__name__}"
+            )
+        if self.row_count < 0:
+            raise ValueError(
+                f"ValidationResult 'row_count' must be >= 0, got {self.row_count}"
+            )
+        if isinstance(self.issue_count, bool) or not isinstance(self.issue_count, int):
+            raise TypeError(
+                f"ValidationResult 'issue_count' must be a non-negative int, "
+                f"got {type(self.issue_count).__name__}"
+            )
+        if self.issue_count < 0:
+            raise ValueError(
+                f"ValidationResult 'issue_count' must be >= 0, got {self.issue_count}"
+            )
+        if not isinstance(self.issues, list):
+            raise TypeError(
+                f"ValidationResult 'issues' must be a list of ValidationIssue instances, "
+                f"got {type(self.issues).__name__}"
+            )
+        for i, item in enumerate(self.issues):
+            if not isinstance(item, ValidationIssue):
+                raise TypeError(
+                    f"ValidationResult 'issues[{i}]' must be a ValidationIssue instance, "
+                    f"got {type(item).__name__}"
+                )
+        if not isinstance(self.bad_rows, list):
+            raise TypeError(
+                f"ValidationResult 'bad_rows' must be a list of non-negative ints, "
+                f"got {type(self.bad_rows).__name__}"
+            )
+        for i, item in enumerate(self.bad_rows):
+            if isinstance(item, bool) or not isinstance(item, int):
+                raise TypeError(
+                    f"ValidationResult 'bad_rows[{i}]' must be an int, "
+                    f"got {type(item).__name__}"
+                )
+            if item < 0:
+                raise ValueError(
+                    f"ValidationResult 'bad_rows[{i}]' must be >= 0, got {item}"
+                )
+        if self.issue_count != len(self.issues):
+            raise ValueError(
+                f"ValidationResult 'issue_count' ({self.issue_count}) does not match "
+                f"len(issues) ({len(self.issues)})"
+            )
+
     @property
     def passed(self) -> bool:
         """Whether validation passed with zero error-level issues."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -391,6 +391,87 @@ def test_schema_reports_missing_and_unexpected_columns(sample_csv):
     assert "unexpected_column" in rules
 
 
+# --- ValidationResult constructor validation (regression for #1684) ---
+
+
+def test_validation_result_rejects_string_row_count():
+    with pytest.raises(TypeError, match="row_count"):
+        ar.ValidationResult(row_count="1", issue_count=0, issues=[])
+
+
+def test_validation_result_rejects_negative_row_count():
+    with pytest.raises(ValueError, match="row_count"):
+        ar.ValidationResult(row_count=-1, issue_count=0, issues=[])
+
+
+def test_validation_result_rejects_bool_row_count():
+    with pytest.raises(TypeError, match="row_count"):
+        ar.ValidationResult(row_count=True, issue_count=0, issues=[])
+
+
+def test_validation_result_rejects_string_issue_count():
+    with pytest.raises(TypeError, match="issue_count"):
+        ar.ValidationResult(row_count=1, issue_count="0", issues=[])
+
+
+def test_validation_result_rejects_negative_issue_count():
+    with pytest.raises(ValueError, match="issue_count"):
+        ar.ValidationResult(row_count=1, issue_count=-1, issues=[])
+
+
+def test_validation_result_rejects_bool_issue_count():
+    with pytest.raises(TypeError, match="issue_count"):
+        ar.ValidationResult(row_count=1, issue_count=False, issues=[])
+
+
+def test_validation_result_rejects_non_list_issues():
+    with pytest.raises(TypeError, match="issues"):
+        ar.ValidationResult(row_count=1, issue_count=0, issues=None)
+
+
+def test_validation_result_rejects_string_item_in_issues():
+    with pytest.raises(TypeError, match="issues"):
+        ar.ValidationResult(row_count=1, issue_count=1, issues=["bad"])
+
+
+def test_validation_result_rejects_string_bad_rows():
+    with pytest.raises(TypeError, match="bad_rows"):
+        ar.ValidationResult(row_count=1, issue_count=0, issues=[], bad_rows="abc")
+
+
+def test_validation_result_rejects_negative_bad_rows_entry():
+    with pytest.raises(ValueError, match="bad_rows"):
+        ar.ValidationResult(row_count=1, issue_count=0, issues=[], bad_rows=[-1])
+
+
+def test_validation_result_rejects_non_int_bad_rows_entry():
+    with pytest.raises(TypeError, match="bad_rows"):
+        ar.ValidationResult(row_count=1, issue_count=0, issues=[], bad_rows=["1"])
+
+
+def test_validation_result_rejects_mismatched_issue_count():
+    issue = ar.ValidationIssue(column="x", rule="dtype", message="bad type")
+    with pytest.raises(ValueError, match="issue_count"):
+        ar.ValidationResult(row_count=1, issue_count=2, issues=[issue])
+
+
+def test_validation_result_valid_construction():
+    issue = ar.ValidationIssue(column="x", rule="dtype", message="bad type")
+    result = ar.ValidationResult(
+        row_count=5,
+        issue_count=1,
+        issues=[issue],
+        bad_rows=[0],
+    )
+    assert result.row_count == 5
+    assert result.issue_count == 1
+    assert len(result.issues) == 1
+    assert result.bad_rows == [0]
+
+
+# --- end ValidationResult constructor validation ---
+
+
 def test_validation_result_to_pandas_empty_has_stable_columns():
     result = ar.ValidationResult(
         row_count=3,


### PR DESCRIPTION
## Summary

Fixes #1684

Add constructor validation to `ValidationResult` so invalid state is rejected at creation time instead of causing misleading output or runtime failures later.

## Changes

### ValidationResult.__post_init__

Added validation for:

- `row_count` must be a non-negative integer
- `issue_count` must be a non-negative integer
- `issues` must be a list of `ValidationIssue` instances
- `bad_rows` must be a list of non-negative integers
- `issue_count` must match `len(issues)`

### Tests

Added focused regression tests covering:

- invalid `row_count` type
- negative `row_count`
- invalid `issue_count` type
- negative `issue_count`
- invalid `issues` container type
- invalid `ValidationIssue` entries inside `issues`
- mismatch between `issue_count` and `len(issues)`
- invalid `bad_rows` container type
- invalid `bad_rows` entry type
- negative values in `bad_rows`
- valid `ValidationResult` construction path

## Motivation

`ValidationResult` is part of the public schema API and can be constructed directly by users in tests, notebooks, custom validators, and documentation examples.

Previously, invalid constructor arguments could be accepted and later lead to misleading output or runtime failures in methods such as:

- `passed`
- `summary()`
- `to_dict()`
- `to_markdown()`

This change ensures invalid state is rejected early with clear `TypeError` or `ValueError` exceptions.

## Testing

- Added focused regression tests for constructor validation.
- Verified all new tests pass.
- Verified existing schema tests continue to pass.

<img width="951" height="174" alt="Screenshot 2026-05-30 113514" src="https://github.com/user-attachments/assets/633c6e69-9f86-45fa-8487-d27b756b42a1" />

<img width="953" height="206" alt="Screenshot 2026-05-30 113523" src="https://github.com/user-attachments/assets/6d103b4f-6dde-4d76-94b0-05f210619477" />
