### PR TITLE
fix(convert): validate scalar values in from_dict

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -457,9 +457,7 @@ def from_dict(data: dict) -> ArFrame:
         unique_lengths = set(lengths.values())
 
         if len(unique_lengths) > 1:
-            details = ", ".join(
-                f"{name}={length}" for name, length in lengths.items()
-            )
+            details = ", ".join(f"{name}={length}" for name, length in lengths.items())
 
             raise ValueError(f"from_dict() column lengths differ: {details}")
 

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -434,23 +434,38 @@ def from_dict(data: dict) -> ArFrame:
         raise TypeError(f"Expected dict datatype but instead got {type(data).__name__}")
     if not all(isinstance(k, str) for k in data.keys()):
         raise TypeError("All dictionary keys must be strings")
+
     lengths = {}
 
     for col_name, value in data.items():
         if isinstance(value, dict):
             raise ValueError(f"Nested objects are not supported in column '{col_name}'")
 
-        if hasattr(value, "__len__") and not isinstance(value, (str, bytes)):
-            lengths[col_name] = len(value)
+        if isinstance(value, (str, bytes)):
+            raise TypeError(
+                f"Column '{col_name}' must be a sequence of values, not {type(value).__name__}"
+            )
+
+        if not hasattr(value, "__len__"):
+            raise TypeError(
+                f"Column '{col_name}' must be a sequence of values, not {type(value).__name__}"
+            )
+
+        lengths[col_name] = len(value)
 
     if lengths:
         unique_lengths = set(lengths.values())
 
         if len(unique_lengths) > 1:
-            details = ", ".join(f"{name}={length}" for name, length in lengths.items())
+            details = ", ".join(
+                f"{name}={length}" for name, length in lengths.items()
+            )
 
             raise ValueError(f"from_dict() column lengths differ: {details}")
+
     df = pd.DataFrame(data)
+
     for col_name in df.columns:
         _check_unsupported_dtype(col_name, df[col_name])
+
     return from_pandas(df)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -751,6 +751,55 @@ class TestFromPandas:
         assert result.shape == (2, 2)
         assert list(result.columns) == ["id", "name"]
 
+    def test_from_dict_rejects_scalar_value(self):
+        with pytest.raises(
+            TypeError,
+            match="Column 'a' must be a sequence of values",
+        ):
+            ar.from_dict({"a": 1})
+
+
+    def test_from_dict_rejects_mixed_scalar_and_list(self):
+        with pytest.raises(
+            TypeError,
+            match="Column 'b' must be a sequence of values",
+        ):
+            ar.from_dict(
+                {
+                    "a": [1, 2],
+                    "b": 3,
+                }
+            )
+
+
+    def test_from_dict_accepts_tuple_values(self):
+        frame = ar.from_dict(
+            {
+                "a": (1, 2),
+                "b": ("x", "y"),
+            }
+        )
+
+        result = ar.to_pandas(frame)
+
+        assert result.shape == (2, 2)
+
+
+    def test_from_dict_rejects_string_value(self):
+        with pytest.raises(
+            TypeError,
+            match="Column 'a' must be a sequence of values",
+        ):
+            ar.from_dict({"a": "abc"})
+
+
+    def test_from_dict_rejects_bytes_value(self):
+        with pytest.raises(
+            TypeError,
+            match="Column 'a' must be a sequence of values",
+        ):
+            ar.from_dict({"a": b"abc"})
+
 
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -758,7 +758,6 @@ class TestFromPandas:
         ):
             ar.from_dict({"a": 1})
 
-
     def test_from_dict_rejects_mixed_scalar_and_list(self):
         with pytest.raises(
             TypeError,
@@ -770,7 +769,6 @@ class TestFromPandas:
                     "b": 3,
                 }
             )
-
 
     def test_from_dict_accepts_tuple_values(self):
         frame = ar.from_dict(
@@ -784,14 +782,12 @@ class TestFromPandas:
 
         assert result.shape == (2, 2)
 
-
     def test_from_dict_rejects_string_value(self):
         with pytest.raises(
             TypeError,
             match="Column 'a' must be a sequence of values",
         ):
             ar.from_dict({"a": "abc"})
-
 
     def test_from_dict_rejects_bytes_value(self):
         with pytest.raises(

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -212,16 +212,22 @@ def test_length_mismatch_ArFrame():
 
 
 def test_scalar_dict():
-    # Pandas pd.DataFrame({"a": 1}) fails because it requires an index.
     data = {"name": "Alice", "age": 25}
-    with pytest.raises(ValueError):
+
+    with pytest.raises(
+        TypeError,
+        match="Column 'name' must be a sequence of values",
+    ):
         ar.from_dict(data)
 
 
 def test_scalar_dict_ArFrame():
-    # Pandas pd.DataFrame({"a": 1}) fails because it requires an index.
     data = {"name": "Alice", "age": 25}
-    with pytest.raises(ValueError):
+
+    with pytest.raises(
+        TypeError,
+        match="Column 'name' must be a sequence of values",
+    ):
         ar.ArFrame.from_dict(data)
 
 


### PR DESCRIPTION
## Summary

Validate column values in from_dict() before delegating to pandas.

This change rejects unsupported scalar column values and bare string/bytes values with an Arnio-owned TypeError, preventing inconsistent pandas behaviour such as scalar broadcasting and raw pandas exceptions. Valid sequence inputs such as lists and tuples continue to work unchanged.

## Linked issue

Fixes #1653

## Type of change

 [x] Bug fix
 [x] Tests

## Area

 [x] Python API / ArFrame

## Testing

 [x] python -m compileall arnio tests
 [x] python -m ruff check arnio/convert.py tests/test_convert.py

Added focused regression tests covering:

 all-scalar input
 mixed scalar/list input
 valid tuple values
 bare string values
 bare bytes values

## Contributor checklist

 [x] I kept the PR focused on one issue or one logical change.
 [x] I added or updated tests for behaviour changes.
 [x] My PR title uses Conventional Commits.