### PR TITLE
fix: validate field dtype values

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -34,6 +34,8 @@ DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 URL_SCHEME_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*$")
 
 _VALID_SEVERITIES = {"error", "warning"}
+_VALID_FIELD_DTYPES = frozenset({"int64", "float64", "string", "bool", "datetime"})
+_FIELD_DTYPE_OPTIONS = "int64, float64, string, bool, datetime, or None"
 
 _ALLOWED_FIELD_KEYS = {
     "dtype",
@@ -72,6 +74,16 @@ def _validate_numeric_bound(value: float | int, name: str) -> None:
     """Raise ValueError if value is not a finite number."""
     if not math.isfinite(value):
         raise ValueError(f"{name} must be a finite number, got {value!r}")
+
+
+def _validate_field_dtype(dtype: str | None) -> None:
+    """Raise if a Field dtype is not a supported public dtype."""
+    if dtype is None:
+        return
+    if not isinstance(dtype, str):
+        raise TypeError(f"dtype must be a string or None, got {type(dtype).__name__}")
+    if dtype not in _VALID_FIELD_DTYPES:
+        raise ValueError(f"dtype must be one of {_FIELD_DTYPE_OPTIONS}, got {dtype!r}")
 
 
 _DTYPE_MAP = {
@@ -734,6 +746,8 @@ class Field:
     severity: str = "error"
 
     def __post_init__(self) -> None:
+        _validate_field_dtype(self.dtype)
+
         if not isinstance(self.nullable, bool):
             raise TypeError("nullable must be a bool")
         if not isinstance(self.unique, bool):
@@ -762,10 +776,6 @@ class Field:
             if self.min is not None and self.max is not None:
                 if self.min > self.max:
                     raise ValueError("min must be less than or equal to max")
-        if self.dtype is not None and not isinstance(self.dtype, str):
-            raise TypeError(
-                f"dtype must be a str or None, got {type(self.dtype).__name__}"
-            )
 
         if self.pattern is not None:
             if not isinstance(self.pattern, str):

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -33,15 +33,15 @@ class TestDiffSchema:
 
     def test_returns_empty_diff_for_identical_schemas(self):
         """diff_schema returns empty list when schemas are identical."""
-        s1 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int")})
-        s2 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int")})
+        s1 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int64")})
+        s2 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int64")})
         diff = diff_schema(s1, s2)
         assert diff.difference_count == 0
         assert diff.changed is False
 
     def test_detects_missing_column_in_second_schema(self):
         """diff_schema detects columns missing from second schema."""
-        s1 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int")})
+        s1 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int64")})
         s2 = Schema(fields={"name": Field(dtype="string")})
         diff = diff_schema(s1, s2)
         missing = [d for d in diff.differences if d.change == "missing_column"]
@@ -52,7 +52,7 @@ class TestDiffSchema:
     def test_detects_extra_column_in_second_schema(self):
         """diff_schema detects extra columns in second schema."""
         s1 = Schema(fields={"name": Field(dtype="string")})
-        s2 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int")})
+        s2 = Schema(fields={"name": Field(dtype="string"), "age": Field(dtype="int64")})
         diff = diff_schema(s1, s2)
         extra = [d for d in diff.differences if d.change == "extra_column"]
         assert len(extra) == 1
@@ -61,7 +61,7 @@ class TestDiffSchema:
 
     def test_detects_dtype_change_between_schemas(self):
         """diff_schema detects dtype changes in common columns."""
-        s1 = Schema(fields={"age": Field(dtype="int")})
+        s1 = Schema(fields={"age": Field(dtype="int64")})
         s2 = Schema(fields={"age": Field(dtype="string")})
         diff = diff_schema(s1, s2)
         changed = [
@@ -71,7 +71,7 @@ class TestDiffSchema:
         ]
         assert len(changed) == 1
         assert changed[0].column == "age"
-        assert changed[0].expected == "int"
+        assert changed[0].expected == "int64"
         assert changed[0].observed == "string"
 
     def test_detects_nullable_change(self):
@@ -221,7 +221,7 @@ class TestDiffSchema:
         """diff_schema accepts dict form of expected schema."""
         expected = {"name": Field(dtype="string")}
         observed = Schema(
-            fields={"name": Field(dtype="string"), "age": Field(dtype="int")}
+            fields={"name": Field(dtype="string"), "age": Field(dtype="int64")}
         )
         diff = diff_schema(expected, observed)
         extra = [d for d in diff.differences if d.change == "extra_column"]
@@ -231,7 +231,7 @@ class TestDiffSchema:
     def test_accepts_dict_input_for_observed(self):
         """diff_schema accepts dict form of observed schema."""
         expected = Schema(
-            fields={"name": Field(dtype="string"), "age": Field(dtype="int")}
+            fields={"name": Field(dtype="string"), "age": Field(dtype="int64")}
         )
         observed = {"name": Field(dtype="string")}
         diff = diff_schema(expected, observed)
@@ -242,7 +242,7 @@ class TestDiffSchema:
     def test_accepts_dict_input_for_both(self):
         """diff_schema accepts dict form for both expected and observed."""
         expected = {"name": Field(dtype="string")}
-        observed = {"age": Field(dtype="int")}
+        observed = {"age": Field(dtype="int64")}
         diff = diff_schema(expected, observed)
         assert diff.difference_count == 2
         changes = {d.change for d in diff.differences}
@@ -250,7 +250,7 @@ class TestDiffSchema:
 
     def test_multiple_changed_attributes(self):
         """diff_schema reports all changed attributes for a column."""
-        s1 = Schema(fields={"age": Field(dtype="int", nullable=True)})
+        s1 = Schema(fields={"age": Field(dtype="int64", nullable=True)})
         s2 = Schema(fields={"age": Field(dtype="string", nullable=False)})
         diff = diff_schema(s1, s2)
         changed = [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3845,9 +3845,23 @@ def test_custom_rule_with_invalid_severity_fails_validation_execution():
         schema.validate(frame)
 
 
-def test_field_dtype_rejects_non_string():
-    with pytest.raises(TypeError, match="dtype must be a str or None"):
-        ar.Field(dtype=123)
+@pytest.mark.parametrize("dtype", [123, True, []])
+def test_field_dtype_rejects_non_string(dtype):
+    with pytest.raises(TypeError, match="dtype must be a string or None"):
+        ar.Field(dtype=dtype)
+
+
+def test_field_dtype_accepts_supported_public_dtypes():
+    for dtype in ("int64", "float64", "string", "bool", "datetime", None):
+        field = ar.Field(dtype=dtype)
+
+        assert field.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", ["", "uuid", "int", "FLOAT64"])
+def test_field_dtype_rejects_unsupported_strings(dtype):
+    with pytest.raises(ValueError, match="dtype must be one of"):
+        ar.Field(dtype=dtype)
 
 
 def test_field_pattern_rejects_non_string():

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -263,21 +263,21 @@ def test_set_valued_allowed_normalized():
 
 
 def test_real_schema_field_dtype():
-    schema = ar.Schema({"price": ar.Field(dtype="FLOAT64", nullable=False)})
+    schema = ar.Schema({"price": ar.Field(dtype="float64", nullable=False)})
     result = schema_to_dict(schema)
-    assert result["fields"]["price"]["dtype"] == "FLOAT64"
+    assert result["fields"]["price"]["dtype"] == "float64"
     assert result["fields"]["price"]["nullable"] is False
 
 
 def test_real_schema_field_allowed_set_normalized():
-    schema = ar.Schema({"status": ar.Field(dtype="STRING", allowed={"a", "b", "c"})})
+    schema = ar.Schema({"status": ar.Field(dtype="string", allowed={"a", "b", "c"})})
     result = schema_to_dict(schema)
     assert result["fields"]["status"]["allowed"] == ["a", "b", "c"]
 
 
 def test_real_schema_field_required_if_tuple_normalized():
     schema = ar.Schema(
-        {"col": ar.Field(dtype="STRING", required_if=("other_col", "yes"))}
+        {"col": ar.Field(dtype="string", required_if=("other_col", "yes"))}
     )
     result = schema_to_dict(schema)
     assert isinstance(result["fields"]["col"]["required_if"], list)
@@ -286,7 +286,7 @@ def test_real_schema_field_required_if_tuple_normalized():
 
 def test_real_schema_field_datetime_bounds():
     schema = ar.Schema(
-        {"ts": ar.Field(dtype="DATETIME", min="2020-01-01", max="2025-12-31")}
+        {"ts": ar.Field(dtype="datetime", min="2020-01-01", max="2025-12-31")}
     )
     result = schema_to_dict(schema)
     assert "datetime_min" in result["fields"]["ts"]
@@ -296,7 +296,7 @@ def test_real_schema_field_datetime_bounds():
 
 
 def test_real_schema_with_rules_raises():
-    schema = ar.Schema({"col": ar.Field(dtype="STRING")}, rules=[lambda df: []])
+    schema = ar.Schema({"col": ar.Field(dtype="string")}, rules=[lambda df: []])
     with pytest.raises(ValueError, match="rules"):
         schema_to_dict(schema)
 
@@ -346,9 +346,9 @@ def test_schema_object_fields_named_strict_and_unique_not_dropped():
     """Schema object: fields named strict/unique survive alongside schema metadata."""
     schema = ar.Schema(
         {
-            "strict": ar.Field(dtype="INT64"),
-            "unique": ar.Field(dtype="STRING"),
-            "name": ar.Field(dtype="STRING"),
+            "strict": ar.Field(dtype="int64"),
+            "unique": ar.Field(dtype="string"),
+            "name": ar.Field(dtype="string"),
         },
         strict=True,
         unique=["name"],


### PR DESCRIPTION
## Summary
- Added fail-fast validation for `Field.dtype` during `Field.__post_init__()`.
- Allowed only `None` and the supported public dtype strings: `int64`, `float64`, `string`, `bool`, and `datetime`.
- Added targeted schema tests for valid dtypes, `None`, unsupported strings, empty strings, and non-string values; updated existing schema diff/export fixtures to use canonical public dtype strings.

## Linked issue
Fixes #1675

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` - 2926 passed, 47 skipped, 11 warnings; 95% total coverage
- [ ] `make lint` - fails on pre-existing notebook import ordering in `examples/dataset_profile_comparison.ipynb`
- [x] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
  - `python3 -m pytest tests/test_schema.py -q -k "field_dtype"` - 8 passed
  - `python3 -m pytest tests/test_schema.py tests/test_diff_schema.py tests/test_schema_export.py -q` - 439 passed
  - `python3 -m pytest tests/ -v` - 2926 passed, 47 skipped, 12 warnings
  - `ruff check arnio/schema.py tests/test_schema.py tests/test_diff_schema.py tests/test_schema_export.py` - passed
  - `black --check arnio/schema.py tests/test_schema.py tests/test_diff_schema.py tests/test_schema_export.py` - passed
  - `ruff check . --extend-exclude "*.ipynb"` - passed
  - `black --check --diff .` - passed
  - `git diff --check` - passed

## Screenshots / Media
N/A - Python API validation change only.

## Performance Impact
N/A.

## GSSoC labels
Maintainers only.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes. (N/A - no docs/examples for this raw `Field.dtype` contract were changed.)
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Kept this scoped to the maintainer guidance on #1675: validation happens in `Field.__post_init__()`, invalid non-string/empty/unsupported dtype values fail at construction time, and no C++/CSV/schema behavior outside this dtype contract was changed.