### PR TITLE
fix(cleaning): raise TypeError for non-scalar replace_values mapping keys

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1884,9 +1884,12 @@ def replace_values(
         ):
             normalized_mapping[k] = v
         else:
-            # pandas replace does not support non-scalar mapping keys like tuples
-            # and lists. Ignore those keys rather than raising a user-facing error.
-            continue
+            raise TypeError(
+                f"replace_values() does not support non-scalar mapping keys. "
+                f"Got key {k!r} of type '{type(k).__name__}'. "
+                f"Only scalar values (str, int, float, bool) and null-like keys "
+                f"(None, float('nan'), pd.NA, pd.NaT) are supported."
+            )
 
     if column:
         s = df[column]

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2935,31 +2935,65 @@ class TestReplaceValues:
     def test_replace_values_tuple_mapping_key_does_not_crash(self):
         frame = ar.from_pandas(pd.DataFrame({"col": ["A", "B", "C"]}))
 
-        result = ar.replace_values(
-            frame,
-            {("A", "B"): "X"},
-            column="col",
-        )
-
-        df = ar.to_pandas(result)
-
-        assert list(df["col"]) == ["A", "B", "C"]
+        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+            ar.replace_values(
+                frame,
+                {("A", "B"): "X"},
+                column="col",
+            )
 
     def test_replace_values_mixed_tuple_and_null_keys(self):
         frame = ar.from_pandas(pd.DataFrame({"col": ["A", np.nan, "C"]}))
 
-        result = ar.replace_values(
-            frame,
-            {
-                ("A", "B"): "X",
-                np.nan: "missing",
-            },
-            column="col",
-        )
+        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+            ar.replace_values(
+                frame,
+                {
+                    ("A", "B"): "X",
+                    np.nan: "missing",
+                },
+                column="col",
+            )
 
+    def test_replace_values_list_key_raises_typeerror(self):
+        frame = ar.from_pandas(pd.DataFrame({"col": ["A", "B"]}))
+
+        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+            ar.replace_values(frame, {["A", "B"]: "X"})
+
+    def test_replace_values_numpy_array_key_raises_typeerror(self):
+        frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
+
+        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+            ar.replace_values(frame, {np.array([1, 2]): "X"})
+
+    def test_replace_values_pandas_series_key_raises_typeerror(self):
+        frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
+
+        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+            ar.replace_values(frame, {pd.Series([1, 2]): "X"})
+
+    def test_replace_values_pandas_index_key_raises_typeerror(self):
+        frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
+
+        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+            ar.replace_values(frame, {pd.Index([1, 2]): "X"})
+
+    def test_replace_values_error_message_includes_key_type(self):
+        """TypeError message must name the offending key type."""
+        frame = ar.from_pandas(pd.DataFrame({"col": ["A"]}))
+
+        with pytest.raises(TypeError, match="tuple"):
+            ar.replace_values(frame, {(1, 2): "X"})
+
+    def test_replace_values_scalar_keys_still_work_after_validation(self):
+        """Valid scalar mappings must be completely unaffected by the new check."""
+        frame = ar.from_pandas(pd.DataFrame({"col": ["A", "B", "C"]}))
+
+        result = ar.replace_values(frame, {"A": "Z"}, column="col")
         df = ar.to_pandas(result)
 
-        assert list(df["col"]) == ["A", "missing", "C"]
+        assert list(df["col"]) == ["Z", "B", "C"]
 
     def test_replace_values_pandas_dataframe_input_returns_dataframe(self):
         df = pd.DataFrame({"status": ["active", "inactive"], "flag": ["ok", "ok"]})

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2958,25 +2958,25 @@ class TestReplaceValues:
     def test_replace_values_list_key_raises_typeerror(self):
         frame = ar.from_pandas(pd.DataFrame({"col": ["A", "B"]}))
 
-        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+        with pytest.raises(TypeError):
             ar.replace_values(frame, {["A", "B"]: "X"})
 
     def test_replace_values_numpy_array_key_raises_typeerror(self):
         frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
 
-        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+        with pytest.raises(TypeError):
             ar.replace_values(frame, {np.array([1, 2]): "X"})
 
     def test_replace_values_pandas_series_key_raises_typeerror(self):
         frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
 
-        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+        with pytest.raises(TypeError):
             ar.replace_values(frame, {pd.Series([1, 2]): "X"})
 
     def test_replace_values_pandas_index_key_raises_typeerror(self):
         frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
 
-        with pytest.raises(TypeError, match="non-scalar mapping keys"):
+        with pytest.raises(TypeError):
             ar.replace_values(frame, {pd.Index([1, 2]): "X"})
 
     def test_replace_values_error_message_includes_key_type(self):

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -2955,30 +2955,6 @@ class TestReplaceValues:
                 column="col",
             )
 
-    def test_replace_values_list_key_raises_typeerror(self):
-        frame = ar.from_pandas(pd.DataFrame({"col": ["A", "B"]}))
-
-        with pytest.raises(TypeError):
-            ar.replace_values(frame, {["A", "B"]: "X"})
-
-    def test_replace_values_numpy_array_key_raises_typeerror(self):
-        frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
-
-        with pytest.raises(TypeError):
-            ar.replace_values(frame, {np.array([1, 2]): "X"})
-
-    def test_replace_values_pandas_series_key_raises_typeerror(self):
-        frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
-
-        with pytest.raises(TypeError):
-            ar.replace_values(frame, {pd.Series([1, 2]): "X"})
-
-    def test_replace_values_pandas_index_key_raises_typeerror(self):
-        frame = ar.from_pandas(pd.DataFrame({"col": [1, 2, 3]}))
-
-        with pytest.raises(TypeError):
-            ar.replace_values(frame, {pd.Index([1, 2]): "X"})
-
     def test_replace_values_error_message_includes_key_type(self):
         """TypeError message must name the offending key type."""
         frame = ar.from_pandas(pd.DataFrame({"col": ["A"]}))


### PR DESCRIPTION
## Summary
Raise a clear `TypeError` when `replace_values()` receives unsupported non-scalar mapping keys instead of silently ignoring them.

Fixes #1632

---

## Problem
`replace_values()` currently skips unsupported mapping keys during key normalization. Keys such as tuples are silently ignored, which can hide user mistakes and make debugging difficult.

---

## Changes Made

### Implementation
- Replaced the silent-ignore behavior in `arnio/cleaning.py` with a `TypeError`
- Error message includes the offending key and its type to provide actionable feedback
- Preserved existing behavior for valid scalar keys and supported null-like keys

### Tests

Updated existing tests that previously verified silent-ignore behavior:
- `test_replace_values_tuple_mapping_key_does_not_crash`
- `test_replace_values_mixed_tuple_and_null_keys`

Added focused regression coverage for unsupported hashable non-scalar key types:
- `tuple`

Added regression coverage to confirm valid scalar mappings continue to work as expected.

> **Note:** `list`, `numpy.ndarray`, `pandas.Series`, and `pandas.Index` were removed from the test coverage because those types are unhashable and cannot be used as Python dict keys — they raise `TypeError` before `replace_values()` is called, so testing them would verify Python dict construction rather than Arnio behavior.

---

## Verification
- Confirmed unsupported non-scalar tuple keys now raise `TypeError`
- Confirmed valid scalar and null-like mapping keys retain existing behavior
- Updated and extended test coverage to match the new validation behavior

---

## Scope

Files changed:
- `arnio/cleaning.py`
- `tests/test_cleaning.py`

No changes to unrelated cleaning functionality, public APIs, documentation, or runtime behavior for valid inputs.