### PR TITLE
fix: include website text assets in UTF-8 validation

### DIFF
--- a/scripts/check_docs_utf8.py
+++ b/scripts/check_docs_utf8.py
@@ -11,6 +11,8 @@ from pathlib import Path
 DOC_SUFFIXES = {".md", ".rst"}
 DOC_TEXT_SUFFIXES = {".txt"}
 DOC_DIRECTORIES = {"docs"}
+WEBSITE_TEXT_SUFFIXES = {".html", ".css", ".js"}
+WEBSITE_DIRECTORY = "website"
 SKIP_PARTS = {
     ".git",
     ".mypy_cache",
@@ -46,7 +48,11 @@ def _is_doc_file(path: Path) -> bool:
         return False
     if path.suffix.lower() in DOC_SUFFIXES:
         return True
-    return path.suffix.lower() in DOC_TEXT_SUFFIXES and path.parts[0] in DOC_DIRECTORIES
+    if path.suffix.lower() in DOC_TEXT_SUFFIXES and path.parts[0] in DOC_DIRECTORIES:
+        return True
+    return (
+        path.suffix.lower() in WEBSITE_TEXT_SUFFIXES and WEBSITE_DIRECTORY in path.parts
+    )
 
 
 def _candidate_files(paths: Iterable[Path]) -> list[Path]:

--- a/tests/test_docs_utf8_check.py
+++ b/tests/test_docs_utf8_check.py
@@ -17,3 +17,74 @@ def test_docs_utf8_check_ignores_non_docs_files(tmp_path):
     binary_fixture.write_bytes(b"\x95")
 
     assert check_utf8([binary_fixture]) == []
+
+
+def test_docs_utf8_check_reports_invalid_website_html(tmp_path):
+    website_dir = tmp_path / "website"
+    website_dir.mkdir()
+    invalid_html = website_dir / "index.html"
+    invalid_html.write_bytes(b"<html>\x95</html>")
+
+    errors = check_utf8([invalid_html])
+
+    assert len(errors) == 1
+    assert "index.html" in errors[0]
+    assert "invalid UTF-8 byte" in errors[0]
+
+
+def test_docs_utf8_check_reports_invalid_website_css(tmp_path):
+    website_dir = tmp_path / "website"
+    website_dir.mkdir()
+    invalid_css = website_dir / "style.css"
+    invalid_css.write_bytes(b"body { color: \x95; }")
+
+    errors = check_utf8([invalid_css])
+
+    assert len(errors) == 1
+    assert "style.css" in errors[0]
+
+
+def test_docs_utf8_check_reports_invalid_website_js(tmp_path):
+    website_dir = tmp_path / "website"
+    website_dir.mkdir()
+    invalid_js = website_dir / "main.js"
+    invalid_js.write_bytes(b"const x = '\x95';")
+
+    errors = check_utf8([invalid_js])
+
+    assert len(errors) == 1
+    assert "main.js" in errors[0]
+
+
+def test_docs_utf8_check_accepts_valid_website_files(tmp_path):
+    website_dir = tmp_path / "website"
+    website_dir.mkdir()
+    (website_dir / "index.html").write_text(
+        "<html><body>Hello</body></html>", encoding="utf-8"
+    )
+    (website_dir / "style.css").write_text("body { color: red; }", encoding="utf-8")
+    (website_dir / "main.js").write_text("const x = 'hello';", encoding="utf-8")
+
+    files = [
+        website_dir / "index.html",
+        website_dir / "style.css",
+        website_dir / "main.js",
+    ]
+    assert check_utf8(files) == []
+
+
+def test_docs_utf8_check_ignores_non_website_html(tmp_path):
+    # HTML files outside the website/ directory should not be checked
+    html_file = tmp_path / "random.html"
+    html_file.write_bytes(b"<html>\x95</html>")
+
+    assert check_utf8([html_file]) == []
+
+
+def test_docs_utf8_check_ignores_website_binary_assets(tmp_path):
+    website_dir = tmp_path / "website"
+    website_dir.mkdir()
+    binary_asset = website_dir / "logo.png"
+    binary_asset.write_bytes(b"\x89PNG\r\n\x1a\n\x95")
+
+    assert check_utf8([binary_asset]) == []


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>Extends the UTF-8 validation script to include website text assets under <code>website/</code>, closing the blind spot identified in #1879.</p>
<p>Fixes #1879</p>
<hr>
<h2>Changes</h2>
<h3><code>scripts/check_docs_utf8.py</code></h3>
<p>Added two new constants:</p>
<pre><code class="language-python">WEBSITE_TEXT_SUFFIXES = {".html", ".css", ".js"}
WEBSITE_DIRECTORY = "website"
</code></pre>
<p>Extended <code>_is_doc_file</code> with a third return branch:</p>
<pre><code class="language-python">return (
    path.suffix.lower() in WEBSITE_TEXT_SUFFIXES
    and WEBSITE_DIRECTORY in path.parts
)
</code></pre>
<p>This mirrors the existing <code>DOC_DIRECTORIES</code> pattern for <code>.txt</code> files. Only files whose suffix is in <code>WEBSITE_TEXT_SUFFIXES</code> <strong>and</strong> whose path contains <code>website/</code> are candidates — binary/media assets (<code>.svg</code>, <code>.png</code>, etc.) are naturally excluded because they are not in that set.</p>
<p>No CI workflow changes: the existing <code>python scripts/check_docs_utf8.py</code> step in <code>ci.yml</code> already covers the new candidates.</p>
<h3><code>tests/test_docs_utf8_check.py</code></h3>
<p>Added 6 new tests alongside the 2 existing ones:</p>

Test | What it covers
-- | --
test_docs_utf8_check_reports_invalid_website_html | Bad byte in website/*.html → error reported
test_docs_utf8_check_reports_invalid_website_css | Bad byte in website/*.css → error reported
test_docs_utf8_check_reports_invalid_website_js | Bad byte in website/*.js → error reported
test_docs_utf8_check_accepts_valid_website_files | Valid UTF-8 HTML, CSS, JS → no errors
test_docs_utf8_check_ignores_non_website_html | .html outside website/ → ignored
test_docs_utf8_check_ignores_website_binary_assets | .png inside website/ → ignored


<hr>
<h2>Test results</h2>

<img width="950" height="351" alt="image" src="https://github.com/user-attachments/assets/2b562a63-696b-4add-b7fb-b1c5d15e619c" />

<hr>
<h2>Checklist</h2>
<ul>
<li>[x] Scoped to <code>scripts/check_docs_utf8.py</code> and <code>tests/test_docs_utf8_check.py</code> only</li>
<li>[x] No CI workflow changes</li>
<li>[x] Binary/media assets excluded</li>
<li>[x] HTML outside <code>website/</code> excluded</li>
<li>[x] All existing tests still pass</li>
<li>[x] Issue linked with <code>Fixes #1879</code></li>
</ul></body></html><!--EndFragment-->
</body>
</html>