### PR TITLE
docs: expand CSV guide option table

### DIFF
--- a/website/docs.html
+++ b/website/docs.html
@@ -97,6 +97,13 @@ result = ar.validate(clean, schema, max_errors=50)</code></pre></div>
           <thead><tr><th>Option</th><th>Use</th></tr></thead>
           <tbody>
             <tr><td><code>skiprows</code></td><td>Skip leading rows before header or data parsing.</td></tr>
+            <tr><td><code>has_header</code></td><td>Control whether the first row is treated as column headers.</td></tr>
+            <tr><td><code>usecols</code></td><td>Read only a selected subset of columns.</td></tr>
+            <tr><td><code>nrows</code></td><td>Limit the number of rows read from the file.</td></tr>
+            <tr><td><code>trim_headers</code></td><td>Remove leading and trailing whitespace from column names.</td></tr>
+            <tr><td><code>thousands_separator</code></td><td>Parse numbers containing thousands separators such as commas.</td></tr>
+            <tr><td><code>null_values</code></td><td>Treat specified values as null or missing data.</td></tr>
+            <tr><td><code>mode</code></td><td>Control CSV parsing behavior for strict or relaxed ingestion workflows.</td></tr>
             <tr><td><code>decimal_separator</code></td><td>Parse locale-specific decimal characters such as comma decimals.</td></tr>
             <tr><td><code>dtype</code></td><td>Force selected columns to supported Arnio dtypes.</td></tr>
             <tr><td><code>encoding_errors</code></td><td>Choose <code>strict</code>, <code>replace</code>, or <code>ignore</code> for decode failures.</td></tr>
@@ -105,10 +112,16 @@ result = ar.validate(clean, schema, max_errors=50)</code></pre></div>
         </table>
         <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python">frame = ar.read_csv(
     "orders.csv",
-    delimiter=",",
+    has_header=True,
+    usecols=["order_id", "amount", "customer"],
+    nrows=50_000,
     skiprows=2,
+    trim_headers=True,
+    thousands_separator=",",
+    null_values=["", "N/A", "NULL"],
     decimal_separator=".",
     dtype={"order_id": "string"},
+    mode="strict",
     encoding_errors="replace",
     on_bad_lines="warn",
 )</code></pre></div>


### PR DESCRIPTION
## Summary

Expanded the CSV guide documentation to cover additional parser controls currently supported by `read_csv()` but missing from the website documentation.

Added documentation entries for:

* `has_header`
* `usecols`
* `nrows`
* `trim_headers`
* `thousands_separator`
* `null_values`
* `mode`

Also refreshed the CSV example to demonstrate a more realistic ingestion workflow using these options.

## Linked issue

Fixes #2167

## Type of change

* [x] Documentation

## Area

* [x] CSV parser / I/O
* [x] Docs / website

## Testing

* [x] Other: Reviewed parameter behavior directly from `arnio/io.py`
* [x] Other: Verified documentation formatting matches the existing CSV guide structure
* [x] Other: Confirmed changes are limited to `website/docs.html`

## Screenshots / Media

Not applicable (documentation-only change).

## Performance Impact

None. Documentation-only update.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [ ] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

The update is limited to `website/docs.html` and the CSV guide table/example as requested in the issue scope.
