### PR TITLE
fix: add context to custom validator errors

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2563,7 +2563,12 @@ def _validate_column(
             else:
                 invalid = non_null[
                     ~non_null.map(
-                        lambda v: _normalize_validator_result(fn(v), validator_name)
+                        lambda v: _run_custom_validator(
+                            fn,
+                            v,
+                            column=name,
+                            validator_name=validator_name,
+                        )
                     )
                 ]
                 issues.extend(
@@ -3008,6 +3013,24 @@ def _normalize_validator_result(result: object, validator_name: str) -> bool:
         f"{type(result).__name__!r} ({result!r}); "
         "validators must return True (pass) or False (fail)."
     )
+
+
+def _run_custom_validator(
+    fn: Callable[[Any], object],
+    value: Any,
+    *,
+    column: str,
+    validator_name: str,
+) -> bool:
+    """Run a registered custom validator and add schema context on failure."""
+    try:
+        result = fn(value)
+    except Exception as exc:
+        raise ArnioError(
+            f"Custom validator {validator_name!r} failed for column "
+            f"{column!r} with value {value!r}: {exc}"
+        ) from exc
+    return _normalize_validator_result(result, validator_name)
 
 
 def Custom(

--- a/tests/test_register_validator.py
+++ b/tests/test_register_validator.py
@@ -318,6 +318,25 @@ class TestCustomValidatorReturnNormalization:
         with pytest.raises(TypeError, match="returns_str"):
             ar.validate(frame, {"x": ar.Custom("returns_str")})
 
+    def test_validator_exception_includes_schema_context(self):
+        """A validator exception is wrapped with column and validator context."""
+
+        def raises_for_value(value):
+            raise RuntimeError(f"bad value: {value}")
+
+        register_validator("raises_for_value", raises_for_value)
+        frame = ar.from_pandas(pd.DataFrame({"score": [42]}))
+
+        with pytest.raises(ar.ArnioError) as exc_info:
+            ar.validate(frame, {"score": ar.Custom("raises_for_value")})
+
+        message = str(exc_info.value)
+        assert "raises_for_value" in message
+        assert "score" in message
+        assert "42" in message
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert str(exc_info.value.__cause__) == "bad value: 42"
+
     def test_mixed_true_false_none_pd_na(self):
         """Mixed True/False/None/pd.NA: only True rows pass, others fail."""
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2866,7 +2866,7 @@ def test_register_validator_raises_for_empty_name():
         raise AssertionError("Expected ValueError for empty name")
 
 
-def test_custom_validator_exceptions_propagate(tmp_path):
+def test_custom_validator_exceptions_include_schema_context(tmp_path):
     def broken_validator(value):
         raise RuntimeError("validator exploded")
 
@@ -2875,13 +2875,17 @@ def test_custom_validator_exceptions_propagate(tmp_path):
     path = tmp_path / "scores.csv"
     path.write_text("score\n1\n")
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(ar.ArnioError) as exc:
         ar.validate(
             ar.read_csv(path),
             {"score": ar.Custom("broken")},
         )
 
-    assert "validator exploded" in str(exc.value)
+    message = str(exc.value)
+    assert "broken" in message
+    assert "score" in message
+    assert "validator exploded" in message
+    assert isinstance(exc.value.__cause__, RuntimeError)
 
 
 def test_schema_rules_multiple_rules_all_run(tmp_path):


### PR DESCRIPTION
Fixes #2111

This PR keeps the change scoped to the custom-validator exception path in schema validation.

What changed:
- Added a small helper around registered custom validator execution.
- If the validator itself raises, the error is wrapped with the custom validator name, column name, and offending value.
- Preserves the original validator exception as `__cause__`.
- Leaves existing True/False/None/pd.NA and invalid return-value behavior unchanged.
- Added regression coverage in `tests/test_register_validator.py`.
- Updated the existing schema test that previously asserted raw exception propagation.

Validation:
- `.venv-codex/bin/python -m pytest tests/test_register_validator.py -q`
- `.venv-codex/bin/python -m pytest tests/test_schema.py tests/test_register_validator.py -q`
- `.venv-codex/bin/ruff check arnio/schema.py tests/test_register_validator.py tests/test_schema.py`
- `BLACK_NUM_WORKERS=1 .venv-codex/bin/black --check arnio/schema.py tests/test_register_validator.py tests/test_schema.py`
- `git diff --check`

This is for GSSoC 2026 and stays limited to the assigned schema bug.
