### PR TITLE
fix: raise ValueError for empty columns in ArFrame.from_records with …

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -155,6 +155,11 @@ class ArFrame:
                             f"nested values are not supported; "
                             f"column {col!r} at row {i} contains a {type(val).__name__!r}"
                         )
+            if columns is not None and len(columns) == 0:
+                raise ValueError(
+                    "columns must not be empty when records are dicts; "
+                    "pass columns=None to infer column names from the record keys"
+                )
             df = pd.DataFrame.from_records(records, columns=columns)
 
         elif isinstance(first, (list, tuple)):

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1683,3 +1683,33 @@ def test_shallow_copy_independent_frame():
     assert shallow._frame is not original._frame
     ar.rename_columns(original, {"a": "b"})
     assert "a" in shallow.columns  # mutation must not leak
+
+
+# ── from_records empty-columns guard ─────────────────────────────────────────
+
+
+def test_from_records_dict_empty_columns_raises():
+    """columns=[] with dict records must raise ValueError, not silently lose rows."""
+    with pytest.raises(ValueError, match="columns must not be empty"):
+        ar.ArFrame.from_records([{"a": 1}, {"a": 2}], columns=[])
+
+
+def test_from_records_dict_empty_columns_message_is_helpful():
+    """The error message should mention passing columns=None."""
+    with pytest.raises(ValueError, match="columns=None"):
+        ar.ArFrame.from_records([{"a": 1}], columns=[])
+
+
+def test_from_records_dict_columns_none_infers_from_keys():
+    """columns=None (default) should infer column names from dict keys."""
+    frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}])
+    assert frame.shape == (2, 1)
+    assert frame.columns == ["a"]
+
+
+def test_from_records_dict_explicit_valid_columns_subset():
+    """A non-empty explicit columns list should select only those columns."""
+    frame = ar.ArFrame.from_records([{"a": 1, "b": 2}, {"a": 3, "b": 4}], columns=["a"])
+    assert frame.shape == (2, 1)
+    assert frame.columns == ["a"]
+    assert frame["a"] == [1, 3]


### PR DESCRIPTION
Fixes #1795

## Summary


`ArFrame.from_records()` silently returned an empty `(0, 0)` frame when dict records were passed with `columns=[]`. This caused silent data loss with no indication to the caller.

## Changes

**`arnio/frame.py`**
- Added a `ValueError` guard in the dict branch of `ArFrame.from_records()` that rejects `columns=[]` with a clear, actionable message pointing the caller to use `columns=None` instead.

**`tests/test_frame.py`**
- `test_from_records_dict_empty_columns_raises` —> verifies `columns=[]` raises `ValueError`
- `test_from_records_dict_empty_columns_message_is_helpful` —> verifies the error message mentions `columns=None`
- `test_from_records_dict_columns_none_infers_from_keys` —> verifies default behavior (infer from keys) is unchanged
- `test_from_records_dict_explicit_valid_columns_subset` —> verifies a valid non-empty explicit column list still works correctly

## Behavior

**Before**
```python
frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}], columns=[])
print(frame.shape)  # (0, 0) — silent data loss
```

**After**
```python
frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}], columns=[])
# ValueError: columns must not be empty when records are dicts;
# pass columns=None to infer column names from the record keys
```

## Notes

- Scoped strictly to the dict records path in `from_records()` as requested
- Existing behavior for `columns=None` and valid explicit column subsets is fully preserved
- 8 pre-existing test failures in `test_describe_*` are unrelated to this change and were present on `main` before this branch