### PR TITLE
fix: reject NaN for approx_top_values_min_ratio in profile()

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -736,7 +736,11 @@ def profile(
         approx_top_values_min_ratio, bool
     ):
         raise TypeError("approx_top_values_min_ratio must be a float")
-    if approx_top_values_min_ratio < 0 or approx_top_values_min_ratio > 1:
+    if (
+        not math.isfinite(approx_top_values_min_ratio)
+        or approx_top_values_min_ratio < 0
+        or approx_top_values_min_ratio > 1
+    ):
         raise ValueError("approx_top_values_min_ratio must be between 0 and 1")
     if not isinstance(approx_top_values_sample_size, int) or isinstance(
         approx_top_values_sample_size, bool

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -682,6 +682,11 @@ def test_profile_approx_top_values_validation(tmp_path):
     ):
         ar.profile(frame, approx_top_values_sample_size=0)
 
+    with pytest.raises(
+        ValueError, match="approx_top_values_min_ratio must be between 0 and 1"
+    ):
+        ar.profile(frame, approx_top_values_min_ratio=float("nan"))
+
 
 # ── top_values tests ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
`profile()` accepted `float("nan")` for `approx_top_values_min_ratio` because
NaN comparisons are always false, letting it slip past the existing `< 0 or > 1`
bounds check. Added `math.isfinite()` to the validation so NaN, inf, and -inf
are now rejected with a clear `ValueError`.

## Linked issue
Fixes #1692

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` — all 92 tests pass including new NaN validation test
- [x] `make lint` — pre-commit run --all-files passed clean
- [ ] Other:

## Screenshots / Media
N/A

## Performance Impact
N/A — validation-only change, no hot path affected.

## GSSoC labels
N/A — maintainers only.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
One-line fix: added `not math.isfinite(approx_top_values_min_ratio)` to the
existing bounds check in `profile()`. `math` was already imported.