### PR TITLE
chore: add test-quick make target for faster iteration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint format benchmark doctor clean help
+.PHONY: install test test-quick lint format benchmark doctor clean help
 
 help:  ## Show this help message
 	@python -c "import re; [print(f'\033[36m{m[0]:<15}\033[0m {m[1]}') for m in sorted([re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line).groups() for line in open('$(MAKEFILE_LIST)') if re.match(r'^[a-zA-Z_-]+:.*?## .*$$', line)])]"
@@ -12,6 +12,9 @@ doctor: ## Check Python dependencies, native core, and local build tools
 
 test: ## Run tests with coverage
 	pytest tests/ -v --cov=arnio --cov-report=term-missing
+
+test-quick: ## Run tests without coverage (fast, pass/fail only)
+	pytest tests/ -v
 
 lint: ## Check linting
 	ruff check .


### PR DESCRIPTION
Fixes #1214

## Summary

Add a `test-quick` Makefile target to provide a faster test workflow for contributors who only need pass/fail feedback without coverage collection.

## Changes

- Add `test-quick` to `.PHONY`
- Add a new `test-quick` target immediately after `test`
- Keep the existing `test` target unchanged
- Follow the existing Makefile help-comment style (`##`) so the target appears automatically in `make help`

## Usage

```bash
make test-quick
```

Runs:

```bash
pytest tests/ -v
```

without coverage instrumentation for faster local iteration.

## Verification

```bash
make help
```

shows:

```text
test-quick      Run tests without coverage (fast, pass/fail only)
```

and the full test suite passes locally:

```text
2983 passed, 47 skipped
```

<img width="662" height="293" alt="image" src="https://github.com/user-attachments/assets/3a4c69be-bc89-4294-88df-fb98d78bcf5d" />