### PR TITLE
fix: deduplicate strict auto_clean after normalization

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -2286,6 +2286,39 @@ def _validate_confirmed_casts(
     return normalized
 
 
+def _has_duplicate_rows(frame: ArFrame) -> bool:
+    """Return whether a frame contains any full-row duplicates."""
+    if frame.shape[0] <= 1:
+        return False
+    return bool(to_pandas(frame).duplicated().any())
+
+
+def _drop_strict_duplicates_introduced_by_cleaning(
+    result: ArFrame,
+    step_records: list[CleanStepRecord],
+) -> ArFrame:
+    if any(record.step == "drop_duplicates" for record in step_records):
+        return result
+    if not _has_duplicate_rows(result):
+        return result
+
+    rows_before_step = result.shape[0]
+    kwargs = {"keep": "first"}
+    result = drop_duplicates(result, **kwargs)
+    rows_after_step = result.shape[0]
+    step_records.append(
+        CleanStepRecord(
+            step="drop_duplicates",
+            kwargs=kwargs,
+            rows_before=rows_before_step,
+            rows_after=rows_after_step,
+            rows_removed=rows_before_step - rows_after_step,
+            reason="Remove duplicate rows introduced by earlier strict-mode normalization steps.",
+        )
+    )
+    return result
+
+
 def auto_clean(
     frame: ArFrame,
     *,
@@ -2435,6 +2468,12 @@ def auto_clean(
                 rows_removed=rows_before_step - rows_after_step,
                 reason=reason,
             )
+        )
+
+    if mode == "strict":
+        result = _drop_strict_duplicates_introduced_by_cleaning(
+            result,
+            step_records,
         )
 
     rows_after_all = result.shape[0]

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -640,6 +640,33 @@ def test_auto_clean_strict_applies_exact_deduplication(tmp_path):
     assert clean.shape == (1, 1)
 
 
+def test_auto_clean_strict_drops_duplicates_created_by_whitespace():
+    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", " Alice "]}))
+
+    clean = ar.auto_clean(frame, mode="strict")
+    result = ar.to_pandas(clean)
+
+    assert clean.shape == (1, 1)
+    assert list(result["name"]) == ["Alice"]
+
+
+def test_auto_clean_strict_drops_duplicates_created_by_casts():
+    frame = ar.from_pandas(pd.DataFrame({"amount": ["1", "1.0"]}))
+    report = ar.auto_clean(frame, mode="strict", dry_run=True)
+
+    clean = ar.auto_clean(
+        frame,
+        mode="strict",
+        allow_lossy_casts=True,
+        confirmed_casts=dict(report.suggestions)["cast_types"],
+    )
+    result = ar.to_pandas(clean)
+
+    assert clean.shape == (1, 1)
+    assert list(result["amount"]) == [1.0]
+    assert pd.api.types.is_float_dtype(result["amount"])
+
+
 def test_auto_clean_strict_casts_require_explicit_opt_in():
     frame = ar.from_pandas(pd.DataFrame({"active": ["true", "false"]}))
 
@@ -1190,6 +1217,17 @@ def test_identifier_numeric_cast_prevention():
     assert list(result["id"]) == ["001", "002", "003"]
     assert list(result["customer_id"]) == ["00123", "00456", "00789"]
     assert list(result["zip_code"]) == ["01234", "02345", "03456"]
+
+
+def test_auto_clean_strict_keeps_protected_identifier_values_distinct():
+    frame = ar.from_pandas(pd.DataFrame({"user_id": ["001", "1"]}))
+
+    clean = ar.auto_clean(frame, mode="strict", allow_lossy_casts=True)
+    result = ar.to_pandas(clean)
+
+    assert clean.shape == (2, 1)
+    assert list(result["user_id"]) == ["001", "1"]
+    assert pd.api.types.is_string_dtype(result["user_id"])
 
 
 def test_profile_detects_near_constant_column():
@@ -2596,6 +2634,28 @@ def test_auto_clean_explain_steps_recorded(tmp_path):
     assert len(step.reason) > 0
 
 
+def test_auto_clean_explain_records_post_normalization_dedup():
+    frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", " Alice "]}))
+
+    cleaned, explanation = ar.auto_clean(
+        frame,
+        mode="strict",
+        explain=True,
+        allow_lossy_casts=True,
+    )
+
+    drop_steps = [
+        record for record in explanation.steps if record.step == "drop_duplicates"
+    ]
+    assert cleaned.shape == (1, 1)
+    assert len(drop_steps) == 1
+    assert drop_steps[0].kwargs == {"keep": "first"}
+    assert drop_steps[0].rows_before == 2
+    assert drop_steps[0].rows_after == 1
+    assert drop_steps[0].rows_removed == 1
+    assert "strict-mode normalization" in drop_steps[0].reason
+
+
 def test_auto_clean_explain_with_return_report(tmp_path):
     """explain=True and return_report=True should return (ArFrame, DataQualityReport, CleanExplanation)."""
     path = tmp_path / "data.csv"
@@ -2630,6 +2690,7 @@ def test_auto_clean_explain_no_steps_clean_data(tmp_path):
 
     assert explanation.rows_removed == 0
     assert explanation.rows_before == explanation.rows_after
+    assert explanation.steps == []
 
 
 def test_auto_clean_explain_str_representation(tmp_path):


### PR DESCRIPTION
Summary
Closes #1900

This fixes the strict auto_clean path where the initial quality profile decides whether drop_duplicates should run before normalization has happened. If strict-mode normalization later makes rows identical, auto_clean now does one final duplicate check only when drop_duplicates has not already run.

What changed
- Added a strict-only post-normalization duplicate check after the existing suggestion loop.
- Reuses the existing drop_duplicates(..., keep='first') behavior.
- Records the additional CleanStepRecord when explain=True.
- Leaves safe mode and the existing suggestion-generation behavior unchanged.
- Added regressions for whitespace-created duplicates, cast-created duplicates, explanation output, no-op clean data, and protected identifier/leading-zero behavior.

Validation
- .venv-codex/bin/python -m pytest tests/test_quality.py -q -k "auto_clean or identifier_numeric_cast_prevention" - 27 passed
- .venv-codex/bin/python -m pytest tests/test_quality.py -q - 200 passed
- .venv-codex/bin/ruff check arnio/quality.py tests/test_quality.py
- env BLACK_NUM_WORKERS=1 .venv-codex/bin/black --check arnio/quality.py tests/test_quality.py
- git diff --check

I also ran the full local pytest suite. The changed quality tests passed, but the run fails later in tests/test_to_arrow_edge_cases.py because the current local branch does not expose ArFrame.from_pandas, which is unrelated to this PR.

This is for GSSoC 2026 and stays scoped to the assigned strict auto_clean duplicate-cleanup bug.