### PR TITLE
fix(cleaning): validate safe_divide_columns column name types

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1596,20 +1596,32 @@ def safe_divide_columns(
     frame, is_arframe = _validate_frame(frame, allow_pandas=True)
     columns = frame.columns
 
+    if not isinstance(numerator, str):
+        raise TypeError("numerator must be a string column name")
+
+    if not isinstance(denominator, str):
+        raise TypeError("denominator must be a string column name")
+
     if numerator not in columns:
         raise ValueError(f"Numerator column '{numerator}' not found in frame.")
+
     if denominator not in columns:
         raise ValueError(f"Denominator column '{denominator}' not found in frame.")
+
     if not isinstance(output_column, str) or not output_column.strip():
         raise ValueError("output_column must be a non-empty string.")
+
     if isinstance(fill_value, bool):
         raise TypeError("fill_value must be a finite float, not bool")
+
     if not isinstance(fill_value, (int, float)):
         raise TypeError(
             f"fill_value must be a finite float, got {type(fill_value).__name__!r}"
         )
+
     if not math.isfinite(fill_value):
         raise ValueError(f"fill_value must be finite, got {fill_value}")
+
     if output_column in columns:
         import warnings
 
@@ -1641,16 +1653,9 @@ def safe_divide_columns(
     numerator_series = df[numerator]
     denominator_series = df[denominator]
 
-    # Always coerce through pd.to_numeric so that numeric-looking strings
-    # ("0", "0.0", "2.5") are handled identically to their numeric equivalents.
-    # This fixes the bug where string "0" was not caught as a zero denominator.
     numerator_values = pd.to_numeric(numerator_series, errors="coerce")
     denominator_values = pd.to_numeric(denominator_series, errors="coerce")
 
-    # Distinguish null originals (None / pd.NA → use fill_value) from
-    # invalid non-null strings ("abc" → raise ValueError).
-    # A value is "bad" if pd.to_numeric produced NaN but the original was
-    # not null — i.e. it was a non-null, non-numeric string.
     bad_numerator = numerator_values.isna() & numerator_series.notna()
     bad_denominator = denominator_values.isna() & denominator_series.notna()
 
@@ -1659,17 +1664,17 @@ def safe_divide_columns(
         raise ValueError(
             f"Numerator column '{numerator}' contains non-numeric values: {bad_values}"
         )
+
     if bad_denominator.any():
         bad_values = df.loc[bad_denominator, denominator].head(3).tolist()
         raise ValueError(
             f"Denominator column '{denominator}' contains non-numeric values: {bad_values}"
         )
 
-    # Mask zero and null denominators — both numeric 0 and string "0" / "0.0"
-    # are caught here because denominator_values is already coerced to float.
     is_zero_or_null = denominator_values.isna() | (denominator_values == 0)
     safe_denom = denominator_values.mask(is_zero_or_null)
     result = numerator_values / safe_denom
+
     df = df.copy(deep=False)
     df[output_column] = result.fillna(fill_value)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3245,6 +3245,47 @@ class TestSafeDivideColumns:
                 output_column="ratio",
             )
 
+    def test_numerator_must_be_string(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+
+        with pytest.raises(TypeError, match="numerator must be a string column name"):
+            ar.safe_divide_columns(
+                frame,
+                numerator=123,
+                denominator="cost",
+                output_column="ratio",
+            )
+
+    def test_denominator_must_be_string(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+
+        with pytest.raises(TypeError, match="denominator must be a string column name"):
+            ar.safe_divide_columns(
+                frame,
+                numerator="revenue",
+                denominator=None,
+                output_column="ratio",
+            )
+
+    def test_valid_string_columns_still_work(self, tmp_path):
+        path = tmp_path / "data.csv"
+        path.write_text("revenue,cost\n100,50\n")
+        frame = ar.read_csv(path)
+
+        result = ar.safe_divide_columns(
+            frame,
+            numerator="revenue",
+            denominator="cost",
+            output_column="ratio",
+        )
+
+        df = ar.to_pandas(result)
+        assert df["ratio"].iloc[0] == 2.0
+
     def test_output_column_already_exists(self, tmp_path):
         import warnings
 


### PR DESCRIPTION
## Summary

Adds explicit type validation for `safe_divide_columns()` column-name parameters.

Previously, passing non-string values such as `123` or `None` for `numerator` or `denominator` resulted in misleading "column not found" `ValueError`s. This change raises clear `TypeError`s before column membership checks while preserving existing behavior for valid string column names.

## Linked issue

Fixes #1647

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] make test
* [ ] make lint
* [ ] python -m pytest tests -v --tb=short -x
* [x] Other

Verified with:

python -m black arnio/cleaning.py tests/test_cleaning.py
python -m ruff check arnio/cleaning.py tests/test_cleaning.py
git diff --check

Added focused regression tests for invalid numerator/denominator types and preserved valid-string behavior.

## Screenshots / Media

N/A

## Performance Impact

No performance impact.

## GSSoC labels

Maintainers only.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behaviour changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits.

## Maintainer notes

This change is intentionally limited to numerator/denominator type validation before column membership checks and adds focused regression coverage for the reported issue.