### PR TITLE
fix: reject whitespace-only names in register_validator

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2967,8 +2967,8 @@ def register_validator(
     """
     if not callable(fn):
         raise TypeError("fn must be callable")
-    if not isinstance(name, str) or not name:
-        raise ValueError("name must be a non-empty string")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Validator name must be a non-empty, non-whitespace string")
     if name in _CUSTOM_VALIDATORS and not overwrite:
         raise ValueError(
             f"Validator {name!r} is already registered. "

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -51,12 +51,12 @@ class TestRegisterValidator:
 
     def test_raises_value_error_when_name_is_empty_string(self):
         """register_validator raises ValueError when name is empty string."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        with pytest.raises(ValueError, match="non-empty, non-whitespace string"):
             register_validator("", lambda x: True)
 
     def test_raises_value_error_when_name_is_not_string(self):
         """register_validator raises ValueError when name is not a string."""
-        with pytest.raises(ValueError, match="non-empty string"):
+        with pytest.raises(ValueError, match="non-empty, non-whitespace string"):
             register_validator(123, lambda x: True)
 
     def test_duplicate_validator_requires_explicit_overwrite(self):
@@ -377,3 +377,31 @@ class TestCustomValidatorNameValidation:
         """A valid string name that isn't registered raises the registry error, not the name error."""
         with pytest.raises(ValueError, match="No validator registered"):
             Custom("unregistered_name_xyz")
+
+
+class TestRegisterValidatorNameValidation:
+    """Input-validation tests for register_validator() name parameter."""
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="non-empty, non-whitespace"):
+            ar.register_validator("", lambda v: True)
+
+    def test_rejects_space_only(self):
+        with pytest.raises(ValueError, match="non-empty, non-whitespace"):
+            ar.register_validator(" ", lambda v: True)
+
+    def test_rejects_tab_only(self):
+        with pytest.raises(ValueError, match="non-empty, non-whitespace"):
+            ar.register_validator("\t", lambda v: True)
+
+    def test_rejects_mixed_whitespace(self):
+        with pytest.raises(ValueError, match="non-empty, non-whitespace"):
+            ar.register_validator("  \t  \n  ", lambda v: True)
+
+    def test_rejects_non_string(self):
+        with pytest.raises((ValueError, TypeError)):
+            ar.register_validator(123, lambda v: True)
+
+    def test_accepts_valid_name(self):
+        # Should not raise
+        ar.register_validator("positive", lambda v: v > 0)


### PR DESCRIPTION
## Summary

- `register_validator()` accepted whitespace-only strings (e.g. `" "`, `"\t"`) as validator names. 
- Updated validation from `not name` → `not name.strip()` and updated the error message to mention non-whitespace requirement in `arnio/schema.py`.
- Added 6 test cases covering empty string, space-only, tab-only, mixed whitespace, non-string, and valid name in `tests/test_register_validator.py`.

## Linked issue
Fixes #1677 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` 
- [x] Other: Explicitly by script.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).