### PR TITLE
feat: support file-like inputs in scan_csv(#1842)

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -946,7 +946,7 @@ def write_csv(
 
 
 def scan_csv(
-    path: str | os.PathLike[str],
+    path: str | os.PathLike[str] | io.TextIOBase,
     *,
     delimiter: str | None = None,
     encoding: str = "utf-8",
@@ -964,10 +964,10 @@ def scan_csv(
 
     Parameters
     ----------
-    path : str
-        Path to the CSV file. Any file extension is accepted. For ``.tsv``
-        files, the delimiter is automatically set to ``'\t'`` when
-        ``delimiter`` is omitted.
+    path : str or file-like object
+        Filesystem path or text file-like object containing CSV data.
+        Any file extension is accepted. For ``.tsv`` files, the delimiter
+        is automatically set to ``'\t'`` when ``delimiter`` is omitted.
     delimiter : str or None, default None
         Field delimiter character.  When ``None`` (the default) the
         delimiter is inferred from the file extension: ``'\t'`` for
@@ -1041,46 +1041,48 @@ def scan_csv(
     >>> schema = ar.scan_csv("data.dat")              # non-standard extension accepted
     """
 
-    path = os.fspath(path)
+    path, should_cleanup, _ = _materialize_csv_input(path)
 
-    _validate_csv_path(path, encoding, reject_utf8_nul_bytes=False)
-
-    path_lower = path.lower()
-
-    # Resolve the sentinel: auto-detect tab for .tsv only when the caller
-    # truly omitted delimiter (None).  An explicit delimiter="," is always
-    # honoured, even for .tsv paths.
-    if delimiter is None:
-        delimiter = "\t" if path_lower.endswith(".tsv") else ","
-
-    decimal_separator = _validate_decimal_separator(decimal_separator)
-    _validate_thousands_separator(thousands_separator, decimal_separator)
-    delimiter = _validate_delimiter(delimiter)
-    encoding_errors = _validate_encoding_errors(encoding_errors)
-    mode = _validate_parser_mode(mode)
-    on_bad_lines = _validate_on_bad_lines(on_bad_lines)
-    config = _CsvConfig()
-    config.delimiter = delimiter
-    config.encoding = encoding
-    config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
-    config.decimal_separator = decimal_separator
-    config.thousands_separator = thousands_separator
-    config.has_header = _validate_bool_option(has_header, "has_header")
-    config.encoding_errors = encoding_errors
-    config.mode = mode
-
-    if null_values is not None:
-        config.null_values = _validate_null_values(null_values)
-
-    if sample_size is not None:
-        if not isinstance(sample_size, int) or isinstance(sample_size, bool):
-            raise TypeError("sample_size must be an integer.")
-        if sample_size <= 0:
-            raise ValueError("sample_size must be a positive integer greater than 0.")
-        config.sample_size = sample_size
-
-    reader = _CsvReader(config)
     try:
+        _validate_csv_path(path, encoding, reject_utf8_nul_bytes=False)
+
+        path_lower = path.lower()
+
+        # Resolve the sentinel: auto-detect tab for .tsv only when the caller
+        # truly omitted delimiter (None).  An explicit delimiter="," is always
+        # honoured, even for .tsv paths.
+        if delimiter is None:
+            delimiter = "\t" if path_lower.endswith(".tsv") else ","
+
+        decimal_separator = _validate_decimal_separator(decimal_separator)
+        _validate_thousands_separator(thousands_separator, decimal_separator)
+        delimiter = _validate_delimiter(delimiter)
+        encoding_errors = _validate_encoding_errors(encoding_errors)
+        mode = _validate_parser_mode(mode)
+        on_bad_lines = _validate_on_bad_lines(on_bad_lines)
+        config = _CsvConfig()
+        config.delimiter = delimiter
+        config.encoding = encoding
+        config.trim_headers = _validate_bool_option(trim_headers, "trim_headers")
+        config.decimal_separator = decimal_separator
+        config.thousands_separator = thousands_separator
+        config.has_header = _validate_bool_option(has_header, "has_header")
+        config.encoding_errors = encoding_errors
+        config.mode = mode
+
+        if null_values is not None:
+            config.null_values = _validate_null_values(null_values)
+
+        if sample_size is not None:
+            if not isinstance(sample_size, int) or isinstance(sample_size, bool):
+                raise TypeError("sample_size must be an integer.")
+            if sample_size <= 0:
+                raise ValueError(
+                    "sample_size must be a positive integer greater than 0."
+                )
+            config.sample_size = sample_size
+
+        reader = _CsvReader(config)
         # Schema inference only needs a sample, avoiding full-file transcode.
         # sample_rows is passed so _utf8_csv_path uses record-aware sampling
         # without rewriting decoded CSV text before native parsing.
@@ -1102,6 +1104,12 @@ def scan_csv(
             return cast(dict[str, str], schema)
     except RuntimeError as e:
         raise CsvReadError(str(e)) from None
+    finally:
+        if should_cleanup and os.path.exists(path):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
 
 def _reject_non_finite(constant: str) -> None:

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -3018,3 +3018,61 @@ def test_read_csv_chunked_text_stream_encoding_override():
     chunks = list(ar.read_csv_chunked(stream, encoding="utf-16"))
     pandas_df = ar.to_pandas(chunks[0])
     assert pandas_df["col2"][0] == "café"
+
+
+# --- Tests for scan_csv file-like input support (issue #1842) ---
+
+
+def test_scan_csv_stringio_basic():
+    """scan_csv should accept an io.StringIO and return a schema dict."""
+    stream = io.StringIO("name,age\nAlice,30\nBob,25\n")
+    schema = ar.scan_csv(stream)
+    assert isinstance(schema, dict)
+    assert "name" in schema
+    assert "age" in schema
+
+
+def test_scan_csv_stringio_schema_matches_path(tmp_path):
+    """scan_csv on a StringIO should return the same schema as a file path."""
+    csv_text = "id,value,label\n1,3.14,hello\n2,2.72,world\n"
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_text)
+
+    schema_from_path = ar.scan_csv(csv_file)
+    schema_from_stream = ar.scan_csv(io.StringIO(csv_text))
+    assert schema_from_path == schema_from_stream
+
+
+def test_scan_csv_stringio_cleans_up_temp_file():
+    """Temp file created from StringIO should be cleaned up after scan."""
+    import glob
+    import tempfile
+
+    before = set(glob.glob(os.path.join(tempfile.gettempdir(), "*.csv")))
+    ar.scan_csv(io.StringIO("a,b\n1,2\n"))
+    after = set(glob.glob(os.path.join(tempfile.gettempdir(), "*.csv")))
+    # No new temp CSV files should remain
+    assert after - before == set()
+
+
+def test_scan_csv_stringio_cleans_up_on_error():
+    """Temp file should be cleaned up even when scan_csv raises an error."""
+    import glob
+    import tempfile
+
+    before = set(glob.glob(os.path.join(tempfile.gettempdir(), "*.csv")))
+    # Empty stream should trigger CsvReadError (empty file)
+    with pytest.raises(CsvReadError):
+        ar.scan_csv(io.StringIO(""))
+    after = set(glob.glob(os.path.join(tempfile.gettempdir(), "*.csv")))
+    assert after - before == set()
+
+
+def test_scan_csv_file_like_object():
+    """scan_csv should work with any object that has a read() method."""
+    stream = ChunkTrackingTextStream(["x,y\n", "1,2\n", "3,4\n"])
+    schema = ar.scan_csv(stream)
+    assert "x" in schema
+    assert "y" in schema
+    assert stream.read_sizes
+    assert -1 not in stream.read_sizes


### PR DESCRIPTION
## Summary
Currently, `scan_csv` only accepts string paths or `os.PathLike` objects, failing if an in-memory stream (such as `io.StringIO`) is provided. This restricts users who want to inspect the schema of a CSV directly from memory, forcing them to use `read_csv` instead. This PR updates `scan_csv` to delegate path materialization to `_materialize_csv_input`, matching the behavior of `read_csv` and bringing parity to the API. It also includes proper cleanup of temporary files in a `try...finally` block.

## Linked issue
Fixes #1842

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
