### PR TITLE
perf: defer non-critical JS and lazy load footer images

### DIFF
--- a/website/api.html
+++ b/website/api.html
@@ -268,7 +268,7 @@ result = schema.validate(frame)</code></pre></div></div>
  <footer class="site-footer">
     <div class="container">
       <div class="footer-grid">
-        <div class="footer-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
+        <div class="footer-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32" loading="lazy" decoding="async"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
         <div><h4 class="footer-heading">Project</h4><ul class="footer-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="changelog.html">Changelog</a></li></ul></div>
         <div><h4 class="footer-heading">Engineering</h4><ul class="footer-links"><li><a href="architecture.html">Architecture</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="roadmap.html">Roadmap</a></li></ul></div>
         <div><h4 class="footer-heading">Community</h4><ul class="footer-links"><li><a href="contributing.html">Contributing</a></li><li><a href="community.html">Community</a></li>
@@ -289,7 +289,7 @@ result = schema.validate(frame)</code></pre></div></div>
       <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
   </footer>
-  <script src="js/main.js"></script>
-  <script src="js/code.js"></script>
+  <script src="js/main.js" defer></script>
+  <script src="js/code.js" defer></script>
 </body>
 </html>

--- a/website/docs.html
+++ b/website/docs.html
@@ -211,7 +211,7 @@ report  # DataQualityReport renders its full HTML dashboard</code></pre></div>
   <footer class="site-footer">
     <div class="container">
       <div class="footer-grid">
-        <div class="footer-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
+        <div class="footer-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32" loading="lazy" decoding="async"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
         <div><h4 class="footer-heading">Project</h4><ul class="footer-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="changelog.html">Changelog</a></li></ul></div>
         <div><h4 class="footer-heading">Engineering</h4><ul class="footer-links"><li><a href="architecture.html">Architecture</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="roadmap.html">Roadmap</a></li></ul></div>
         <div><h4 class="footer-heading">Community</h4><ul class="footer-links"><li><a href="contributing.html">Contributing</a></li><li><a href="community.html">Community</a></li>
@@ -232,7 +232,7 @@ report  # DataQualityReport renders its full HTML dashboard</code></pre></div>
       <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
     </div>
   </footer>
-  <script src="js/main.js"></script>
-  <script src="js/code.js"></script>
+  <script src="js/main.js" defer></script>
+  <script src="js/code.js" defer></script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -160,7 +160,7 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
   <footer class="site-footer">
     <div class="container">
       <div class="footer-grid">
-        <div class="footer-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
+        <div class="footer-brand"><img src="arnio-transparent-logo.svg" alt="Arnio" height="32" loading="lazy" decoding="async"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
         <div><h4 class="footer-heading">Project</h4><ul class="footer-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="changelog.html">Changelog</a></li></ul></div>
         <div><h4 class="footer-heading">Engineering</h4><ul class="footer-links"><li><a href="architecture.html">Architecture</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="roadmap.html">Roadmap</a></li></ul></div>
         <div><h4 class="footer-heading">Community</h4><ul class="footer-links"><li><a href="contributing.html">Contributing</a></li><li><a href="community.html">Community</a></li>
@@ -181,8 +181,8 @@ ar.write_parquet(clean, "sales.parquet", compression="zstd")</code></pre>
       <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.18.0</span></div>
     </div>
   </footer>
-  <script src="js/main.js"></script>
-  <script src="js/code.js"></script>
-  <script src="js/github.js"></script>
+  <script src="js/main.js" defer></script>
+  <script src="js/code.js" defer></script>
+  <script src="js/github.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #2054

## Summary

Improve page load performance by deferring non-critical JavaScript and lazy-loading below-the-fold footer images.

## Changes

* Add `defer` to:

  * `main.js`
  * `code.js`
  * `github.js` (where present)

* Add `loading="lazy"` and `decoding="async"` to footer logo images on:

  * `index.html`
  * `api.html`
  * `docs.html`

## Notes

* `theme.js` remains synchronous to avoid theme flash during initial render.
* Navigation and header logos remain eager-loaded because they are visible in the initial viewport.
* No CSS, Python, runtime, or API changes.
