### PR TITLE
feat: add orient support to ArFrame.to_dict

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -427,13 +427,22 @@ class ArFrame:
             self._frame.select_rows(start, actual_n), attrs=copy.deepcopy(self._attrs)
         )
 
-    def to_dict(self) -> dict[str, list]:
+    def to_dict(
+        self,
+        orient: str = "list",
+    ):
         """Export the frame as a Python dictionary.
+
+        Parameters
+        ----------
+        orient : str, default "list"
+            Output format. Supported values are
+            "list", "records", and "split".
 
         Returns
         -------
-        dict[str, list]
-            A dictionary mapping column names to lists of values.
+        dict | list
+            Frame data in the requested orientation.
 
         Examples
         --------
@@ -443,12 +452,37 @@ class ArFrame:
         """
         col_names = self.columns
         num_cols = self.shape[1]
-        return {
+        data = {
             col_names[i]: [
                 self._frame.column_by_index(i).at(r) for r in range(len(self))
             ]
             for i in range(num_cols)
         }
+        supported = {"list", "records", "split"}
+        if orient not in supported:
+            raise ValueError("orient must be one of: list, records, split")
+
+        if orient == "list":
+            return data
+
+        if orient == "records":
+            row_count = len(self)
+
+            return [
+                {column: data[column][row] for column in col_names}
+                for row in range(row_count)
+            ]
+
+        if orient == "split":
+            row_count = len(self)
+
+            return {
+                "columns": list(col_names),
+                "data": [
+                    [data[column][row] for column in col_names]
+                    for row in range(row_count)
+                ],
+            }
 
     def select_columns(self, columns: list[str]) -> ArFrame:
         """Return a new ArFrame with only the selected columns.

--- a/tests/test_to_dict.py
+++ b/tests/test_to_dict.py
@@ -118,3 +118,71 @@ class TestArFrameToDictExtended:
             ValueError, match="does not support duplicate column labels"
         ):
             ar.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["a", "b", "a"]))
+
+    def test_to_dict_records_orient(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
+
+        result = frame.to_dict(orient="records")
+
+        assert result == [
+            {"a": 1, "b": 3},
+            {"a": 2, "b": 4},
+        ]
+
+    def test_to_dict_split_orient(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
+
+        result = frame.to_dict(orient="split")
+
+        assert result == {
+            "columns": ["a", "b"],
+            "data": [
+                [1, 3],
+                [2, 4],
+            ],
+        }
+
+    def test_to_dict_invalid_orient(self):
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2]}))
+
+        with pytest.raises(
+            ValueError,
+            match="orient must be one of",
+        ):
+            frame.to_dict(orient="invalid")
+
+    def test_to_dict_split_empty_frame(self):
+        frame = ar.from_pandas(pd.DataFrame(columns=["a", "b"]))
+
+        result = frame.to_dict(orient="split")
+
+        assert result == {
+            "columns": ["a", "b"],
+            "data": [],
+        }
+
+    def test_to_dict_records_preserves_none(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {"name": ["Alice", None]},
+                dtype=object,
+            )
+        )
+
+        result = frame.to_dict(orient="records")
+
+        assert result == [
+            {"name": "Alice"},
+            {"name": None},
+        ]
+
+    def test_to_dict_split_preserves_column_order(self):
+        frame = ar.from_pandas(pd.DataFrame({"z": [1], "a": [2], "m": [3]}))
+
+        result = frame.to_dict(orient="split")
+
+        assert result["columns"] == [
+            "z",
+            "a",
+            "m",
+        ]


### PR DESCRIPTION
## Summary

Added pandas-style `orient` support to `ArFrame.to_dict()` while preserving backward-compatible default behavior.

Supported orientations:

* `list` (existing/default behavior)
* `records`
* `split`

Also added validation for unsupported orientation values and expanded test coverage for orientation handling, empty frames, null preservation, and column ordering.

## Linked issue

Fixes #1905

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [x] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [ ] `make lint`
* [x] `pytest tests/test_to_dict.py -v` (20 passed)
* [x] `python -m black --check arnio/frame.py tests/test_to_dict.py`
* [x] `python -m ruff check arnio/frame.py tests/test_to_dict.py`
* [ ] Other:

## Screenshots / Media

N/A (no UI changes)

## Performance Impact

No expected performance impact beyond the requested orientation conversions.

## GSSoC labels

Maintainers only.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR keeps the existing `to_dict()` behavior as the default (`orient="list"`) and adds support for `records` and `split` orientations with focused tests covering edge cases and validation.
