### PR TITLE
fix: use frame.clone() in ArFrame.__copy__ for mutation isolation

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -876,7 +876,7 @@ class ArFrame:
         return True
 
     def __copy__(self) -> ArFrame:
-        return ArFrame(self._frame, attrs=self._attrs.copy())
+        return ArFrame(self._frame.clone(), attrs=self._attrs.copy())
 
     def __deepcopy__(self, memo: dict) -> ArFrame:
         if id(self) in memo:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -775,7 +775,7 @@ class TestArFrame:
         copied = copy.copy(frame)
         assert copied == frame
         assert copied is not frame
-        assert copied._frame is frame._frame
+        assert copied._frame is not frame._frame
 
     def test_arframe_deep_copy(self):
         frame = ar.ArFrame.from_records([{"a": 1}])
@@ -1657,3 +1657,18 @@ def test_selection_methods_preserve_attrs():
     # Deep copy isolation check
     res_dtypes._attrs["metadata"]["version"] = 2
     assert frame._attrs["metadata"]["version"] == 1
+
+
+def test_shallow_copy_independent_frame():
+    import copy
+
+    import pandas as pd
+
+    import arnio as ar
+
+    original = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+    shallow = copy.copy(original)
+
+    assert shallow._frame is not original._frame
+    ar.rename_columns(original, {"a": "b"})
+    assert "a" in shallow.columns  # mutation must not leak


### PR DESCRIPTION
## Summary
`ArFrame.__copy__()` was reusing `self._frame` directly, causing both the original 
and the shallow copy to share the same mutable C++ frame. Mutations on one silently 
affected the other. Fixed by calling `self._frame.clone()` — matching the isolation 
guarantee already used by `__deepcopy__()`.

## Linked issue
Fixes #1629

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `python -m pytest tests -v -k "copy"`
35 passed, 2 skipped in 1.47s

## Screenshots / Media
<img width="2940" height="1228" alt="image" src="https://github.com/user-attachments/assets/532d0fba-fcea-418c-b88c-f792c0d03964" />

## Performance Impact
None — `clone()` was already used in `__deepcopy__()`. Shallow copy now has 
the same cost as deep copy, which is the correct tradeoff for mutation isolation.

## GSSoC labels
<!-- For maintainers -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix:`).

## Maintainer notes
The existing `test_arframe_shallow_copy` was asserting the buggy behavior 
(`copied._frame is frame._frame`). Updated it to assert the correct behavior. 
Added `test_shallow_copy_independent_frame` as explicit regression coverage 
per the issue spec.