### PR TITLE
fix: handle zero-column frames in drop_columns_matching

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1764,6 +1764,9 @@ def drop_columns_matching(frame, pattern):
 
     cols_to_drop = [col for col in df.columns if re.search(pattern, str(col))]
 
+    if len(df.columns) == 0:
+        return frame if is_arframe else df
+
     if len(cols_to_drop) == len(df.columns):
         raise ValueError(
             "Pattern matches all columns. At least one column must remain."

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3957,6 +3957,20 @@ def test_drop_columns_matching_all_columns():
         ar.drop_columns_matching(df, ".*")
 
 
+def test_drop_columns_matching_zero_column_pandas():
+    df = pd.DataFrame(index=range(2))
+    result = ar.drop_columns_matching(df, "^tmp")
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape == (2, 0)
+
+
+def test_drop_columns_matching_zero_column_arframe():
+    frame = ar.from_pandas(pd.DataFrame(index=range(2)))
+    result = ar.drop_columns_matching(frame, "^tmp")
+    assert isinstance(result, ar.ArFrame)
+    assert result.shape == (2, 0)
+
+
 def test_fill_nulls_validation_lossy_and_non_finite():
     """
     Ensure that fill_nulls rejects non-finite values and lossy float-to-int conversions


### PR DESCRIPTION
## Summary
drop_columns_matching() raised ValueError("Pattern matches all columns...") on zero-column frames even when the pattern matched nothing, because both len(cols_to_drop) and len(df.columns) were 0. Added an early return for zero-column frames before the all-columns guard.

## Linked issue
Fixes #1703

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
pytest tests/test_cleaning.py -k "drop_columns_matching" -v
8 passed
pytest tests/test_cleaning.py -q
441 passed, 2 pre-existing failures unrelated to this change
python -m black arnio/cleaning.py tests/test_cleaning.py
python -m ruff check .
ruff error is pre-existing in examples/dataset_profile_comparison.ipynb, not touched by this PR

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
The 2 pre-existing test failures (test_clip_numeric_out_of_range_bound_on_int64_raises and test_fill_nulls_validation_lossy_and_non_finite) exist on main before this PR. 