### PR TITLE
fix(io): prevent temp file leak when close() raises in _materialize_c…

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -390,8 +390,14 @@ def _materialize_csv_input(
             tmp.close()
             return tmp.name, True, True
         except Exception:
-            tmp.close()
-            os.unlink(tmp.name)
+            try:
+                tmp.close()
+            except OSError:
+                pass
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
             raise
 
     raise TypeError("read_csv expected a filesystem path or text file-like object")

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -76,7 +76,6 @@ class TestMaterializeCsvCleanup:
 
     def test_unlink_failure_does_not_mask_original_exception(self):
         """If unlink() also raises during cleanup, the original exception propagates."""
-        real_unlink = os.unlink
 
         def close_raising_ntf(**kwargs):
             handle = tempfile.NamedTemporaryFile(**kwargs)

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -7,6 +7,7 @@ must still run so the temp file is not leaked on disk.
 
 import io
 import os
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,22 @@ class _FailOnReadStream:
 
     def read(self, size=-1):
         raise OSError("simulated read failure")
+
+
+def _ntf_with_flaky_close(**kwargs):
+    """Return a real NamedTemporaryFile whose close() raises on first call."""
+    handle = tempfile.NamedTemporaryFile(**kwargs)
+    real_close = handle.close
+    call_count = [0]
+
+    def flaky_close():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise OSError("simulated flush error on close")
+        real_close()
+
+    handle.close = flaky_close
+    return handle
 
 
 class TestMaterializeCsvCleanup:
@@ -41,8 +58,8 @@ class TestMaterializeCsvCleanup:
 
         with (
             patch(
-                "arnio.io.tempfile.NamedTemporaryFile.close",
-                side_effect=OSError("simulated flush error on close"),
+                "arnio.io.tempfile.NamedTemporaryFile",
+                side_effect=_ntf_with_flaky_close,
             ),
             patch("arnio.io.os.unlink", side_effect=tracking_unlink),
         ):
@@ -59,11 +76,21 @@ class TestMaterializeCsvCleanup:
 
     def test_unlink_failure_does_not_mask_original_exception(self):
         """If unlink() also raises during cleanup, the original exception propagates."""
+        real_unlink = os.unlink
+
+        def close_raising_ntf(**kwargs):
+            handle = tempfile.NamedTemporaryFile(**kwargs)
+            handle.close = lambda: (_ for _ in ()).throw(
+                OSError("simulated close error")
+            )
+            return handle
+
         source = _FailOnReadStream()
+
         with (
             patch(
-                "arnio.io.tempfile.NamedTemporaryFile.close",
-                side_effect=OSError("close error"),
+                "arnio.io.tempfile.NamedTemporaryFile",
+                side_effect=close_raising_ntf,
             ),
             patch("arnio.io.os.unlink", side_effect=OSError("unlink error")),
         ):

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -14,6 +14,10 @@ import pytest
 
 from arnio.io import _materialize_csv_input
 
+# Capture the real os.unlink once at module level so no test can accidentally
+# capture a patched version via a delayed assignment.
+_REAL_UNLINK = os.unlink
+
 
 class _FailOnReadStream:
     """A file-like that raises on read() to trigger the except path."""
@@ -35,19 +39,42 @@ class _FailAfterFirstChunkStream:
         raise OSError("simulated mid-read failure")
 
 
+class _FakeTmp:
+    """
+    Lightweight fake NamedTemporaryFile whose close() raises OSError.
+    Used to verify that os.unlink() is still called even when close() fails.
+    """
+
+    def __init__(self, suffix=".csv", **kwargs):
+        self._real = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        self.name = self._real.name
+
+    def write(self, data):
+        self._real.write(data)
+
+    def close(self):
+        self._real.close()
+        raise OSError("simulated flush error on close")
+
+
+def _make_tracking_unlink():
+    """Return (tracking_unlink, unlinked_list) pair using the real unlink."""
+    unlinked = []
+
+    def tracking_unlink(path):
+        unlinked.append(path)
+        try:
+            _REAL_UNLINK(path)
+        except OSError:
+            pass
+
+    return tracking_unlink, unlinked
+
+
 class TestMaterializeCsvCleanup:
     def test_unlink_called_on_read_failure(self):
         """os.unlink must be called when read() raises, so no temp file is leaked."""
-        real_unlink = os.unlink
-        unlinked = []
-
-        def tracking_unlink(path):
-            unlinked.append(path)
-            try:
-                real_unlink(path)
-            except OSError:
-                pass
-
+        tracking_unlink, unlinked = _make_tracking_unlink()
         source = _FailOnReadStream()
 
         with patch("arnio.io.os.unlink", side_effect=tracking_unlink):
@@ -58,20 +85,28 @@ class TestMaterializeCsvCleanup:
 
     def test_unlink_called_on_mid_read_failure(self):
         """os.unlink must be called even when failure occurs after partial write."""
-        real_unlink = os.unlink
-        unlinked = []
-
-        def tracking_unlink(path):
-            unlinked.append(path)
-            try:
-                real_unlink(path)
-            except OSError:
-                pass
-
+        tracking_unlink, unlinked = _make_tracking_unlink()
         source = _FailAfterFirstChunkStream()
 
         with patch("arnio.io.os.unlink", side_effect=tracking_unlink):
             with pytest.raises(OSError, match="simulated mid-read failure"):
+                _materialize_csv_input(source)
+
+        assert unlinked, "os.unlink was never called — temp file was leaked"
+
+    def test_unlink_runs_when_close_raises_on_cleanup(self):
+        """
+        Core regression for #2194: if tmp.close() raises during exception
+        cleanup, os.unlink() must still be called so the file is not leaked.
+        """
+        tracking_unlink, unlinked = _make_tracking_unlink()
+        source = _FailOnReadStream()
+
+        with (
+            patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=_FakeTmp),
+            patch("arnio.io.os.unlink", side_effect=tracking_unlink),
+        ):
+            with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
 
         assert unlinked, "os.unlink was never called — temp file was leaked"
@@ -89,52 +124,6 @@ class TestMaterializeCsvCleanup:
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
 
-    def test_unlink_runs_when_close_raises_on_cleanup(self):
-        """
-        Core regression for #2194: if tmp.close() raises during exception
-        cleanup, os.unlink() must still be called so the file is not leaked.
-        """
-        real_unlink = os.unlink
-        unlinked = []
-
-        def tracking_unlink(path):
-            unlinked.append(path)
-            try:
-                real_unlink(path)
-            except OSError:
-                pass
-
-        class _FakeTmp:
-            """Lightweight fake NamedTemporaryFile with a close() that raises."""
-
-            name = None
-
-            def __init__(self):
-                # Use a real temp file so the name is a valid path on disk.
-                self._real = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
-                self.name = self._real.name
-
-            def write(self, data):
-                self._real.write(data)
-
-            def close(self):
-                self._real.close()
-                raise OSError("simulated flush error on close")
-
-        def fake_ntf(**kwargs):
-            return _FakeTmp()
-
-        source = _FailOnReadStream()
-
-        with (
-            patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=fake_ntf),
-            patch("arnio.io.os.unlink", side_effect=tracking_unlink),
-        ):
-            with pytest.raises(OSError, match="simulated read failure"):
-                _materialize_csv_input(source)
-
-        assert unlinked, "os.unlink was never called — temp file was leaked"
-
     def test_normal_path_still_works(self):
         """Regression: the happy path must still return a valid temp file path."""
         source = io.StringIO("col1,col2\n1,2\n3,4\n")
@@ -146,7 +135,7 @@ class TestMaterializeCsvCleanup:
             assert should_delete is True
         finally:
             try:
-                os.unlink(path)
+                _REAL_UNLINK(path)
             except OSError:
                 pass
 

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -7,6 +7,7 @@ must still run so the temp file is not leaked on disk.
 
 import io
 import os
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -87,6 +88,52 @@ class TestMaterializeCsvCleanup:
         with patch("arnio.io.os.unlink", side_effect=OSError("unlink error")):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
+
+    def test_unlink_runs_when_close_raises_on_cleanup(self):
+        """
+        Core regression for #2194: if tmp.close() raises during exception
+        cleanup, os.unlink() must still be called so the file is not leaked.
+        """
+        real_unlink = os.unlink
+        unlinked = []
+
+        def tracking_unlink(path):
+            unlinked.append(path)
+            try:
+                real_unlink(path)
+            except OSError:
+                pass
+
+        class _FakeTmp:
+            """Lightweight fake NamedTemporaryFile with a close() that raises."""
+
+            name = None
+
+            def __init__(self):
+                # Use a real temp file so the name is a valid path on disk.
+                self._real = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
+                self.name = self._real.name
+
+            def write(self, data):
+                self._real.write(data)
+
+            def close(self):
+                self._real.close()
+                raise OSError("simulated flush error on close")
+
+        def fake_ntf(**kwargs):
+            return _FakeTmp()
+
+        source = _FailOnReadStream()
+
+        with (
+            patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=fake_ntf),
+            patch("arnio.io.os.unlink", side_effect=tracking_unlink),
+        ):
+            with pytest.raises(OSError, match="simulated read failure"):
+                _materialize_csv_input(source)
+
+        assert unlinked, "os.unlink was never called — temp file was leaked"
 
     def test_normal_path_still_works(self):
         """Regression: the happy path must still return a valid temp file path."""

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -8,7 +8,7 @@ must still run so the temp file is not leaked on disk.
 import io
 import os
 import tempfile
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 import pytest
 
@@ -17,57 +17,35 @@ from arnio.io import _materialize_csv_input
 
 class _FailOnReadStream:
     """A file-like that raises on read() to trigger the except path."""
+
     def read(self, size=-1):
         raise OSError("simulated read failure")
 
 
 class TestMaterializeCsvCleanup:
-
     def test_unlink_runs_even_when_close_raises(self):
         """
         If tmp.close() raises in the cleanup path, os.unlink must still be
         called so the temp file is not leaked.
         """
+        real_unlink = os.unlink  # capture before patching to avoid recursion
         unlinked = []
-
-        # Track which temp file gets created so we can assert unlink was called on it
-        created_tmp_name = []
-        real_ntf = tempfile.NamedTemporaryFile
-
-        def patched_ntf(**kwargs):
-            handle = real_ntf(**kwargs)
-            created_tmp_name.append(handle.name)
-            return handle
-
-        close_call_count = [0]
-        real_close = None
-
-        def patched_close(self_handle):
-            close_call_count[0] += 1
-            if close_call_count[0] == 1:
-                # First call is the cleanup call — raise to simulate flush error
-                raise OSError("simulated flush error on close")
-            # Subsequent calls (if any) succeed
-            real_close(self_handle)
 
         def tracking_unlink(path):
             unlinked.append(path)
-            # Actually delete so we don't leave files behind
             try:
-                os.unlink(path)
+                real_unlink(path)
             except OSError:
                 pass
 
         source = _FailOnReadStream()
 
         with (
-            patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf),
-            patch("arnio.io.os.unlink", side_effect=tracking_unlink),
             patch(
                 "arnio.io.tempfile.NamedTemporaryFile.close",
                 side_effect=OSError("simulated flush error on close"),
-                autospec=False,
             ),
+            patch("arnio.io.os.unlink", side_effect=tracking_unlink),
         ):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
@@ -84,12 +62,11 @@ class TestMaterializeCsvCleanup:
         """If unlink() also raises during cleanup, the original exception propagates."""
         source = _FailOnReadStream()
         with (
-            patch("arnio.io.os.unlink", side_effect=OSError("unlink error")),
             patch(
                 "arnio.io.tempfile.NamedTemporaryFile.close",
                 side_effect=OSError("close error"),
-                autospec=False,
             ),
+            patch("arnio.io.os.unlink", side_effect=OSError("unlink error")),
         ):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -17,6 +17,7 @@ from arnio.io import _materialize_csv_input
 
 class _FailOnReadStream:
     """A file-like that raises on read() to trigger the except path."""
+
     def read(self, size=-1):
         raise OSError("simulated read failure")
 
@@ -47,8 +48,10 @@ class TestMaterializeCsvCleanup:
 
         source = _FailOnReadStream()
 
-        with patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf), \
-             patch("arnio.io.os.unlink", side_effect=tracking_unlink):
+        with (
+            patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf),
+            patch("arnio.io.os.unlink", side_effect=tracking_unlink),
+        ):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
 
@@ -69,8 +72,10 @@ class TestMaterializeCsvCleanup:
 
         source = _FailOnReadStream()
 
-        with patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf), \
-             patch("arnio.io.os.unlink", side_effect=OSError("unlink error")):
+        with (
+            patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf),
+            patch("arnio.io.os.unlink", side_effect=OSError("unlink error")),
+        ):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
 

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -17,6 +17,7 @@ from arnio.io import _materialize_csv_input
 # Capture the real os.unlink once at module level so no test can accidentally
 # capture a patched version via a delayed assignment.
 _REAL_UNLINK = os.unlink
+_REAL_NAMED_TEMPORARY_FILE = tempfile.NamedTemporaryFile
 
 
 class _FailOnReadStream:
@@ -46,7 +47,7 @@ class _FakeTmp:
     """
 
     def __init__(self, suffix=".csv", **kwargs):
-        self._real = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        self._real = _REAL_NAMED_TEMPORARY_FILE(delete=False, suffix=suffix)
         self.name = self._real.name
 
     def write(self, data):

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -1,0 +1,93 @@
+"""
+Regression tests for the temp-file cleanup path in _materialize_csv_input.
+
+Fixes #2194: when tmp.close() raises during exception cleanup, os.unlink
+must still run so the temp file is not leaked on disk.
+"""
+
+import io
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from arnio.io import _materialize_csv_input
+
+
+class _FailOnReadStream:
+    """A file-like that raises on read() to trigger the except path."""
+    def read(self, size=-1):
+        raise OSError("simulated read failure")
+
+
+class TestMaterializeCsvCleanup:
+
+    def test_unlink_runs_even_when_close_raises(self, tmp_path):
+        unlinked = []
+        real_ntf = tempfile.NamedTemporaryFile
+
+        def patched_ntf(**kwargs):
+            handle = real_ntf(**kwargs)
+            original_close = handle.close
+            call_count = [0]
+
+            def flaky_close():
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    raise OSError("simulated flush error on close")
+                original_close()
+
+            handle.close = flaky_close
+            return handle
+
+        def tracking_unlink(path):
+            unlinked.append(path)
+            os.unlink(path)
+
+        source = _FailOnReadStream()
+
+        with patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf), \
+             patch("arnio.io.os.unlink", side_effect=tracking_unlink):
+            with pytest.raises(OSError, match="simulated read failure"):
+                _materialize_csv_input(source)
+
+        assert unlinked, "os.unlink was never called — temp file was leaked"
+
+    def test_original_exception_is_reraised(self):
+        source = _FailOnReadStream()
+        with pytest.raises(OSError, match="simulated read failure"):
+            _materialize_csv_input(source)
+
+    def test_unlink_failure_does_not_mask_original_exception(self, tmp_path):
+        real_ntf = tempfile.NamedTemporaryFile
+
+        def patched_ntf(**kwargs):
+            handle = real_ntf(**kwargs)
+            handle.close = lambda: (_ for _ in ()).throw(OSError("close error"))
+            return handle
+
+        source = _FailOnReadStream()
+
+        with patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf), \
+             patch("arnio.io.os.unlink", side_effect=OSError("unlink error")):
+            with pytest.raises(OSError, match="simulated read failure"):
+                _materialize_csv_input(source)
+
+    def test_normal_path_still_works(self):
+        source = io.StringIO("col1,col2\n1,2\n3,4\n")
+        path, created, should_delete = _materialize_csv_input(source)
+        try:
+            assert isinstance(path, str)
+            assert os.path.exists(path)
+            assert created is True
+            assert should_delete is True
+        finally:
+            os.unlink(path)
+
+    def test_no_temp_file_for_path_input(self, tmp_path):
+        p = tmp_path / "data.csv"
+        p.write_text("a,b\n1,2\n")
+        path, created, _ = _materialize_csv_input(str(p))
+        assert path == str(p)
+        assert created is False

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -8,7 +8,7 @@ must still run so the temp file is not leaked on disk.
 import io
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, call
 
 import pytest
 
@@ -17,40 +17,57 @@ from arnio.io import _materialize_csv_input
 
 class _FailOnReadStream:
     """A file-like that raises on read() to trigger the except path."""
-
     def read(self, size=-1):
         raise OSError("simulated read failure")
 
 
 class TestMaterializeCsvCleanup:
 
-    def test_unlink_runs_even_when_close_raises(self, tmp_path):
+    def test_unlink_runs_even_when_close_raises(self):
+        """
+        If tmp.close() raises in the cleanup path, os.unlink must still be
+        called so the temp file is not leaked.
+        """
         unlinked = []
+
+        # Track which temp file gets created so we can assert unlink was called on it
+        created_tmp_name = []
         real_ntf = tempfile.NamedTemporaryFile
 
         def patched_ntf(**kwargs):
             handle = real_ntf(**kwargs)
-            original_close = handle.close
-            call_count = [0]
-
-            def flaky_close():
-                call_count[0] += 1
-                if call_count[0] == 1:
-                    raise OSError("simulated flush error on close")
-                original_close()
-
-            handle.close = flaky_close
+            created_tmp_name.append(handle.name)
             return handle
+
+        close_call_count = [0]
+        real_close = None
+
+        def patched_close(self_handle):
+            close_call_count[0] += 1
+            if close_call_count[0] == 1:
+                # First call is the cleanup call — raise to simulate flush error
+                raise OSError("simulated flush error on close")
+            # Subsequent calls (if any) succeed
+            real_close(self_handle)
 
         def tracking_unlink(path):
             unlinked.append(path)
-            os.unlink(path)
+            # Actually delete so we don't leave files behind
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
         source = _FailOnReadStream()
 
         with (
             patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf),
             patch("arnio.io.os.unlink", side_effect=tracking_unlink),
+            patch(
+                "arnio.io.tempfile.NamedTemporaryFile.close",
+                side_effect=OSError("simulated flush error on close"),
+                autospec=False,
+            ),
         ):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
@@ -58,28 +75,27 @@ class TestMaterializeCsvCleanup:
         assert unlinked, "os.unlink was never called — temp file was leaked"
 
     def test_original_exception_is_reraised(self):
+        """The cleanup path must re-raise the original exception."""
         source = _FailOnReadStream()
         with pytest.raises(OSError, match="simulated read failure"):
             _materialize_csv_input(source)
 
-    def test_unlink_failure_does_not_mask_original_exception(self, tmp_path):
-        real_ntf = tempfile.NamedTemporaryFile
-
-        def patched_ntf(**kwargs):
-            handle = real_ntf(**kwargs)
-            handle.close = lambda: (_ for _ in ()).throw(OSError("close error"))
-            return handle
-
+    def test_unlink_failure_does_not_mask_original_exception(self):
+        """If unlink() also raises during cleanup, the original exception propagates."""
         source = _FailOnReadStream()
-
         with (
-            patch("arnio.io.tempfile.NamedTemporaryFile", side_effect=patched_ntf),
             patch("arnio.io.os.unlink", side_effect=OSError("unlink error")),
+            patch(
+                "arnio.io.tempfile.NamedTemporaryFile.close",
+                side_effect=OSError("close error"),
+                autospec=False,
+            ),
         ):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
 
     def test_normal_path_still_works(self):
+        """Regression: the happy path must still return a valid temp file path."""
         source = io.StringIO("col1,col2\n1,2\n3,4\n")
         path, created, should_delete = _materialize_csv_input(source)
         try:
@@ -88,9 +104,13 @@ class TestMaterializeCsvCleanup:
             assert created is True
             assert should_delete is True
         finally:
-            os.unlink(path)
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
     def test_no_temp_file_for_path_input(self, tmp_path):
+        """A plain file path must pass through without creating a temp file."""
         p = tmp_path / "data.csv"
         p.write_text("a,b\n1,2\n")
         path, created, _ = _materialize_csv_input(str(p))

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -7,7 +7,6 @@ must still run so the temp file is not leaked on disk.
 
 import io
 import os
-import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -22,29 +21,23 @@ class _FailOnReadStream:
         raise OSError("simulated read failure")
 
 
-def _ntf_with_flaky_close(**kwargs):
-    """Return a real NamedTemporaryFile whose close() raises on first call."""
-    handle = tempfile.NamedTemporaryFile(**kwargs)
-    real_close = handle.close
-    call_count = [0]
+class _FailAfterFirstChunkStream:
+    """A file-like that returns one chunk then raises, so write() is called."""
 
-    def flaky_close():
-        call_count[0] += 1
-        if call_count[0] == 1:
-            raise OSError("simulated flush error on close")
-        real_close()
+    def __init__(self):
+        self._calls = 0
 
-    handle.close = flaky_close
-    return handle
+    def read(self, size=-1):
+        self._calls += 1
+        if self._calls == 1:
+            return "col1,col2\n"
+        raise OSError("simulated mid-read failure")
 
 
 class TestMaterializeCsvCleanup:
-    def test_unlink_runs_even_when_close_raises(self):
-        """
-        If tmp.close() raises in the cleanup path, os.unlink must still be
-        called so the temp file is not leaked.
-        """
-        real_unlink = os.unlink  # capture before patching to avoid recursion
+    def test_unlink_called_on_read_failure(self):
+        """os.unlink must be called when read() raises, so no temp file is leaked."""
+        real_unlink = os.unlink
         unlinked = []
 
         def tracking_unlink(path):
@@ -56,43 +49,42 @@ class TestMaterializeCsvCleanup:
 
         source = _FailOnReadStream()
 
-        with (
-            patch(
-                "arnio.io.tempfile.NamedTemporaryFile",
-                side_effect=_ntf_with_flaky_close,
-            ),
-            patch("arnio.io.os.unlink", side_effect=tracking_unlink),
-        ):
+        with patch("arnio.io.os.unlink", side_effect=tracking_unlink):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
 
         assert unlinked, "os.unlink was never called — temp file was leaked"
 
+    def test_unlink_called_on_mid_read_failure(self):
+        """os.unlink must be called even when failure occurs after partial write."""
+        real_unlink = os.unlink
+        unlinked = []
+
+        def tracking_unlink(path):
+            unlinked.append(path)
+            try:
+                real_unlink(path)
+            except OSError:
+                pass
+
+        source = _FailAfterFirstChunkStream()
+
+        with patch("arnio.io.os.unlink", side_effect=tracking_unlink):
+            with pytest.raises(OSError, match="simulated mid-read failure"):
+                _materialize_csv_input(source)
+
+        assert unlinked, "os.unlink was never called — temp file was leaked"
+
     def test_original_exception_is_reraised(self):
-        """The cleanup path must re-raise the original exception."""
+        """The cleanup path must re-raise the original exception, not swallow it."""
         source = _FailOnReadStream()
         with pytest.raises(OSError, match="simulated read failure"):
             _materialize_csv_input(source)
 
-    def test_unlink_failure_does_not_mask_original_exception(self):
+    def test_original_exception_reraised_even_when_unlink_fails(self):
         """If unlink() also raises during cleanup, the original exception propagates."""
-
-        def close_raising_ntf(**kwargs):
-            handle = tempfile.NamedTemporaryFile(**kwargs)
-            handle.close = lambda: (_ for _ in ()).throw(
-                OSError("simulated close error")
-            )
-            return handle
-
         source = _FailOnReadStream()
-
-        with (
-            patch(
-                "arnio.io.tempfile.NamedTemporaryFile",
-                side_effect=close_raising_ntf,
-            ),
-            patch("arnio.io.os.unlink", side_effect=OSError("unlink error")),
-        ):
+        with patch("arnio.io.os.unlink", side_effect=OSError("unlink error")):
             with pytest.raises(OSError, match="simulated read failure"):
                 _materialize_csv_input(source)
 

--- a/tests/test_materialize_csv_cleanup.py
+++ b/tests/test_materialize_csv_cleanup.py
@@ -7,7 +7,6 @@ must still run so the temp file is not leaked on disk.
 
 import io
 import os
-import tempfile
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
prevent temp file leak when close() raises in _materialize_csv_input

Fixes #2194