### PR TITLE
fix:normalized sets consistently inside nested dict/lists

### DIFF
--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -301,6 +301,7 @@ def test_real_schema_with_rules_raises():
         schema_to_dict(schema)
 
 
+# ── Regression tests for issue #1441 ────────────────────────────────────────
 # test unsupported raw field value
 def test_raw_field_object_raises():
     with pytest.raises(TypeError):
@@ -312,6 +313,14 @@ def test_nested_set_normalized():
     result = schema_to_dict({"x": {"meta": {"tags": {"b", "a"}}}})
 
     assert result == {"fields": {"x": {"meta": {"tags": ["a", "b"]}}}}
+
+
+# ── Regression tests for issue #1573 ────────────────────────────────────────
+# test for nested set normalization
+def test_nested_set_inside_list_normalized():
+    result = schema_to_dict({"field": {"nested": [{"allowed_values": {"b", "a"}}]}})
+
+    assert result == {"fields": {"field": {"nested": [{"allowed_values": ["a", "b"]}]}}}
 
 
 # test for nested unsupported object inside dict


### PR DESCRIPTION
## Summary
Added regression coverage for nested set normalization during schema export.The implementation is already present on main. This PR adds a regression test to ensure nested sets continue to be normalized correctly and to prevent future regressions.

## Linked issue
 #1573 

## Type of change

* [ ] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [x] Schema validation
* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [x] `python -m pytest tests/test_schema_export.py`
* [x] `python -m ruff check .`
* [x] `python -m black --check .`
* [x] Other:

Verified the original issue reproducer now succeeds:

```python
import arnio as ar

ar.schema_to_yaml({
    "field": {
        "nested": [
            {"allowed_values": {"a", "b"}}
        ]
    }
})
```

Result: YAML is emitted successfully and no `TypeError` is raised.

Test result:

```
60 passed
```

## Screenshots / Media

N/A

## Performance Impact

None. This PR adds regression test coverage only .

## GSSoC labels
"area:schema","gssoc:approved","level:beginner"


## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Adds regression coverage for nested set normalization in nested schema structures to prevent future regressions.