### PR TITLE
docs: fix label name mismatches in ISSUE_TRIAGE.md

### DIFF
--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -15,7 +15,7 @@ Every issue that lands in our backlog gets categorized along key dimensions:
 5. **Type** — what kind of change it is
 6. **Area** — which part of the codebase it touches
 
-This makes the backlog navigable: a beginner GSSoC contributor can filter for `level:beginner` + `size: s` + `status: ready` and instantly find an entry point. Maintainers can spot `priority: critical` + `status: blocked` issues that need unblocking.
+This makes the backlog navigable: a beginner GSSoC contributor can filter for `level:beginner` + `size:s` + `status:ready` and instantly find an entry point. Maintainers can spot `priority:critical` + `status:blocked` issues that need unblocking.
 
 ---
 
@@ -27,10 +27,10 @@ How urgent is this issue?
 
 | Label | Meaning | Example |
 |:---|:---|:---|
-| `priority: critical` | Production-breaking bug, security issue, or release blocker. Drop everything. | A regression that crashes `read_csv()` on valid input |
-| `priority: high` | Important and time-sensitive. Should be picked up this week. | A documented public API returns wrong results for common case |
-| `priority: medium` | Solid improvement, not urgent. Pick up this milestone. | Add new pipeline step or improve an existing one |
-| `priority: low` | Nice-to-have. May sit in backlog for a while. | Tweak terminology in an internal log message |
+| `priority:critical` | Production-breaking bug, security issue, or release blocker. Drop everything. | A regression that crashes `read_csv()` on valid input |
+| `priority:high` | Important and time-sensitive. Should be picked up this week. | A documented public API returns wrong results for common case |
+| `priority:medium` | Solid improvement, not urgent. Pick up this milestone. | Add new pipeline step or improve an existing one |
+| `priority:low` | Nice-to-have. May sit in backlog for a while. | Tweak terminology in an internal log message |
 
 ---
 
@@ -53,10 +53,10 @@ How much effort will this take?
 
 | Label | Estimate | Typical scope |
 |:---|:---|:---|
-| `size: xs` | < 30 minutes | Single docstring, tiny fix, comment update |
-| `size: s` | < 2 hours | Single function, doc fix, small test addition |
-| `size: m` | Half a day | New pipeline step + tests, small refactor |
-| `size: l` | 1–2 days | New module, multi-file feature, schema validation |
+| `size:xs` | < 30 minutes | Single docstring, tiny fix, comment update |
+| `size:s` | < 2 hours | Single function, doc fix, small test addition |
+| `size:m` | Half a day | New pipeline step + tests, small refactor |
+| `size:l` | 1–2 days | New module, multi-file feature, schema validation |
 
 ---
 
@@ -85,21 +85,21 @@ Which part of the codebase does this touch?
 
 | Label | Covers |
 |:---|:---|
-| `area: csv-parser` | CSV reading, RFC 4180 compliance, BOM handling |
-| `area: cpp-core` | C++ runtime — types, columns, frames, cleaning engine |
-| `area: python-api` | Python API in `arnio/` — IO, pipeline, conversion |
-| `area: pipeline` | Step registry, pipeline executor, custom steps |
-| `area: cleaning` | Cleaning primitives — drop_nulls, fill_nulls, dedup, etc. |
-| `area: pandas-interop` | pandas bridge, zero-copy conversion, buffer protocol |
-| `area: quality` | Data quality engine, profiling, validation, suggestions |
-| `area: schema` | Schema definition, type casting, validation |
-| `area: docs` | README, architecture docs, guides, examples |
-| `area: website` | arnio.vercel.app, landing page, tutorials |
-| `area: ci-packaging` | GitHub Actions, PyPI wheels, releases |
-| `area: benchmarks` | Performance testing, reproduction scripts |
-| `area: examples` | Usage examples, notebooks, tutorials |
-| `area: developer-experience` | Error messages, CLI tooling, dev setup |
-| `area: release` | Version bumping, changelogs, deployment |
+| `area:csv-parser` | CSV reading, RFC 4180 compliance, BOM handling |
+| `area:cpp-core` | C++ runtime — types, columns, frames, cleaning engine |
+| `area:python-api` | Python API in `arnio/` — IO, pipeline, conversion |
+| `area:pipeline` | Step registry, pipeline executor, custom steps |
+| `area:cleaning` | Cleaning primitives — drop_nulls, fill_nulls, dedup, etc. |
+| `area:pandas-interop` | pandas bridge, zero-copy conversion, buffer protocol |
+| `area:quality` | Data quality engine, profiling, validation, suggestions |
+| `area:schema` | Schema definition, type casting, validation |
+| `area:docs` | README, architecture docs, guides, examples |
+| `area:website` | arnio.vercel.app, landing page, tutorials |
+| `area:ci-packaging` | GitHub Actions, PyPI wheels, releases |
+| `area:benchmarks` | Performance testing, reproduction scripts |
+| `area:examples` | Usage examples, notebooks, tutorials |
+| `area:developer-experience` | Error messages, CLI tooling, dev setup |
+| `area:release` | Version bumping, changelogs, deployment |
 
 ---
 
@@ -109,11 +109,11 @@ Where is the issue in the lifecycle?
 
 | Label | Meaning |
 |:---|:---|
-| `status: needs triage` | New issue, not yet categorized or scoped |
-| `status: ready` | Triaged, scoped, ready for a contributor to pick up |
-| `status: claimed` | Assigned and being actively worked on |
-| `status: blocked` | Cannot proceed — waiting on a decision, dependency, or upstream change |
-| `status: needs maintainer` | Requires maintainer decision or code review |
+| `status:needs-triage` | New issue, not yet categorized or scoped |
+| `status:ready` | Triaged, scoped, ready for a contributor to pick up |
+| `status:claimed` | Assigned and being actively worked on |
+| `status:blocked` | Cannot proceed — waiting on a decision, dependency, or upstream change |
+| `status:needs-maintainer` | Requires maintainer decision or code review |
 
 ---
 
@@ -125,7 +125,7 @@ For [GSSoC 2026](https://gssoc.girlscript.tech/) participants:
 |:---|:---|
 | `gssoc` | Issue is eligible for GSSoC contribution credit |
 | `gssoc:approved` | PR has been accepted/merged for GSSoC credit |
-| `gssoc: good first issue` | Strongly recommended starting point for new GSSoC contributors |
+| `gssoc:good-first-issue` | Strongly recommended starting point for new GSSoC contributors |
 | `level:beginner` | Beginner-tier scoring |
 | `level:intermediate` | Intermediate-tier scoring |
 | `level:advanced` | Advanced-tier scoring |
@@ -143,20 +143,20 @@ When a new issue arrives, work through these steps in order:
 
 ### 1. Read and reproduce
 
-- For bugs: try to reproduce locally. If the report lacks information, apply `status: needs triage` and ask for: OS, Python version, arnio version, minimal reproduction.
-- For feature requests: confirm the proposed behavior fits the project scope. If unclear, apply `status: needs triage` and start a discussion.
+- For bugs: try to reproduce locally. If the report lacks information, apply `status:needs-triage` and ask for: OS, Python version, arnio version, minimal reproduction.
+- For feature requests: confirm the proposed behavior fits the project scope. If unclear, apply `status:needs-triage` and start a discussion.
 
 ### 2. Categorize
 
 Apply labels from each required category:
 
-- ✅ `priority: *` (required)
+- ✅ `priority:*` (required)
 - ✅ `level:*` (required for GSSoC-scored issues/PRs)
-- ✅ `size: *` (required)
-- ✅ `status: *` (required — start with `status: needs triage`)
+- ✅ `size:*` (required)
+- ✅ `status:*` (required — start with `status:needs-triage`)
 - ✅ `type:*` (required)
-- ✅ `area: *` (one or more, required)
-- 🟡 `gssoc: *` (only if appropriate for GSSoC contributors)
+- ✅ `area:*` (one or more, required)
+- 🟡 `gssoc:*` (only if appropriate for GSSoC contributors)
 
 ### 3. Scope the issue
 
@@ -167,20 +167,20 @@ A well-triaged issue includes:
 - **Scope** — what's in and out of scope
 - **Acceptance criteria** — checkboxes the contributor can tick off
 
-If any of these are missing, keep the issue at `status: needs triage`.
+If any of these are missing, keep the issue at `status:needs-triage`.
 
 ### 4. Set status and assign
 
-- Move to `status: ready` once the issue is fully scoped and ready for pickup
-- Move to `status: claimed` when a contributor is assigned
-- Move to `status: blocked` if external dependencies appear during work
-- Use `status: needs maintainer` if you need another maintainer's input
+- Move to `status:ready` once the issue is fully scoped and ready for pickup
+- Move to `status:claimed` when a contributor is assigned
+- Move to `status:blocked` if external dependencies appear during work
+- Use `status:needs-maintainer` if you need another maintainer's input
 
 ---
 
 ### 5. Remove status and reassign inactive issues
 
-- Remove `status: claimed` when a contributor does not post a progress update, request a time extension or open a draft/regular PR within 3 days of assignment.
+- Remove `status:claimed` when a contributor does not post a progress update, request a time extension or open a draft/regular PR within 3 days of assignment.
 - Unassign or reassign the issue to someone else if the contributor remains inactive after 5 days of no PR, no update or no extension request.
 
 ## Worked Example
@@ -191,12 +191,12 @@ If any of these are missing, keep the issue at `status: needs triage`.
 
 | Label | Value | Reasoning |
 |:---|:---|:---|
-| Priority | `priority: high` | Performance is a roadmap focus for v1.2 |
+| Priority | `priority:high` | Performance is a roadmap focus for v1.2 |
 | Level | `level:advanced` | Requires C++ work in the cleaning engine |
-| Size | `size: l` | Hash-based comparison replacement is multi-file |
-| Status | `status: ready` | Reproducible, well-scoped, fix path is clear |
+| Size | `size:l` | Hash-based comparison replacement is multi-file |
+| Status | `status:ready` | Reproducible, well-scoped, fix path is clear |
 | Type | `type:performance` | Performance improvement |
-| Area | `area: cpp-core` | Lives in `cpp/src/cleaning.cpp` |
+| Area | `area:cpp-core` | Lives in `cpp/src/cleaning.cpp` |
 | GSSoC | `level:advanced` | Advanced-tier scoring if a GSSoC contributor picks it up |
 
 ---
@@ -205,13 +205,13 @@ If any of these are missing, keep the issue at `status: needs triage`.
 
 When in doubt, default to:
 
-- **Priority** → `priority: medium`
+- **Priority** → `priority:medium`
 - **Level** → match the actual code complexity, not the issue description length
 - **Size** → estimate as a maintainer would do it, not as a beginner would
-- **Status** → start at `status: needs triage` if anything is unclear; promote to `status: ready` once scoped
+- **Status** → start at `status:needs-triage` if anything is unclear; promote to `status:ready` once scoped
 - **Type** → `type:discussion` if direction is unclear
 
-For consistency, every issue should reach `status: ready` before being advertised as a good first issue or GSSoC pickup.
+For consistency, every issue should reach `status:ready` before being advertised as a good first issue or GSSoC pickup.
 
 ---
 

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -74,7 +74,7 @@ What kind of change is this?
 | `type:performance` | Speed or memory improvements |
 | `type:security` | Security fix or hardening |
 | `type:design` | Visual, docs-layout, logo, or product design work |
-| `type:ci` | GitHub Actions, build pipeline, release tooling |
+| `type:devops` | GitHub Actions, build pipeline, release tooling |
 | `type:discussion` | Needs community input before implementation |
 
 ---


### PR DESCRIPTION
 ## Summary
Fix label name mismatches in `.github/ISSUE_TRIAGE.md`. All documented labels used `category: value` format (with space after colon) but actual GitHub labels use `category:value`. Also fixes `status:needs triage` → `status:needs-triage` and `status:needs maintainer` → `status:needs-maintainer` which had missing hyphens in addition to spacing issues.

## Linked issue
Fixes #1744

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
No code changes — documentation only. Verified every label in the file against `https://github.com/im-anishraj/arnio/labels` manually.
- [ ] `make test`
- [ ] `make lint`
- [ ] Other:

## Screenshots / Media
N/A

## Performance Impact
N/A

## GSSoC labels
N/A

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`docs: fix label name mismatches in ISSUE_TRIAGE.md`).

## Maintainer notes
Four area labels (`area:quality`, `area:schema`, `area:website`, `area:release`) were already present in the file and are unchanged — only spacing/hyphen mismatches were fixed per the issue scope.