### PR TITLE
fix: resolve __version__ from pyproject.toml in source checkouts

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -4,51 +4,7 @@ arnio — Fast CSV processing and data cleaning companion for pandas.
 import arnio as ar
 """
 
-
-def _resolve_version() -> str:
-    """Resolve __version__ robustly for both installed and source-checkout imports.
-
-    Strategy
-    --------
-    1. Try importlib.metadata first (fast path for installed distributions).
-    2. If pyproject.toml exists next to the package directory, we are likely
-       in a source checkout — read the version from pyproject.toml directly
-       instead of trusting metadata that may belong to a different install.
-    3. Fall back to importlib.metadata when no pyproject.toml is present
-       (normal installed-package import).
-    4. Final fallback: "unknown".
-    """
-    import pathlib
-    import re
-
-    _here = pathlib.Path(__file__).resolve().parent
-    _pyproject = _here.parent / "pyproject.toml"
-
-    # If pyproject.toml exists we are in a source checkout.
-    # Read the version directly so we never report a stale installed version.
-    if _pyproject.exists():
-        try:
-            _text = _pyproject.read_text(encoding="utf-8")
-            _match = re.search(r'^\s*version\s*=\s*"([^"]+)"', _text, re.MULTILINE)
-            if _match:
-                return _match.group(1)
-        except Exception:
-            pass
-
-    # Normal installed-package import: trust importlib.metadata.
-    try:
-        from importlib.metadata import version
-
-        return version("arnio")
-    except Exception:
-        pass
-
-    return "unknown"
-
-
-__version__ = _resolve_version()
-del _resolve_version
-
+from ._version import __version__ as __version__
 from .cleaning import (
     cast_types,
     clean,

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -4,12 +4,50 @@ arnio — Fast CSV processing and data cleaning companion for pandas.
 import arnio as ar
 """
 
-try:
-    from importlib.metadata import version
 
-    __version__ = version("arnio")
-except Exception:
-    __version__ = "unknown"
+def _resolve_version() -> str:
+    """Resolve __version__ robustly for both installed and source-checkout imports.
+
+    Strategy
+    --------
+    1. Try importlib.metadata first (fast path for installed distributions).
+    2. If pyproject.toml exists next to the package directory, we are likely
+       in a source checkout — read the version from pyproject.toml directly
+       instead of trusting metadata that may belong to a different install.
+    3. Fall back to importlib.metadata when no pyproject.toml is present
+       (normal installed-package import).
+    4. Final fallback: "unknown".
+    """
+    import pathlib
+    import re
+
+    _here = pathlib.Path(__file__).resolve().parent
+    _pyproject = _here.parent / "pyproject.toml"
+
+    # If pyproject.toml exists we are in a source checkout.
+    # Read the version directly so we never report a stale installed version.
+    if _pyproject.exists():
+        try:
+            _text = _pyproject.read_text(encoding="utf-8")
+            _match = re.search(r'^\s*version\s*=\s*"([^"]+)"', _text, re.MULTILINE)
+            if _match:
+                return _match.group(1)
+        except Exception:
+            pass
+
+    # Normal installed-package import: trust importlib.metadata.
+    try:
+        from importlib.metadata import version
+
+        return version("arnio")
+    except Exception:
+        pass
+
+    return "unknown"
+
+
+__version__ = _resolve_version()
+del _resolve_version
 
 from .cleaning import (
     cast_types,

--- a/arnio/_version.py
+++ b/arnio/_version.py
@@ -1,0 +1,45 @@
+"""Version resolution for arnio."""
+
+import pathlib
+import re
+
+
+def _resolve_version() -> str:
+    """Resolve __version__ robustly for both installed and source-checkout imports.
+
+    Strategy
+    --------
+    1. Try importlib.metadata first (fast path for installed distributions).
+    2. If pyproject.toml exists next to the package directory, we are likely
+       in a source checkout — read the version from pyproject.toml directly
+       instead of trusting metadata that may belong to a different install.
+    3. Fall back to importlib.metadata when no pyproject.toml is present
+       (normal installed-package import).
+    4. Final fallback: "unknown".
+    """
+    _here = pathlib.Path(__file__).resolve().parent
+    _pyproject = _here.parent / "pyproject.toml"
+
+    # If pyproject.toml exists we are in a source checkout.
+    # Read the version directly so we never report a stale installed version.
+    if _pyproject.exists():
+        try:
+            _text = _pyproject.read_text(encoding="utf-8")
+            _match = re.search(r'^\s*version\s*=\s*"([^"]+)"', _text, re.MULTILINE)
+            if _match:
+                return _match.group(1)
+        except Exception:
+            pass
+
+    # Normal installed-package import: trust importlib.metadata.
+    try:
+        from importlib.metadata import version
+
+        return version("arnio")
+    except Exception:
+        pass
+
+    return "unknown"
+
+
+__version__ = _resolve_version()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,6 @@
 import importlib
+import importlib.util
+import pathlib
 import sys
 
 import pytest
@@ -9,10 +11,8 @@ def test_missing_cpp_extension_error_message(monkeypatch):
     try:
         import arnio  # noqa: F401
     except ImportError as e:
-        # If arnio is already failing to import due to missing extension (like in local tests)
         error_msg = str(e)
     else:
-        # If it is installed, we force it to fail
         monkeypatch.setitem(sys.modules, "arnio._arnio_cpp", None)
         monkeypatch.delitem(sys.modules, "arnio._core", raising=False)
         with pytest.raises(ImportError) as exc_info:
@@ -48,30 +48,35 @@ def test_version_not_unknown_on_installed_package():
     ), "__version__ fell through to 'unknown' even though arnio is installed"
 
 
-def test_version_reads_pyproject_in_source_checkout(tmp_path):
-    """When pyproject.toml sits next to the package dir, its version is used."""
-    import importlib.util
-    import pathlib
+def _load_version_module(tmp_path: pathlib.Path) -> object:
+    """Copy arnio/_version.py into tmp_path/arnio/ and load it as a standalone module.
 
-    # Copy the version-resolution block from the real __init__.py into a tmp package.
-    real_init = pathlib.Path(__file__).parent.parent / "arnio" / "__init__.py"
-    src = real_init.read_text(encoding="utf-8")
-    version_block = src[: src.index("from .")]
-
+    _version.py uses Path(__file__).resolve().parent.parent to locate pyproject.toml,
+    so the file must sit one level below tmp_path (tmp_path/arnio/_version.py) so
+    that _here.parent == tmp_path, matching where the test places pyproject.toml.
+    """
+    real_version = pathlib.Path(__file__).parent.parent / "arnio" / "_version.py"
+    src = real_version.read_text(encoding="utf-8")
     pkg_dir = tmp_path / "arnio"
     pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text(version_block, encoding="utf-8")
+    version_file = pkg_dir / "_version.py"
+    version_file.write_text(src, encoding="utf-8")
 
-    # Place a pyproject.toml with a sentinel version next to the package dir.
+    spec = importlib.util.spec_from_file_location(
+        "_arnio_version_isolated", version_file
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_version_reads_pyproject_in_source_checkout(tmp_path):
+    """When pyproject.toml sits next to the package dir, its version is used."""
     (tmp_path / "pyproject.toml").write_text(
         '[project]\nname = "arnio"\nversion = "9.9.9"\n', encoding="utf-8"
     )
 
-    spec = importlib.util.spec_from_file_location(
-        "arnio_checkout", pkg_dir / "__init__.py"
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = _load_version_module(tmp_path)
 
     assert (
         mod.__version__ == "9.9.9"
@@ -83,17 +88,6 @@ def test_version_fallback_unknown_when_no_pyproject_and_no_metadata(
 ):
     """When neither pyproject.toml nor metadata is available, fall back to 'unknown'."""
     import importlib.metadata
-    import importlib.util
-    import pathlib
-
-    real_init = pathlib.Path(__file__).parent.parent / "arnio" / "__init__.py"
-    src = real_init.read_text(encoding="utf-8")
-    version_block = src[: src.index("from .")]
-
-    pkg_dir = tmp_path / "arnio"
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text(version_block, encoding="utf-8")
-    # No pyproject.toml — simulates an install without source tree.
 
     monkeypatch.setattr(
         importlib.metadata,
@@ -103,10 +97,6 @@ def test_version_fallback_unknown_when_no_pyproject_and_no_metadata(
         ),
     )
 
-    spec = importlib.util.spec_from_file_location(
-        "arnio_isolated", pkg_dir / "__init__.py"
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = _load_version_module(tmp_path)
 
     assert mod.__version__ == "unknown", f"Expected 'unknown', got {mod.__version__!r}"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,3 +23,90 @@ def test_missing_cpp_extension_error_message(monkeypatch):
     assert "pip install -e ." in error_msg
     assert "Desktop development with C++" in error_msg
     assert "gcc or clang" in error_msg
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #1892:
+# __version__ must reflect the source checkout, not a stale installed dist.
+# ---------------------------------------------------------------------------
+
+
+def test_version_is_string():
+    """arnio.__version__ must always be a non-empty string."""
+    import arnio
+
+    assert isinstance(arnio.__version__, str)
+    assert len(arnio.__version__) > 0
+
+
+def test_version_not_unknown_on_installed_package():
+    """In a normal test environment (package installed) version must not be 'unknown'."""
+    import arnio
+
+    assert (
+        arnio.__version__ != "unknown"
+    ), "__version__ fell through to 'unknown' even though arnio is installed"
+
+
+def test_version_reads_pyproject_in_source_checkout(tmp_path):
+    """When pyproject.toml sits next to the package dir, its version is used."""
+    import importlib.util
+    import pathlib
+
+    # Copy the version-resolution block from the real __init__.py into a tmp package.
+    real_init = pathlib.Path(__file__).parent.parent / "arnio" / "__init__.py"
+    src = real_init.read_text(encoding="utf-8")
+    version_block = src[: src.index("from .")]
+
+    pkg_dir = tmp_path / "arnio"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(version_block, encoding="utf-8")
+
+    # Place a pyproject.toml with a sentinel version next to the package dir.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "arnio"\nversion = "9.9.9"\n', encoding="utf-8"
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "arnio_checkout", pkg_dir / "__init__.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert (
+        mod.__version__ == "9.9.9"
+    ), f"Expected '9.9.9' from pyproject.toml, got {mod.__version__!r}"
+
+
+def test_version_fallback_unknown_when_no_pyproject_and_no_metadata(
+    tmp_path, monkeypatch
+):
+    """When neither pyproject.toml nor metadata is available, fall back to 'unknown'."""
+    import importlib.metadata
+    import importlib.util
+    import pathlib
+
+    real_init = pathlib.Path(__file__).parent.parent / "arnio" / "__init__.py"
+    src = real_init.read_text(encoding="utf-8")
+    version_block = src[: src.index("from .")]
+
+    pkg_dir = tmp_path / "arnio"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(version_block, encoding="utf-8")
+    # No pyproject.toml — simulates an install without source tree.
+
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        lambda name: (_ for _ in ()).throw(
+            importlib.metadata.PackageNotFoundError(name)
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "arnio_isolated", pkg_dir / "__init__.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert mod.__version__ == "unknown", f"Expected 'unknown', got {mod.__version__!r}"


### PR DESCRIPTION
## Summary

Fixes stale `arnio.__version__` values when importing directly from a source checkout.

Closes #1892

## Problem

`arnio.__version__` was always resolved via `importlib.metadata.version("arnio")`. When an older Arnio distribution was installed in the environment, importing Arnio from a source checkout could report the installed distribution's version instead of the version corresponding to the imported source tree.

## Changes Made

* Updated `arnio/__init__.py` to support source-checkout version resolution.
* When a local `pyproject.toml` is available, read the version directly from it.
* Retain existing `importlib.metadata` behavior for normal installed-package usage.
* Fall back to `"unknown"` if no reliable version source is available.
* Added focused regression tests covering:

  * Version is exposed as a string.
  * Installed-package version resolution.
  * Source-checkout version resolution from `pyproject.toml`.
  * Fallback behavior when neither metadata nor `pyproject.toml` is available.

## Verification

```bash
python3 -c "
import sys
sys.path.insert(0, '.')
import arnio
print('__file__:', arnio.__file__)
print('__version__:', arnio.__version__)
"
```

Output:

```text
__file__: /home/kali/Desktop/arnio/arnio/__init__.py
__version__: 1.19.0
```

Targeted tests:

```bash
python3 -m pytest tests/test_core.py -v -k "version"
```

Result:

```text
4 passed
```
<img width="949" height="463" alt="image" src="https://github.com/user-attachments/assets/edbedc4d-0b60-4c41-a76d-c2d79cb87a66" />



## Scope

* `arnio/__init__.py`
* `tests/test_core.py`

No changes to runtime APIs, packaging configuration, release automation, documentation, or unrelated tests.
