### PR TITLE
fix: add clear path type errors in path-only readers

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1047,6 +1047,9 @@ def scan_csv(
     >>> schema = ar.scan_csv("data.dat")              # non-standard extension accepted
     """
 
+    if not isinstance(path, (str, bytes, os.PathLike)) and not hasattr(path, "read"):
+        raise TypeError("scan_csv expected a filesystem path")
+
     path, should_cleanup, _ = _materialize_csv_input(path)
 
     try:
@@ -1278,6 +1281,9 @@ def read_jsonl(
     """
     _validate_jsonl_encoding(encoding)
 
+    if not isinstance(path, (str, bytes, os.PathLike)):
+        raise TypeError("read_jsonl expected a filesystem path")
+
     path = os.fspath(path)
     encoding_errors = _validate_encoding_errors(encoding_errors)
     nrows = _validate_jsonl_nrows(nrows)
@@ -1415,6 +1421,9 @@ def sniff_delimiter(
     ValueError
         If the sample size is invalid or the delimiter is ambiguous.
     """
+    if not isinstance(path, (str, bytes, os.PathLike)):
+        raise TypeError("sniff_delimiter expected a filesystem path")
+
     path = os.fspath(path)
 
     # 1. Parameter Validation

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -3076,3 +3076,18 @@ def test_scan_csv_file_like_object():
     assert "y" in schema
     assert stream.read_sizes
     assert -1 not in stream.read_sizes
+
+
+# clear path type errors in path-only readers
+
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [123, 3.14, None, object(), ["a.csv"]],
+)
+def test_scan_csv_invalid_path_type(bad_input):
+    with pytest.raises(
+        TypeError,
+        match="scan_csv expected a filesystem path",
+    ):
+        ar.scan_csv(bad_input)

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -583,3 +583,16 @@ class TestReadJsonlChunked:
 
         with pytest.raises(ar.JsonlReadError, match="decode"):
             list(ar.read_jsonl_chunked(path, encoding="utf-8"))
+
+
+class TestReadJsonlInvalidPathType:
+    @pytest.mark.parametrize(
+        "bad_input",
+        [123, 3.14, None, object(), ["a.jsonl"]],
+    )
+    def test_raises_type_error(self, bad_input):
+        with pytest.raises(
+            TypeError,
+            match="read_jsonl expected a filesystem path",
+        ):
+            ar.read_jsonl(bad_input)

--- a/tests/test_sniff_delimiter.py
+++ b/tests/test_sniff_delimiter.py
@@ -278,3 +278,16 @@ class TestReadCsvDelimiterDetection:
         p.write_text("名前,年齢\n太郎,30\n花子,25", encoding="utf-8")
         df = ar.read_csv(p)
         assert df.columns == ["名前", "年齢"]
+
+
+class TestSniffDelimiterInvalidPathType:
+    @pytest.mark.parametrize(
+        "bad_input",
+        [123, 3.14, None, object(), ["a.csv"]],
+    )
+    def test_raises_type_error(self, bad_input):
+        with pytest.raises(
+            TypeError,
+            match="sniff_delimiter expected a filesystem path",
+        ):
+            sniff_delimiter(bad_input)


### PR DESCRIPTION
## Summary
This PR adds explicit path validation to scan_csv(), sniff_delimiter(), and read_jsonl() before calling os.fspath(). Previously, passing an invalid path type would surface Python's generic os.fspath() error. With this change, these path-only reader APIs now raise clear, consistent Arnio-level TypeError messages indicating that a filesystem path is expected. Focused tests were also added to verify the new behavior for invalid path types across all three functions.

## Linked issue
Fixes #1671

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
pytest tests/test_sniff_delimiter.py tests/test_csv.py tests/test_jsonl.py -v -k "invalid_path_type or InvalidPathType"
-15 passed

ruff check arnio/io.py tests/test_sniff_delimiter.py tests/test_csv.py tests/test_jsonl.py
-All checks passed!

black arnio/io.py tests/test_sniff_delimiter.py tests/test_csv.py tests/test_jsonl.py
-4 files reformatted, all clean after reformat

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
<!-- Optional: risks, migration notes, release notes, or follow-up work. -->
