### PR TITLE
fix(website): handle unavailable localStorage in theme script

### DIFF
--- a/website/js/theme.js
+++ b/website/js/theme.js
@@ -9,8 +9,24 @@
   const DARK = 'dark';
   const LIGHT = 'light';
 
+  function safeGet(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function safeSet(key, value) {
+    try {
+      localStorage.setItem(key, value);
+    } catch (e) {
+      // Ignore quota or access errors
+    }
+  }
+
   function getPreferred() {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = safeGet(STORAGE_KEY);
     if (stored === DARK || stored === LIGHT) return stored;
     // Fall back to system preference
     return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? DARK : LIGHT;
@@ -22,7 +38,7 @@
 
   function apply(theme) {
     document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem(STORAGE_KEY, theme);
+    safeSet(STORAGE_KEY, theme);
     updateToggleIcon(theme);
   }
 
@@ -44,7 +60,7 @@
   // Listen for system preference changes
   if (window.matchMedia) {
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
-      if (!localStorage.getItem(STORAGE_KEY)) {
+      if (!safeGet(STORAGE_KEY)) {
         applyWithoutSaving(e.matches ? DARK : LIGHT);
       }
     });


### PR DESCRIPTION
Fixes #1640.

### Description
This PR addresses issue #1640 by wrapping all \localStorage\ access in \website/js/theme.js\ with defensive \	ry...catch\ blocks. This ensures that the website theme script (which runs in the \<head>\) does not crash in browser environments where storage access is blocked (e.g., privacy-restricted modes or certain embedded views).

### Changes
- Implemented \safeGet(key)\ and \safeSet(key, value)\ helper functions.
- Replaced all direct \localStorage\ calls with these safe wrappers.
- Verified that theme persistence still works when storage is available and degrades gracefully to system/default preferences when storage is blocked.