### PR TITLE
Validate empty HTML report output paths

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -648,6 +648,8 @@ class DataQualityReport:
                 raise TypeError(
                     f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
                 )
+            if file_path == "":
+                raise ValueError("file_path must not be empty")
 
         redact_top_values = _validate_bool_option(
             redact_top_values, "redact_top_values"
@@ -677,7 +679,7 @@ class DataQualityReport:
             redact_top_values=redact_top_values,
             exclude_columns=validated_exclude,
         )
-        if file_path:
+        if file_path is not None:
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(html_out)
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1975,6 +1975,39 @@ def test_report_to_html_rejects_invalid_filepath_types():
             report.to_html(file_path=invalid_path)
 
 
+def test_report_to_html_rejects_empty_filepath():
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[],
+    )
+
+    with pytest.raises(ValueError, match="file_path must not be empty"):
+        report.to_html(file_path="")
+
+
+def test_report_to_html_writes_valid_pathlike_filepath(tmp_path):
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[],
+    )
+    out_path = tmp_path / "report.html"
+
+    result = report.to_html(file_path=out_path)
+
+    assert result == out_path.read_text(encoding="utf-8")
+    assert result.startswith("<!DOCTYPE html>")
+
+
 def test_report_to_html_limits_suggestions():
     report = ar.DataQualityReport(
         row_count=2,


### PR DESCRIPTION
## Summary

Fixed `DataQualityReport.to_html(file_path="")` so an explicitly empty output path now raises a clear `ValueError` instead of being treated like `file_path=None`. The write branch now checks `file_path is not None` after validation.

## Linked issue
fixes #1681 

## Type of change
- [ ] Bug fix
- [ ] Tests

## Area

- [ ] Data quality / profiling


## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

powershell
 -python -m py_compile arnio\quality.py tests\test_quality.py

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [ ] I read the contributing guide.
- [ ] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Focused change only: file_path=None still returns the HTML string, while file_path="" now fails clearly.
