### PR TITLE
docs: align README custom pipeline example with subset API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1828,8 +1828,8 @@ Most new features are pure Python pipeline steps:
 
 ```python
 # 1. Write a function that takes a DataFrame and returns a DataFrame
-def remove_special_chars(df, columns=None):
-    cols = columns or df.select_dtypes("object").columns
+def remove_special_chars(df, subset=None):
+    cols = subset or df.select_dtypes("object").columns
     for col in cols:
         df[col] = df[col].str.replace(r"[^a-zA-Z0-9\s]", "", regex=True)
     return df


### PR DESCRIPTION
Fixes #1878

## Summary

- Updated the README custom pipeline example to use `subset=None` instead of `columns=None`
- Updated the related variable name in the example to match the current API convention
- Aligned the README example with the contributor guide and existing cleaning helper conventions

## Validation

- Documentation-only change
- No implementation code modified
- No tests or benchmarks modified
- No behavior or API functionality changed
