### PR TITLE
chore: run benchmarks for binding changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - "arnio/**"
+      - "bindings/**"
       - "cpp/**"
       - "benchmarks/**"
       - ".github/workflows/benchmark.yml"


### PR DESCRIPTION
## Summary
- add `bindings/**` to the benchmark workflow pull request path filters
- keep the existing benchmark jobs and commands unchanged

Fixes #1898

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/benchmark.yml"); puts "benchmark workflow YAML parses"'`\n- `git diff --check`