### PR TITLE
fix: clarify HTML repr for non-empty zero-column frames

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -987,8 +987,10 @@ class ArFrame:
         )
 
         # ── empty-frame fast path ─────────────────────────────────────────
-        if num_cols == 0 or num_rows == 0:
+        if num_rows == 0:
             return summary + "<p><em>(empty)</em></p>"
+        if num_cols == 0:
+            return summary + "<p><em>(no columns to display)</em></p>"
 
         # ── column header ─────────────────────────────────────────────────
         th_style = (

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1356,6 +1356,18 @@ def test_repr_html_empty_frame_no_crash(tmp_path):
     assert len(out) > 0
 
 
+def test_repr_html_zero_columns_preserves_row_count():
+    frame = ar.from_pandas(pd.DataFrame({"a": [None, None]}))
+    zero = ar.drop_empty_columns(frame)
+
+    out = zero._repr_html_()
+
+    assert zero.shape == (2, 0)
+    assert "ArFrame [2 rows × 0 cols]" in out
+    assert "(no columns to display)" in out
+    assert "(empty)" not in out
+
+
 def test_repr_html_with_nulls_no_crash(csv_with_nulls):
     frame = ar.read_csv(csv_with_nulls)
     out = frame._repr_html_()


### PR DESCRIPTION
Updated frame.py so `_repr_html_()` now treats zero rows and zero columns separately: zero rows still render “(empty)”, while non-empty zero-column frames render “(no columns to display)”. I also added a regression test in test_frame.py that builds a zero-column frame via `drop_empty_columns()` and checks that the row count is preserved in the HTML repr.

Validation: `python -m py_compile frame.py tests/test_frame.py` passed. 

closes #1650