### PR TITLE
fix(a11y): respect reduced motion preference for anchor scrolling

### DIFF
--- a/website/js/main.js
+++ b/website/js/main.js
@@ -62,14 +62,21 @@
     // ── Smooth scroll for anchor links ───────────────────────
     document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
       anchor.addEventListener('click', function (e) {
-        const target = document.querySelector(this.getAttribute('href'));
-        if (target) {
-          e.preventDefault();
-          target.scrollIntoView({ behavior: 'smooth' });
-          // Update URL without triggering scroll
-          history.pushState(null, '', this.getAttribute('href'));
-        }
-      });
+  const target = document.querySelector(this.getAttribute('href'));
+
+  if (target) {
+    e.preventDefault();
+
+    const prefersReducedMotion =
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    target.scrollIntoView({
+      behavior: prefersReducedMotion ? 'auto' : 'smooth'
+    });
+
+    history.pushState(null, '', this.getAttribute('href'));
+  }
+});
     });
 
     // ── Sidebar active section tracking (docs pages) ─────────

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -62,21 +62,21 @@
     // ── Smooth scroll for anchor links ───────────────────────
     document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
       anchor.addEventListener('click', function (e) {
-  const target = document.querySelector(this.getAttribute('href'));
+        const target = document.querySelector(this.getAttribute('href'));
 
-  if (target) {
-    e.preventDefault();
+        if (target) {
+          e.preventDefault();
 
-    const prefersReducedMotion =
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+          const prefersReducedMotion =
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    target.scrollIntoView({
-      behavior: prefersReducedMotion ? 'auto' : 'smooth'
-    });
+          target.scrollIntoView({
+            behavior: prefersReducedMotion ? 'auto' : 'smooth'
+          });
 
-    history.pushState(null, '', this.getAttribute('href'));
-  }
-});
+          history.pushState(null, '', this.getAttribute('href'));
+        }
+      });
     });
 
     // ── Sidebar active section tracking (docs pages) ─────────


### PR DESCRIPTION
## Summary

Fixes #2172

Updated website anchor scrolling behavior to respect the user's `prefers-reduced-motion` setting.

## Changes

* Detect `prefers-reduced-motion: reduce` using `window.matchMedia`
* Use `scrollIntoView({ behavior: 'auto' })` when reduced motion is enabled
* Preserve existing smooth scrolling behavior for users who have not requested reduced motion

## Testing

* Verified anchor navigation still works correctly
* Verified smooth scrolling remains enabled by default
* Verified reduced-motion users receive non-animated anchor navigation
