### PR TITLE
docs: Update README with current active URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2022,7 +2022,7 @@ arnio/
 ├── tests/                   # pytest suite — CSV, cleaning, pipeline, conversions
 ├── benchmarks/              # Reproducible arnio vs pandas benchmark
 ├── examples/                # basic_usage.py, auto_clean_tutorial.py, custom_step.py and ready to run recipes for sales, customers, survey, logs, finance
-└── website/                 # Project website — arniolib.vercel.app
+└── website/                 # Project website — arnio.vercel.app
 ```
 
 <br>
@@ -2047,7 +2047,7 @@ arnio/
 <a href="https://pypi.org/project/arnio/"><img src="https://img.shields.io/pypi/dm/arnio?style=flat-square&logo=pypi&logoColor=white&labelColor=0d1117&color=3572A5&label=installs" alt="Downloads"></a>&ensp;
 <a href="https://github.com/im-anishraj/arnio/stargazers"><img src="https://img.shields.io/github/stars/im-anishraj/arnio?style=flat-square&logo=github&labelColor=0d1117&color=e3b341&label=stars" alt="Stars"></a>&ensp;
 <a href="https://github.com/im-anishraj/arnio/network/members"><img src="https://img.shields.io/github/forks/im-anishraj/arnio?style=flat-square&logo=github&labelColor=0d1117&color=8b949e&label=forks" alt="Forks"></a>&ensp;
-<a href="https://arniolib.vercel.app/"><img src="https://img.shields.io/badge/website-arniolib.vercel.app-blue?style=flat-square&labelColor=0d1117" alt="Website"></a>&ensp;
+<a href="https://arnio.vercel.app/"><img src="https://img.shields.io/badge/website-arnio.vercel.app-blue?style=flat-square&labelColor=0d1117" alt="Website"></a>&ensp;
 <a href="https://discord.gg/xsEw7r78M"><img src="https://img.shields.io/badge/community-Discord-5865F2?style=flat-square&logo=discord&logoColor=white&labelColor=0d1117" alt="Discord"></a>
 
 <br>


### PR DESCRIPTION
## Summary
Replace two stale `arniolib.vercel.app` references in `README.md` with the current canonical URL `arnio.vercel.app`, consistent with the Open Graph/Twitter metadata used across `website/index.html`, `website/docs.html`, and `website/api.html`.

## Linked issue
Fixes #1748

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
No code changes — docs-only fix. Manually verified:
- Searched `README.md` for `arniolib.vercel.app` → 0 results after fix
- Confirmed badge link and label both resolve to `https://arnio.vercel.app/`
- [ ] Other: grep search to confirm no remaining stale references

## Screenshots / Media
N/A — no visual changes beyond the badge URL update.

## Performance Impact
None.

## GSSoC labels
<!-- Maintainers only -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`docs: fix stale arniolib.vercel.app URL in README`).

## Maintainer notes
Two-line diff, `README.md` only. No logic, no tests, no API surface affected.