### PR TITLE
fix(website): fix code highlighter corrupting copied Python snippets

### DIFF
--- a/website/js/code.js
+++ b/website/js/code.js
@@ -100,35 +100,69 @@
     }
 
     // ── Minimal syntax highlighting ──────────────────────────
+    //
+    // The previous implementation read block.innerHTML and ran keyword regexes
+    // over it.  Because the injected <span> tags contain attributes like
+    // class="token-keyword", subsequent keyword passes (e.g. "class", "in")
+    // matched inside those attribute strings, producing malformed HTML such as:
+    //
+    //   <span <span class="token-keyword">class</span>="token-keyword">import</span>
+    //
+    // The browser then exposed the broken attribute text ("class=\"token-keyword\">")
+    // as DOM text nodes, so code.textContent — used by the copy button — returned
+    // corrupted content instead of valid Python code.  By always starting from the original raw text, we avoid this problem.
+    function escapeHTML(str) {
+      return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function applyToTextOnly(html, re, replacement) {
+      // Split into alternating [text, tag, text, tag, ...] segments.
+      // Even indices are plain text; odd indices are tag strings like "<span ...>".
+      var parts = html.split(/(<[^>]*>)/);
+      for (var i = 0; i < parts.length; i += 2) {
+        parts[i] = parts[i].replace(re, replacement);
+      }
+      return parts.join('');
+    }
+
     document.querySelectorAll('pre code.language-python').forEach(function (block) {
-      let html = block.innerHTML;
+      var raw = block.textContent;
+      var html = escapeHTML(raw);
 
-      // Comments
-      html = html.replace(/(#[^\n]*)/g, '<span class="token-comment">$1</span>');
+      // Comments — must run first so later passes don't highlight inside them.
+      html = applyToTextOnly(html, /(#[^\n]*)/g, '<span class="token-comment">$1</span>');
 
-      // Strings (double and single quoted)
-      html = html.replace(/(&quot;[^&]*&quot;|"[^"]*")/g, '<span class="token-string">$1</span>');
-      html = html.replace(/('[^']*')/g, '<span class="token-string">$1</span>');
+      // Strings: after escapeHTML, double-quotes are &quot; and single-quotes are &#39;.
+      html = applyToTextOnly(html, /(&quot;(?:[^&]|&(?!quot;))*&quot;)/g, '<span class="token-string">$1</span>');
+      html = applyToTextOnly(html, /(&#39;(?:[^&]|&(?!#39;))*&#39;)/g, '<span class="token-string">$1</span>');
 
-      // Keywords
-      const keywords = ['import', 'from', 'as', 'def', 'return', 'if', 'else', 'elif', 'for', 'in', 'while', 'class', 'with', 'try', 'except', 'raise', 'True', 'False', 'None', 'and', 'or', 'not', 'is', 'pass', 'lambda', 'yield', 'assert'];
+      // Keywords — \b anchors prevent partial-word matches.
+      var keywords = ['import', 'from', 'as', 'def', 'return', 'if', 'else', 'elif', 'for', 'in', 'while', 'class', 'with', 'try', 'except', 'raise', 'True', 'False', 'None', 'and', 'or', 'not', 'is', 'pass', 'lambda', 'yield', 'assert'];
       keywords.forEach(function (kw) {
-        const re = new RegExp('\\b(' + kw + ')\\b', 'g');
-        html = html.replace(re, '<span class="token-keyword">$1</span>');
+        var re = new RegExp('\\b(' + kw + ')\\b', 'g');
+        html = applyToTextOnly(html, re, '<span class="token-keyword">$1</span>');
       });
 
-      // Numbers
-      html = html.replace(/\b(\d+\.?\d*)\b/g, '<span class="token-number">$1</span>');
+      // Numbers.
+      html = applyToTextOnly(html, /\b(\d+\.?\d*)\b/g, '<span class="token-number">$1</span>');
 
       block.innerHTML = html;
     });
 
     document.querySelectorAll('pre code.language-bash').forEach(function (block) {
-      let html = block.innerHTML;
-      // Comments
-      html = html.replace(/(#[^\n]*)/g, '<span class="token-comment">$1</span>');
-      // Strings
-      html = html.replace(/(&quot;[^&]*&quot;|"[^"]*")/g, '<span class="token-string">$1</span>');
+      var raw = block.textContent;
+      var html = escapeHTML(raw);
+
+      // Comments.
+      html = applyToTextOnly(html, /(#[^\n]*)/g, '<span class="token-comment">$1</span>');
+      // Strings.
+      html = applyToTextOnly(html, /(&quot;(?:[^&]|&(?!quot;))*&quot;)/g, '<span class="token-string">$1</span>');
+
       block.innerHTML = html;
     });
   });

--- a/website/js/code.test.js
+++ b/website/js/code.test.js
@@ -133,4 +133,3 @@ tests.forEach(function (t, i) {
 
 console.log('\n' + passed + ' passed, ' + failed + ' failed.');
 if (failed > 0) process.exit(1);
-

--- a/website/js/code.test.js
+++ b/website/js/code.test.js
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for the website code highlighter (website/js/code.js).
+ *
+ * Verifies that highlight() produces innerHTML from which textContent
+ * (what the copy button reads) exactly matches the original source —
+ * no token markup fragments leaked into copied text.
+ *
+ * Run with: node website/js/code.test.js
+ * No test framework or build step required.
+ */
+
+'use strict';
+
+// ─── Inline the two helpers from code.js ────────────────────────────────────
+
+function escapeHTML(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function applyToTextOnly(html, re, replacement) {
+  var parts = html.split(/(<[^>]*>)/);
+  for (var i = 0; i < parts.length; i += 2) {
+    parts[i] = parts[i].replace(re, replacement);
+  }
+  return parts.join('');
+}
+
+// ─── Replicate the exact highlight pipeline from code.js ────────────────────
+
+var KEYWORDS = [
+  'import', 'from', 'as', 'def', 'return', 'if', 'else', 'elif', 'for',
+  'in', 'while', 'class', 'with', 'try', 'except', 'raise', 'True',
+  'False', 'None', 'and', 'or', 'not', 'is', 'pass', 'lambda', 'yield', 'assert'
+];
+
+function highlightPython(raw) {
+  var html = escapeHTML(raw);
+  html = applyToTextOnly(html, /(#[^\n]*)/g, '<span class="token-comment">$1</span>');
+  html = applyToTextOnly(html, /(&quot;(?:[^&]|&(?!quot;))*&quot;)/g, '<span class="token-string">$1</span>');
+  html = applyToTextOnly(html, /(&#39;(?:[^&]|&(?!#39;))*&#39;)/g, '<span class="token-string">$1</span>');
+  KEYWORDS.forEach(function (kw) {
+    var re = new RegExp('\\b(' + kw + ')\\b', 'g');
+    html = applyToTextOnly(html, re, '<span class="token-keyword">$1</span>');
+  });
+  html = applyToTextOnly(html, /\b(\d+\.?\d*)\b/g, '<span class="token-number">$1</span>');
+  return html;
+}
+
+// ─── Simulate browser textContent (strip tags → decode entities) ─────────────
+
+function textContent(innerHTML) {
+  return innerHTML
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+// ─── Test cases ──────────────────────────────────────────────────────────────
+
+var tests = [
+  {
+    label: 'import + as + class (original bug report)',
+    source: 'import arnio as ar\nclass MyModel:\n    pass',
+  },
+  {
+    label: 'from / import + comment + string',
+    source: 'from arnio import ArFrame\n# Load data\ndf = ar.read_csv("data.csv")\nresult = schema.validate(df)',
+  },
+  {
+    label: 'keyword inside an identifier should not match',
+    source: 'import arnio\nclass DataClass:\n    is_valid = True\n    if is_valid:\n        return None',
+  },
+  {
+    label: 'source containing < and > literals',
+    source: '# assert x > 0 and x < 100\nassert x > 0',
+  },
+  {
+    label: 'keyword inside a string literal',
+    source: 'msg = "class is not a problem"\nprint(msg)',
+  },
+  {
+    label: 'no broken nested spans in innerHTML',
+    source: 'import arnio as ar\nclass MyModel:\n    pass',
+    extraCheck: function (innerHTML) {
+      if (innerHTML.includes('<span <span')) {
+        return 'broken nested <span <span> detected in innerHTML';
+      }
+      return null;
+    },
+  },
+];
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+var passed = 0;
+var failed = 0;
+
+tests.forEach(function (t, i) {
+  var innerHTML = highlightPython(t.source);
+  var copied    = textContent(innerHTML);
+  var errors    = [];
+
+  if (copied !== t.source) {
+    errors.push(
+      'textContent mismatch\n' +
+      '  expected: ' + JSON.stringify(t.source) + '\n' +
+      '  got:      ' + JSON.stringify(copied)
+    );
+  }
+
+  if (t.extraCheck) {
+    var extraError = t.extraCheck(innerHTML);
+    if (extraError) errors.push(extraError);
+  }
+
+  if (errors.length === 0) {
+    console.log('PASS [' + (i + 1) + '] ' + t.label);
+    passed++;
+  } else {
+    console.log('FAIL [' + (i + 1) + '] ' + t.label);
+    errors.forEach(function (e) { console.log('     ' + e); });
+    failed++;
+  }
+});
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed.');
+if (failed > 0) process.exit(1);
+


### PR DESCRIPTION
The highlighter was reading block.innerHTML and running keyword regexes (class, in, as, for, not, is…) over the full string, including the class="token-keyword" attributes it had already injected. Later passes re-matched those attribute words and produced broken nested tags:

  <span <span class="token-keyword">class</span>="token-keyword">import</span>

The browser exposed the mangled attribute text as DOM text nodes, so code.textContent — read by the copy button — returned corrupted output instead of valid Python (e.g. class="token-keyword">import arnio).

Fix:
- Read raw source via block.textContent and HTML-escape it before any regex work, so the highlighter always starts from clean plain text.
- Introduce applyToTextOnly() which splits the HTML string on <tag> boundaries and applies each regex only to the text segments between tags, never to tag markup. This prevents any keyword pass from ever corrupting attributes injected by an earlier pass.

Adds website/js/code.test.js with 6 regression cases covering the original bug report, strings/comments, keyword-in-identifier, source with < > literals, and nested-span detection.

Fixes #2154

## Summary
<!-- What changed and why? Keep this short but specific. -->

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
