### PR TITLE
docs: clarify duplicate header handling status

### DIFF
--- a/website/architecture.html
+++ b/website/architecture.html
@@ -85,7 +85,13 @@ Python ArFrame wrapper
       </div>
 
       <h2>Production hardening</h2>
-      <p>Recent releases fixed duplicate-header behavior, malformed CSV row handling, zero-column row-count preservation, duplicate column guards, JSONL <code>nrows</code> parsing, Windows clean targets, and clearer validation errors. These are reflected in the API and changelog pages.</p>
+      <p>
+Recent releases improved malformed CSV row handling, zero-column row-count
+preservation, duplicate column guards, JSONL <code>nrows</code> parsing,
+Windows clean targets, and validation error reporting. Duplicate CSV header
+handling remains an active area of improvement and is still being tracked
+through open issues and testing efforts.
+</p>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary

Fixes #2170

Updates the architecture page to accurately describe the current status of duplicate CSV header handling.

## Changes

* Removed wording that implied duplicate-header behavior is fully fixed
* Clarified that duplicate CSV header handling remains an active area of improvement
* Kept references to other production-hardening improvements already completed

## Testing

* Verified the architecture page content renders correctly
* Confirmed the updated wording aligns with the current project status and open issues
