### PR TITLE
fix(schema): validate schema_to_yaml output paths

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -18,6 +18,7 @@ for anything else so the contract stays explicit.
 
 from __future__ import annotations
 
+import os
 import pathlib
 import re
 from typing import Any
@@ -381,7 +382,13 @@ def schema_to_yaml(
     yaml_str = body if body.endswith("\n") else body + "\n"
 
     if path is not None:
+        if not isinstance(path, (str, os.PathLike)):
+            raise TypeError("path must be a string or os.PathLike")
+        if isinstance(path, str) and not path.strip():
+            raise ValueError("path must not be empty")
         target = pathlib.Path(path)
+        if target.is_dir():
+            raise ValueError("path must point to a file, not a directory")
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(yaml_str, encoding="utf-8")
 

--- a/tests/test_schema_to_yaml_path.py
+++ b/tests/test_schema_to_yaml_path.py
@@ -1,0 +1,152 @@
+"""Tests for schema_to_yaml(..., path=...) output-path validation.
+
+Covers:
+- valid file path (str) writes and returns YAML
+- valid pathlib.Path writes and returns YAML
+- valid os.PathLike writes and returns YAML
+- parent directory creation for nested paths
+- empty string path raises ValueError
+- whitespace-only string path raises ValueError
+- existing directory path raises ValueError
+- non-string / non-PathLike types raise TypeError
+
+Fixes #1674
+"""
+
+import os
+import pathlib
+
+import pytest
+
+import arnio as ar
+
+_SCHEMA = {"id": "int64", "name": "string"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _CustomPathLike(os.PathLike):
+    """Minimal os.PathLike implementation that is NOT a pathlib.Path."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+
+    def __fspath__(self) -> str:
+        return self._path
+
+
+# ---------------------------------------------------------------------------
+# Valid path behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaToYamlValidPaths:
+    def test_str_path_writes_file(self, tmp_path):
+        out = str(tmp_path / "schema.yaml")
+        result = ar.schema_to_yaml(_SCHEMA, path=out)
+        assert pathlib.Path(out).exists()
+        assert pathlib.Path(out).read_text(encoding="utf-8") == result
+
+    def test_pathlib_path_writes_file(self, tmp_path):
+        out = tmp_path / "schema.yaml"
+        result = ar.schema_to_yaml(_SCHEMA, path=out)
+        assert out.exists()
+        assert out.read_text(encoding="utf-8") == result
+
+    def test_os_pathlike_writes_file(self, tmp_path):
+        out = _CustomPathLike(str(tmp_path / "schema.yaml"))
+        result = ar.schema_to_yaml(_SCHEMA, path=out)
+        assert pathlib.Path(os.fspath(out)).exists()
+        assert pathlib.Path(os.fspath(out)).read_text(encoding="utf-8") == result
+
+    def test_yaml_string_always_returned(self, tmp_path):
+        out = tmp_path / "schema.yaml"
+        result = ar.schema_to_yaml(_SCHEMA, path=out)
+        assert isinstance(result, str)
+        assert result.endswith("\n")
+
+    def test_parent_dirs_created(self, tmp_path):
+        out = tmp_path / "a" / "b" / "c" / "schema.yaml"
+        ar.schema_to_yaml(_SCHEMA, path=out)
+        assert out.exists()
+
+    def test_no_path_returns_yaml_string(self):
+        result = ar.schema_to_yaml(_SCHEMA)
+        assert isinstance(result, str)
+        assert "id" in result
+
+    def test_existing_file_overwritten(self, tmp_path):
+        out = tmp_path / "schema.yaml"
+        out.write_text("old content", encoding="utf-8")
+        ar.schema_to_yaml(_SCHEMA, path=out)
+        assert out.read_text(encoding="utf-8") != "old content"
+
+
+# ---------------------------------------------------------------------------
+# Invalid path — TypeError
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaToYamlPathTypeErrors:
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            123,
+            True,
+            False,
+            3.14,
+            ["schema.yaml"],
+            {"path": "schema.yaml"},
+            object(),
+        ],
+    )
+    def test_non_string_non_pathlike_raises_type_error(self, bad_path):
+        with pytest.raises(TypeError, match="path must be a string or os.PathLike"):
+            ar.schema_to_yaml(_SCHEMA, path=bad_path)
+
+
+# ---------------------------------------------------------------------------
+# Invalid path — ValueError (empty)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaToYamlEmptyPath:
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="path must not be empty"):
+            ar.schema_to_yaml(_SCHEMA, path="")
+
+    def test_whitespace_only_string_raises(self):
+        with pytest.raises(ValueError, match="path must not be empty"):
+            ar.schema_to_yaml(_SCHEMA, path="   ")
+
+    def test_tab_only_string_raises(self):
+        with pytest.raises(ValueError, match="path must not be empty"):
+            ar.schema_to_yaml(_SCHEMA, path="\t")
+
+
+# ---------------------------------------------------------------------------
+# Invalid path — ValueError (directory)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaToYamlDirectoryPath:
+    def test_dot_raises(self, tmp_path):
+        with pytest.raises(
+            ValueError, match="path must point to a file, not a directory"
+        ):
+            ar.schema_to_yaml(_SCHEMA, path=".")
+
+    def test_existing_dir_raises(self, tmp_path):
+        with pytest.raises(
+            ValueError, match="path must point to a file, not a directory"
+        ):
+            ar.schema_to_yaml(_SCHEMA, path=str(tmp_path))
+
+    def test_existing_dir_as_pathlib_raises(self, tmp_path):
+        with pytest.raises(
+            ValueError, match="path must point to a file, not a directory"
+        ):
+            ar.schema_to_yaml(_SCHEMA, path=tmp_path)


### PR DESCRIPTION
Fixes #1674

## Summary

Add validation for `schema_to_yaml(..., path=...)` output paths before writing files.

## Changes

- Reject non-string and non-`os.PathLike` values with a clear `TypeError`
- Reject empty string paths with `ValueError`
- Reject existing directory paths with `ValueError`
- Preserve valid file-path behavior, including automatic parent directory creation
- Add focused tests covering:
  - Valid file paths
  - `os.PathLike` paths
  - Empty string paths
  - Directory paths
  - Invalid path types
  - Parent directory creation

## Why

Previously, invalid output paths could fall through to `pathlib.Path.write_text()` and raise low-level filesystem errors such as `PermissionError` or raw `pathlib` exceptions.

This change provides clear API-level validation errors that are easier for users to understand and handle.

## Testing

```bash
pytest tests/test_schema_export.py -v
```
<img width="951" height="178" alt="image" src="https://github.com/user-attachments/assets/5b82d4bb-5da7-4bd3-89e6-1c5be13de119" />

<img width="950" height="188" alt="image" src="https://github.com/user-attachments/assets/d73b3fc4-c5f7-4933-8e5d-0595e8a8844f" />

All tests pass locally.