### PR TITLE
Fix empty subset keep rows null

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -223,7 +223,10 @@ def drop_nulls(
     """
     frame, _ = _validate_frame(frame)
     if subset is not None:
-        subset = _validate_column_sequence(subset, argument_name="subset")
+        subset = _validate_column_sequence(
+                   subset,
+                   argument_name="subset"
+        )
         if len(subset) == 0:
             raise ValueError(
                 "drop_nulls: subset cannot be empty; pass subset=None to check all columns"
@@ -338,6 +341,17 @@ def keep_rows_with_nulls(
     df = to_pandas(frame) if is_arframe else frame
 
     if subset is not None:
+        subset = _validate_column_sequence(
+            subset,
+            argument_name="subset",
+        )
+
+        if len(subset) == 0:
+           raise ValueError(
+               "keep_rows_with_nulls: subset cannot be empty; "
+               "pass subset=None to check all columns"
+           )
+        
         cols = _validate_existing_column_sequence(
             subset,
             available_columns=df.columns,

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -341,11 +341,10 @@ def keep_rows_with_nulls(
         subset = _validate_column_sequence(subset, argument_name="subset")
 
         if len(subset) == 0:
-           raise ValueError(
-               "keep_rows_with_nulls: subset cannot be empty; "
-               "pass subset=None to check all columns"
-           )
-        
+            raise ValueError(
+                "keep_rows_with_nulls: subset cannot be empty; "
+                "pass subset=None to check all columns"
+            )
         cols = _validate_existing_column_sequence(
             subset,
             available_columns=df.columns,

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -223,10 +223,7 @@ def drop_nulls(
     """
     frame, _ = _validate_frame(frame)
     if subset is not None:
-        subset = _validate_column_sequence(
-                   subset,
-                   argument_name="subset"
-        )
+        subset = _validate_column_sequence(subset, argument_name="subset")
         if len(subset) == 0:
             raise ValueError(
                 "drop_nulls: subset cannot be empty; pass subset=None to check all columns"
@@ -341,10 +338,7 @@ def keep_rows_with_nulls(
     df = to_pandas(frame) if is_arframe else frame
 
     if subset is not None:
-        subset = _validate_column_sequence(
-            subset,
-            argument_name="subset",
-        )
+        subset = _validate_column_sequence(subset, argument_name="subset")
 
         if len(subset) == 0:
            raise ValueError(

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -44,6 +44,31 @@ class TestDropNulls:
 
 
 class TestKeepRowsWithNulls:
+    def test_empty_subset_raises(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"name": ["Alice", None]})
+        )
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.keep_rows_with_nulls(frame, subset=[])
+
+    def test_empty_tuple_subset_raises(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"name": ["Alice", None]})
+        )
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.keep_rows_with_nulls(frame, subset=())
+
+    def test_subset_none_still_works(self):
+        frame = ar.from_pandas(
+            pd.DataFrame({"name": ["Alice", None]})
+        )
+
+        result = ar.keep_rows_with_nulls(frame)
+
+        assert result.shape[0] == 1
+
     def test_keeps_only_null_rows(self, csv_with_nulls):
         # full frame has 4 rows, 2 have nulls (row1: null name+score, row2: null age)
         frame = ar.read_csv(csv_with_nulls)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -50,7 +50,6 @@ class TestKeepRowsWithNulls:
         with pytest.raises(ValueError, match="subset"):
             ar.keep_rows_with_nulls(df, subset=[])
 
-
     def test_pandas_input_empty_tuple_subset_raises(self):
         df = pd.DataFrame({"name": ["Alice", None]})
 
@@ -58,25 +57,19 @@ class TestKeepRowsWithNulls:
             ar.keep_rows_with_nulls(df, subset=())
 
     def test_empty_subset_raises(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"name": ["Alice", None]})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", None]}))
 
         with pytest.raises(ValueError, match="subset"):
             ar.keep_rows_with_nulls(frame, subset=[])
 
     def test_empty_tuple_subset_raises(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"name": ["Alice", None]})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", None]}))
 
         with pytest.raises(ValueError, match="subset"):
             ar.keep_rows_with_nulls(frame, subset=())
 
     def test_subset_none_still_works(self):
-        frame = ar.from_pandas(
-            pd.DataFrame({"name": ["Alice", None]})
-        )
+        frame = ar.from_pandas(pd.DataFrame({"name": ["Alice", None]}))
 
         result = ar.keep_rows_with_nulls(frame)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -44,6 +44,19 @@ class TestDropNulls:
 
 
 class TestKeepRowsWithNulls:
+    def test_pandas_input_empty_subset_raises(self):
+        df = pd.DataFrame({"name": ["Alice", None]})
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.keep_rows_with_nulls(df, subset=[])
+
+
+    def test_pandas_input_empty_tuple_subset_raises(self):
+        df = pd.DataFrame({"name": ["Alice", None]})
+
+        with pytest.raises(ValueError, match="subset"):
+            ar.keep_rows_with_nulls(df, subset=())
+
     def test_empty_subset_raises(self):
         frame = ar.from_pandas(
             pd.DataFrame({"name": ["Alice", None]})

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1771,29 +1771,6 @@ def test_extra_empty_field_is_rejected(tmp_path):
         ar.read_csv(csv_path)
 
 
-def test_quoted_empty_csv_field_preserved(tmp_path):
-    import warnings
-    
-
-    csv_path = tmp_path / "quoted_empty.csv"
-
-    csv_path.write_text(
-        'a,b,c\n'
-        '"",2,3\n'
-        ',4,5\n'
-        '6,7,8\n'
-    )
-
-    with warnings.catch_warnings(record=True):
-        warnings.simplefilter("always")
-        frame = ar.read_csv(csv_path, on_bad_lines="warn")
-
-    df = ar.to_pandas(frame)
-
-    assert df["a"].iloc[0] == ""
-    assert pd.isna(df["a"].iloc[1])
-
-    
 def test_permissive_mode_rejects_extra_fields(tmp_path):
     csv_path = tmp_path / "permissive_extra.csv"
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1773,8 +1773,7 @@ def test_extra_empty_field_is_rejected(tmp_path):
 
 def test_quoted_empty_csv_field_preserved(tmp_path):
     import warnings
-    import pandas as pd
-    import arnio as ar
+    
 
     csv_path = tmp_path / "quoted_empty.csv"
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1771,6 +1771,30 @@ def test_extra_empty_field_is_rejected(tmp_path):
         ar.read_csv(csv_path)
 
 
+def test_quoted_empty_csv_field_preserved(tmp_path):
+    import warnings
+    import pandas as pd
+    import arnio as ar
+
+    csv_path = tmp_path / "quoted_empty.csv"
+
+    csv_path.write_text(
+        'a,b,c\n'
+        '"",2,3\n'
+        ',4,5\n'
+        '6,7,8\n'
+    )
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        frame = ar.read_csv(csv_path, on_bad_lines="warn")
+
+    df = ar.to_pandas(frame)
+
+    assert df["a"].iloc[0] == ""
+    assert pd.isna(df["a"].iloc[1])
+
+    
 def test_permissive_mode_rejects_extra_fields(tmp_path):
     csv_path = tmp_path / "permissive_extra.csv"
 


### PR DESCRIPTION
## Summary

Adds validation for empty `subset` inputs in `keep_rows_with_nulls()`.

This PR:

* raises `ValueError` for `subset=[]`
* raises `ValueError` for `subset=()`
* preserves existing `subset=None` behavior
* adds regression tests for empty subset validation

## Linked issue

Fixes #1655

## Type of change

* [x] Bug fix
* [x] Tests

## Area

* [x] Python API / ArFrame
* [x] Pipeline / custom steps

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Added regression coverage in `tests/test_cleaning.py`

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits.
