### PR TITLE
fix: preserve chunked csv streaming validation

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -396,10 +396,13 @@ def _reject_utf8_nul_bytes(path: str) -> None:
         _raise_csv_path_os_error(path, e)
 
 
-def _validate_csv_path(path: str, encoding: str) -> None:
+def _validate_csv_path(
+    path: str, encoding: str, *, reject_utf8_nul_bytes: bool = True
+) -> None:
     """Shared validation for CSV-style file inputs."""
 
-    if _is_utf8_encoding(encoding):
+    is_utf8 = _is_utf8_encoding(encoding)
+    if reject_utf8_nul_bytes and is_utf8:
         _reject_utf8_nul_bytes(path)
 
     try:
@@ -717,7 +720,7 @@ def read_csv_chunked(
                     "Only .csv, .txt, and .tsv are supported."
                 )
 
-        _validate_csv_path(path, encoding)
+        _validate_csv_path(path, encoding, reject_utf8_nul_bytes=False)
 
         decimal_separator = _validate_decimal_separator(decimal_separator)
         _validate_thousands_separator(thousands_separator, decimal_separator)
@@ -939,7 +942,7 @@ def scan_csv(
 
     path = os.fspath(path)
 
-    _validate_csv_path(path, encoding)
+    _validate_csv_path(path, encoding, reject_utf8_nul_bytes=False)
 
     path_lower = path.lower()
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -2,6 +2,7 @@
 
 import builtins
 import io
+import os
 import re
 from pathlib import Path
 
@@ -805,6 +806,42 @@ class TestReadCsv:
         assert stream.read_sizes
         assert -1 not in stream.read_sizes
 
+    def test_read_csv_chunked_utf8_path_skips_python_nul_prescan(
+        self, tmp_path, monkeypatch
+    ):
+        csv_path = tmp_path / "streaming.csv"
+        csv_path.write_text("name,age\nAlice,30\nBob,25\n", encoding="utf-8")
+        real_open = builtins.open
+
+        def blocked_binary_open(*args, **kwargs):
+            mode = args[1] if len(args) > 1 else kwargs.get("mode", "r")
+            if Path(args[0]) == csv_path and mode == "rb":
+                raise AssertionError(
+                    "read_csv_chunked should not pre-scan the whole UTF-8 file"
+                )
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", blocked_binary_open)
+
+        chunks = ar.read_csv_chunked(str(csv_path), chunksize=1)
+        first = next(chunks)
+
+        assert ar.to_pandas(first)["name"].tolist() == ["Alice"]
+
+    def test_read_csv_chunked_late_nul_rejected_by_streaming_reader(self, tmp_path):
+        csv_path = tmp_path / "late-nul.csv"
+        csv_path.write_bytes(b"name,age\nAlice,30\n\0binary,99\n")
+
+        chunks = ar.read_csv_chunked(csv_path, chunksize=1)
+        first = next(chunks)
+
+        assert ar.to_pandas(first)["name"].tolist() == ["Alice"]
+        with pytest.raises(
+            ar.CsvReadError,
+            match="CSV input contains NUL bytes and appears to be binary or corrupted",
+        ):
+            next(chunks)
+
     def test_file_like_input_rejects_bytes(self):
         with pytest.raises(TypeError, match="file-like objects must return text"):
             ar.read_csv(io.BytesIO(b"name,age\nAlice,30\n"))
@@ -1188,6 +1225,25 @@ class TestScanCsv:
 
         assert schema == {"name": "string", "age": "int64"}
 
+    def test_scan_csv_utf8_path_skips_python_nul_prescan(self, tmp_path, monkeypatch):
+        csv_path = tmp_path / "scan-streaming.csv"
+        csv_path.write_text("name,age\nAlice,30\nBob,25\n", encoding="utf-8")
+        real_open = builtins.open
+
+        def blocked_binary_open(*args, **kwargs):
+            mode = args[1] if len(args) > 1 else kwargs.get("mode", "r")
+            if Path(args[0]) == csv_path and mode == "rb":
+                raise AssertionError(
+                    "scan_csv should not pre-scan the whole UTF-8 file"
+                )
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", blocked_binary_open)
+
+        schema = ar.scan_csv(str(csv_path), sample_size=1)
+
+        assert schema == {"name": "string", "age": "int64"}
+
     def test_scan_csv_with_thousands_separator(self, tmp_path):
         csv_path = tmp_path / "scan_thousands.csv"
         csv_path.write_text('value\n"1,234"\n')
@@ -1214,7 +1270,7 @@ class TestScanCsv:
         ):
             ar.scan_csv(file_path)
 
-    def test_scan_late_binary_file_outside_sample(self, tmp_path):
+    def test_scan_late_binary_file_outside_sample_uses_sample_only(self, tmp_path):
         file_path = str(tmp_path / "data.csv")
 
         with open(file_path, "wb") as f:
@@ -1222,11 +1278,7 @@ class TestScanCsv:
             f.write(b"a,b\n" * 400)
             f.write(b"\0binary,data\n")
 
-        with pytest.raises(
-            ar.CsvReadError,
-            match="CSV input contains NUL bytes and appears to be binary or corrupted",
-        ):
-            ar.scan_csv(file_path)
+        assert ar.scan_csv(file_path) == {"col1": "string", "col2": "string"}
 
     def test_scan_late_binary_file_rejection_with_larger_sample(self, tmp_path):
         file_path = str(tmp_path / "data.csv")
@@ -1235,12 +1287,6 @@ class TestScanCsv:
             f.write(b"col1,col2\n")
             f.write(b"a,b\n" * 400)
             f.write(b"\0binary,data\n")
-
-        with pytest.raises(
-            ar.CsvReadError,
-            match="CSV input contains NUL bytes and appears to be binary or corrupted",
-        ):
-            ar.scan_csv(file_path)
 
         with pytest.raises(
             ar.CsvReadError,
@@ -1355,14 +1401,15 @@ class TestScanCsv:
         csv_path = tmp_path / "scan-permission.csv"
         csv_path.write_text("a,b\n1,2\n")
         csv_path_str = str(csv_path)
-        real_open = builtins.open
 
-        def blocked_open(*args, **kwargs):
-            if args[0] == csv_path_str and args[1] == "rb":
+        real_getsize = os.path.getsize
+
+        def blocked_getsize(path):
+            if path == csv_path_str:
                 raise PermissionError(13, "Access is denied")
-            return real_open(*args, **kwargs)
+            return real_getsize(path)
 
-        monkeypatch.setattr(builtins, "open", blocked_open)
+        monkeypatch.setattr(os.path, "getsize", blocked_getsize)
 
         with pytest.raises(
             CsvReadError,


### PR DESCRIPTION
Fixes #2134

This PR keeps the eager UTF-8 NUL-byte pre-scan for read_csv(), but stops both read_csv_chunked() and scan_csv() from walking the whole file in Python before native parsing begins.

What changed:
- added a small validation flag to _validate_csv_path() so existing callers keep the current behavior by default
- passed reject_utf8_nul_bytes=False from read_csv_chunked() and scan_csv()
- kept path, empty-file, and encoding type validation in Python
- added regressions proving chunked UTF-8 reads and sampled scan_csv() calls do not call Python open(..., 'rb') for a full pre-scan
- kept native NUL-byte errors for data reached by the streaming/chunked reader or the scan sample
- updated scan_csv late-NUL coverage to reflect sample-limited schema inference: a NUL outside the scan sample no longer forces a full-file pre-read, while a larger sample still reports the same CsvReadError

Quick local timing on a 32 MiB UTF-8 CSV validation path:
- eager validation with Python NUL scan: 0.0112s
- streaming-friendly validation without that scan: 0.0000s

Validation:
- .venv-codex/bin/python -m pytest tests/test_csv.py -q -k "scan_csv_permission_error_includes_path_and_os_reason or scan_csv_encoding_non_string_raises_type_error or scan_csv_encoding_none_raises_type_error or scan_csv_utf8_path_skips_python_nul_prescan or scan_late_binary" - 6 passed
- .venv-codex/bin/python -m pytest tests/test_csv.py -q - 322 passed
- .venv-codex/bin/ruff check arnio/io.py tests/test_csv.py
- env BLACK_NUM_WORKERS=1 .venv-codex/bin/black --check arnio/io.py tests/test_csv.py
- git diff --check

This is for GSSoC 2026 and stays scoped to the assigned CSV streaming/scanning performance issue.