### PR TITLE
test: add comprehensive tests for schema summary methods (Fixes #1819)

### DIFF
--- a/tests/test_schema_summary.py
+++ b/tests/test_schema_summary.py
@@ -271,3 +271,544 @@ class TestSchemaSummaryEdgeCases:
         frame = ar.from_pandas(df)
         res = ar.schema_export.schema_to_dict(frame.schema_summary)
         assert res == {"fields": {"age": {"type": "INT64", "nullable": False}}}
+
+
+# ---------------------------------------------------------------------------
+# ValidationResult.summary()
+# ---------------------------------------------------------------------------
+
+
+class TestValidationResultSummary:
+    """Tests for arnio.schema.ValidationResult.summary()."""
+
+    # ------------------------------------------------------------------
+    # Return type and top-level keys
+    # ------------------------------------------------------------------
+
+    def test_summary_returns_dict(self):
+        result = ar.ValidationResult(row_count=5, issue_count=0, issues=[], bad_rows=[])
+        assert isinstance(result.summary(), dict)
+
+    def test_summary_has_expected_keys(self):
+        result = ar.ValidationResult(row_count=5, issue_count=0, issues=[], bad_rows=[])
+        summary = result.summary()
+        assert "passed" in summary
+        assert "issue_count" in summary
+        assert "bad_row_count" in summary
+        assert "issues_by_rule" in summary
+        assert "severity_counts" in summary
+        assert "issues_by_column" in summary
+        assert "issues_by_column_and_rule" in summary
+
+    # ------------------------------------------------------------------
+    # Basic schema — simple fields, no failures
+    # ------------------------------------------------------------------
+
+    def test_summary_passes_for_valid_basic_schema(self):
+        df = pd.DataFrame({"id": [1, 2], "name": ["Alice", "Bob"]})
+        frame = ar.from_pandas(df)
+        schema = ar.Schema(
+            {"id": ar.Int64(nullable=False), "name": ar.String(nullable=False)}
+        )
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is True
+        assert summary["issue_count"] == 0
+        assert summary["bad_row_count"] == 0
+        assert summary["issues_by_rule"] == {}
+        assert summary["issues_by_column"] == {}
+        assert summary["issues_by_column_and_rule"] == {}
+
+    # ------------------------------------------------------------------
+    # Empty schema — no fields in schema, no issues expected
+    # ------------------------------------------------------------------
+
+    def test_summary_empty_schema_no_issues(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        frame = ar.from_pandas(df)
+        schema = ar.Schema({})
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is True
+        assert summary["issue_count"] == 0
+        assert summary["issues_by_rule"] == {}
+
+    def test_summary_empty_result_all_empty_dicts(self):
+        result = ar.ValidationResult(row_count=0, issue_count=0, issues=[], bad_rows=[])
+        summary = result.summary()
+        assert summary["issues_by_rule"] == {}
+        assert summary["issues_by_column"] == {}
+        assert summary["issues_by_column_and_rule"] == {}
+        assert summary["severity_counts"] == {}
+
+    # ------------------------------------------------------------------
+    # Mixed field types — numeric, string, bool
+    # ------------------------------------------------------------------
+
+    def test_summary_mixed_field_types_no_violations(self):
+        df = pd.DataFrame(
+            {
+                "age": [25, 30, 35],
+                "score": [9.5, 8.0, 7.5],
+                "name": ["Alice", "Bob", "Charlie"],
+                "active": [True, False, True],
+            }
+        )
+        frame = ar.from_pandas(df)
+        schema = ar.Schema(
+            {
+                "age": ar.Int64(nullable=False, min=0, max=120),
+                "score": ar.Float64(nullable=False, min=0.0, max=10.0),
+                "name": ar.String(nullable=False),
+                "active": ar.Bool(nullable=False),
+            }
+        )
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is True
+        assert summary["issue_count"] == 0
+
+    def test_summary_mixed_field_types_with_violations(self):
+        df = pd.DataFrame(
+            {
+                "age": [25, -5],  # -5 violates min=0
+                "score": [9.5, 11.0],  # 11.0 violates max=10.0
+                "name": ["Alice", None],  # None violates nullable=False
+            }
+        )
+        frame = ar.from_pandas(df)
+        schema = ar.Schema(
+            {
+                "age": ar.Int64(nullable=False, min=0),
+                "score": ar.Float64(nullable=False, max=10.0),
+                "name": ar.String(nullable=False),
+            }
+        )
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is False
+        assert summary["issue_count"] > 0
+        assert summary["bad_row_count"] > 0
+        assert "issues_by_column" in summary
+        assert (
+            "age" in summary["issues_by_column"]
+            or "score" in summary["issues_by_column"]
+        )
+
+    # ------------------------------------------------------------------
+    # Semantic validators — Email and URL
+    # ------------------------------------------------------------------
+
+    def test_summary_email_validator_violation_appears_in_issues_by_column(self):
+        df = pd.DataFrame(
+            {"email": ["alice@example.com", "not-an-email", "bob@test.com"]}
+        )
+        frame = ar.from_pandas(df)
+        schema = ar.Schema({"email": ar.Email(nullable=False)})
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is False
+        assert "email" in summary["issues_by_column"]
+        assert summary["issues_by_column"]["email"] >= 1
+
+    def test_summary_email_validator_all_valid_no_issues(self):
+        df = pd.DataFrame({"email": ["alice@example.com", "bob@test.com"]})
+        frame = ar.from_pandas(df)
+        schema = ar.Schema({"email": ar.Email(nullable=False)})
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is True
+        assert summary["issue_count"] == 0
+        assert "email" not in summary["issues_by_column"]
+
+    def test_summary_url_validator_violation_appears_in_issues_by_rule(self):
+        df = pd.DataFrame({"site": ["https://example.com", "not-a-url"]})
+        frame = ar.from_pandas(df)
+        schema = ar.Schema({"site": ar.URL(nullable=False)})
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is False
+        assert "site" in summary["issues_by_column"]
+        # The rule key for URL validation should be present in issues_by_rule
+        assert len(summary["issues_by_rule"]) > 0
+
+    def test_summary_semantic_validator_rule_recorded_in_issues_by_rule(self):
+        df = pd.DataFrame({"email": ["bad-email"]})
+        frame = ar.from_pandas(df)
+        schema = ar.Schema({"email": ar.Email(nullable=False)})
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        # The rule name for email issues should be in issues_by_rule
+        assert any("email" in rule for rule in summary["issues_by_rule"])
+
+    # ------------------------------------------------------------------
+    # Custom validators
+    # ------------------------------------------------------------------
+
+    def test_summary_custom_validator_issues_appear_correctly(self):
+        from arnio import schema as _schema
+
+        original = dict(_schema._CUSTOM_VALIDATORS)
+        try:
+            ar.register_validator(
+                "positive_score", lambda v: isinstance(v, (int, float)) and v > 0
+            )
+            df = pd.DataFrame({"score": [10, -1, 5, -3]})
+            frame = ar.from_pandas(df)
+            schema = ar.Schema({"score": ar.Custom("positive_score", nullable=False)})
+            result = ar.validate(frame, schema)
+            summary = result.summary()
+            assert summary["passed"] is False
+            assert summary["issues_by_column"].get("score", 0) == 2
+            assert "custom" in summary["issues_by_rule"]
+            assert summary["issues_by_column_and_rule"]["score"]["custom"] == 2
+        finally:
+            _schema._CUSTOM_VALIDATORS.clear()
+            _schema._CUSTOM_VALIDATORS.update(original)
+
+    def test_summary_custom_validator_all_pass(self):
+        from arnio import schema as _schema
+
+        original = dict(_schema._CUSTOM_VALIDATORS)
+        try:
+            ar.register_validator("is_positive_v2", lambda v: v > 0)
+            df = pd.DataFrame({"x": [1, 2, 3]})
+            frame = ar.from_pandas(df)
+            schema = ar.Schema({"x": ar.Custom("is_positive_v2", nullable=False)})
+            result = ar.validate(frame, schema)
+            summary = result.summary()
+            assert summary["passed"] is True
+            assert summary["issue_count"] == 0
+            assert summary["issues_by_column"] == {}
+        finally:
+            _schema._CUSTOM_VALIDATORS.clear()
+            _schema._CUSTOM_VALIDATORS.update(original)
+
+    # ------------------------------------------------------------------
+    # Severity counts
+    # ------------------------------------------------------------------
+
+    def test_summary_severity_counts_errors_only(self):
+        result = ar.ValidationResult(
+            row_count=3,
+            issue_count=2,
+            issues=[
+                ar.ValidationIssue(
+                    column="age", rule="min", message="too small", row_index=1
+                ),
+                ar.ValidationIssue(
+                    column="age", rule="min", message="too small", row_index=2
+                ),
+            ],
+            bad_rows=[1, 2],
+        )
+        summary = result.summary()
+        assert summary["severity_counts"] == {"error": 2}
+
+    def test_summary_severity_counts_warnings_only(self):
+        result = ar.ValidationResult(
+            row_count=2,
+            issue_count=1,
+            issues=[
+                ar.ValidationIssue(
+                    column="age",
+                    rule="min",
+                    message="low",
+                    row_index=1,
+                    severity="warning",
+                ),
+            ],
+            bad_rows=[],
+        )
+        summary = result.summary()
+        assert summary["severity_counts"] == {"warning": 1}
+        # Warnings alone should not fail validation
+        assert summary["passed"] is True
+
+    def test_summary_severity_counts_mixed_error_and_warning(self):
+        result = ar.ValidationResult(
+            row_count=4,
+            issue_count=3,
+            issues=[
+                ar.ValidationIssue(
+                    column="age",
+                    rule="min",
+                    message="too small",
+                    row_index=1,
+                    severity="error",
+                ),
+                ar.ValidationIssue(
+                    column="age",
+                    rule="max",
+                    message="too large",
+                    row_index=2,
+                    severity="error",
+                ),
+                ar.ValidationIssue(
+                    column="score",
+                    rule="min",
+                    message="low score",
+                    row_index=3,
+                    severity="warning",
+                ),
+            ],
+            bad_rows=[1, 2],
+        )
+        summary = result.summary()
+        assert summary["severity_counts"]["error"] == 2
+        assert summary["severity_counts"]["warning"] == 1
+
+    # ------------------------------------------------------------------
+    # issues_by_column_and_rule grouping
+    # ------------------------------------------------------------------
+
+    def test_summary_issues_by_column_and_rule_grouped_correctly(self):
+        result = ar.ValidationResult(
+            row_count=5,
+            issue_count=4,
+            issues=[
+                ar.ValidationIssue(
+                    column="age", rule="min", message="too small", row_index=1
+                ),
+                ar.ValidationIssue(
+                    column="age", rule="min", message="too small", row_index=2
+                ),
+                ar.ValidationIssue(
+                    column="age", rule="max", message="too large", row_index=3
+                ),
+                ar.ValidationIssue(
+                    column="email", rule="email", message="bad email", row_index=4
+                ),
+            ],
+            bad_rows=[1, 2, 3, 4],
+        )
+        summary = result.summary()
+        assert summary["issues_by_column_and_rule"]["age"]["min"] == 2
+        assert summary["issues_by_column_and_rule"]["age"]["max"] == 1
+        assert summary["issues_by_column_and_rule"]["email"]["email"] == 1
+
+    def test_summary_column_none_not_included_in_issues_by_column(self):
+        result = ar.ValidationResult(
+            row_count=2,
+            issue_count=2,
+            issues=[
+                ar.ValidationIssue(
+                    column=None, rule="required_column", message="missing col"
+                ),
+                ar.ValidationIssue(
+                    column="email", rule="email", message="bad email", row_index=1
+                ),
+            ],
+            bad_rows=[1],
+        )
+        summary = result.summary()
+        # column=None rows should not appear as a column key
+        assert None not in summary["issues_by_column"]
+        # Non-None column should appear
+        assert "email" in summary["issues_by_column"]
+        # The rule itself is still counted in issues_by_rule
+        assert "required_column" in summary["issues_by_rule"]
+
+    # ------------------------------------------------------------------
+    # Large schema
+    # ------------------------------------------------------------------
+
+    def test_summary_large_schema_scales_correctly(self):
+        """summary() should handle 50+ columns and 500+ issues without error."""
+        # Build a frame with 50 int columns and a schema that rejects negative values
+        num_cols = 50
+        data = {f"col_{i}": [-1] * 10 for i in range(num_cols)}
+        df = pd.DataFrame(data)
+        frame = ar.from_pandas(df)
+        schema = ar.Schema({f"col_{i}": ar.Int64(min=0) for i in range(num_cols)})
+        result = ar.validate(frame, schema)
+        summary = result.summary()
+        assert summary["passed"] is False
+        assert summary["issue_count"] == num_cols * 10
+        assert len(summary["issues_by_column"]) == num_cols
+        for i in range(num_cols):
+            assert summary["issues_by_column"][f"col_{i}"] == 10
+
+    # ------------------------------------------------------------------
+    # passed flag logic
+    # ------------------------------------------------------------------
+
+    def test_summary_passed_is_false_when_any_error_issue(self):
+        result = ar.ValidationResult(
+            row_count=1,
+            issue_count=1,
+            issues=[
+                ar.ValidationIssue(column="x", rule="min", message="err", row_index=1)
+            ],
+            bad_rows=[1],
+        )
+        summary = result.summary()
+        assert summary["passed"] is False
+
+    def test_summary_passed_is_true_for_zero_issues(self):
+        result = ar.ValidationResult(
+            row_count=100, issue_count=0, issues=[], bad_rows=[]
+        )
+        summary = result.summary()
+        assert summary["passed"] is True
+
+    def test_summary_passed_is_true_when_only_warning_issues(self):
+        result = ar.ValidationResult(
+            row_count=2,
+            issue_count=1,
+            issues=[
+                ar.ValidationIssue(
+                    column="age",
+                    rule="min",
+                    message="low",
+                    row_index=1,
+                    severity="warning",
+                )
+            ],
+            bad_rows=[],
+        )
+        summary = result.summary()
+        assert summary["passed"] is True
+
+    # ------------------------------------------------------------------
+    # bad_row_count
+    # ------------------------------------------------------------------
+
+    def test_summary_bad_row_count_matches_bad_rows(self):
+        result = ar.ValidationResult(
+            row_count=10,
+            issue_count=3,
+            issues=[
+                ar.ValidationIssue(
+                    column="age", rule="min", message="err", row_index=1
+                ),
+                ar.ValidationIssue(
+                    column="age", rule="min", message="err", row_index=2
+                ),
+                ar.ValidationIssue(
+                    column="age", rule="min", message="err", row_index=3
+                ),
+            ],
+            bad_rows=[1, 2, 3],
+        )
+        summary = result.summary()
+        assert summary["bad_row_count"] == 3
+
+    # ------------------------------------------------------------------
+    # Stable across repeated calls
+    # ------------------------------------------------------------------
+
+    def test_summary_is_stable_across_repeated_calls(self):
+        result = ar.ValidationResult(
+            row_count=2,
+            issue_count=1,
+            issues=[
+                ar.ValidationIssue(column="age", rule="min", message="err", row_index=1)
+            ],
+            bad_rows=[1],
+        )
+        assert result.summary() == result.summary()
+
+
+# ---------------------------------------------------------------------------
+# SchemaDiff.summary()
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaDiffSummary:
+    """Tests for arnio.schema.SchemaDiff.summary()."""
+
+    # ------------------------------------------------------------------
+    # Return type and top-level keys
+    # ------------------------------------------------------------------
+
+    def test_schema_diff_summary_returns_dict(self):
+        schema_a = ar.Schema({"id": ar.Int64()})
+        schema_b = ar.Schema({"id": ar.Int64()})
+        diff = ar.diff_schema(schema_a, schema_b)
+        assert isinstance(diff.summary(), dict)
+
+    def test_schema_diff_summary_has_expected_keys(self):
+        schema_a = ar.Schema({"id": ar.Int64()})
+        schema_b = ar.Schema({"id": ar.Int64()})
+        diff = ar.diff_schema(schema_a, schema_b)
+        summary = diff.summary()
+        assert "changed" in summary
+        assert "difference_count" in summary
+        assert "differences_by_change" in summary
+        assert "differences_by_column" in summary
+
+    # ------------------------------------------------------------------
+    # No differences
+    # ------------------------------------------------------------------
+
+    def test_schema_diff_summary_unchanged_schemas(self):
+        schema_a = ar.Schema({"id": ar.Int64(), "name": ar.String()})
+        schema_b = ar.Schema({"id": ar.Int64(), "name": ar.String()})
+        diff = ar.diff_schema(schema_a, schema_b)
+        summary = diff.summary()
+        assert summary["changed"] is False
+        assert summary["difference_count"] == 0
+        assert summary["differences_by_change"] == {}
+        assert summary["differences_by_column"] == {}
+
+    def test_schema_diff_summary_empty_schemas(self):
+        diff = ar.diff_schema(ar.Schema({}), ar.Schema({}))
+        summary = diff.summary()
+        assert summary["changed"] is False
+        assert summary["difference_count"] == 0
+
+    # ------------------------------------------------------------------
+    # Missing columns
+    # ------------------------------------------------------------------
+
+    def test_schema_diff_summary_missing_column(self):
+        schema_a = ar.Schema({"id": ar.Int64(), "email": ar.Email()})
+        schema_b = ar.Schema({"id": ar.Int64()})
+        diff = ar.diff_schema(schema_a, schema_b)
+        summary = diff.summary()
+        assert summary["changed"] is True
+        assert summary["differences_by_change"].get("missing_column", 0) >= 1
+        assert "email" in summary["differences_by_column"]
+
+    # ------------------------------------------------------------------
+    # Extra columns
+    # ------------------------------------------------------------------
+
+    def test_schema_diff_summary_extra_column(self):
+        schema_a = ar.Schema({"id": ar.Int64()})
+        schema_b = ar.Schema({"id": ar.Int64(), "extra": ar.String()})
+        diff = ar.diff_schema(schema_a, schema_b)
+        summary = diff.summary()
+        assert summary["changed"] is True
+        assert summary["differences_by_change"].get("extra_column", 0) >= 1
+        assert "extra" in summary["differences_by_column"]
+
+    # ------------------------------------------------------------------
+    # Multiple change kinds
+    # ------------------------------------------------------------------
+
+    def test_schema_diff_summary_multiple_change_kinds_counted_separately(self):
+        schema_a = ar.Schema(
+            {"id": ar.Int64(), "name": ar.String(), "score": ar.Float64()}
+        )
+        schema_b = ar.Schema({"id": ar.Int64(), "title": ar.String()})
+        diff = ar.diff_schema(schema_a, schema_b)
+        summary = diff.summary()
+        assert summary["changed"] is True
+        # "name" and "score" are missing; "title" is extra
+        assert "missing_column" in summary["differences_by_change"]
+        assert "extra_column" in summary["differences_by_change"]
+        assert summary["differences_by_change"]["missing_column"] == 2
+        assert summary["differences_by_change"]["extra_column"] == 1
+        assert summary["difference_count"] == 3
+
+    # ------------------------------------------------------------------
+    # Stable across repeated calls
+    # ------------------------------------------------------------------
+
+    def test_schema_diff_summary_is_stable_across_calls(self):
+        schema_a = ar.Schema({"id": ar.Int64(), "name": ar.String()})
+        schema_b = ar.Schema({"id": ar.Int64()})
+        diff = ar.diff_schema(schema_a, schema_b)
+        assert diff.summary() == diff.summary()


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for `arnio.schema` summary methods in `tests/test_schema_summary.py`. Two new test classes cover `ValidationResult.summary()` (24 tests) and `SchemaDiff.summary()` (8 tests) — including basic schemas, empty schemas, mixed field types, semantic validators (Email, URL), custom validators, severity counts, large schemas, and stability checks.

## Linked issue

Fixes #1819

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing

```powershell
python -m pytest tests/test_schema_summary.py -q
```

**Result:** 70 passed in < 1s (38 pre-existing + 32 new tests)

- [x] `python -m pytest tests/test_schema_summary.py -q --tb=short`
- [x] `python -m black --check .` — passed (auto-formatted by pre-commit hook)
- [x] `python -m ruff check .` — passed

## Screenshots / Media

N/A — tests only, no UI or output changes.

## Performance Impact

N/A — test file only, no production code changed.

## GSSoC labels

<!-- Maintainers only -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes. *(N/A — tests only)*
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`test: add comprehensive tests for schema summary methods`).

## Maintainer notes

**New test coverage added in `TestValidationResultSummary` (24 tests):**
- Return type and all 7 expected keys (`passed`, `issue_count`, `bad_row_count`, `issues_by_rule`, `severity_counts`, `issues_by_column`, `issues_by_column_and_rule`)
- Basic schema — valid frame, no violations
- Empty schema (no fields) and zero-issue result
- Mixed field types: Int64, Float64, String, Bool — pass and fail cases
- Semantic validators: Email (valid/invalid), URL (invalid), rule name in `issues_by_rule`
- Custom validators via `register_validator()` — failures counted, all-pass case
- Severity counts: error-only, warning-only, mixed error+warning
- `issues_by_column_and_rule` nested grouping, `column=None` not leaked
- Large schema: 50 columns × 10 rows = 500 issues
- `passed` flag: False on error, True on zero issues, True on warning-only
- `bad_row_count` matches `len(bad_rows)`
- Stability: repeated calls return equal dicts

**New test coverage added in `TestSchemaDiffSummary` (8 tests):**
- Return type and all 4 expected keys
- Identical schemas → no differences
- Empty schemas → no differences
- Missing columns counted in `differences_by_change` and `differences_by_column`
- Extra columns counted correctly
- Multiple change kinds (missing + extra) grouped separately
- Stability: repeated calls return equal dicts