### PR TITLE
feat: add CLI arguments to benchmark summary generator

### DIFF
--- a/benchmarks/generate_pr_summary.py
+++ b/benchmarks/generate_pr_summary.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 from pathlib import Path
 
@@ -49,13 +50,37 @@ def generate_summary(results, baseline):
     return "\n".join(lines) + "\n"
 
 
-def main():
-    results = load_json(RESULTS_FILE)
-    baseline = load_json(BASELINE_FILE)
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Generate a Markdown benchmark summary comparing results to a baseline."
+    )
+    parser.add_argument(
+        "--results",
+        default=RESULTS_FILE,
+        help=f"Path to the benchmark results JSON file (default: {RESULTS_FILE})",
+    )
+    parser.add_argument(
+        "--baseline",
+        default=BASELINE_FILE,
+        help=f"Path to the baseline JSON file (default: {BASELINE_FILE})",
+    )
+    parser.add_argument(
+        "--output",
+        default=OUTPUT_FILE,
+        help=f"Path to write the Markdown summary (default: {OUTPUT_FILE})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    results = load_json(args.results)
+    baseline = load_json(args.baseline)
 
     summary = generate_summary(results, baseline)
 
-    output_path = Path(OUTPUT_FILE)
+    output_path = Path(args.output)
     output_path.write_text(summary)
 
     print(summary)

--- a/tests/test_generate_pr_summary.py
+++ b/tests/test_generate_pr_summary.py
@@ -1,4 +1,12 @@
-from benchmarks.generate_pr_summary import generate_summary
+import pytest
+
+from benchmarks.generate_pr_summary import (
+    BASELINE_FILE,
+    OUTPUT_FILE,
+    RESULTS_FILE,
+    generate_summary,
+    parse_args,
+)
 
 
 def test_generate_summary_handles_missing_baseline():
@@ -56,3 +64,55 @@ def test_generate_summary_handles_missing_case_baseline():
     summary = generate_summary(results, baseline)
 
     assert "No comparable baseline data available." in summary
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_defaults():
+    """No arguments → defaults match the module-level path constants."""
+    args = parse_args([])
+
+    assert args.results == RESULTS_FILE
+    assert args.baseline == BASELINE_FILE
+    assert args.output == OUTPUT_FILE
+
+
+def test_parse_args_custom_paths():
+    """Custom --results, --baseline, and --output are honoured."""
+    args = parse_args(
+        [
+            "--results",
+            "custom_results.json",
+            "--baseline",
+            "custom_baseline.json",
+            "--output",
+            "custom_output.md",
+        ]
+    )
+
+    assert args.results == "custom_results.json"
+    assert args.baseline == "custom_baseline.json"
+    assert args.output == "custom_output.md"
+
+
+def test_parse_args_help_exits_successfully(capsys):
+    """--help must print usage information and exit with code 0."""
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "--results" in captured.out
+    assert "--baseline" in captured.out
+    assert "--output" in captured.out
+
+
+def test_parse_args_invalid_argument_fails():
+    """Unknown arguments must cause argparse to exit with a non-zero code."""
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["--unknown-flag"])
+
+    assert exc_info.value.code != 0


### PR DESCRIPTION
## Summary

This PR adds command-line argument support to `benchmarks/generate_pr_summary.py` using Python's `argparse` module while preserving the script's existing behavior.

Previously, the script relied on hard-coded file paths and ignored any command-line arguments passed to it. As a result, running the script with `--help` would still execute the summary generation workflow instead of displaying usage information.

## Changes Made

### CLI Support

Added an argument parser with support for the following optional arguments:

* `--results` – path to the benchmark results file
* `--baseline` – path to the baseline benchmark file
* `--output` – path to the generated summary output file

### Backward Compatibility

The existing default file paths are preserved, so running the script without any arguments behaves exactly as before.

### Help & Validation

* `--help` now displays usage information and exits successfully without generating a summary.
* Invalid or unsupported arguments are handled through argparse's standard validation and error messages.

### Tests Added

Added focused test coverage for:

* Default argument values
* Custom CLI path arguments
* `--help` output and successful exit behavior
* Invalid argument handling

## Verification

* Existing summary generation logic remains unchanged.
* Existing output format remains unchanged.
* No CI, workflow, configuration, or project structure files were modified.
* Ruff checks pass.
* Black formatting passes.
* Test suite passes successfully.

Fixes #1909 