### PR TITLE
Prevent unregistering built-in Python steps

### DIFF
--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -168,7 +168,6 @@ def register_step(name: str, fn: Callable, overwrite: bool = False):
     >>> ar.register_step("custom_clean", new_custom_clean, overwrite=True)
     """
     with _REGISTRY_LOCK:
-
         if not isinstance(name, str) or not name or not name.strip():
             raise ValueError("parameter 'name' must be a non-empty string")
         if not callable(fn):
@@ -210,7 +209,6 @@ def register_step(name: str, fn: Callable, overwrite: bool = False):
 def unregister_step(name: str) -> None:
     """Unregister a custom Python pipeline step."""
     with _REGISTRY_LOCK:
-
         if not isinstance(name, str):
             raise TypeError(
                 f"parameter 'name' must be a string, not {type(name).__name__}"
@@ -324,19 +322,17 @@ def _validate_pipeline_steps(
     for step in steps:
         if not isinstance(step, tuple) or not (1 <= len(step) <= 2):
             raise ValueError(
-                f"Invalid step format: {step!r}. " "Expected (name,) or (name, kwargs)"
+                f"Invalid step format: {step!r}. Expected (name,) or (name, kwargs)"
             )
 
         name = step[0]
 
         if not isinstance(name, str):
-            raise ValueError(
-                f"Invalid pipeline step name: {name!r}. " "Expected a string"
-            )
+            raise ValueError(f"Invalid pipeline step name: {name!r}. Expected a string")
 
         if len(step) == 2 and not isinstance(step[1], dict):
             raise ValueError(
-                f"Invalid step kwargs for '{name}': " f"{step[1]!r}. Expected a dict"
+                f"Invalid step kwargs for '{name}': {step[1]!r}. Expected a dict"
             )
 
         if name not in available_steps:

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -229,7 +229,9 @@ def unregister_step(name: str) -> None:
         # underlying callable happens to live in arnio.cleaning.
         if name in _BUILTIN_PYTHON_STEP_REGISTRY:
             available_steps = sorted(set(_STEP_REGISTRY) | set(_PYTHON_STEP_REGISTRY))
-            raise ValueError("built-in steps cannot be unregistered")
+            raise ValueError(
+    f"Cannot unregister built-in step '{name}'. Only custom user-registered steps can be unregistered."
+)
         del _PYTHON_STEP_REGISTRY[name]
 
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -230,8 +230,8 @@ def unregister_step(name: str) -> None:
         if name in _BUILTIN_PYTHON_STEP_REGISTRY:
             available_steps = sorted(set(_STEP_REGISTRY) | set(_PYTHON_STEP_REGISTRY))
             raise ValueError(
-    f"Cannot unregister built-in step '{name}'. Only custom user-registered steps can be unregistered."
-)
+                f"Cannot unregister built-in step '{name}'. Only custom user-registered steps can be unregistered."
+            )
         del _PYTHON_STEP_REGISTRY[name]
 
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -229,7 +229,7 @@ def unregister_step(name: str) -> None:
         # underlying callable happens to live in arnio.cleaning.
         if name in _BUILTIN_PYTHON_STEP_REGISTRY:
             available_steps = sorted(set(_STEP_REGISTRY) | set(_PYTHON_STEP_REGISTRY))
-            raise UnknownStepError(name, available_steps)
+            raise ValueError("built-in steps cannot be unregistered")
         del _PYTHON_STEP_REGISTRY[name]
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -631,13 +631,13 @@ class TestPipeline:
             ar.unregister_step("missing_step")
 
     def test_unregister_builtin_python_step(self):
-     for step_name in [       
-        "standardize_missing_tokens",
-        "filter_rows",
-        "replace_values",
-    ]:
-        with pytest.raises(ValueError):
-            ar.unregister_step(step_name)
+        for step_name in [
+            "standardize_missing_tokens",
+            "filter_rows",
+            "replace_values",
+        ]:
+            with pytest.raises(ValueError):
+                ar.unregister_step(step_name)
 
     def test_unregister_custom_step(self):
         def custom_step(df):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -631,8 +631,13 @@ class TestPipeline:
             ar.unregister_step("missing_step")
 
     def test_unregister_builtin_python_step(self):
+     for step_name in [       
+        "standardize_missing_tokens",
+        "filter_rows",
+        "replace_values",
+    ]:
         with pytest.raises(ValueError):
-            ar.unregister_step("standardize_missing_tokens")
+            ar.unregister_step(step_name)
 
     def test_unregister_custom_step(self):
         def custom_step(df):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -631,7 +631,7 @@ class TestPipeline:
             ar.unregister_step("missing_step")
 
     def test_unregister_builtin_python_step(self):
-        with pytest.raises(ar.UnknownStepError):
+        with pytest.raises(ValueError):
             ar.unregister_step("standardize_missing_tokens")
 
     def test_unregister_custom_step(self):

--- a/tests/test_register_step_safety.py
+++ b/tests/test_register_step_safety.py
@@ -157,4 +157,4 @@ class TestUnregisterStepBuiltinAlias:
 
         for step_name in list(_BUILTIN_PYTHON_STEP_REGISTRY):
             with pytest.raises(ValueError):
-              unregister_step(step_name)
+                unregister_step(step_name)

--- a/tests/test_register_step_safety.py
+++ b/tests/test_register_step_safety.py
@@ -153,7 +153,6 @@ class TestUnregisterStepBuiltinAlias:
         Ensures the fix does not weaken protection for real built-in names
         such as 'filter_rows', 'normalize_whitespace', 'coalesce_columns'.
         """
-        
 
         for step_name in list(_BUILTIN_PYTHON_STEP_REGISTRY):
             with pytest.raises(ValueError):

--- a/tests/test_register_step_safety.py
+++ b/tests/test_register_step_safety.py
@@ -153,7 +153,7 @@ class TestUnregisterStepBuiltinAlias:
         Ensures the fix does not weaken protection for real built-in names
         such as 'filter_rows', 'normalize_whitespace', 'coalesce_columns'.
         """
-        from arnio.exceptions import UnknownStepError
+        
 
         for step_name in list(_BUILTIN_PYTHON_STEP_REGISTRY):
             with pytest.raises(ValueError):

--- a/tests/test_register_step_safety.py
+++ b/tests/test_register_step_safety.py
@@ -156,5 +156,5 @@ class TestUnregisterStepBuiltinAlias:
         from arnio.exceptions import UnknownStepError
 
         for step_name in list(_BUILTIN_PYTHON_STEP_REGISTRY):
-            with pytest.raises(UnknownStepError):
-                unregister_step(step_name)
+            with pytest.raises(ValueError):
+              unregister_step(step_name)


### PR DESCRIPTION
## Summary
Prevent unregistering built-in Python steps.

Changed unregister_step() to raise ValueError when attempting to unregister built-in steps. Updated tests to verify the new behavior.

## Linked issue
Fixes #1777

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
  ```
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
pytest tests/test_pipeline.py -k unregister

Result: 5 passed

## Screenshots / Media
<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [ ] I read the contributing guide.
- [ ] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [ ] I checked that generated files, logs, and local build artifacts are not committed.
- [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
