### PR TITLE
Fix/pipeline step container validation 1656

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -305,6 +305,27 @@ def _resolve_step_name(name: str, deprecated_step_aliases: dict[str, str]) -> st
     return canonical_name
 
 
+def _validate_pipeline_step_container(steps: Any) -> None:
+    if steps is None:
+        raise TypeError("steps must be a list of step tuples, got None")
+
+    if isinstance(steps, (str, bytes)):
+        raise TypeError(
+            f"steps must be a list of step tuples, got {type(steps).__name__}. "
+            "Each step must be (name,) or (name, kwargs), for example "
+            '[("drop_nulls",)].'
+        )
+    if isinstance(steps, tuple):
+        raise TypeError(
+            f"steps must be a list of step tuples, got bare step tuple {steps!r}. "
+            f"Use [{steps!r}] instead."
+        )
+    if not isinstance(steps, list):
+        raise TypeError(
+            f"steps must be a list of step tuples, got {type(steps).__name__}. "
+        )
+
+
 def _validate_pipeline_steps(
     steps: list[tuple],
     python_step_registry: dict[str, Callable],
@@ -412,6 +433,8 @@ def pipeline(
         python_step_registry = dict(_PYTHON_STEP_REGISTRY)
         namespaced_builtin_steps = _get_namespaced_builtin_steps(python_step_registry)
         deprecated_step_aliases = dict(_DEPRECATED_STEP_ALIASES)
+
+    _validate_pipeline_step_container(steps)
 
     _validate_pipeline_steps(
         steps,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2018,3 +2018,25 @@ class TestRegisterStepValidation:
             register_step(None, dummy_clean)  # type: ignore
         with pytest.raises(ValueError, match="must be a non-empty string"):
             register_step(42, dummy_clean)  # type: ignore
+
+
+class TestPipelineStepContainerValidation:
+    @pytest.fixture
+    def frame(self, sample_csv):
+        return ar.read_csv(sample_csv)
+
+    @pytest.mark.parametrize(
+        "invalid_steps",
+        [None, "drop_nulls", b"drop_nulls", {"drop_nulls": {}}, ("drop_nulls",)],
+    )
+    def test_pipeline_rejects_invalid_step_containers(self, frame, invalid_steps):
+        with pytest.raises(TypeError):
+            ar.pipeline(frame, invalid_steps)
+
+    def test_pipeline_rejects_bare_step_tuple_with_helpful_message(self, frame):
+        with pytest.raises(TypeError, match=r"\[\(\'drop_nulls\',\)\]"):
+            ar.pipeline(frame, ("drop_nulls",))
+
+    def test_pipeline_accepts_valid_step_container(self, frame):
+        result = ar.pipeline(frame, [("strip_whitespace",)])
+        assert isinstance(result, ar.ArFrame)


### PR DESCRIPTION
Closes #1656 

## Summary
Validate the `steps` container in `pipeline()` before `_validate_pipeline_steps()` iterates it.

## Changes
- Reject `None`, `str`, `bytes`, `dict`, and bare step tuples such as `("drop_nulls",)`.
- Bare tuple errors suggest the correct list form, e.g. `[("drop_nulls",)]`.
- Preserve existing valid `list[tuple]` step forms.
- Add regression tests in `tests/test_pipeline.py`.

## Test plan
- [x] `pytest tests/test_pipeline.py -v -k StepContainer`
- [x] `pytest tests/test_pipeline.py -v`
- [x] `make lint`