### PR TITLE
Fix: remove stale native extension artifacts in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,13 @@ benchmark-sparse-nulls: ## Run sparse-null benchmark
 
 clean: ## Remove build artifacts
 ifeq ($(OS),Windows_NT)
-	python -c "import shutil, os, glob; [shutil.rmtree(p, ignore_errors=True) for p in ['dist', 'build', '.pytest_cache'] + glob.glob('*.egg-info') + glob.glob('**/__pycache__', recursive=True)]; [os.remove(f) for f in glob.glob('**/*.pyc', recursive=True)]"
+	python -c "import shutil, os, glob; [shutil.rmtree(p, ignore_errors=True) for p in ['dist', 'build', '.pytest_cache'] + glob.glob('*.egg-info') + glob.glob('**/__pycache__', recursive=True)]; [os.remove(f) for f in glob.glob('**/*.pyc', recursive=True) + glob.glob('arnio/_arnio_cpp*.pyd') + glob.glob('arnio/_arnio_cpp*.dll')]"
 else
 	find . -type d -name "__pycache__" -exec rm -rf {} +
 	find . -name "*.pyc" -delete
 	rm -rf .pytest_cache dist build *.egg-info
+	find arnio -name "_arnio_cpp*.so" -delete
+	find arnio -name "_arnio_cpp*.dylib" -delete
+	find arnio -name "_arnio_cpp*.pyd" -delete
+	find arnio -name "_arnio_cpp*.dll" -delete
 endif


### PR DESCRIPTION
## Summary
Extend the `clean` Makefile target to remove `_arnio_cpp` native extension artifacts from the `arnio/` package tree on both Unix-like and Windows paths. Existing cleanup for `dist`, `build`, caches, and bytecode is preserved.

## Linked issue
Fixes #1870

## Type of change
- [x] Bug fix

## Area
- [x] Developer tooling

## Testing
- [x] Other: ran `make clean` in WSL - all `_arnio_cpp*.so/.dylib/.pyd/.dll` artifacts removed, existing cleanup behavior preserved, `.pyi` stub correctly left in place.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix:`).