### PR TITLE
fix(integrations): reject whitespace-only DuckDB relation names

### DIFF
--- a/arnio/integrations/duckdb.py
+++ b/arnio/integrations/duckdb.py
@@ -35,7 +35,7 @@ def register_duckdb(
     TypeError
         If frame is not an ArFrame or name is not a string.
     ValueError
-        If name is empty.
+        If name is empty or whitespace-only.
 
     Examples
     --------
@@ -50,8 +50,8 @@ def register_duckdb(
         raise TypeError("frame must be an ArFrame")
     if not isinstance(name, str):
         raise TypeError("name must be a string")
-    if not name:
-        raise ValueError("name must not be empty")
+    if not name or not name.strip():
+        raise ValueError("name must not be empty or whitespace-only")
 
     register = getattr(conn, "register", None)
 

--- a/tests/test_integrations_duckdb.py
+++ b/tests/test_integrations_duckdb.py
@@ -76,3 +76,57 @@ def test_register_duckdb_noncallable_register_attribute():
         match="conn must be a DuckDB connection with a callable register\\(\\) method",
     ):
         ar.register_duckdb(frame, FakeConnection(), "tbl")
+
+
+def test_register_duckdb_whitespace_only_name_space():
+    import pandas as pd
+
+    class FakeConnection:
+        def register(self, name, df):
+            pass
+
+    frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+    with pytest.raises(ValueError, match="whitespace-only"):
+        ar.register_duckdb(frame, FakeConnection(), " ")
+
+
+def test_register_duckdb_whitespace_only_name_tab():
+    import pandas as pd
+
+    class FakeConnection:
+        def register(self, name, df):
+            pass
+
+    frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+    with pytest.raises(ValueError, match="whitespace-only"):
+        ar.register_duckdb(frame, FakeConnection(), "\t")
+
+
+def test_register_duckdb_whitespace_only_name_newline():
+    import pandas as pd
+
+    class FakeConnection:
+        def register(self, name, df):
+            pass
+
+    frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+    with pytest.raises(ValueError, match="whitespace-only"):
+        ar.register_duckdb(frame, FakeConnection(), "\n")
+
+
+def test_register_duckdb_valid_name_passes():
+    import pandas as pd
+
+    registered = {}
+
+    class FakeConnection:
+        def register(self, name, df):
+            registered["name"] = name
+
+    frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+    ar.register_duckdb(frame, FakeConnection(), "my_table")
+
+    assert registered["name"] == "my_table"


### PR DESCRIPTION
Fixes #1670

## Summary

Update `register_duckdb()` to reject whitespace-only relation names in addition to empty strings.

## Changes

- Reject relation names where `name.strip()` is empty
- Update validation error message
- Update docstring to mention whitespace-only names
- Add tests for:
  - Space-only names
  - Tab-only names
  - Newline-only names
  - Valid relation names

## Testing

pytest tests/test_integrations_duckdb.py -v

<img width="948" height="382" alt="image" src="https://github.com/user-attachments/assets/0d516fb9-c8b3-4726-820a-722618a4c048" />


All tests pass.