### PR TITLE
Docs:  add pandas accessor examples for suggest_cleaning, auto_clean, and validate #2176

### DIFF
--- a/website/docs.html
+++ b/website/docs.html
@@ -180,6 +180,15 @@ yaml_text = ar.schema_to_yaml(schema)</code></pre></div>
 frame = df.arnio.to_arframe()
 profile = df.arnio.profile()
 
+suggestions = df.arnio.suggest_cleaning()
+clean = df.arnio.to_arframe()
+for step, params in suggestions:
+    clean = ar.pipeline(clean, [(step, params)])
+
+clean_df = df.arnio.auto_clean()
+
+result = df.arnio.validate({"email": ar.Email(nullable=False), "age": ar.Int64(min=0)})
+
 arrow_table = ar.to_arrow(frame)
 ar.register_duckdb(frame, conn, "clean_sales")</code></pre></div>
       </article>


### PR DESCRIPTION
Add practical pandas-first examples for the Arnio pandas accessor methods that were only listed in the API reference but not demonstrated in the Integrations section of the documentation.
- df.arnio.suggest_cleaning() - shows how to iterate suggestions
- df.arnio.auto_clean() - demonstrates automatic cleaning
- df.arnio.validate() - shows schema validation from pandas

Fixes #2176

Summary
Added practical pandas-first examples for the Arnio pandas accessor methods (suggest_cleaning, auto_clean, validate) that were only listed in the API reference but not demonstrated in the Integrations section of the documentation.

Linked issue
Fixes #2176

Type of change
- [x] Documentation Area
- [x] Docs / website Testing
- [x] Other: No code changes, so no tests required beyond documentation build.


Screenshots / Media
None


Performance Impact
None


Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (feat:, fix:, docs:, test:, refactor:, chore:).

Maintainer notes
None