### PR TITLE
fix: reject NaN/Infinity/-Infinity in read_jsonl with JsonlReadError line context

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1101,6 +1101,11 @@ def scan_csv(
         raise CsvReadError(str(e)) from None
 
 
+def _reject_non_finite(constant: str) -> None:
+    """Reject non-finite JSON constants (NaN, Infinity, -Infinity)."""
+    raise ValueError(f"Non-finite JSON constant not allowed: {constant!r}")
+
+
 def read_jsonl(
     path: str | os.PathLike[str],
     *,
@@ -1201,14 +1206,16 @@ def read_jsonl(
                 if nrows is not None and len(records) >= nrows:
                     break
                 try:
-                    obj = json.loads(line, object_pairs_hook=_reject_duplicate_keys)
+                    obj = json.loads(line, object_pairs_hook=_reject_duplicate_keys, parse_constant=_reject_non_finite)
                 except json.JSONDecodeError as exc:
                     raise JsonlReadError(
                         f"Invalid JSON on line {lineno} of {path!r}: {exc}"
                     ) from exc
                 except ValueError as exc:
+                    s = str(exc)
+                    prefix = "Duplicate key" if s.startswith("duplicate key") else "Invalid value"
                     raise JsonlReadError(
-                        f"Duplicate key on line {lineno} of {path!r}: {exc}"
+                        f"{prefix} on line {lineno} of {path!r}: {exc}"
                     ) from exc
                 if not isinstance(obj, dict):
                     raise JsonlReadError(

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1206,14 +1206,22 @@ def read_jsonl(
                 if nrows is not None and len(records) >= nrows:
                     break
                 try:
-                    obj = json.loads(line, object_pairs_hook=_reject_duplicate_keys, parse_constant=_reject_non_finite)
+                    obj = json.loads(
+                        line,
+                        object_pairs_hook=_reject_duplicate_keys,
+                        parse_constant=_reject_non_finite,
+                    )
                 except json.JSONDecodeError as exc:
                     raise JsonlReadError(
                         f"Invalid JSON on line {lineno} of {path!r}: {exc}"
                     ) from exc
                 except ValueError as exc:
                     s = str(exc)
-                    prefix = "Duplicate key" if s.startswith("duplicate key") else "Invalid value"
+                    prefix = (
+                        "Duplicate key"
+                        if s.startswith("duplicate key")
+                        else "Invalid value"
+                    )
                     raise JsonlReadError(
                         f"{prefix} on line {lineno} of {path!r}: {exc}"
                     ) from exc

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -415,3 +415,35 @@ class TestReadJsonlDuplicateKeys:
 
         with pytest.raises(ar.JsonlReadError):
             ar.read_jsonl(p)
+
+
+class TestReadJsonlNonFiniteConstants:
+    def test_nan_raises_jsonl_read_error(self, tmp_path):
+        p = tmp_path / "nan.jsonl"
+        p.write_text('{"x": NaN}\n', encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="line 1"):
+            ar.read_jsonl(p)
+
+    def test_infinity_raises_jsonl_read_error(self, tmp_path):
+        p = tmp_path / "inf.jsonl"
+        p.write_text('{"x": Infinity}\n', encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="line 1"):
+            ar.read_jsonl(p)
+
+    def test_negative_infinity_raises_jsonl_read_error(self, tmp_path):
+        p = tmp_path / "neginf.jsonl"
+        p.write_text('{"x": -Infinity}\n', encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="line 1"):
+            ar.read_jsonl(p)
+
+    def test_non_finite_error_includes_line_number(self, tmp_path):
+        p = tmp_path / "multi.jsonl"
+        p.write_text('{"x": 1}\n{"x": NaN}\n', encoding="utf-8")
+        with pytest.raises(ar.JsonlReadError, match="line 2"):
+            ar.read_jsonl(p)
+
+    def test_valid_jsonl_unaffected(self, tmp_path):
+        p = tmp_path / "valid.jsonl"
+        p.write_text('{"x": 1}\n{"x": 2}\n', encoding="utf-8")
+        frame = ar.read_jsonl(p)
+        assert frame.shape == (2, 1)


### PR DESCRIPTION
## Summary
`read_jsonl()` accepted `NaN`, `Infinity`, and `-Infinity` inconsistently — `NaN` was silently parsed as data, while `Infinity` leaked a raw `ValueError` without line context. Fixed by passing `parse_constant=_reject_non_finite` to `json.loads`, so all three constants are rejected at parse time and surfaced as `JsonlReadError` with the correct 1-based line number.

## Linked issue
Fixes #1943 

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] Python API / ArFrame

## Testing
-  `python -m pytest tests/test_jsonl.py -v` — all JSONL tests pass including 5 new non-finite constant tests
- `python -m pytest tests -v --tb=short` — 2786 passed, 54 skipped; 24 failures are pre-existing on main (C++ backend issues in CSV/frame/cleaning, unrelated to this change — verified by running the suite on the unmodified branch before applying this fix)
- `python -m ruff check .` — clean
- `python -m black --check .` — clean

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).