### PR TITLE
fix:DataQualityReport.to_pandas

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -271,6 +271,41 @@ class ColumnProfile:
         }
 
 
+QUALITY_REPORT_COLUMNS = [
+    "name",
+    "dtype",
+    "semantic_type",
+    "null_count",
+    "null_ratio",
+    "unique_count",
+    "unique_ratio",
+    "empty_string_count",
+    "whitespace_count",
+    "suggested_dtype",
+    "email_validity_ratio",
+    "url_validity_ratio",
+    "min",
+    "max",
+    "mean",
+    "std",
+    "warnings",
+    "top_values",
+    "top_values_is_approximate",
+    "top_values_sample_count",
+    "top_values_sample_ratio",
+    "histogram",
+    "q25",
+    "q50",
+    "q75",
+    "q95",
+    "iqr",
+    "outlier_lower_bound",
+    "outlier_upper_bound",
+    "outlier_count",
+    "outlier_ratio",
+]
+
+
 @dataclass(frozen=True)
 class DataQualityReport:
     """Whole-frame data quality report."""
@@ -982,7 +1017,8 @@ class DataQualityReport:
                     "histogram": column.histogram,
                 }
                 for column in self.columns.values()
-            ]
+            ],
+            columns=QUALITY_REPORT_COLUMNS,
         )
 
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -971,6 +971,10 @@ class DataQualityReport:
 
     def to_pandas(self) -> pd.DataFrame:
         """Return one row per column as a pandas DataFrame."""
+        expected_columns = QUALITY_REPORT_COLUMNS
+        if not self.columns:
+            return pd.DataFrame(columns=expected_columns)
+
         return pd.DataFrame(
             [
                 {
@@ -1018,7 +1022,7 @@ class DataQualityReport:
                 }
                 for column in self.columns.values()
             ],
-            columns=QUALITY_REPORT_COLUMNS,
+            columns=expected_columns,
         )
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -9,8 +9,8 @@ import pytest
 
 import arnio as ar
 from arnio.quality import (
-    CleaningSuggestion,
     QUALITY_REPORT_COLUMNS,
+    CleaningSuggestion,
     _validate_gate_bool,
     _validate_gate_ratio_threshold,
     _validate_gate_threshold,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -45,6 +45,7 @@ def test_report_summary_and_pandas_output(csv_with_whitespace):
     assert summary["rows"] == 3
     assert summary["columns_with_whitespace"] == ["name", "city"]
     assert isinstance(df, pd.DataFrame)
+    assert df.columns.tolist() == QUALITY_REPORT_COLUMNS
     assert set(df["name"]) == {"name", "city"}
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -10,6 +10,7 @@ import pytest
 import arnio as ar
 from arnio.quality import (
     CleaningSuggestion,
+    QUALITY_REPORT_COLUMNS,
     _validate_gate_bool,
     _validate_gate_ratio_threshold,
     _validate_gate_threshold,
@@ -45,6 +46,58 @@ def test_report_summary_and_pandas_output(csv_with_whitespace):
     assert summary["columns_with_whitespace"] == ["name", "city"]
     assert isinstance(df, pd.DataFrame)
     assert set(df["name"]) == {"name", "city"}
+
+
+def test_report_to_pandas_uses_stable_columns_for_empty_report():
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[],
+    )
+
+    df = report.to_pandas()
+
+    assert df.columns.tolist() == QUALITY_REPORT_COLUMNS
+    assert df.shape == (0, len(QUALITY_REPORT_COLUMNS))
+
+
+def test_report_to_pandas_uses_stable_columns_when_all_columns_are_excluded():
+    frame = ar.from_pandas(pd.DataFrame({"id": [1, 2], "name": ["Alice", "Bob"]}))
+
+    report = ar.profile(frame, exclude_columns=["id", "name"])
+    df = report.to_pandas()
+
+    assert report.column_count == 0
+    assert report.columns == {}
+    assert df.columns.tolist() == QUALITY_REPORT_COLUMNS
+    assert df.shape == (0, len(QUALITY_REPORT_COLUMNS))
+
+
+def test_report_to_pandas_preserves_columns_and_values_for_normal_reports():
+    report = ar.profile(
+        ar.from_pandas(pd.DataFrame({"name": ["Alice", "Bob"], "score": [1.0, 2.0]}))
+    )
+
+    df = report.to_pandas()
+
+    assert df.columns.tolist() == QUALITY_REPORT_COLUMNS
+    assert df["name"].tolist() == ["name", "score"]
+
+    name_row = df.loc[df["name"] == "name"].iloc[0]
+    score_row = df.loc[df["name"] == "score"].iloc[0]
+
+    assert name_row["name"] == "name"
+    assert name_row["null_count"] == 0
+    assert pd.isna(name_row["q25"])
+    assert score_row["name"] == "score"
+    assert score_row["null_count"] == 0
+    assert score_row["min"] == 1.0
+    assert score_row["max"] == 2.0
+    assert pd.notna(score_row["q25"])
 
 
 def test_profile_numeric_quantiles():


### PR DESCRIPTION
DataQualityReport.to_pandas now explicitly returns an empty DataFrame with the declared quality-report schema when there are no profiled columns, while keeping the existing populated-row export path unchanged. The change is in quality.py.

Regression coverage now includes a direct empty report, a fully excluded report, and a normal populated report that preserves both column order and values in test_quality.py and test_quality.py.

closes #1668