### PR TITLE
docs(api): document auto_clean safety options and return shapes

### DIFF
--- a/website/api.html
+++ b/website/api.html
@@ -89,7 +89,21 @@
         <div class="api-func"><div class="api-func-header">profile(frame, *, exclude_columns=None, sample_size=5, approx_top_values=False, approx_top_values_min_unique=1000, approx_top_values_min_ratio=0.2, approx_top_values_sample_size=2000)</div><div class="api-func-body"><p>Return <code>DataQualityReport</code> with row/column counts, duplicate metrics, column profiles, warnings, quality score, score components, and cleaning suggestions.</p></div></div>
         <div class="api-func"><div class="api-func-header">DataQualityReport._repr_html_()</div><div class="api-func-body"><p>Jupyter/IPython automatically calls this to render the report dashboard HTML directly in the notebook output area.</p></div></div>
         <div class="api-func"><div class="api-func-header">DataQualityReport.to_dict(redact_sample_values=False, exclude_columns=None), to_json(), to_markdown(), to_html(), summary(), to_pandas()</div><div class="api-func-body"><p>Export reports for notebooks, CI, docs, and automation.</p></div></div>
-        <div class="api-func"><div class="api-func-header">compare_profiles(left, right), check_quality_gates(baseline, current), suggest_cleaning(frame_or_report), auto_clean(frame, *, mode="safe", dry_run=False, explain=False)</div><div class="api-func-body"><p>Compare quality over time, fail CI on drift, generate pipeline-compatible steps, or run automatic cleaning with optional audit output.</p></div></div>
+        <div class="api-func"><div class="api-func-header">compare_profiles(left, right), check_quality_gates(baseline, current), suggest_cleaning(frame_or_report), auto_clean(frame, *, mode="safe", return_report=False, dry_run=False, allow_lossy_casts=False, confirmed_casts=None, explain=False)</div><div class="api-func-body"><p>Compare quality over time, fail CI on drift, generate pipeline-compatible steps, or run automatic cleaning with optional reports and audit output.</p><p><strong>Additional options:</strong></p><ul><li><code>return_report</code> – return the pre-cleaning quality report alongside cleaned output.</li><li><code>allow_lossy_casts</code> – opt in to strict-mode casts that may lose information.</li><li><code>confirmed_casts</code> – explicit column-to-dtype confirmations required before strict-mode casts are applied.</li></ul><p><strong>Return values:</strong></p><ul><li><code>auto_clean(...)</code> → <code>ArFrame</code></li><li><code>auto_clean(..., return_report=True)</code> → <code>(ArFrame, DataQualityReport)</code></li><li><code>auto_clean(..., dry_run=True)</code> → <code>DataQualityReport</code></li><li><code>auto_clean(..., explain=True)</code> → <code>(ArFrame, CleanExplanation)</code></li><li><code>auto_clean(..., return_report=True, explain=True)</code> → <code>(ArFrame, DataQualityReport, CleanExplanation)</code></li></ul><pre><code># Preview proposed changes
+report = ar.auto_clean(frame, mode="strict", dry_run=True)
+
+# Clean and return report
+cleaned, report = ar.auto_clean(
+    frame,
+    return_report=True,
+)
+
+# Clean with explanation
+cleaned, explanation = ar.auto_clean(
+    frame,
+    explain=True,
+)
+</code></pre></div></div>
         <div class="api-func"><div class="api-func-header">Quality result classes</div><div class="api-func-body"><p><code>ColumnProfile</code>, <code>CleaningSuggestion</code>, <code>CleanStepRecord</code>, <code>CleanExplanation</code>, <code>ProfileComparison</code>, <code>QualityGateIssue</code>, and <code>QualityGateResult</code> describe structured profiling, cleaning, comparison, and gate output.</p></div></div>
 
         <h2 id="schema">Schema</h2>


### PR DESCRIPTION
## Summary

- Updated the documented `auto_clean()` signature
- Added documentation for:
  - `return_report`
  - `allow_lossy_casts`
  - `confirmed_casts`
- Documented return behavior for `return_report`, `dry_run`, and `explain`
- Added a small usage example covering dry-run, report, and explain modes


## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [ ] I read the contributing guide.
- [ ] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
