### PR TITLE
ci: strengthen Windows wheel smoke test beyond import checks

### DIFF
--- a/.github/workflows/windows-msvc-wheel-smoke.yml
+++ b/.github/workflows/windows-msvc-wheel-smoke.yml
@@ -43,16 +43,5 @@ jobs:
       - name: Build wheel
         run: pip wheel . --no-deps -w dist/
 
-      - name: Install wheel in fresh environment
-        run: |
-          python -m venv smoke_env
-          smoke_env\Scripts\pip install --upgrade pip
-          smoke_env\Scripts\pip install pandas numpy
-          smoke_env\Scripts\pip install --find-links dist/ arnio --no-index
-
-      - name: Run smoke test from temp directory
-        run: |
-          $smokePython = "${{ github.workspace }}\smoke_env\Scripts\python"
-          cd $env:TEMP
-          & $smokePython -c "import arnio; print('arnio import OK:', arnio.__version__)"
-          & $smokePython -c "from arnio import ArFrame; print('ArFrame import OK')"
+      - name: Run wheel smoke test
+        run: python tests/smoke_wheel_install.py --wheelhouse dist


### PR DESCRIPTION
### Summary
This PR fixes #1897 by updating `.github/workflows/windows-msvc-wheel-smoke.yml` to use the shared `tests/smoke_wheel_install.py` script. This ensures the Windows MSVC wheel smoke test runs the actual runtime checks (such as importing and running `read_csv` on a temp file) instead of just checking imports.

### Changes
- Updated `windows-msvc-wheel-smoke.yml` to call `python tests/smoke_wheel_install.py --wheelhouse dist`.

### Verification
Ran the smoke test script locally:
```bash
python3 tests/smoke_wheel_install.py --wheelhouse dist
```
<img width="383" height="173" alt="Screenshot 2026-05-31 at 10 09 31 PM" src="https://github.com/user-attachments/assets/a1bcbff9-9323-4782-949b-3f71b911f588" />

