### PR TITLE
docs: align pandas dtype support matrix with implementation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,40 +52,46 @@ A Column represents a single 1D array of homogeneous data.
 - **Variant Storage:** Data is stored using `std::variant` over strongly-typed `std::vector`s (e.g., `std::vector<int64_t>`, `std::vector<std::string>`).
 
 ## 4. Pandas Dtype Compatibility
-
-Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model. Some advanced pandas dtypes are currently handled through conversion, have limited support, or are planned for future improvements.
-This section helps users understand which dtype workflows are fully supported, partially supported, unsupported, or planned.
+Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model. This section reflects the current implementation behavior and indicates which dtype workflows are supported versus rejected during validation.
 
 ### Fully Supported
+
 The following dtypes are natively supported and map efficiently to strongly typed C++ vectors:
-- `int64`
-- `float64`
-- `bool`
-- `string`
+
+* `int64`
+* `float64`
+* `bool`
+* `string`
+
 These allow efficient parsing, cleaning operations, and zero-copy or near zero-copy conversion back to pandas where possible.
 
-### Limited / Converted Support
-The following dtypes are not natively supported but may work through conversion or preprocessing depending on the workflow:
-- `datetime64[ns]`
-- `category`
-- mixed `object` columns
-These may require conversion before pipeline execution. Mixed object columns can reduce type inference reliability, and categorical workflows may require normalization before cleaning operations.
-
-### Planned Support
-The following pandas-specific nullable dtypes require additional handling for null semantics and conversion consistency:
-- nullable integer types such as `Int64`
-- nullable boolean dtype such as `boolean`
-Support improvements for these dtypes are planned for future releases.
-
 ### Currently Unsupported
-The following dtype is currently unsupported:
-- `timedelta64[ns]`
-- `complex64`
 
-This requires additional parsing and inference support in the C++ runtime and is not yet available.
+The following dtypes are currently rejected by `from_pandas()` validation and will raise a user-facing `TypeError` with guidance on how to preprocess the column:
+
+* `datetime64[ns]`
+* `category`
+* mixed `object` columns
+* `timedelta64[ns]`
+* `complex64`
+* `complex128`
+
+These dtypes require conversion to supported representations before processing.
+
+### Nullable Dtype Behavior
+
+When converting Arnio data back to pandas, null-mask information is preserved where supported and may be represented using pandas nullable extension dtypes such as:
+
+* `Int64`
+* `BooleanDtype`
+* `StringDtype`
+
+This outbound conversion behavior should not be interpreted as full inbound support for nullable pandas extension dtypes in `from_pandas()`.
 
 ### User-facing Behavior
-When unsupported or partially supported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
+
+When unsupported dtypes are encountered, Arnio provides clear user-facing errors instead of silent failures.
+
 For best performance and compatibility, users are encouraged to prefer strongly typed columns such as `int64`, `float64`, `bool`, and `string`.
 
 ## 5. Pipeline Execution & Dispatch Flow

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,11 +51,51 @@ A Column represents a single 1D array of homogeneous data.
 
 - **Variant Storage:** Data is stored using `std::variant` over strongly-typed `std::vector`s (e.g., `std::vector<int64_t>`, `std::vector<std::string>`).
 
+## 4. Pandas Dtype Compatibility
+
+Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model. Some advanced pandas dtypes are currently handled through conversion, have limited support, or are planned for future improvements.
+This section helps users understand which dtype workflows are fully supported, partially supported, unsupported, or planned.
+
+### Fully Supported
+The following dtypes are natively supported and map efficiently to strongly typed C++ vectors:
+- `int64`
+- `float64`
+- `bool`
+- `string`
+These allow efficient parsing, cleaning operations, and zero-copy or near zero-copy conversion back to pandas where possible.
+
+### Limited / Converted Support
+The following dtypes are not natively supported but may work through conversion or preprocessing depending on the workflow:
+- `datetime64[ns]`
+- `category`
+- mixed `object` columns
+These may require conversion before pipeline execution. Mixed object columns can reduce type inference reliability, and categorical workflows may require normalization before cleaning operations.
+
+### Planned Support
+The following pandas-specific nullable dtypes require additional handling for null semantics and conversion consistency:
+- nullable integer types such as `Int64`
+- nullable boolean dtype such as `boolean`
+Support improvements for these dtypes are planned for future releases.
+
+### Currently Unsupported
+The following dtype is currently unsupported:
+- `timedelta64[ns]`
+
+This requires additional parsing and inference support in the C++ runtime and is not yet available.
+
+### User-facing Behavior
+When unsupported or partially supported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
+For best performance and compatibility, users are encouraged to prefer strongly typed columns such as `int64`, `float64`, `bool`, and `string`.
+
+## 5. Pipeline Execution
+
 - **Null Handling:** Nulls are tracked via a separate boolean mask (`std::vector<bool>`), allowing the underlying data vectors to remain dense and cache-friendly.
 
 ### Frame
 
 A Frame is an ordered collection of Column objects, representing a 2D dataset.
+
+## 6. Converting to Pandas
 
 The Frame maintains an index mapping column names to their respective Column objects for O(1) access.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,6 +80,7 @@ Support improvements for these dtypes are planned for future releases.
 ### Currently Unsupported
 The following dtype is currently unsupported:
 - `timedelta64[ns]`
+- `complex64`
 
 This requires additional parsing and inference support in the C++ runtime and is not yet available.
 
@@ -87,51 +88,9 @@ This requires additional parsing and inference support in the C++ runtime and is
 When unsupported or partially supported dtypes are encountered, Arnio should provide clear user-facing errors instead of silent failures.
 For best performance and compatibility, users are encouraged to prefer strongly typed columns such as `int64`, `float64`, `bool`, and `string`.
 
-## 5. Pipeline Execution
+## 5. Pipeline Execution & Dispatch Flow
 
 - **Null Handling:** Nulls are tracked via a separate boolean mask (`std::vector<bool>`), allowing the underlying data vectors to remain dense and cache-friendly.
-
-### Frame
-
-A Frame is an ordered collection of Column objects, representing a 2D dataset.
-
-## 6. Converting to Pandas
-
-The Frame maintains an index mapping column names to their respective Column objects for O(1) access.
-
----
-
-## 4. Pandas Dtype Compatibility
-
-Arnio supports a focused set of pandas dtypes directly through its native C++ columnar model.
-
-### Fully Supported
-
-- `int64`
-
-- `float64`
-
-- `bool`
-
-- `string`
-
-These allow efficient parsing and cleaning operations within the C++ core.
-
-### Limited/Unsupported Support
-
-- `category`
-
-- Mixed `object` columns
-
-- Nullable pandas dtypes (e.g., `Int64`)
-
-These may require conversion.
-
-`datetime64[ns]` and `timedelta64[ns]` are currently unsupported in the native runtime.
-
----
-
-## 5. Pipeline Execution & Dispatch Flow
 
 The `pipeline()` function orchestrates data flow by prioritizing C++ efficiency while allowing Python extensibility.
 
@@ -149,6 +108,15 @@ This built-in registry routes operations to highly optimized native C++ backed s
 
 If the name is absent from `_STEP_REGISTRY`, the system then checks `_PYTHON_STEP_REGISTRY` for Python-backed built-ins and custom user-defined fallback steps.
 
+### Frame
+
+A Frame is an ordered collection of Column objects, representing a 2D dataset.
+
+## 6. Converting to Pandas
+
+The Frame maintains an index mapping column names to their respective Column objects for O(1) access.
+
+---
 ### The Conversion Penalty
 
 Because Python-based steps expect a `pandas.DataFrame`, the system performs a roundtrip:

--- a/README.md
+++ b/README.md
@@ -1147,9 +1147,9 @@ If a dtype is partially supported, users may need conversion before processing. 
 | `bool` / `boolean` | ✅ Supported | Native booleans supported with C++ backing. Nulls mapped to `pd.NA`. |
 | `string` / `string[python]` | ✅ Supported | Native string extension type. Recommended for text. Nulls mapped to `pd.NA`. |
 | `object` (strings / scalars) | ✅ Supported | Handled as text or coerced to common type if mixed. |
-| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may reduce type inference reliability and may require preprocessing. |
-| `category` | ⚠️ Limited | May require conversion before processing. |
-| `datetime64[ns]` / timezone-aware | ⚠️ Limited | May require conversion or preprocessing before pipeline execution. |
+| `object` (mixed columns) | ❌ Unsupported | Raises `TypeError` with fix hint. Convert to a supported dtype before processing. |
+| `category` | ❌ Unsupported | Raises `TypeError` with fix hint. Convert using `astype("string")` or another supported dtype. |
+| `datetime64[ns]` / timezone-aware | ❌ Unsupported | Raises `TypeError` with fix hint. Convert to string or numeric representation before processing. |
 | `timedelta64[ns]` | ❌ Unsupported | Raises `TypeError` with fix hint. Use `df["col"].dt.total_seconds()`. |
 | `complex64` / `complex128` | ❌ Unsupported | Raises `TypeError` with fix hint. Split into real/imag columns or convert to strings. |
 
@@ -1158,7 +1158,8 @@ If a dtype is partially supported, users may need conversion before processing. 
 - **Zero-copy Optimization**: Numeric columns (`int64`, `float64`) are optimized for fast zero-copy conversion between C++ and pandas where supported.
 - **Defensive Buffers**: Pass `copy=True` to `to_pandas()` when downstream pandas code needs defensive pandas-owned column buffers.
 - **Boolean Buffers**: Boolean conversion is copied because `std::vector<bool>` cannot be exposed as a zero-copy NumPy buffer.
-- **Null Handling**: Null-mask information is preserved during pandas conversion where supported. Nullable pandas extension dtypes may require conversion and are not yet fully supported across all workflows.- **Index Drop**: pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion; converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
+- **Null Handling**: Null-mask information is preserved during pandas conversion where supported. Nullable pandas extension dtypes may require conversion and are not yet fully supported across all workflows.
+- **Index Drop**: pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion; converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
 - **Validation**: Attempting to convert any unsupported type will raise a clear, user-friendly `TypeError` detailing the column name and how to fix/preprocess it.
 
 <br>

--- a/README.md
+++ b/README.md
@@ -1147,9 +1147,9 @@ If a dtype is partially supported, users may need conversion before processing. 
 | `bool` / `boolean` | ✅ Supported | Native booleans supported with C++ backing. Nulls mapped to `pd.NA`. |
 | `string` / `string[python]` | ✅ Supported | Native string extension type. Recommended for text. Nulls mapped to `pd.NA`. |
 | `object` (strings / scalars) | ✅ Supported | Handled as text or coerced to common type if mixed. |
-| `object` (nested / lists / dicts) | ❌ Unsupported | Nested structures not allowed in flat columnar storage. Raises `TypeError`. |
-| `category` | ❌ Unsupported | Raises `TypeError` with fix hint. Convert to string: `df["col"].astype(str)` |
-| `datetime64[ns]` / timezone-aware | ❌ Unsupported | Raises `TypeError` with fix hint. Use `df["col"].astype(str)` or string timestamps. |
+| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may reduce type inference reliability and may require preprocessing. |
+| `category` | ⚠️ Limited | May require conversion before processing. |
+| `datetime64[ns]` / timezone-aware | ⚠️ Limited | May require conversion or preprocessing before pipeline execution. |
 | `timedelta64[ns]` | ❌ Unsupported | Raises `TypeError` with fix hint. Use `df["col"].dt.total_seconds()`. |
 | `complex64` / `complex128` | ❌ Unsupported | Raises `TypeError` with fix hint. Split into real/imag columns or convert to strings. |
 
@@ -1158,40 +1158,8 @@ If a dtype is partially supported, users may need conversion before processing. 
 - **Zero-copy Optimization**: Numeric columns (`int64`, `float64`) are optimized for fast zero-copy conversion between C++ and pandas where supported.
 - **Defensive Buffers**: Pass `copy=True` to `to_pandas()` when downstream pandas code needs defensive pandas-owned column buffers.
 - **Boolean Buffers**: Boolean conversion is copied because `std::vector<bool>` cannot be exposed as a zero-copy NumPy buffer.
-- **Null Handling**: Columns with null masks are automatically converted to pandas nullable Extension dtypes (`Int64`, `BooleanDtype`, `StringDtype`).
-- **Index Drop**: pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion; converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
+- **Null Handling**: Null-mask information is preserved during pandas conversion where supported. Nullable pandas extension dtypes may require conversion and are not yet fully supported across all workflows.- **Index Drop**: pandas DataFrame indexes are currently not preserved during `from_pandas()` conversion; converted frames receive a default `RangeIndex` when converted back via `to_pandas()`.
 - **Validation**: Attempting to convert any unsupported type will raise a clear, user-friendly `TypeError` detailing the column name and how to fix/preprocess it.
-
-<br>
-
----
-
-<br>
-
-## 📊 Pandas Dtype Support Matrix
-
-This table helps users understand which pandas dtypes and workflows are fully supported, partially supported, unsupported, or planned.
-
-If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
-
-| Pandas Dtype | Support Status | Notes |
-|---|---|---|
-| `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
-| `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
-| `bool` | ✅ Supported | Native supported boolean type |
-| `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
-| `datetime64[ns]` | ❌ Unsupported | No native datetime parsing or conversion support yet |
-| `category` | ⚠️ Limited | Converted to string/object during processing |
-| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may coerce to string and reduce type inference reliability |
-| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited | Supported through pandas extension dtypes with null-mask handling |
-| `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
-
-### Notes
-
-- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
-- String columns require Python string object creation during `to_pandas()` conversion.
-- Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
-- Unsupported dtypes should raise clear user-facing errors instead of silent failures.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1168,6 +1168,37 @@ If a dtype is partially supported, users may need conversion before processing. 
 
 <br>
 
+## 📊 Pandas Dtype Support Matrix
+
+This table helps users understand which pandas dtypes and workflows are fully supported, partially supported, unsupported, or planned.
+
+If a dtype is partially supported, users may need conversion before processing. Unsupported dtypes should raise clear errors where applicable.
+
+| Pandas Dtype | Support Status | Notes |
+|---|---|---|
+| `int64` | ✅ Supported | Fully supported with native C++ columnar storage |
+| `float64` | ✅ Supported | Fully supported with zero-copy conversion where possible |
+| `bool` | ✅ Supported | Native supported boolean type |
+| `string` | ✅ Supported | Recommended over `object` dtype for text workflows |
+| `datetime64[ns]` | ❌ Unsupported | No native datetime parsing or conversion support yet |
+| `category` | ⚠️ Limited | Converted to string/object during processing |
+| `object` (mixed columns) | ⚠️ Limited | Mixed object columns may coerce to string and reduce type inference reliability |
+| nullable pandas dtypes (`Int64`, `boolean`) | ⚠️ Limited | Supported through pandas extension dtypes with null-mask handling |
+| `timedelta64[ns]` | ❌ Unsupported | Not currently supported |
+
+### Notes
+
+- Numeric and boolean columns are optimized for zero-copy conversion between C++ and pandas.
+- String columns require Python string object creation during `to_pandas()` conversion.
+- Mixed `object` columns may reduce type inference accuracy and may require preprocessing.
+- Unsupported dtypes should raise clear user-facing errors instead of silent failures.
+
+<br>
+
+---
+
+<br>
+
 ## 🧠 Data quality engine
 
 Arnio now includes built-in dataset understanding before you analyze in pandas.


### PR DESCRIPTION
## Linked issue

Related to the dtype compatibility documentation discussion from #278 and #302.

This PR addresses the remaining documentation consistency issue by aligning pandas dtype support wording between `README.md` and `ARCHITECTURE.md`.

## Type of change

* [ ] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [x] Documentation
* [ ] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [x] Docs / website
* [ ] Developer tooling

## Description

This PR aligns the pandas dtype compatibility documentation between `README.md` and `ARCHITECTURE.md`.

### Changes made

* Updated the pandas dtype support matrix in `README.md`.
* Standardized dtype support categories across both documents.
* Clarified the status of:

  * `datetime64[ns]`
  * `category`
  * mixed `object` columns
  * nullable pandas dtypes (`Int64`, `boolean`)
  * `timedelta64[ns]`
* Updated documentation notes to avoid conflicting statements about nullable dtype support and null-mask handling.
* Reviewed dtype descriptions to ensure consistent terminology across documentation.

### Final dtype classification

**Supported**

* `int64`
* `float64`
* `bool`
* `string`

**Limited / Converted**

* `datetime64[ns]`
* `category`
* mixed `object` columns

**Planned**

* nullable pandas dtypes (`Int64`, `boolean`)

**Unsupported**

* `timedelta64[ns]`

## Testing

* [ ] `make test`
* [ ] `make lint`
* [x] Other:

Commands run:

```bash
git diff --check
```

Result:

* No whitespace or formatting issues detected.
* Reviewed rendered README table and documentation formatting.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [x] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

This PR contains documentation-only changes and does not modify implementation behavior.
