### PR TITLE
Test: add pytest execution path for custom_step_with_tests.py example

### DIFF
--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -151,3 +151,23 @@ def test_example_script_runs_successfully(spec: ExampleSpec) -> None:
         f"Stdout:\n{result.stdout}\n"
         f"Stderr:\n{result.stderr}"
     )
+
+
+@pytest.mark.skipif(not HAS_CORE, reason="Arnio C++ extension is not compiled.")
+def test_pytest_example_custom_step_with_tests() -> None:
+    """Run the pytest-oriented custom step example via pytest subprocess."""
+    script = EXAMPLES_DIR / "custom_step_with_tests.py"
+    if not script.exists():
+        pytest.skip("custom_step_with_tests.py not present in examples/.")
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(script), "-q"],
+        capture_output=True,
+        text=True,
+        env=_subprocess_env(),
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"custom_step_with_tests.py failed.\n"
+        f"Stdout:\n{result.stdout}\n"
+        f"Stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary
Pair the existing `custom_step_with_tests.py` exclusion in `EXCLUDED_EXAMPLES` with a new `test_pytest_example_custom_step_with_tests` test that runs the file via `pytest` subprocess. The example can no longer silently drift without CI catching it.

## Linked issue
Fixes #1881

## Type of change
- [x] Tests

## Area
- [x] Developer tooling
- [x] Pipeline / custom steps

## Testing
- [x] Other: `python3 -m pytest tests/test_examples_smoke.py::test_pytest_example_custom_step_with_tests -v` - 1 passed in 2.51s

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`test:`).