### PR TITLE
fix: Reject non-finite float values in schema conversion hints

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2549,7 +2549,11 @@ def _is_safely_convertible_to_dtype(
             return True
 
         if expected_dtype == "float64":
-            pd.to_numeric(values, errors="raise")
+            parsed = pd.to_numeric(values, errors="raise")
+
+            if not np.isfinite(parsed.to_numpy()).all():
+                return False
+
             return True
 
     except Exception:
@@ -2583,7 +2587,9 @@ def _validate_column(
                     name,
                 )
             ):
-                message += f". Values appear safely convertible to '{field_def.dtype}'"
+                message += (
+                    f". Values appear safely convertible " f"to '{field_def.dtype}'"
+                )
 
             issues.append(
                 ValidationIssue(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,7 +12,6 @@ import arnio as ar
 from arnio.schema import _is_safely_convertible_to_dtype
 
 
-
 def test_dtype_validation_reports_safe_int_conversion_for_numeric_strings():
     frame = ar.from_pandas(
         pd.DataFrame(
@@ -51,6 +50,8 @@ def test_dtype_validation_reports_safe_float_conversion_for_numeric_strings():
 
     assert not result.passed
     assert "safely convertible to 'float64'" in result.issues[0].message
+
+
 def test_dtype_validation_does_not_report_safe_float_conversion_for_inf():
     frame = ar.from_pandas(
         pd.DataFrame(
@@ -129,6 +130,7 @@ def test_dtype_validation_does_not_report_safe_float_conversion_for_mixed_finite
 
     assert not result.passed
     assert "safely convertible" not in result.issues[0].message
+
 
 def test_schema_validation_row_indexed_issues_respect_cap():
     frame = ar.from_pandas(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,6 +12,7 @@ import arnio as ar
 from arnio.schema import _is_safely_convertible_to_dtype
 
 
+
 def test_dtype_validation_reports_safe_int_conversion_for_numeric_strings():
     frame = ar.from_pandas(
         pd.DataFrame(
@@ -50,7 +51,84 @@ def test_dtype_validation_reports_safe_float_conversion_for_numeric_strings():
 
     assert not result.passed
     assert "safely convertible to 'float64'" in result.issues[0].message
+def test_dtype_validation_does_not_report_safe_float_conversion_for_inf():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "score": pd.Series(
+                    ["inf", "2.0"],
+                    dtype="string",
+                )
+            }
+        )
+    )
 
+    schema = ar.Schema({"score": ar.Float64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
+
+
+def test_dtype_validation_does_not_report_safe_float_conversion_for_negative_inf():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "score": pd.Series(
+                    ["-inf", "2.0"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"score": ar.Float64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
+
+
+def test_dtype_validation_does_not_report_safe_float_conversion_for_infinity():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "score": pd.Series(
+                    ["Infinity", "2.0"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"score": ar.Float64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
+
+
+def test_dtype_validation_does_not_report_safe_float_conversion_for_mixed_finite_and_nonfinite():
+    frame = ar.from_pandas(
+        pd.DataFrame(
+            {
+                "score": pd.Series(
+                    ["2.0", "inf"],
+                    dtype="string",
+                )
+            }
+        )
+    )
+
+    schema = ar.Schema({"score": ar.Float64()})
+
+    result = ar.validate(frame, schema)
+
+    assert not result.passed
+    assert "safely convertible" not in result.issues[0].message
 
 def test_schema_validation_row_indexed_issues_respect_cap():
     frame = ar.from_pandas(


### PR DESCRIPTION
## Summary

Fix schema validation float conversion hints for non-finite values.

Schema validation previously reported strings such as `inf`, `-inf`, and `Infinity` as safely convertible to `float64`. This was misleading because non-finite values are not treated as safe float conversion targets elsewhere in Arnio.

This change updates `_is_safely_convertible_to_dtype()` to reject non-finite parsed float values using `np.isfinite(...)` before reporting a safe conversion hint.

## Linked issue

Fixes #1902

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [x] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test`
* [ ] `make lint`
* [ ] optionally `python -m pytest tests -v --tb=short -x`
* [x] Other:

```bash
pytest tests/test_schema.py::test_dtype_validation_does_not_report_safe_float_conversion_for_inf
pytest tests/test_schema.py -k "inf"
```

Result: Tests passed.

## Screenshots / Media

N/A

## Performance Impact

No expected performance impact.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Adds regression coverage for:

* `inf`
* `-inf`
* `Infinity`
* mixed finite/non-finite float strings

Finite numeric string conversion behavior remains unchanged.
