### PR TITLE
fix: safe_divide_columns rejects existing output columns (#592)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1638,8 +1638,7 @@ def safe_divide_columns(
         Column name to use as the denominator.
     output_column : str
         Name of the new column to store the division result. Must be a
-        non-empty string. If the column already exists, it will be
-        overwritten and a ``UserWarning`` is raised.
+        non-empty string. If the column already exists, a ``ValueError`` is raised.
     fill_value : float, optional
         Value to use when denominator is zero or null. Defaults to 0.0.
 
@@ -1684,13 +1683,7 @@ def safe_divide_columns(
         raise ValueError(f"fill_value must be finite, got {fill_value}")
 
     if output_column in columns:
-        import warnings
-
-        warnings.warn(
-            f"Output column '{output_column}' already exists and will be overwritten.",
-            UserWarning,
-            stacklevel=2,
-        )
+        raise ValueError(f"Output column '{output_column}' already exists.")
 
     if is_arframe:
         numerator_dtype = frame.dtypes.get(numerator)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3541,20 +3541,13 @@ class TestSafeDivideColumns:
         assert df["ratio"].iloc[0] == 2.0
 
     def test_output_column_already_exists(self, tmp_path):
-        import warnings
-
         path = tmp_path / "data.csv"
         path.write_text("revenue,cost,ratio\n100,50,99\n200,100,99\n")
         frame = ar.read_csv(path)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            result = ar.safe_divide_columns(
+        with pytest.raises(ValueError, match="Output column 'ratio' already exists"):
+            ar.safe_divide_columns(
                 frame, numerator="revenue", denominator="cost", output_column="ratio"
             )
-            assert len(w) == 1
-            assert "already exists" in str(w[0].message)
-        df = ar.to_pandas(result)
-        assert df["ratio"].iloc[0] == 2.0
 
     def test_string_zero_denominator_is_treated_as_zero(self):
         frame = ar.from_pandas(
@@ -3676,30 +3669,6 @@ class TestSafeDivideColumns:
         df = original_to_pandas(result)
 
         assert list(df["ratio"]) == [10.0, 10.0]
-
-    def test_native_output_column_overwrite_preserves_column_order(self):
-        frame = ar.from_pandas(
-            pd.DataFrame(
-                {
-                    "revenue": [100, 200],
-                    "ratio": [99, 99],
-                    "cost": [25, 50],
-                }
-            )
-        )
-
-        with pytest.warns(UserWarning, match="already exists"):
-            result = ar.safe_divide_columns(
-                frame,
-                numerator="revenue",
-                denominator="cost",
-                output_column="ratio",
-            )
-
-        df = ar.to_pandas(result)
-
-        assert list(df.columns) == ["revenue", "ratio", "cost"]
-        assert list(df["ratio"]) == [4.0, 4.0]
 
     # --- Regression tests for string zero denominators (bug fix) ---
 


### PR DESCRIPTION
## Summary
Tightens validation at the public boundary for `safe_divide_columns` to reject an existing `output_column` with a `ValueError`, instead of emitting a `UserWarning` and silently overwriting the column. This aligns its behavior with `combine_columns` and prevents accidental data loss.

## Linked issue
Fixes #592

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately:
  ```powershell
  python -m ruff check .
  python -m black --check .
