### PR TITLE
docs: add interactive Jupyter notebooks with Colab badges (fixes #2058)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ pip install arnio
 ```
 
 Colab install smoke test: **[COLAB_SMOKE_TEST.md](COLAB_SMOKE_TEST.md)**
+**Interactive Notebooks:**
+[![Basic Usage](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/basic_usage.ipynb)
+[![Pandas Interop](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/arnio_with_pandas.ipynb)
+[![Schema Validation](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/schema_validation.ipynb)
 
 <br>
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,16 @@ Ready-to-run cleaning recipes for common messy CSV formats.
 
 Each folder contains a small synthetic CSV with realistic data quality issues and a `recipe.py` that cleans, profiles, and validates it using the arnio API.
 
+## Interactive Notebooks (1-Click Colab)
+
+Run these notebooks instantly in your browser — no local setup needed!
+
+| Notebook | Description | Open |
+|---|---|---|
+| Basic Usage | Core Arnio functionality: read, profile, and clean a CSV | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/basic_usage.ipynb) |
+| Arnio + Pandas | Pandas interoperability: clean with Arnio, analyse with pandas | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/arnio_with_pandas.ipynb) |
+| Schema Validation | End-to-end schema validation with typed fields | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/schema_validation.ipynb) |
+
 ## Recipes
 
 | Dataset | CSV | Issues Covered | arnio Features Used |

--- a/examples/arnio_with_pandas.ipynb
+++ b/examples/arnio_with_pandas.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f179ddde",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/arnio_with_pandas.ipynb)\n",
+    "\n",
+    "# Arnio + Pandas Interoperability\n",
+    "This notebook demonstrates how to:\n",
+    "- Start with messy data in pandas\n",
+    "- Clean and normalize it using Arnio's pipeline\n",
+    "- Convert it back to pandas for analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2628580",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install arnio pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5944840",
+   "metadata": {},
+   "source": [
+    "## Step 1: Create Messy Dataset (pandas)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "735ffc57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import arnio as ar\n",
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.DataFrame({\n",
+    "    'name': [' Alice ', 'Bob', 'CHARLIE', None],\n",
+    "    'age': ['25', '30', None, '40'],\n",
+    "})\n",
+    "print('Original Data:')\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "002dc5a9",
+   "metadata": {},
+   "source": [
+    "## Step 2: Convert pandas → Arnio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3f3c2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frame = ar.from_pandas(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "162380fd",
+   "metadata": {},
+   "source": [
+    "## Step 3: Clean Data using Arnio Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec4f9b3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cleaned = ar.pipeline(\n",
+    "    frame,\n",
+    "    [\n",
+    "        ('drop_nulls',),\n",
+    "        ('strip_whitespace',),\n",
+    "        ('normalize_case', {'case_type': 'lower'}),\n",
+    "        ('cast_types', {'mapping': {'age': 'int64'}}),\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da676d5b",
+   "metadata": {},
+   "source": [
+    "## Step 4: Convert Arnio → pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12eb2ec7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_df = ar.to_pandas(cleaned)\n",
+    "print('Cleaned Data:')\n",
+    "print(clean_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8b45f87",
+   "metadata": {},
+   "source": [
+    "## Step 5: Use pandas for Analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cd14920",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Summary Statistics (pandas):')\n",
+    "print(clean_df.describe())"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/basic_usage.ipynb
+++ b/examples/basic_usage.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4b4baf21",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/basic_usage.ipynb)\n",
+    "\n",
+    "# Basic Usage of Arnio\n",
+    "This notebook demonstrates the core functionality of Arnio:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7114a7c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install arnio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f8eda52",
+   "metadata": {},
+   "source": [
+    "## Step 2: Create Sample Messy CSV Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d01d544",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import arnio as ar\n",
+    "\n",
+    "sample_csv = 'sample_messy_data.csv'\n",
+    "with open(sample_csv, 'w') as f:\n",
+    "    f.write('name,age,city\\n')\n",
+    "    f.write('  Alice  ,30,New York\\n')\n",
+    "    f.write('Bob,,\\n')\n",
+    "    f.write('Charlie,35,  London  \\n')\n",
+    "    f.write('Alice,30,New York\\n')\n",
+    "\n",
+    "print(f'Created sample file: {sample_csv}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88ec24df",
+   "metadata": {},
+   "source": [
+    "## Step 3: Load Raw Data using Arnio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2979d25c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frame = ar.read_csv(sample_csv)\n",
+    "print('--- Raw Data Schema ---')\n",
+    "print(frame.dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4b0cb90",
+   "metadata": {},
+   "source": [
+    "## Step 4: Profile Data Quality"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9638b31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report = ar.profile(frame)\n",
+    "print('--- Data Quality Report ---')\n",
+    "print(f'Rows: {report.row_count}, Columns: {report.column_count}')\n",
+    "print(f'Duplicates: {report.duplicate_rows}')\n",
+    "if report.suggestions:\n",
+    "    print(f'Suggested steps: {report.suggestions}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa14362b",
+   "metadata": {},
+   "source": [
+    "## Step 5: Define Cleaning Pipeline\n",
+    "Arnio pipelines are readable and chainable.\n",
+    "Each step is a tuple: `(step_name, {optional_params})`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a3a58e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_frame = ar.pipeline(\n",
+    "    frame,\n",
+    "    [\n",
+    "        ('strip_whitespace',),\n",
+    "        ('normalize_case', {'case_type': 'title'}),\n",
+    "        ('fill_nulls', {'value': 0, 'subset': ['age']}),\n",
+    "        ('fill_nulls', {'value': 'Unknown', 'subset': ['city']}),\n",
+    "        ('drop_duplicates',),\n",
+    "    ],\n",
+    ")\n",
+    "print('--- Cleaned Data ---')\n",
+    "print(clean_frame)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/schema_validation.ipynb
+++ b/examples/schema_validation.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7b5fd051",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/im-anishraj/arnio/blob/main/examples/schema_validation.ipynb)\n",
+    "\n",
+    "# Schema Validation with Arnio\n",
+    "This notebook demonstrates an end-to-end schema validation workflow:\n",
+    "- Define a Schema with typed fields\n",
+    "- Validate intentionally mixed-quality data\n",
+    "- Inspect ValidationResult summaries and markdown output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a251d26b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install arnio pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a01d4a42",
+   "metadata": {},
+   "source": [
+    "## Step 1: Create Mixed-Quality Dataset\n",
+    "We create a dataset with intentional errors to test schema validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c835538",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import arnio as ar\n",
+    "\n",
+    "frame = ar.from_pandas(pd.DataFrame([\n",
+    "    {\n",
+    "        'user_id': 101,\n",
+    "        'email': 'alice@example.com',\n",
+    "        'age': 31,\n",
+    "        'signup_date': '2026-05-01T09:30:00',\n",
+    "        'country': 'IN',\n",
+    "        'is_active': True,\n",
+    "    },\n",
+    "    {\n",
+    "        'user_id': 101,\n",
+    "        'email': 'broken-email',\n",
+    "        'age': -4,\n",
+    "        'signup_date': 'not-a-date',\n",
+    "        'country': None,\n",
+    "        'is_active': 'yes',\n",
+    "    },\n",
+    "    {\n",
+    "        'user_id': None,\n",
+    "        'email': 'charlie@example.com',\n",
+    "        'age': 22,\n",
+    "        'signup_date': '2026-05-03T12:15:00',\n",
+    "        'country': 'USA',\n",
+    "        'is_active': False,\n",
+    "    },\n",
+    "]))\n",
+    "print('Dataset created successfully!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8acee015",
+   "metadata": {},
+   "source": [
+    "## Step 2: Define Schema\n",
+    "Each field has a type and constraints like nullable, min, format etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c316ca3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema = ar.Schema(\n",
+    "    {\n",
+    "        'user_id': ar.Int64(nullable=False),\n",
+    "        'email': ar.Email(nullable=False),\n",
+    "        'age': ar.Int64(nullable=False, min=0),\n",
+    "        'signup_date': ar.DateTime(nullable=False, format='%Y-%m-%dT%H:%M:%S'),\n",
+    "        'country': ar.CountryCode(nullable=True),\n",
+    "        'is_active': ar.Bool(nullable=False),\n",
+    "    },\n",
+    "    unique=['user_id'],\n",
+    "    strict=True,\n",
+    ")\n",
+    "print('Schema defined successfully!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10ba028c",
+   "metadata": {},
+   "source": [
+    "## Step 3: Validate Data Against Schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b88a769",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = ar.validate(frame, schema)\n",
+    "print('--- Validation Summary ---')\n",
+    "print(result.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9114f9ee",
+   "metadata": {},
+   "source": [
+    "## Step 4: Inspect Results in Markdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b218fea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result.to_markdown())"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description
Fixes #2058

## Changes Made
- Added `examples/basic_usage.ipynb` - Interactive notebook for core Arnio functionality
- Added `examples/arnio_with_pandas.ipynb` - Pandas interoperability notebook  
- Added `examples/schema_validation.ipynb` - Schema validation workflow notebook
- Added Open in Colab badges in README.md for 1-click browser execution

## Why
Lowers the barrier to entry for new users — no local setup required.
Users can instantly try Arnio in Google Colab with 1 click.