### PR TITLE
fix: reject empty subset in fill_nullsfix: reject empty subset in fill_nulls

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -416,6 +416,11 @@ def fill_nulls(
     """
     frame, _ = _validate_frame(frame)
     if subset is not None:
+        subset = _validate_column_sequence(subset, argument_name="subset")
+        if len(subset) == 0:
+            raise ValueError(
+                "fill_nulls: subset cannot be empty; pass subset=None to fill all columns"
+            )
         subset = _validate_existing_column_sequence(
             subset,
             available_columns=frame.columns,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4002,6 +4002,20 @@ def test_fill_nulls_validation_lossy_and_non_finite():
             float_frame, [("fill_nulls", {"value": float("inf"), "subset": ["x"]})]
         )
 
+def test_fill_nulls_empty_subset_raises():
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, None], "b": [None, 2]}))
+    with pytest.raises(ValueError, match="subset cannot be empty"):
+        ar.fill_nulls(frame, 0, subset=[])
+
+def test_fill_nulls_none_subset_fills_all():
+    frame = ar.from_pandas(pd.DataFrame({"a": [1, None], "b": [None, 2]}))
+    result = ar.fill_nulls(frame, 0, subset=None)
+    df = ar.to_pandas(result)
+    assert df["a"].tolist() == [1.0, 0.0]
+    assert df["b"].tolist() == [0.0, 2.0]
+
+
+
 
 class TestSelectColumns:
     def test_select_columns_keeps_requested_columns_and_preserves_order(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4002,10 +4002,12 @@ def test_fill_nulls_validation_lossy_and_non_finite():
             float_frame, [("fill_nulls", {"value": float("inf"), "subset": ["x"]})]
         )
 
+
 def test_fill_nulls_empty_subset_raises():
     frame = ar.from_pandas(pd.DataFrame({"a": [1, None], "b": [None, 2]}))
     with pytest.raises(ValueError, match="subset cannot be empty"):
         ar.fill_nulls(frame, 0, subset=[])
+
 
 def test_fill_nulls_none_subset_fills_all():
     frame = ar.from_pandas(pd.DataFrame({"a": [1, None], "b": [None, 2]}))
@@ -4013,8 +4015,6 @@ def test_fill_nulls_none_subset_fills_all():
     df = ar.to_pandas(result)
     assert df["a"].tolist() == [1.0, 0.0]
     assert df["b"].tolist() == [0.0, 2.0]
-
-
 
 
 class TestSelectColumns:


### PR DESCRIPTION
Fixes #1964

## Summary
`fill_nulls(subset=[])` previously silently accepted an empty subset and performed no replacement, leaving null values unchanged without any warning or error.

## Type of change
- [x] Bug fix

## What changed in `arnio/cleaning.py`
- Added explicit empty subset validation in `fill_nulls()` before calling the native implementation
- Raises a clear `ValueError` with message: `fill_nulls: subset cannot be empty; pass subset=None to fill all columns`

## Testing
Added two new tests in `tests/test_cleaning.py`:
- `test_fill_nulls_empty_subset_raises` — verifies empty subset raises `ValueError`
- `test_fill_nulls_none_subset_fills_all` — verifies `subset=None` correctly fills all columns

## Contributor checklist
- [x] I read the contributing guide
- [x] I kept the PR focused on one issue or one logical change
- [x] My PR title uses Conventional Commits (`fix:`)