### PR TITLE
perf: vectorize date semantic validation

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -11,7 +11,6 @@ import re
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any, Callable
 from zoneinfo import available_timezones
 
@@ -2599,19 +2598,16 @@ def _validate_column(
                 )
             else:
                 if field_def.semantic == "date":
-                    invalid_values = []
-                    for index, value in non_null.items():
-                        value_str = str(value)
-                        if DATE_PATTERN.fullmatch(value_str) is None:
-                            invalid_values.append((index, value))
-                            continue
-                        try:
-                            datetime.strptime(value_str, "%Y-%m-%d")
-                        except ValueError:
-                            invalid_values.append((index, value))
-                    invalid = pd.Series(
-                        {index: value for index, value in invalid_values}
+                    values_as_text = non_null.astype("string")
+                    format_valid = values_as_text.str.fullmatch(
+                        DATE_PATTERN.pattern, na=False
                     )
+                    parsed = pd.to_datetime(
+                        values_as_text.where(format_valid),
+                        format="%Y-%m-%d",
+                        errors="coerce",
+                    )
+                    invalid = non_null[~(format_valid & parsed.notna())]
                 elif field_def.semantic == "country_code":
                     values = (
                         non_null.str.upper()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2555,6 +2555,25 @@ def test_date_validation_rejects_non_zero_padded_dates(tmp_path):
     assert "date" in rules
 
 
+def test_date_validation_reports_only_invalid_vectorized_values(tmp_path):
+    path = tmp_path / "mixed_dates.csv"
+    path.write_text(
+        "created_at\n" "2026-05-15\n" "2026-02-30\n" "2026-5-15\n" "2024-02-29\n"
+    )
+
+    result = ar.validate(
+        ar.read_csv(path),
+        {"created_at": ar.Date(nullable=False)},
+    )
+
+    assert not result.passed
+    assert [(issue.row_index, issue.value) for issue in result.issues] == [
+        (2, "2026-02-30"),
+        (3, "2026-5-15"),
+    ]
+    assert {issue.rule for issue in result.issues} == {"date"}
+
+
 def test_required_if_validation_passes_when_condition_matches(tmp_path):
     path = tmp_path / "conditional_pass.csv"
     path.write_text("user_type,country\n" "international,IN\n" "local,\n")


### PR DESCRIPTION
Fixes #2060

This PR keeps the change scoped to `semantic == "date"` validation in `arnio/schema.py`.

What changed:
- Replaced the per-value Python loop using `DATE_PATTERN.fullmatch(...)` and `datetime.strptime(...)` with a vectorized path.
- Keeps the same accepted contract: strict zero-padded `YYYY-MM-DD` strings only.
- Still rejects impossible calendar dates such as `2026-02-30`.
- Preserves invalid row indexes and original values in `ValidationIssue` output.
- Leaves nullable handling and the emitted `date` rule unchanged.
- Added regression coverage for mixed valid/invalid date values, including leap-day, impossible date, and non-zero-padded date cases.

Local timing note:
- On a local 200,002-row Series with two invalid values, the old loop took `2.6778s`; the vectorized path took `0.1107s`, with identical invalid rows returned.

Validation:
- `.venv-codex/bin/python -m pytest tests/test_schema.py -q -k "date_validation"`
- `.venv-codex/bin/python -m pytest tests/test_schema.py -q`
- `.venv-codex/bin/ruff check arnio/schema.py tests/test_schema.py`
- `BLACK_NUM_WORKERS=1 .venv-codex/bin/black --check arnio/schema.py tests/test_schema.py`
- `git diff --check`

This is for GSSoC 2026 and stays limited to the assigned schema performance issue.
