### PR TITLE
Fix/website version v1.19.0

### DIFF
--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -15,7 +15,7 @@ Every issue that lands in our backlog gets categorized along key dimensions:
 5. **Type** — what kind of change it is
 6. **Area** — which part of the codebase it touches
 
-This makes the backlog navigable: a beginner GSSoC contributor can filter for `level:beginner` + `size: s` + `status: ready` and instantly find an entry point. Maintainers can spot `priority: critical` + `status: blocked` issues that need unblocking.
+This makes the backlog navigable: a beginner GSSoC contributor can filter for `level:beginner` + `size:s` + `status:ready` and instantly find an entry point. Maintainers can spot `priority:critical` + `status:blocked` issues that need unblocking.
 
 ---
 
@@ -27,10 +27,10 @@ How urgent is this issue?
 
 | Label | Meaning | Example |
 |:---|:---|:---|
-| `priority: critical` | Production-breaking bug, security issue, or release blocker. Drop everything. | A regression that crashes `read_csv()` on valid input |
-| `priority: high` | Important and time-sensitive. Should be picked up this week. | A documented public API returns wrong results for common case |
-| `priority: medium` | Solid improvement, not urgent. Pick up this milestone. | Add new pipeline step or improve an existing one |
-| `priority: low` | Nice-to-have. May sit in backlog for a while. | Tweak terminology in an internal log message |
+| `priority:critical` | Production-breaking bug, security issue, or release blocker. Drop everything. | A regression that crashes `read_csv()` on valid input |
+| `priority:high` | Important and time-sensitive. Should be picked up this week. | A documented public API returns wrong results for common case |
+| `priority:medium` | Solid improvement, not urgent. Pick up this milestone. | Add new pipeline step or improve an existing one |
+| `priority:low` | Nice-to-have. May sit in backlog for a while. | Tweak terminology in an internal log message |
 
 ---
 
@@ -53,10 +53,10 @@ How much effort will this take?
 
 | Label | Estimate | Typical scope |
 |:---|:---|:---|
-| `size: xs` | < 30 minutes | Single docstring, tiny fix, comment update |
-| `size: s` | < 2 hours | Single function, doc fix, small test addition |
-| `size: m` | Half a day | New pipeline step + tests, small refactor |
-| `size: l` | 1–2 days | New module, multi-file feature, schema validation |
+| `size:xs` | < 30 minutes | Single docstring, tiny fix, comment update |
+| `size:s` | < 2 hours | Single function, doc fix, small test addition |
+| `size:m` | Half a day | New pipeline step + tests, small refactor |
+| `size:l` | 1–2 days | New module, multi-file feature, schema validation |
 
 ---
 
@@ -85,21 +85,21 @@ Which part of the codebase does this touch?
 
 | Label | Covers |
 |:---|:---|
-| `area: csv-parser` | CSV reading, RFC 4180 compliance, BOM handling |
-| `area: cpp-core` | C++ runtime — types, columns, frames, cleaning engine |
-| `area: python-api` | Python API in `arnio/` — IO, pipeline, conversion |
-| `area: pipeline` | Step registry, pipeline executor, custom steps |
-| `area: cleaning` | Cleaning primitives — drop_nulls, fill_nulls, dedup, etc. |
-| `area: pandas-interop` | pandas bridge, zero-copy conversion, buffer protocol |
-| `area: quality` | Data quality engine, profiling, validation, suggestions |
-| `area: schema` | Schema definition, type casting, validation |
-| `area: docs` | README, architecture docs, guides, examples |
-| `area: website` | arnio.vercel.app, landing page, tutorials |
-| `area: ci-packaging` | GitHub Actions, PyPI wheels, releases |
-| `area: benchmarks` | Performance testing, reproduction scripts |
-| `area: examples` | Usage examples, notebooks, tutorials |
-| `area: developer-experience` | Error messages, CLI tooling, dev setup |
-| `area: release` | Version bumping, changelogs, deployment |
+| `area:csv-parser` | CSV reading, RFC 4180 compliance, BOM handling |
+| `area:cpp-core` | C++ runtime — types, columns, frames, cleaning engine |
+| `area:python-api` | Python API in `arnio/` — IO, pipeline, conversion |
+| `area:pipeline` | Step registry, pipeline executor, custom steps |
+| `area:cleaning` | Cleaning primitives — drop_nulls, fill_nulls, dedup, etc. |
+| `area:pandas-interop` | pandas bridge, zero-copy conversion, buffer protocol |
+| `area:quality` | Data quality engine, profiling, validation, suggestions |
+| `area:schema` | Schema definition, type casting, validation |
+| `area:docs` | README, architecture docs, guides, examples |
+| `area:website` | arnio.vercel.app, landing page, tutorials |
+| `area:ci-packaging` | GitHub Actions, PyPI wheels, releases |
+| `area:benchmarks` | Performance testing, reproduction scripts |
+| `area:examples` | Usage examples, notebooks, tutorials |
+| `area:developer-experience` | Error messages, CLI tooling, dev setup |
+| `area:release` | Version bumping, changelogs, deployment |
 
 ---
 
@@ -109,11 +109,11 @@ Where is the issue in the lifecycle?
 
 | Label | Meaning |
 |:---|:---|
-| `status: needs triage` | New issue, not yet categorized or scoped |
-| `status: ready` | Triaged, scoped, ready for a contributor to pick up |
-| `status: claimed` | Assigned and being actively worked on |
-| `status: blocked` | Cannot proceed — waiting on a decision, dependency, or upstream change |
-| `status: needs maintainer` | Requires maintainer decision or code review |
+| `status:needs-triage` | New issue, not yet categorized or scoped |
+| `status:ready` | Triaged, scoped, ready for a contributor to pick up |
+| `status:claimed` | Assigned and being actively worked on |
+| `status:blocked` | Cannot proceed — waiting on a decision, dependency, or upstream change |
+| `status:needs-maintainer` | Requires maintainer decision or code review |
 
 ---
 
@@ -125,7 +125,7 @@ For [GSSoC 2026](https://gssoc.girlscript.tech/) participants:
 |:---|:---|
 | `gssoc` | Issue is eligible for GSSoC contribution credit |
 | `gssoc:approved` | PR has been accepted/merged for GSSoC credit |
-| `gssoc: good first issue` | Strongly recommended starting point for new GSSoC contributors |
+| `gssoc:good-first-issue` | Strongly recommended starting point for new GSSoC contributors |
 | `level:beginner` | Beginner-tier scoring |
 | `level:intermediate` | Intermediate-tier scoring |
 | `level:advanced` | Advanced-tier scoring |
@@ -143,20 +143,20 @@ When a new issue arrives, work through these steps in order:
 
 ### 1. Read and reproduce
 
-- For bugs: try to reproduce locally. If the report lacks information, apply `status: needs triage` and ask for: OS, Python version, arnio version, minimal reproduction.
-- For feature requests: confirm the proposed behavior fits the project scope. If unclear, apply `status: needs triage` and start a discussion.
+- For bugs: try to reproduce locally. If the report lacks information, apply `status:needs-triage` and ask for: OS, Python version, arnio version, minimal reproduction.
+- For feature requests: confirm the proposed behavior fits the project scope. If unclear, apply `status:needs-triage` and start a discussion.
 
 ### 2. Categorize
 
 Apply labels from each required category:
 
-- ✅ `priority: *` (required)
+- ✅ `priority:*` (required)
 - ✅ `level:*` (required for GSSoC-scored issues/PRs)
-- ✅ `size: *` (required)
-- ✅ `status: *` (required — start with `status: needs triage`)
+- ✅ `size:*` (required)
+- ✅ `status:*` (required — start with `status:needs-triage`)
 - ✅ `type:*` (required)
-- ✅ `area: *` (one or more, required)
-- 🟡 `gssoc: *` (only if appropriate for GSSoC contributors)
+- ✅ `area:*` (one or more, required)
+- 🟡 `gssoc:*` (only if appropriate for GSSoC contributors)
 
 ### 3. Scope the issue
 
@@ -167,20 +167,20 @@ A well-triaged issue includes:
 - **Scope** — what's in and out of scope
 - **Acceptance criteria** — checkboxes the contributor can tick off
 
-If any of these are missing, keep the issue at `status: needs triage`.
+If any of these are missing, keep the issue at `status:needs-triage`.
 
 ### 4. Set status and assign
 
-- Move to `status: ready` once the issue is fully scoped and ready for pickup
-- Move to `status: claimed` when a contributor is assigned
-- Move to `status: blocked` if external dependencies appear during work
-- Use `status: needs maintainer` if you need another maintainer's input
+- Move to `status:ready` once the issue is fully scoped and ready for pickup
+- Move to `status:claimed` when a contributor is assigned
+- Move to `status:blocked` if external dependencies appear during work
+- Use `status:needs-maintainer` if you need another maintainer's input
 
 ---
 
 ### 5. Remove status and reassign inactive issues
 
-- Remove `status: claimed` when a contributor does not post a progress update, request a time extension or open a draft/regular PR within 3 days of assignment.
+- Remove `status:claimed` when a contributor does not post a progress update, request a time extension or open a draft/regular PR within 3 days of assignment.
 - Unassign or reassign the issue to someone else if the contributor remains inactive after 5 days of no PR, no update or no extension request.
 
 ## Worked Example
@@ -191,12 +191,12 @@ If any of these are missing, keep the issue at `status: needs triage`.
 
 | Label | Value | Reasoning |
 |:---|:---|:---|
-| Priority | `priority: high` | Performance is a roadmap focus for v1.2 |
+| Priority | `priority:high` | Performance is a roadmap focus for v1.2 |
 | Level | `level:advanced` | Requires C++ work in the cleaning engine |
-| Size | `size: l` | Hash-based comparison replacement is multi-file |
-| Status | `status: ready` | Reproducible, well-scoped, fix path is clear |
+| Size | `size:l` | Hash-based comparison replacement is multi-file |
+| Status | `status:ready` | Reproducible, well-scoped, fix path is clear |
 | Type | `type:performance` | Performance improvement |
-| Area | `area: cpp-core` | Lives in `cpp/src/cleaning.cpp` |
+| Area | `area:cpp-core` | Lives in `cpp/src/cleaning.cpp` |
 | GSSoC | `level:advanced` | Advanced-tier scoring if a GSSoC contributor picks it up |
 
 ---
@@ -205,13 +205,13 @@ If any of these are missing, keep the issue at `status: needs triage`.
 
 When in doubt, default to:
 
-- **Priority** → `priority: medium`
+- **Priority** → `priority:medium`
 - **Level** → match the actual code complexity, not the issue description length
 - **Size** → estimate as a maintainer would do it, not as a beginner would
-- **Status** → start at `status: needs triage` if anything is unclear; promote to `status: ready` once scoped
+- **Status** → start at `status:needs-triage` if anything is unclear; promote to `status:ready` once scoped
 - **Type** → `type:discussion` if direction is unclear
 
-For consistency, every issue should reach `status: ready` before being advertised as a good first issue or GSSoC pickup.
+For consistency, every issue should reach `status:ready` before being advertised as a good first issue or GSSoC pickup.
 
 ---
 

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -74,7 +74,7 @@ What kind of change is this?
 | `type:performance` | Speed or memory improvements |
 | `type:security` | Security fix or hardening |
 | `type:design` | Visual, docs-layout, logo, or product design work |
-| `type:ci` | GitHub Actions, build pipeline, release tooling |
+| `type:devops` | GitHub Actions, build pipeline, release tooling |
 | `type:discussion` | Needs community input before implementation |
 
 ---

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 Static website for Arnio documentation, API reference, release notes, benchmarks, roadmap, architecture, community, and contributor guidance.
 
-The current content is aligned with the latest published release `v1.18.0` and post-release `origin/main` changes that are marked as current-main or unreleased.
+The current content is aligned with the latest published release `v1.19.0` and post-release `origin/main` changes that are marked as current-main or unreleased.
 
 Run locally from the repository root:
 

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -110,7 +110,7 @@ Python ArFrame wrapper
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -99,7 +99,7 @@ python benchmarks/benchmark_auto_clean_memory.py --rows 100000</code></pre></div
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Changelog — Arnio</title>
-  <meta name="description" content="Arnio changelog covering current main, v1.18.0, v1.17.1, and v1.17.0.">
+  <meta name="description" content="Arnio changelog covering current main, v1.19.0, v1.18.0, v1.17.1, and v1.17.0.">
   <link rel="icon" type="image/svg+xml" href="updated-icon.svg">
   <link rel="stylesheet" href="css/variables.css?v=20260522">
   <link rel="stylesheet" href="css/base.css?v=20260522">
@@ -27,7 +27,7 @@
   <nav class="top-nav" aria-label="Main navigation"><div class="container container--wide"><a href="index.html" class="nav-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32"></a><ul class="nav-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="contributing.html">Contributing</a></li><li><a href="architecture.html">Architecture</a></li><li><a href="roadmap.html">Roadmap</a></li><li><a href="community.html">Community</a></li><li><a href="changelog.html">Changelog</a></li></ul><div class="nav-actions"><a href="https://discord.gg/xsEw7r78M" class="nav-discord" target="_blank" rel="noopener">Discord</a><a href="https://github.com/im-anishraj/arnio" class="nav-github" target="_blank" rel="noopener">GitHub</a><button class="theme-toggle" aria-label="Toggle theme">Theme</button><button class="nav-hamburger" aria-label="Open menu" aria-expanded="false">☰</button></div></div></nav>
   <div class="mobile-menu" aria-label="Mobile navigation"><a href="index.html">Home</a><a href="docs.html">Documentation</a><a href="api.html">API Reference</a><a href="benchmarks.html">Benchmarks</a><a href="contributing.html">Contributing</a><a href="architecture.html">Architecture</a><a href="roadmap.html">Roadmap</a><a href="community.html">Community</a><a href="https://discord.gg/xsEw7r78M" target="_blank" rel="noopener">Discord</a><a href="changelog.html">Changelog</a></div>
 
-  <header class="page-hero"><div class="container"><h1>Changelog</h1><p>Latest published release: v1.18.0. Current main also contains unreleased documentation, quality, frame, and benchmark updates.</p></div></header>
+  <header class="page-hero"><div class="container"><h1>Changelog</h1><p>Latest published release: v1.19.0. Current main also contains unreleased documentation, quality, frame, and benchmark updates.</p></div></header>
 
   <main id="main-content" class="main-content">
     <div class="container">
@@ -122,7 +122,7 @@
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/community.html
+++ b/website/community.html
@@ -94,7 +94,7 @@
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/contributing.html
+++ b/website/contributing.html
@@ -114,7 +114,7 @@ ar.register_step("trim_customer_id", trim_customer_id, overwrite=True)</code></p
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/docs.html
+++ b/website/docs.html
@@ -207,7 +207,7 @@ ar.register_duckdb(frame, conn, "clean_sales")</code></pre></div>
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/index.html
+++ b/website/index.html
@@ -58,7 +58,7 @@
         <div class="hero-actions">
           <a href="docs.html" class="btn btn-primary btn-lg">Read the docs</a>
           <a href="api.html" class="btn btn-secondary btn-lg">View API</a>
-          <a href="https://pypi.org/project/arnio/" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">PyPI v1.18.0</a>
+          <a href="https://pypi.org/project/arnio/" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">PyPI v1.19.0</a>
         </div>
         <div class="hero-install" data-cmd="pip install arnio" role="button" tabindex="0" aria-label="Copy install command">
           <span class="dollar">$</span><span>pip install arnio</span><span class="copy-hint">click to copy</span>
@@ -74,13 +74,13 @@
     <section class="section">
       <div class="container">
         <div class="release-strip">
-          <div><span class="release-kicker">Latest release</span><span class="release-value">v1.18.0</span></div>
+          <div><span class="release-kicker">Latest release</span><span class="release-value">v1.19.0</span></div>
           <div><span class="release-kicker">Runtime</span><span class="release-value">Python 3.9+</span></div>
           <div><span class="release-kicker">Core</span><span class="release-value">C++ + pybind11</span></div>
           <div><span class="release-kicker">Current main</span><span class="release-value">Unreleased updates</span></div>
         </div>
         <h2>What Arnio ships today</h2>
-        <p class="section-lede">The website now reflects the release train through v1.18.0 and the merged work currently on main after that release.</p>
+        <p class="section-lede">The website now reflects the release train through v1.19.0 and the merged work currently on main after that release.</p>
         <div class="feature-list">
           <article class="card">
             <h3>Hardened CSV I/O</h3>
@@ -135,7 +135,7 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
     <section class="section">
       <div class="container">
         <h2>Current main / unreleased</h2>
-        <p class="section-lede">These changes are already merged after v1.18.0 and should be treated as upcoming release notes.</p>
+        <p class="section-lede">These changes are already merged after v1.19.0 and should be treated as upcoming release notes.</p>
         <div class="grid grid-3">
           <div class="card"><h3>Frame ergonomics</h3><p><code>ArFrame.__getitem__</code> column selection, <code>ArFrame.drop_columns</code>, and stronger tuple-key replacement handling.</p></div>
           <div class="card"><h3>Quality exports</h3><p><code>profile(exclude_columns=...)</code>, <code>DataQualityReport.to_dict(exclude_columns=...)</code>, and <code>DataQualityReport.to_json()</code>.</p></div>
@@ -151,7 +151,7 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
           <a href="docs.html" class="quick-link-card"><div><h4 class="card-title">Documentation</h4><p class="card-desc">Install, read, clean, validate, export, and integrate.</p></div></a>
           <a href="api.html" class="quick-link-card"><div><h4 class="card-title">API Reference</h4><p class="card-desc">Current public functions, classes, and options.</p></div></a>
           <a href="benchmarks.html" class="quick-link-card"><div><h4 class="card-title">Benchmarks</h4><p class="card-desc">Reproducible benchmark commands and CI checks.</p></div></a>
-          <a href="changelog.html" class="quick-link-card"><div><h4 class="card-title">Changelog</h4><p class="card-desc">v1.18.0 plus current-main changes.</p></div></a>
+          <a href="changelog.html" class="quick-link-card"><div><h4 class="card-title">Changelog</h4><p class="card-desc">v1.19.0 plus current-main changes.</p></div></a>
         </div>
       </div>
     </section>
@@ -178,7 +178,7 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -102,7 +102,7 @@
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>


### PR DESCRIPTION
## Summary
Update all user-facing latest-release version references in `website/` 
from `v1.18.0` to `v1.19.0`. PyPI already published v1.19.0 on 
May 28, 2026 but the website still showed v1.18.0 as the latest release 
across all pages.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #2115

## Type of change
✅  Documentation
 

## Area
✅ Docs / website
 

## Testing
Ran grep verification in Git Bash to confirm zero stale references remain:

grep -rn "Latest release: v1\.18\.0" website/
grep -rn "PyPI v1\.18\.0" website/
grep -rn "latest published release.*v1\.18\.0" website/ -i

All three returned blank output — no stale v1.18.0 latest-release 
references remain anywhere in website/.

## Screenshots / Media
No UI layout changes. Only version text updated.

## Performance Impact
No performance impact. Static text change only.

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
 
✅I read the contributing guide.
✅ I kept the PR focused on one issue or one logical change.
✅ I checked that generated files, logs, and local build artifacts are not committed.
✅ My PR title uses Conventional Commits (docs:)

## Maintainer notes
Historical references such as "Added in v1.18.0" in api.html, the 
v1.18.0 changelog entry block, and roadmap history entries are 
intentionally preserved as accurate historical records. Only 
user-facing "latest release" strings were updated.
No Python code, package metadata, release logic, or generated 
files were touched.