### PR TITLE
docs(website): update latest-release references from v1.18.0 to v1.19.0

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 Static website for Arnio documentation, API reference, release notes, benchmarks, roadmap, architecture, community, and contributor guidance.
 
-The current content is aligned with the latest published release `v1.18.0` and post-release `origin/main` changes that are marked as current-main or unreleased.
+The current content is aligned with the latest published release `v1.19.0` and post-release `origin/main` changes that are marked as current-main or unreleased.
 
 Run locally from the repository root:
 

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -116,7 +116,7 @@ through open issues and testing efforts.
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -99,7 +99,7 @@ python benchmarks/benchmark_auto_clean_memory.py --rows 100000</code></pre></div
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -32,7 +32,7 @@
   <main id="main-content" class="main-content">
     <div class="container">
       <article class="changelog-entry">
-        <div class="changelog-entry-header"><span class="changelog-entry-version">Current main</span><span class="badge badge-warning">Unreleased</span><span class="changelog-entry-date">after v1.18.0</span></div>
+        <div class="changelog-entry-header"><span class="changelog-entry-version">Current main</span><span class="badge badge-warning">Unreleased</span><span class="changelog-entry-date">after v1.19.0</span></div>
         <div class="changelog-entry-body">
           <h3>Added</h3>
           <ul>
@@ -49,8 +49,18 @@
         </div>
       </article>
 
+       <article class="changelog-entry">
+        <div class="changelog-entry-header"><span class="changelog-entry-version">v1.19.0</span><span class="badge badge-success">Latest release</span><span class="changelog-entry-date">2026-05-28</span></div>
+        <div class="changelog-entry-body">
+          <h3>Documentation</h3>
+          <ul>
+            <li>Updated website latest-release references from v1.18.0 to v1.19.0 across all pages.</li>
+          </ul>
+        </div>
+      </article>
+
       <article class="changelog-entry">
-        <div class="changelog-entry-header"><span class="changelog-entry-version">v1.18.0</span><span class="badge badge-success">Latest release</span><span class="changelog-entry-date">2026-05-22</span></div>
+        <div class="changelog-entry-header"><span class="changelog-entry-version">v1.18.0</span><span class="badge badge-success">Released</span><span class="changelog-entry-date">2026-05-22</span></div>
         <div class="changelog-entry-body">
           <h3>Features</h3>
           <ul>

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Changelog — Arnio</title>
-  <meta name="description" content="Arnio changelog covering current main, v1.18.0, v1.17.1, and v1.17.0.">
+  <meta name="description" content="Arnio changelog covering current main, v1.19.0, v1.18.0, v1.17.1, and v1.17.0.">
   <link rel="icon" type="image/svg+xml" href="updated-icon.svg">
   <link rel="stylesheet" href="css/variables.css?v=20260522">
   <link rel="stylesheet" href="css/base.css?v=20260522">
@@ -27,7 +27,7 @@
   <nav class="top-nav" aria-label="Main navigation"><div class="container container--wide"><a href="index.html" class="nav-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32"></a><ul class="nav-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="contributing.html">Contributing</a></li><li><a href="architecture.html">Architecture</a></li><li><a href="roadmap.html">Roadmap</a></li><li><a href="community.html">Community</a></li><li><a href="changelog.html">Changelog</a></li></ul><div class="nav-actions"><a href="https://discord.gg/xsEw7r78M" class="nav-discord" target="_blank" rel="noopener">Discord</a><a href="https://github.com/im-anishraj/arnio" class="nav-github" target="_blank" rel="noopener">GitHub</a><button class="theme-toggle" aria-label="Toggle theme">Theme</button><button class="nav-hamburger" aria-label="Open menu" aria-expanded="false">☰</button></div></div></nav>
   <div class="mobile-menu" aria-label="Mobile navigation"><a href="index.html">Home</a><a href="docs.html">Documentation</a><a href="api.html">API Reference</a><a href="benchmarks.html">Benchmarks</a><a href="contributing.html">Contributing</a><a href="architecture.html">Architecture</a><a href="roadmap.html">Roadmap</a><a href="community.html">Community</a><a href="https://discord.gg/xsEw7r78M" target="_blank" rel="noopener">Discord</a><a href="changelog.html">Changelog</a></div>
 
-  <header class="page-hero"><div class="container"><h1>Changelog</h1><p>Latest published release: v1.18.0. Current main also contains unreleased documentation, quality, frame, and benchmark updates.</p></div></header>
+  <header class="page-hero"><div class="container"><h1>Changelog</h1><p>Latest published release: v1.19.0. Current main also contains unreleased documentation, quality, frame, and benchmark updates.</p></div></header>
 
   <main id="main-content" class="main-content">
     <div class="container">
@@ -122,7 +122,7 @@
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/community.html
+++ b/website/community.html
@@ -94,7 +94,7 @@
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/contributing.html
+++ b/website/contributing.html
@@ -114,7 +114,7 @@ ar.register_step("trim_customer_id", trim_customer_id, overwrite=True)</code></p
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/docs.html
+++ b/website/docs.html
@@ -216,7 +216,7 @@ ar.register_duckdb(frame, conn, "clean_sales")</code></pre></div>
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/index.html
+++ b/website/index.html
@@ -58,7 +58,7 @@
         <div class="hero-actions">
           <a href="docs.html" class="btn btn-primary btn-lg">Read the docs</a>
           <a href="api.html" class="btn btn-secondary btn-lg">View API</a>
-          <a href="https://pypi.org/project/arnio/" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">PyPI v1.18.0</a>
+          <a href="https://pypi.org/project/arnio/" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">PyPI v1.19.0</a>
         </div>
         <div class="hero-install" data-cmd="pip install arnio" role="button" tabindex="0" aria-label="Copy install command">
           <span class="dollar">$</span><span>pip install arnio</span><span class="copy-hint">click to copy</span>
@@ -74,13 +74,13 @@
     <section class="section">
       <div class="container">
         <div class="release-strip">
-          <div><span class="release-kicker">Latest release</span><span class="release-value">v1.18.0</span></div>
+          <div><span class="release-kicker">Latest release</span><span class="release-value">v1.19.0</span></div>
           <div><span class="release-kicker">Runtime</span><span class="release-value">Python 3.9+</span></div>
           <div><span class="release-kicker">Core</span><span class="release-value">C++ + pybind11</span></div>
           <div><span class="release-kicker">Current main</span><span class="release-value">Unreleased updates</span></div>
         </div>
         <h2>What Arnio ships today</h2>
-        <p class="section-lede">The website now reflects the release train through v1.18.0 and the merged work currently on main after that release.</p>
+        <p class="section-lede">The website now reflects the release train through v1.19.0 and the merged work currently on main after that release.</p>
         <div class="feature-list">
           <article class="card">
             <h3>Hardened CSV I/O</h3>
@@ -135,7 +135,7 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
     <section class="section">
       <div class="container">
         <h2>Current main / unreleased</h2>
-        <p class="section-lede">These changes are already merged after v1.18.0 and should be treated as upcoming release notes.</p>
+        <p class="section-lede">These changes are already merged after v1.19.0 and should be treated as upcoming release notes.</p>
         <div class="grid grid-3">
           <div class="card"><h3>Frame ergonomics</h3><p><code>ArFrame.__getitem__</code> column selection, <code>ArFrame.drop_columns</code>, and stronger tuple-key replacement handling.</p></div>
           <div class="card"><h3>Quality exports</h3><p><code>profile(exclude_columns=...)</code>, <code>DataQualityReport.to_dict(exclude_columns=...)</code>, and <code>DataQualityReport.to_json()</code>.</p></div>
@@ -151,7 +151,7 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
           <a href="docs.html" class="quick-link-card"><div><h4 class="card-title">Documentation</h4><p class="card-desc">Install, read, clean, validate, export, and integrate.</p></div></a>
           <a href="api.html" class="quick-link-card"><div><h4 class="card-title">API Reference</h4><p class="card-desc">Current public functions, classes, and options.</p></div></a>
           <a href="benchmarks.html" class="quick-link-card"><div><h4 class="card-title">Benchmarks</h4><p class="card-desc">Reproducible benchmark commands and CI checks.</p></div></a>
-          <a href="changelog.html" class="quick-link-card"><div><h4 class="card-title">Changelog</h4><p class="card-desc">v1.18.0 plus current-main changes.</p></div></a>
+          <a href="changelog.html" class="quick-link-card"><div><h4 class="card-title">Changelog</h4><p class="card-desc">v1.19.0 plus current-main changes.</p></div></a>
         </div>
       </div>
     </section>
@@ -178,7 +178,7 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>

--- a/website/roadmap.html
+++ b/website/roadmap.html
@@ -102,7 +102,7 @@
             </a>
           </li></ul></div>
       </div>
-      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
+      <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
   <script src="js/main.js"></script>


### PR DESCRIPTION
Supersedes #2184 (rebased to remove unrelated commits)
## Summary
Update all user-facing latest-release version references in `website/` from `v1.18.0` to `v1.19.0`. PyPI already published v1.19.0 on May 28, 2026 but the website still showed v1.18.0 as the latest release across all pages.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #2115

## Type of change
✅  Documentation

## Area
✅ Docs/website
 

## Testing
Ran grep verification in Git Bash to confirm zero stale references remain:

grep -rn "Latest release: v1\.18\.0" website/
grep -rn "PyPI v1\.18\.0" website/
grep -rn "latest published release.*v1\.18\.0" website/ -i

All three returned blank output — no stale v1.18.0 latest-release 
references remain anywhere in website/.

## Screenshots / Media
 No UI layout changes. Only version text updated.

## Performance Impact
No performance impact. Static text change only.

## GSSoC labels
 

## Contributor checklist
✅ I read the contributing guide.
✅  I kept the PR focused on one issue or one logical change.
✅  I checked that generated files, logs, and local build artifacts are not committed.
✅  My PR title uses Conventional Commits (docs:)

## Maintainer notes
Historical references such as "Added in v1.18.0" in api.html, the 
v1.18.0 changelog entry block, and roadmap history entries are 
intentionally preserved as accurate historical records. Only 
user-facing "latest release" strings were updated.
No Python code, package metadata, release logic, or generated 
files were touched.
