### PR TITLE
chore: document contributor PR CI visibility

### DIFF
--- a/.github/CI_VISIBILITY.md
+++ b/.github/CI_VISIBILITY.md
@@ -1,0 +1,59 @@
+# Arnio CI Visibility Policy
+
+This policy documents the PR checks maintainers should see before reviewing or
+merging code-changing pull requests. It covers fork PRs where GitHub may wait
+for maintainer approval before running Actions.
+
+## Expected PR Signal
+
+For a code-changing pull request targeting `main`, maintainers should be able to
+see an Arnio-owned CI signal after any required GitHub approval step:
+
+- `PR Guard` checks sensitive workflow changes and stray root files.
+- `CI` runs lint, C++ native tests, the Python test matrix, notebook smoke
+  tests, and scikit-learn integration tests.
+- `Examples Smoke` runs the public example scripts, including the DuckDB smoke
+  example.
+- `Compatibility Matrix` runs for runtime, test, dependency, and matrix workflow
+  changes.
+
+Additional path-scoped workflows may also appear for packaging, optional
+dependency, website, wheel, or release-related files. External checks such as
+Vercel are useful, but they are not a substitute for Arnio CI.
+
+## Fork PR Approval Path
+
+GitHub can hold workflow runs from a fork or first-time contributor until a
+maintainer with write access approves them. When a PR shows only Vercel or other
+external checks:
+
+1. Open the PR checks list and the repository Actions tab for pending workflow
+   approval notices.
+2. Inspect the PR diff, especially `.github/workflows/`, before approving the
+   run.
+3. Approve the GitHub Actions run only when the workflow changes are expected
+   for the issue and safe to execute.
+4. Wait for the Arnio CI signal above to appear and complete.
+5. Do not merge code-changing PRs that show only Vercel or another external
+   check with no Arnio CI result.
+
+If the Arnio CI workflows still do not appear after maintainer approval, check
+the workflow triggers, path filters, repository Actions settings, and any
+maintainer-side branch protection or ruleset configuration before review.
+
+## Workflow Trigger Policy
+
+Workflows that check out, build, test, lint, or otherwise execute contributor
+code must use the `pull_request` event with read-only repository permissions.
+Do not add `pull_request_target` to those workflows.
+
+`pull_request_target` may only be considered for metadata-only automation that
+does not check out or execute untrusted contributor code. That requires explicit
+maintainer review before it is added.
+
+## Maintainer Merge Gate
+
+Branch protection or repository rulesets are configured outside pull requests,
+but the policy expectation is clear: code-changing PRs should not be merged when
+only external checks are visible. Require the Arnio-owned CI signal that matches
+the changed files, then review the PR.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,6 +132,18 @@ def test_remove_special_chars(sample_csv):
 8. Open the pull request and link the issue with `Fixes #issue-number` when complete.
 9. Ensure your PR title follows **Conventional Commits**.
 
+### CI visibility for fork PRs
+
+GitHub may hold Actions runs from forks or first-time contributors until a
+maintainer approves them. If your PR shows only Vercel or other external checks,
+do not assume Arnio CI has been skipped; ask a maintainer to review and approve
+the pending GitHub Actions run.
+
+Arnio's maintainer policy for this path is documented in
+[CI_VISIBILITY.md](CI_VISIBILITY.md). Keep workflow changes scoped to issues
+that explicitly request them, and do not add `pull_request_target` to workflows
+that check out, build, lint, or test contributor code.
+
 ## C++ extension stubs
 
 If you change the C++ pybind11 API, update the stub file at

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,6 +52,8 @@
 - [ ] I kept the PR focused on one issue or one logical change.
 - [ ] I added or updated tests for behavior changes.
 - [ ] I added or updated docs/examples for public API changes.
+- [ ] I checked that the Arnio CI signal is visible, or requested maintainer
+      approval if fork workflows are pending.
 - [ ] I checked that generated files, logs, and local build artifacts are not committed.
 - [ ] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
 

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   guard-sensitive-paths:
     name: Guard Sensitive Paths and Root Files

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,6 +37,17 @@ Before merging, check:
 - GSSoC PR labels use the exact official strings where applicable:
   `gssoc:approved`, `level:*`, `quality:*`, and `type:*`.
 
+## CI visibility
+
+Use [.github/CI_VISIBILITY.md](.github/CI_VISIBILITY.md) when a contributor PR,
+especially a fork PR, shows only Vercel or other external checks. Code-changing
+PRs need a visible Arnio CI signal before review or merge. If GitHub Actions are
+waiting for maintainer approval, inspect the diff first, approve the run when it
+is safe, and wait for the expected Arnio checks to finish.
+
+Do not merge code-changing PRs that lack the relevant Arnio-owned checks, and do
+not add `pull_request_target` to workflows that run untrusted contributor code.
+
 ## Release Notes
 
 Release-worthy changes should be easy to describe in one sentence:

--- a/tests/test_ci_visibility_policy.py
+++ b/tests/test_ci_visibility_policy.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).parent.parent
+WORKFLOW_DIR = PROJECT_ROOT / ".github" / "workflows"
+
+
+def load_workflow(name: str) -> dict:
+    with (WORKFLOW_DIR / name).open(encoding="utf-8") as workflow_file:
+        return yaml.load(workflow_file, Loader=yaml.BaseLoader)
+
+
+def workflow_triggers(workflow: dict) -> dict:
+    return workflow.get("on", {})
+
+
+def test_required_pr_ci_workflows_run_on_pull_requests_without_target_event():
+    required_workflows = {
+        "ci.yml": {"lint", "cpp_tests", "build_and_test"},
+        "examples-smoke.yml": {"examples-core", "examples-duckdb"},
+        "compat-matrix.yml": {"compat"},
+        "pr-guard.yml": {"guard-sensitive-paths"},
+    }
+
+    for workflow_name, expected_jobs in required_workflows.items():
+        workflow = load_workflow(workflow_name)
+        triggers = workflow_triggers(workflow)
+
+        assert "pull_request" in triggers, f"{workflow_name} must run on PRs"
+        assert (
+            "pull_request_target" not in triggers
+        ), f"{workflow_name} must not run untrusted PR code via pull_request_target"
+
+        actual_jobs = set(workflow.get("jobs", {}))
+        assert expected_jobs <= actual_jobs
+
+
+def test_pr_ci_workflows_use_read_only_contents_permissions():
+    for workflow_name in (
+        "ci.yml",
+        "examples-smoke.yml",
+        "compat-matrix.yml",
+        "pr-guard.yml",
+    ):
+        workflow = load_workflow(workflow_name)
+
+        assert workflow.get("permissions", {}).get("contents") == "read"
+
+
+def test_ci_visibility_policy_is_documented_for_contributors_and_maintainers():
+    policy_doc = PROJECT_ROOT / ".github" / "CI_VISIBILITY.md"
+    contributor_doc = PROJECT_ROOT / ".github" / "CONTRIBUTING.md"
+    maintainer_doc = PROJECT_ROOT / "MAINTAINERS.md"
+    pr_template = PROJECT_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+
+    assert policy_doc.exists()
+
+    policy_text = policy_doc.read_text(encoding="utf-8")
+    for required_text in (
+        "first-time contributor",
+        "maintainer approval",
+        "pull_request_target",
+        "Do not merge",
+        "Vercel",
+        "CI",
+        "Examples Smoke",
+        "Compatibility Matrix",
+        "PR Guard",
+    ):
+        assert required_text in policy_text
+
+    assert "CI visibility" in contributor_doc.read_text(encoding="utf-8")
+    assert "CI visibility" in maintainer_doc.read_text(encoding="utf-8")
+    assert "Arnio CI signal" in pr_template.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add a CI visibility policy for fork PR approval, expected Arnio-owned checks, and the no-merge-with-only-Vercel rule.
- Document the contributor and maintainer path when GitHub Actions are pending approval or missing.
- Add a regression test that locks the expected PR workflow triggers, read-only permissions, and policy docs.
- Set `PR Guard` to explicit `contents: read` permissions.

## Linked issue
Fixes #1503

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [x] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
- [x] `python3 -m pytest tests/test_ci_visibility_policy.py tests/test_docs_utf8_check.py -q`
  - Result: 11 passed
- [x] `python3 -m ruff check tests/test_ci_visibility_policy.py`
  - Result: all checks passed
- [x] `python3 -m black --check --fast tests/test_ci_visibility_policy.py`
  - Result: file would be left unchanged
- [x] `python3 scripts/check_docs_utf8.py`
  - Result: Documentation UTF-8 check passed
- [x] `git diff --check`
  - Result: no whitespace errors

## Maintainer notes
This PR intentionally changes `.github/workflows/pr-guard.yml` for the scoped CI visibility issue, and the workflow diff is limited to explicit read-only `contents: read` permissions. Per maintainer follow-up, no duplicate PR is needed; this workflow-file change is waiting on explicit maintainer review.

No branch protection settings are changed in this PR, and no workflow is moved to `pull_request_target`.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that the Arnio CI signal is visible, or requested maintainer approval if fork workflows are pending.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
