### PR TITLE
fix: validate indent argument in quality serializers to_json

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -489,6 +489,7 @@ class DataQualityReport:
         Example:
         report.to_json(indent=2)
         """
+        indent = _validate_json_indent(indent)
 
         json_out = json.dumps(
             self.to_dict(
@@ -1128,6 +1129,7 @@ class ProfileComparison:
         Example:
         comparison.to_json(indent=2)
         """
+        indent = _validate_json_indent(indent)
         json_out = json.dumps(
             self.to_dict(
                 redact_sample_values=redact_sample_values,
@@ -1343,6 +1345,7 @@ class QualityGateResult:
         Example:
         result.to_json(indent=2)
         """
+        indent = _validate_json_indent(indent)
         json_out = json.dumps(self.to_dict(), indent=indent)
 
         if output is None:
@@ -1855,6 +1858,17 @@ def _validate_bool_option(value: bool, name: str) -> bool:
     if not isinstance(value, bool):
         raise TypeError(f"{name} must be a bool")
     return value
+
+
+def _validate_json_indent(indent: int | None) -> int | None:
+    """Validate that JSON indent is either None or a non-boolean non-negative integer."""
+    if indent is None:
+        return None
+    if not isinstance(indent, int) or isinstance(indent, bool):
+        raise TypeError("indent must be an integer or None")
+    if indent < 0:
+        raise ValueError("indent cannot be negative")
+    return indent
 
 
 def _relative_delta(baseline: Any, current: Any) -> float | None:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -4284,15 +4284,18 @@ class TestQualityGateResultConstructorValidation:
 class TestValidateJsonIndent:
     def test_none_is_accepted(self):
         from arnio.quality import _validate_json_indent
+
         assert _validate_json_indent(None) is None
 
     def test_valid_integers(self):
         from arnio.quality import _validate_json_indent
+
         assert _validate_json_indent(0) == 0
         assert _validate_json_indent(4) == 4
 
     def test_bool_raises_type_error(self):
         from arnio.quality import _validate_json_indent
+
         with pytest.raises(TypeError, match="indent must be an integer or None"):
             _validate_json_indent(True)
         with pytest.raises(TypeError, match="indent must be an integer or None"):
@@ -4300,6 +4303,7 @@ class TestValidateJsonIndent:
 
     def test_invalid_types_raise_type_error(self):
         from arnio.quality import _validate_json_indent
+
         with pytest.raises(TypeError, match="indent must be an integer or None"):
             _validate_json_indent("2")
         with pytest.raises(TypeError, match="indent must be an integer or None"):
@@ -4309,6 +4313,7 @@ class TestValidateJsonIndent:
 
     def test_negative_raises_value_error(self):
         from arnio.quality import _validate_json_indent
+
         with pytest.raises(ValueError, match="indent cannot be negative"):
             _validate_json_indent(-1)
         with pytest.raises(ValueError, match="indent cannot be negative"):
@@ -4376,4 +4381,3 @@ def test_quality_gate_result_to_json_validation():
         result.to_json(indent=True)
     with pytest.raises(ValueError, match="indent cannot be negative"):
         result.to_json(indent=-1)
-

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -4279,3 +4279,101 @@ class TestQualityGateResultConstructorValidation:
                 issues=[issue],
                 thresholds="not a dict",
             )
+
+
+class TestValidateJsonIndent:
+    def test_none_is_accepted(self):
+        from arnio.quality import _validate_json_indent
+        assert _validate_json_indent(None) is None
+
+    def test_valid_integers(self):
+        from arnio.quality import _validate_json_indent
+        assert _validate_json_indent(0) == 0
+        assert _validate_json_indent(4) == 4
+
+    def test_bool_raises_type_error(self):
+        from arnio.quality import _validate_json_indent
+        with pytest.raises(TypeError, match="indent must be an integer or None"):
+            _validate_json_indent(True)
+        with pytest.raises(TypeError, match="indent must be an integer or None"):
+            _validate_json_indent(False)
+
+    def test_invalid_types_raise_type_error(self):
+        from arnio.quality import _validate_json_indent
+        with pytest.raises(TypeError, match="indent must be an integer or None"):
+            _validate_json_indent("2")
+        with pytest.raises(TypeError, match="indent must be an integer or None"):
+            _validate_json_indent(2.5)
+        with pytest.raises(TypeError, match="indent must be an integer or None"):
+            _validate_json_indent([2])
+
+    def test_negative_raises_value_error(self):
+        from arnio.quality import _validate_json_indent
+        with pytest.raises(ValueError, match="indent cannot be negative"):
+            _validate_json_indent(-1)
+        with pytest.raises(ValueError, match="indent cannot be negative"):
+            _validate_json_indent(-4)
+
+
+def test_data_quality_report_to_json_validation():
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+    )
+    with pytest.raises(TypeError, match="indent must be an integer or None"):
+        report.to_json(indent="x")
+    with pytest.raises(TypeError, match="indent must be an integer or None"):
+        report.to_json(indent=True)
+    with pytest.raises(ValueError, match="indent cannot be negative"):
+        report.to_json(indent=-1)
+
+
+def test_profile_comparison_to_json_validation():
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+    )
+    comparison = ar.quality.ProfileComparison(
+        left_profile=report,
+        right_profile=report,
+        drift_report={},
+        status_counts={},
+    )
+    with pytest.raises(TypeError, match="indent must be an integer or None"):
+        comparison.to_json(indent="x")
+    with pytest.raises(TypeError, match="indent must be an integer or None"):
+        comparison.to_json(indent=True)
+    with pytest.raises(ValueError, match="indent cannot be negative"):
+        comparison.to_json(indent=-1)
+
+
+def test_quality_gate_result_to_json_validation():
+    report = ar.DataQualityReport(
+        row_count=0,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+    )
+    result = ar.QualityGateResult(
+        baseline_profile=report,
+        current_profile=report,
+        issues=[],
+        thresholds={},
+    )
+    with pytest.raises(TypeError, match="indent must be an integer or None"):
+        result.to_json(indent="x")
+    with pytest.raises(TypeError, match="indent must be an integer or None"):
+        result.to_json(indent=True)
+    with pytest.raises(ValueError, match="indent cannot be negative"):
+        result.to_json(indent=-1)
+


### PR DESCRIPTION
### Summary

This update adds a check to make sure the indent argument is correct in the `to_json` methods of `DataQualityReport`, `ProfileComparison` and `QualityGateResult`. It fixes the problem with issue #1673.

### Changes Made

- I added a helper function called `_validate_json_indent` to the `arnio/quality.py` file.

- Now the indent has to be either None or a positive whole number that is not a value. If someone tries to use a string or a boolean it will give a TypeError. If they use a negative number it will give a ValueError.

- I applied the validation to `to_json()` methods in:
  - `DataQualityReport`
  - `ProfileComparison`
  - `QualityGateResult`

- I also added a lot of unit tests in the `tests/test_quality.py` file to make sure this works with types, like None, strings, booleans, floats and integers and also with negative inputs.

### Verification
- Verified that all 306 quality tests passed successfully