### PR TITLE
feat: add row lineage metadata through filtering and drop steps

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -62,6 +62,7 @@ from .io import (
     write_parquet,
 )
 from .pipeline import (
+    LineageReport,
     PipelineContext,
     get_builtin_step_signatures,
     list_steps,
@@ -178,6 +179,7 @@ __all__ = [
     "get_builtin_step_signatures",
     "list_steps",
     "PipelineContext",
+    "LineageReport",
     "reset_steps",
     # Data quality
     "profile",

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -86,6 +86,12 @@ class LineageReport:
         Mapping from step name to a sorted list of original row indices that
         were dropped by that step.  Steps that dropped no rows have an empty
         list.
+
+        When the same step name appears more than once in the pipeline, all
+        drops from every invocation of that step are merged under the single
+        key in sorted order.  Use ``track_lineage=True`` together with
+        per-step timing from ``return_metadata=True`` if you need to
+        distinguish individual invocations.
     total_dropped : int
         Total number of rows dropped across all steps.
 
@@ -435,6 +441,10 @@ def pipeline(
         When True, also return a metadata dictionary with per-step timing
         information in execution order.
 
+        Cannot be combined with ``track_lineage=True``.  If you need both
+        row-level lineage and per-step timings, run the pipeline twice: once
+        with ``track_lineage=True`` and once with ``return_metadata=True``.
+
     verbose : bool, default False
         Enable lightweight diagnostic logging through the ``arnio`` logger.
         Logs step index, step name, execution path, elapsed execution
@@ -450,18 +460,28 @@ def pipeline(
         instead of a bare ``ArFrame``.  The sentinel column is always stripped
         from the returned frame before it is handed back to the caller.
 
-        Custom Python steps receive the sentinel column as a regular ``int64``
-        column and **must not drop it**; document this constraint when writing
-        custom steps that will be used with ``track_lineage=True``.
+        When the same step name appears more than once in the pipeline, all
+        drops from every invocation of that step are merged under the single
+        key in ``LineageReport.dropped_by_step``, in sorted order.
 
-        Implies a complete pass through the pipeline (equivalent to
-        ``return_metadata=False`` behaviour for the frame result); use
-        ``return_metadata=True`` separately if per-step timings are also needed.
+        **Incompatible with** ``return_metadata=True``.  Combining both raises
+        ``ValueError``.
+
+        **Input column constraint**: the input frame must not already contain a
+        column named ``__arnio_lineage_id__``.  If it does, ``pipeline`` raises
+        ``ValueError`` before any steps are executed.
+
+        **Custom step contract**: custom Python steps that are used with
+        ``track_lineage=True`` must not drop or rename the sentinel column
+        ``__arnio_lineage_id__``.  If a custom step removes the sentinel, a
+        ``PipelineStepError`` is raised immediately after that step completes.
+
+        Cannot be combined with ``return_metadata=True``.
 
     Returns
     -------
     ArFrame
-        Data frame with all steps applied sequentially (``track_lineage=False``).
+        Data frame with all steps applied sequentially (default).
     tuple[ArFrame, LineageReport]
         Frame and lineage report when ``track_lineage=True``.
     tuple[ArFrame, dict]
@@ -470,11 +490,17 @@ def pipeline(
     Raises
     ------
     TypeError
-        If ``track_lineage`` is not a bool.
+        If any parameter has an unexpected type.
     ValueError
+        If ``track_lineage=True`` and ``return_metadata=True`` are both set.
+        If ``track_lineage=True`` and the input frame already contains a column
+        named ``__arnio_lineage_id__``.
         If step format is invalid.
     UnknownStepError
         If step name is not registered.
+    PipelineStepError
+        If a custom step removes the internal lineage sentinel column while
+        ``track_lineage=True`` is active.
 
     Examples
     --------
@@ -484,6 +510,17 @@ def pipeline(
     ...     ("strip_whitespace",),
     ...     ("drop_duplicates", {"keep": "first"}),
     ... ])
+
+    Row lineage tracking:
+
+    >>> result, lineage = ar.pipeline(frame, [
+    ...     ("drop_nulls",),
+    ...     ("drop_duplicates",),
+    ... ], track_lineage=True)
+    >>> lineage.dropped_by_step
+    {"drop_nulls": [1, 4], "drop_duplicates": [7]}
+    >>> lineage.total_dropped
+    3
     """
     if not isinstance(frame, ArFrame):
         raise TypeError("frame must be an ArFrame")
@@ -499,6 +536,17 @@ def pipeline(
         raise TypeError(
             f"track_lineage must be a bool, got {type(track_lineage).__name__!r}"
         )
+
+    # Fix 1: reject the track_lineage + return_metadata combination upfront
+    # rather than silently ignoring return_metadata.
+    if track_lineage and return_metadata:
+        raise ValueError(
+            "track_lineage=True and return_metadata=True cannot be used together. "
+            "Run the pipeline twice if you need both row-level lineage and "
+            "per-step timings: once with track_lineage=True and once with "
+            "return_metadata=True."
+        )
+
     with _REGISTRY_LOCK:
         python_step_registry = dict(_PYTHON_STEP_REGISTRY)
         namespaced_builtin_steps = _get_namespaced_builtin_steps(python_step_registry)
@@ -520,10 +568,24 @@ def pipeline(
     # exactly which original row indices survive each row-dropping step.
     # The C++ engine treats it as an ordinary column and filters/deduplicates
     # it correctly alongside all other columns.
+    #
+    # Fix 3a: guard against sentinel column name collision in the input frame.
+    # DataFrame.insert would raise a raw pandas ValueError; we replace that
+    # with a clear Arnio-level error before any steps run.
+    #
+    # Fix 2: accumulate drops per step name using a dict[str, list[int]] where
+    # repeated step names extend (not overwrite) the existing list.
     _lineage_dropped_by_step: dict[str, list[int]] = {}
     _lineage_current_ids: set[int] = set()
     if track_lineage:
-        _sentinel_df = to_pandas(frame).copy()
+        _input_df = to_pandas(frame)
+        if _LINEAGE_SENTINEL_COL in _input_df.columns:
+            raise ValueError(
+                f"track_lineage=True requires that the input frame does not already "
+                f"contain a column named {_LINEAGE_SENTINEL_COL!r}.  "
+                f"Please rename or drop that column before calling pipeline()."
+            )
+        _sentinel_df = _input_df.copy()
         _sentinel_df.insert(0, _LINEAGE_SENTINEL_COL, range(len(_sentinel_df)))
         _sentinel_frame = from_pandas(_sentinel_df)
         result = _sentinel_frame
@@ -728,11 +790,33 @@ def pipeline(
         # --- per-step lineage diff ----------------------------------------
         # After each step (C++ or Python), check which sentinel IDs survived.
         # Non-dropping steps produce an empty diff naturally — no special-casing.
+        #
+        # Fix 3b: detect custom steps that removed the sentinel column and raise
+        # a clear PipelineStepError rather than letting a raw KeyError surface.
+        #
+        # Fix 2: extend rather than overwrite when the same step name appears
+        # more than once; keep the merged list in sorted order.
         if track_lineage:
             _after_pdf = to_pandas(working_frame)
+            if _LINEAGE_SENTINEL_COL not in _after_pdf.columns:
+                raise PipelineStepError(
+                    name,
+                    KeyError(
+                        f"Custom pipeline step '{name}' removed the internal lineage "
+                        f"sentinel column {_LINEAGE_SENTINEL_COL!r}.  Custom steps "
+                        f"must not drop or rename this column when track_lineage=True."
+                    ),
+                )
             _surviving_ids: set[int] = set(_after_pdf[_LINEAGE_SENTINEL_COL].tolist())
             _newly_dropped = sorted(_lineage_current_ids - _surviving_ids)
-            _lineage_dropped_by_step[name] = _newly_dropped
+            if name in _lineage_dropped_by_step:
+                # Same step name used more than once: merge and re-sort so the
+                # combined list remains ordered by original index.
+                _lineage_dropped_by_step[name] = sorted(
+                    _lineage_dropped_by_step[name] + _newly_dropped
+                )
+            else:
+                _lineage_dropped_by_step[name] = _newly_dropped
             _lineage_current_ids = _surviving_ids
         # ------------------------------------------------------------------
 

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -61,6 +61,9 @@ _PYTHON_STEP_REGISTRY: dict[str, Callable] = {
 _BUILTIN_PYTHON_STEP_REGISTRY: dict[str, Callable] = {}
 
 
+_LINEAGE_SENTINEL_COL = "__arnio_lineage_id__"
+
+
 @dataclass(frozen=True)
 class PipelineContext:
     """Execution context passed to opt-in Python pipeline steps."""
@@ -69,6 +72,48 @@ class PipelineContext:
     step_index: int
     total_steps: int
     dry_run: bool
+
+
+@dataclass(frozen=True)
+class LineageReport:
+    """Maps dropped rows back to their original indices and the step that dropped them.
+
+    Returned by :func:`pipeline` when ``track_lineage=True``.
+
+    Attributes
+    ----------
+    dropped_by_step : dict[str, list[int]]
+        Mapping from step name to a sorted list of original row indices that
+        were dropped by that step.  Steps that dropped no rows have an empty
+        list.
+    total_dropped : int
+        Total number of rows dropped across all steps.
+
+    Examples
+    --------
+    >>> result, lineage = ar.pipeline(frame, steps, track_lineage=True)
+    >>> lineage.dropped_by_step
+    {"drop_nulls": [1, 2], "drop_duplicates": [4]}
+    >>> lineage.total_dropped
+    3
+    >>> lineage.to_pandas()
+       original_index          step
+    0               1    drop_nulls
+    1               2    drop_nulls
+    2               4  drop_duplicates
+    """
+
+    dropped_by_step: dict[str, list[int]]
+    total_dropped: int
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Return a flat DataFrame with columns ``original_index`` and ``step``."""
+        rows = [
+            {"original_index": idx, "step": step_name}
+            for step_name, indices in self.dropped_by_step.items()
+            for idx in indices
+        ]
+        return pd.DataFrame(rows, columns=["original_index", "step"])
 
 
 class _WritablePipelineSeries(pd.Series):
@@ -372,7 +417,8 @@ def pipeline(
     return_metadata: bool = False,
     dry_run: bool = False,
     verbose: bool = False,
-) -> ArFrame | tuple[ArFrame, dict[str, Any]]:
+    track_lineage: bool = False,
+) -> ArFrame | tuple[ArFrame, dict[str, Any]] | tuple[ArFrame, LineageReport]:
     """Apply a list of cleaning steps sequentially.
 
     Each step is a tuple of (step_name,) or (step_name, kwargs_dict).
@@ -398,13 +444,33 @@ def pipeline(
         Validates pipeline structure and step execution without
         returning transformed output.
 
+    track_lineage : bool, default False
+        When True, inject a hidden sentinel column to track which original row
+        indices are dropped by each step, then return ``(ArFrame, LineageReport)``
+        instead of a bare ``ArFrame``.  The sentinel column is always stripped
+        from the returned frame before it is handed back to the caller.
+
+        Custom Python steps receive the sentinel column as a regular ``int64``
+        column and **must not drop it**; document this constraint when writing
+        custom steps that will be used with ``track_lineage=True``.
+
+        Implies a complete pass through the pipeline (equivalent to
+        ``return_metadata=False`` behaviour for the frame result); use
+        ``return_metadata=True`` separately if per-step timings are also needed.
+
     Returns
     -------
     ArFrame
-        Data frame with all steps applied sequentially.
+        Data frame with all steps applied sequentially (``track_lineage=False``).
+    tuple[ArFrame, LineageReport]
+        Frame and lineage report when ``track_lineage=True``.
+    tuple[ArFrame, dict]
+        Frame and metadata dict when ``return_metadata=True``.
 
     Raises
     ------
+    TypeError
+        If ``track_lineage`` is not a bool.
     ValueError
         If step format is invalid.
     UnknownStepError
@@ -429,6 +495,10 @@ def pipeline(
         raise TypeError(f"dry_run must be a bool, got {type(dry_run).__name__!r}")
     if not isinstance(verbose, bool):
         raise TypeError(f"verbose must be a bool, got {type(verbose).__name__!r}")
+    if not isinstance(track_lineage, bool):
+        raise TypeError(
+            f"track_lineage must be a bool, got {type(track_lineage).__name__!r}"
+        )
     with _REGISTRY_LOCK:
         python_step_registry = dict(_PYTHON_STEP_REGISTRY)
         namespaced_builtin_steps = _get_namespaced_builtin_steps(python_step_registry)
@@ -444,6 +514,22 @@ def pipeline(
 
     result = frame
     working_frame = frame
+
+    # --- lineage tracking setup -------------------------------------------
+    # Inject a hidden int64 sentinel column (values 0..n-1) so we can track
+    # exactly which original row indices survive each row-dropping step.
+    # The C++ engine treats it as an ordinary column and filters/deduplicates
+    # it correctly alongside all other columns.
+    _lineage_dropped_by_step: dict[str, list[int]] = {}
+    _lineage_current_ids: set[int] = set()
+    if track_lineage:
+        _sentinel_df = to_pandas(frame).copy()
+        _sentinel_df.insert(0, _LINEAGE_SENTINEL_COL, range(len(_sentinel_df)))
+        _sentinel_frame = from_pandas(_sentinel_df)
+        result = _sentinel_frame
+        working_frame = _sentinel_frame
+        _lineage_current_ids = set(range(len(_sentinel_df)))
+    # -----------------------------------------------------------------------
 
     step_timings: list[dict[str, Any]] = []
     applied_steps: list[str] = []
@@ -466,6 +552,26 @@ def pipeline(
 
         name = _resolve_step_name(name, deprecated_step_aliases)
         name = namespaced_builtin_steps.get(name, name)
+
+        # --- lineage: sentinel compatibility for drop_duplicates -----------
+        # The sentinel column has a unique value per row.  Without this fix,
+        # drop_duplicates would see every row as distinct and drop nothing.
+        # We auto-restrict its subset to user-visible columns only.
+        if track_lineage and name == "drop_duplicates":
+            _user_cols = [
+                c
+                for c in to_pandas(working_frame).columns
+                if c != _LINEAGE_SENTINEL_COL
+            ]
+            kwargs = {
+                **kwargs,
+                "subset": [
+                    c
+                    for c in kwargs.get("subset", _user_cols)
+                    if c != _LINEAGE_SENTINEL_COL
+                ],
+            }
+        # ------------------------------------------------------------------
 
         if name in _STEP_REGISTRY:
             # C++ backed step - fast path
@@ -618,6 +724,32 @@ def pipeline(
         else:
             available = list(_STEP_REGISTRY.keys()) + list(python_step_registry.keys())
             raise UnknownStepError(name, available)
+
+        # --- per-step lineage diff ----------------------------------------
+        # After each step (C++ or Python), check which sentinel IDs survived.
+        # Non-dropping steps produce an empty diff naturally — no special-casing.
+        if track_lineage:
+            _after_pdf = to_pandas(working_frame)
+            _surviving_ids: set[int] = set(_after_pdf[_LINEAGE_SENTINEL_COL].tolist())
+            _newly_dropped = sorted(_lineage_current_ids - _surviving_ids)
+            _lineage_dropped_by_step[name] = _newly_dropped
+            _lineage_current_ids = _surviving_ids
+        # ------------------------------------------------------------------
+
+    # --- lineage return path -----------------------------------------------
+    # Strip the hidden sentinel column from the result before returning so
+    # callers never see it, then build and return the LineageReport.
+    if track_lineage:
+        _result_pdf = to_pandas(result)
+        result = from_pandas(_result_pdf.drop(columns=[_LINEAGE_SENTINEL_COL]))
+        _lineage_report = LineageReport(
+            dropped_by_step=_lineage_dropped_by_step,
+            total_dropped=sum(
+                len(indices) for indices in _lineage_dropped_by_step.values()
+            ),
+        )
+        return result, _lineage_report
+    # -----------------------------------------------------------------------
 
     if return_metadata:
         return result, {

--- a/tests/test_pipeline_lineage.py
+++ b/tests/test_pipeline_lineage.py
@@ -68,6 +68,81 @@ class TestTrackLineageTypeValidation:
 
 
 # ---------------------------------------------------------------------------
+# Fix 1: track_lineage + return_metadata incompatibility
+# ---------------------------------------------------------------------------
+
+
+class TestTrackLineageAndReturnMetadataIncompatible:
+    """track_lineage=True and return_metadata=True must be rejected upfront."""
+
+    def test_both_true_raises_value_error(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        with pytest.raises(ValueError, match="track_lineage"):
+            ar.pipeline(
+                frame,
+                [("strip_whitespace",)],
+                track_lineage=True,
+                return_metadata=True,
+            )
+
+    def test_error_message_mentions_return_metadata(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        with pytest.raises(ValueError, match="return_metadata"):
+            ar.pipeline(
+                frame,
+                [("drop_nulls",)],
+                track_lineage=True,
+                return_metadata=True,
+            )
+
+    def test_error_raised_before_any_step_executes(self):
+        """The error must fire before pipeline execution, not mid-run."""
+        call_log: list[str] = []
+
+        def spy_step(df: pd.DataFrame) -> pd.DataFrame:
+            call_log.append("executed")
+            return df
+
+        ar.register_step("spy_step_incompatible", spy_step)
+        try:
+            frame = _make_frame({"x": [1, 2, 3]})
+            with pytest.raises(ValueError):
+                ar.pipeline(
+                    frame,
+                    [("spy_step_incompatible",)],
+                    track_lineage=True,
+                    return_metadata=True,
+                )
+            assert call_log == [], "spy step must not have been called"
+        finally:
+            ar.unregister_step("spy_step_incompatible")
+
+    def test_track_lineage_true_return_metadata_false_is_allowed(self):
+        """Explicit return_metadata=False must not raise."""
+        frame = _make_frame({"x": [1, 2, 3]})
+        result, lineage = ar.pipeline(
+            frame,
+            [("strip_whitespace",)],
+            track_lineage=True,
+            return_metadata=False,
+        )
+        assert isinstance(result, ar.ArFrame)
+        assert isinstance(lineage, LineageReport)
+
+    def test_track_lineage_false_return_metadata_true_is_allowed(self):
+        """The original return_metadata path must be unaffected."""
+        frame = _make_frame({"x": [1, 2, 3]})
+        result, meta = ar.pipeline(
+            frame,
+            [("strip_whitespace",)],
+            track_lineage=False,
+            return_metadata=True,
+        )
+        assert isinstance(result, ar.ArFrame)
+        assert "step_timings" in meta
+
+
+# ---------------------------------------------------------------------------
 # Default behaviour unchanged
 # ---------------------------------------------------------------------------
 
@@ -116,6 +191,214 @@ class TestSentinelColumnStripped:
         result, _ = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
         result_col_count = len(ar.to_pandas(result).columns)
         assert result_col_count == original_col_count
+
+
+# ---------------------------------------------------------------------------
+# Fix 3a: sentinel column collision in the input frame
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelColumnCollision:
+    """Input frames that already contain __arnio_lineage_id__ must be rejected."""
+
+    def test_raises_value_error_when_sentinel_col_exists(self):
+        frame = _make_frame({"__arnio_lineage_id__": [10, 20, 30], "x": [1, 2, 3]})
+        with pytest.raises(ValueError, match="__arnio_lineage_id__"):
+            ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+
+    def test_error_message_is_actionable(self):
+        """Error should tell the user to rename or drop the column."""
+        frame = _make_frame({"__arnio_lineage_id__": [1], "y": [2]})
+        with pytest.raises(ValueError, match="rename or drop"):
+            ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+
+    def test_error_raised_before_any_steps_execute(self):
+        """No steps should run when the sentinel collision is detected upfront."""
+        call_log: list[str] = []
+
+        def spy_step(df: pd.DataFrame) -> pd.DataFrame:
+            call_log.append("executed")
+            return df
+
+        ar.register_step("spy_step_collision", spy_step)
+        try:
+            frame = _make_frame({"__arnio_lineage_id__": [1, 2], "x": [3, 4]})
+            with pytest.raises(ValueError):
+                ar.pipeline(
+                    frame,
+                    [("spy_step_collision",)],
+                    track_lineage=True,
+                )
+            assert call_log == [], "spy step must not have been called"
+        finally:
+            ar.unregister_step("spy_step_collision")
+
+    def test_no_collision_when_track_lineage_false(self):
+        """A frame with that column name is fine when track_lineage is off."""
+        frame = _make_frame({"__arnio_lineage_id__": [1, 2, 3]})
+        result = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=False)
+        df = ar.to_pandas(result)
+        assert "__arnio_lineage_id__" in df.columns
+
+
+# ---------------------------------------------------------------------------
+# Fix 3b: custom step removes the sentinel column
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelColumnRemovedByCustomStep:
+    """Custom steps that drop the sentinel must raise PipelineStepError."""
+
+    def test_raises_pipeline_step_error_when_sentinel_removed(self):
+        from arnio.exceptions import PipelineStepError
+
+        def bad_step(df: pd.DataFrame) -> pd.DataFrame:
+            return df.drop(columns=["__arnio_lineage_id__"], errors="ignore")
+
+        ar.register_step("bad_step_removes_sentinel", bad_step)
+        try:
+            frame = _make_frame({"x": [1, 2, 3]})
+            with pytest.raises(PipelineStepError):
+                ar.pipeline(
+                    frame,
+                    [("bad_step_removes_sentinel",)],
+                    track_lineage=True,
+                )
+        finally:
+            ar.unregister_step("bad_step_removes_sentinel")
+
+    def test_error_names_the_offending_step(self):
+        from arnio.exceptions import PipelineStepError
+
+        def drop_sentinel(df: pd.DataFrame) -> pd.DataFrame:
+            return df.drop(columns=["__arnio_lineage_id__"], errors="ignore")
+
+        ar.register_step("drop_sentinel_step", drop_sentinel)
+        try:
+            frame = _make_frame({"x": [1, 2, 3]})
+            with pytest.raises(PipelineStepError, match="drop_sentinel_step"):
+                ar.pipeline(
+                    frame,
+                    [("drop_sentinel_step",)],
+                    track_lineage=True,
+                )
+        finally:
+            ar.unregister_step("drop_sentinel_step")
+
+    def test_well_behaved_custom_step_does_not_raise(self):
+        """A custom step that leaves the sentinel intact must work fine."""
+
+        def good_step(df: pd.DataFrame) -> pd.DataFrame:
+            df = df.copy()
+            if "x" in df.columns:
+                df["x"] = df["x"] * 2
+            return df
+
+        ar.register_step("good_step_sentinel", good_step)
+        try:
+            frame = _make_frame({"x": [1, 2, 3]})
+            result, lineage = ar.pipeline(
+                frame,
+                [("good_step_sentinel",)],
+                track_lineage=True,
+            )
+            assert isinstance(result, ar.ArFrame)
+            assert "__arnio_lineage_id__" not in ar.to_pandas(result).columns
+        finally:
+            ar.unregister_step("good_step_sentinel")
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: repeated step names accumulate rather than overwrite
+# ---------------------------------------------------------------------------
+
+
+class TestLineageRepeatedStepNames:
+    """Same step name used more than once must merge, not overwrite, drops."""
+
+    def test_same_dropping_step_twice_accumulates_indices(self):
+        #  Pass 1 drop_nulls drops rows with null in col 'a' (original row 1).
+        #  Pass 2 drop_nulls has nothing left to drop.
+        #  But if we arrange two null-producing situations across two subsets
+        #  we can isolate each pass.
+        #
+        #  Simpler: just check that both passes contribute to a single key.
+        #  Row 0: a=1,   b=1   — kept both passes
+        #  Row 1: a=None,b=1   — dropped pass 1 (subset=["a"])
+        #  Row 2: a=2,   b=None — dropped pass 2 (subset=["b"])
+        frame = _make_frame({"a": [1, None, 2], "b": [1, 1, None]})
+        _, lineage = ar.pipeline(
+            frame,
+            [
+                ("drop_nulls", {"subset": ["a"]}),
+                ("drop_nulls", {"subset": ["b"]}),
+            ],
+            track_lineage=True,
+        )
+        # Both drops land under the single "drop_nulls" key, sorted.
+        assert lineage.dropped_by_step["drop_nulls"] == [1, 2]
+
+    def test_repeated_step_total_dropped_is_correct(self):
+        frame = _make_frame({"a": [1, None, 2], "b": [1, 1, None]})
+        _, lineage = ar.pipeline(
+            frame,
+            [
+                ("drop_nulls", {"subset": ["a"]}),
+                ("drop_nulls", {"subset": ["b"]}),
+            ],
+            track_lineage=True,
+        )
+        assert lineage.total_dropped == 2
+
+    def test_repeated_step_drops_are_sorted_by_original_index(self):
+        #  Arrange so the second pass drops a lower original index than the first.
+        #  Row 0: a=None, b=1   — dropped by pass 2 (subset=["a"] after pass 1 runs)
+        #  Row 1: a=1,    b=None — dropped by pass 1 (subset=["b"])
+        #
+        #  Actually the sentinel tracks original indices, so regardless of which
+        #  pass ran first the merged list must be [0, 1] not [1, 0].
+        frame = _make_frame({"a": [None, 1], "b": [1, None]})
+        _, lineage = ar.pipeline(
+            frame,
+            [
+                ("drop_nulls", {"subset": ["b"]}),
+                ("drop_nulls", {"subset": ["a"]}),
+            ],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step["drop_nulls"] == [0, 1]
+
+    def test_to_pandas_includes_all_rows_from_repeated_step(self):
+        frame = _make_frame({"a": [1, None, 2], "b": [1, 1, None]})
+        _, lineage = ar.pipeline(
+            frame,
+            [
+                ("drop_nulls", {"subset": ["a"]}),
+                ("drop_nulls", {"subset": ["b"]}),
+            ],
+            track_lineage=True,
+        )
+        df = lineage.to_pandas()
+        assert len(df) == 2
+        assert set(df["step"].tolist()) == {"drop_nulls"}
+        assert sorted(df["original_index"].tolist()) == [1, 2]
+
+    def test_first_invocation_drops_not_lost(self):
+        """Regression: the first pass's drops must survive the second pass."""
+        frame = _make_frame({"x": [None, 1, None, 2]})
+        _, lineage = ar.pipeline(
+            frame,
+            [
+                # Pass 1 drops rows 0 and 2.
+                ("drop_nulls",),
+                # Pass 2 has nothing to drop (all remaining rows are non-null).
+                ("drop_nulls",),
+            ],
+            track_lineage=True,
+        )
+        assert 0 in lineage.dropped_by_step["drop_nulls"]
+        assert 2 in lineage.dropped_by_step["drop_nulls"]
+        assert lineage.total_dropped == 2
 
 
 # ---------------------------------------------------------------------------
@@ -186,8 +469,6 @@ class TestLineageDropDuplicates:
 
 class TestLineageFilterRows:
     def test_filter_rows_records_correct_indices(self):
-        #  Row 0: age=30 — dropped (not > 25 is False; 30 > 25 so KEPT)
-        #  Wait: filter_rows keeps rows WHERE condition is True.
         #  age > 25: rows 0 (30>25=True), 2 (35>25=True) kept; row 1 (25>25=False) dropped.
         frame = _make_frame({"age": [30, 25, 35]})
         _, lineage = ar.pipeline(

--- a/tests/test_pipeline_lineage.py
+++ b/tests/test_pipeline_lineage.py
@@ -1,0 +1,423 @@
+"""Tests for row lineage metadata through filtering and drop steps.
+
+Covers the ``track_lineage=True`` path added to :func:`arnio.pipeline` in
+issue #648.  All fixtures use :func:`arnio.from_pandas` so no C++ CSV reader
+is required.
+
+Run with::
+
+    pytest tests/test_pipeline_lineage.py -v
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import arnio as ar
+from arnio.pipeline import LineageReport
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_frame(data: dict) -> ar.ArFrame:
+    """Convenience wrapper for test frame construction."""
+    return ar.from_pandas(pd.DataFrame(data))
+
+
+# ---------------------------------------------------------------------------
+# LineageReport: importability and type
+# ---------------------------------------------------------------------------
+
+
+class TestLineageReportImport:
+    def test_importable_from_arnio_top_level(self):
+        from arnio import LineageReport as LR  # noqa: F401
+
+        assert LR is LineageReport
+
+    def test_is_dataclass_frozen(self):
+        """LineageReport must be immutable."""
+        report = LineageReport(dropped_by_step={}, total_dropped=0)
+        with pytest.raises((AttributeError, TypeError)):
+            report.total_dropped = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# track_lineage type validation
+# ---------------------------------------------------------------------------
+
+
+class TestTrackLineageTypeValidation:
+    def test_track_lineage_wrong_type_raises_type_error(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        with pytest.raises(TypeError, match="track_lineage"):
+            ar.pipeline(frame, [("strip_whitespace",)], track_lineage="yes")  # type: ignore[arg-type]
+
+    def test_track_lineage_int_raises_type_error(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        with pytest.raises(TypeError, match="track_lineage"):
+            ar.pipeline(frame, [("strip_whitespace",)], track_lineage=1)  # type: ignore[arg-type]
+
+    def test_track_lineage_none_raises_type_error(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        with pytest.raises(TypeError, match="track_lineage"):
+            ar.pipeline(frame, [("strip_whitespace",)], track_lineage=None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultBehaviourUnchanged:
+    def test_track_lineage_false_returns_arframe(self):
+        frame = _make_frame({"name": ["Alice", None, "Charlie"]})
+        result = ar.pipeline(frame, [("drop_nulls",)], track_lineage=False)
+        assert isinstance(result, ar.ArFrame)
+
+    def test_track_lineage_false_no_sentinel_column_in_output(self):
+        frame = _make_frame({"name": ["Alice", "Bob"]})
+        result = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=False)
+        df = ar.to_pandas(result)
+        assert "__arnio_lineage_id__" not in df.columns
+
+    def test_track_lineage_default_is_false(self):
+        """Omitting track_lineage entirely must behave like track_lineage=False."""
+        frame = _make_frame({"name": ["Alice", None]})
+        result = ar.pipeline(frame, [("drop_nulls",)])
+        assert isinstance(result, ar.ArFrame)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel column stripped from output
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelColumnStripped:
+    def test_sentinel_column_not_present_in_output(self):
+        frame = _make_frame({"score": [1.0, None, 3.0]})
+        result, _ = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        df = ar.to_pandas(result)
+        assert "__arnio_lineage_id__" not in df.columns
+
+    def test_sentinel_column_not_present_after_non_dropping_step(self):
+        frame = _make_frame({"name": ["  Alice  ", "  Bob  "]})
+        result, _ = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+        df = ar.to_pandas(result)
+        assert "__arnio_lineage_id__" not in df.columns
+
+    def test_output_shape_excludes_sentinel(self):
+        """Result must have the same number of columns as the original frame."""
+        frame = _make_frame({"a": [1, None, 3], "b": ["x", "y", "z"]})
+        original_col_count = len(ar.to_pandas(frame).columns)
+        result, _ = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        result_col_count = len(ar.to_pandas(result).columns)
+        assert result_col_count == original_col_count
+
+
+# ---------------------------------------------------------------------------
+# drop_nulls lineage
+# ---------------------------------------------------------------------------
+
+
+class TestLineageDropNulls:
+    def test_drop_nulls_records_correct_indices(self):
+        #  Row 0: Alice 30   — kept
+        #  Row 1: None  25   — dropped (null name)
+        #  Row 2: Charlie 35 — kept
+        frame = _make_frame({"name": ["Alice", None, "Charlie"], "age": [30, 25, 35]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        assert lineage.dropped_by_step["drop_nulls"] == [1]
+
+    def test_drop_nulls_subset_records_only_subset_drops(self):
+        #  Row 0: score=None — kept (age column is the subset, age=30 is fine)
+        #  Row 1: age=None   — dropped
+        frame = _make_frame({"score": [None, 9.0], "age": [30, None]})
+        _, lineage = ar.pipeline(
+            frame, [("drop_nulls", {"subset": ["age"]})], track_lineage=True
+        )
+        assert lineage.dropped_by_step["drop_nulls"] == [1]
+
+    def test_drop_nulls_multiple_null_rows(self):
+        frame = _make_frame({"x": [1, None, None, 4]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        assert lineage.dropped_by_step["drop_nulls"] == [1, 2]
+
+    def test_drop_nulls_no_nulls_empty_drop_list(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        assert lineage.dropped_by_step["drop_nulls"] == []
+
+
+# ---------------------------------------------------------------------------
+# drop_duplicates lineage
+# ---------------------------------------------------------------------------
+
+
+class TestLineageDropDuplicates:
+    def test_drop_duplicates_records_correct_indices(self):
+        #  Row 0: Alice 30  — kept (first occurrence)
+        #  Row 1: Bob   25  — kept
+        #  Row 2: Alice 30  — dropped (duplicate of row 0)
+        frame = _make_frame({"name": ["Alice", "Bob", "Alice"], "age": [30, 25, 30]})
+        _, lineage = ar.pipeline(frame, [("drop_duplicates",)], track_lineage=True)
+        assert lineage.dropped_by_step["drop_duplicates"] == [2]
+
+    def test_drop_duplicates_keep_last_drops_first(self):
+        frame = _make_frame({"name": ["Alice", "Bob", "Alice"], "age": [30, 25, 30]})
+        _, lineage = ar.pipeline(
+            frame, [("drop_duplicates", {"keep": "last"})], track_lineage=True
+        )
+        assert lineage.dropped_by_step["drop_duplicates"] == [0]
+
+    def test_drop_duplicates_no_dupes_empty_drop_list(self):
+        frame = _make_frame({"name": ["Alice", "Bob", "Charlie"]})
+        _, lineage = ar.pipeline(frame, [("drop_duplicates",)], track_lineage=True)
+        assert lineage.dropped_by_step["drop_duplicates"] == []
+
+
+# ---------------------------------------------------------------------------
+# filter_rows lineage
+# ---------------------------------------------------------------------------
+
+
+class TestLineageFilterRows:
+    def test_filter_rows_records_correct_indices(self):
+        #  Row 0: age=30 — dropped (not > 25 is False; 30 > 25 so KEPT)
+        #  Wait: filter_rows keeps rows WHERE condition is True.
+        #  age > 25: rows 0 (30>25=True), 2 (35>25=True) kept; row 1 (25>25=False) dropped.
+        frame = _make_frame({"age": [30, 25, 35]})
+        _, lineage = ar.pipeline(
+            frame,
+            [("filter_rows", {"column": "age", "op": ">", "value": 25})],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step["filter_rows"] == [1]
+
+    def test_filter_rows_equality_drops_non_matching(self):
+        #  Only row 0 (Alice) matches == "Alice"; rows 1 and 2 are dropped.
+        frame = _make_frame({"name": ["Alice", "Bob", "Charlie"]})
+        _, lineage = ar.pipeline(
+            frame,
+            [("filter_rows", {"column": "name", "op": "==", "value": "Alice"})],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step["filter_rows"] == [1, 2]
+
+    def test_filter_rows_no_rows_dropped_empty_list(self):
+        frame = _make_frame({"age": [30, 35, 40]})
+        _, lineage = ar.pipeline(
+            frame,
+            [("filter_rows", {"column": "age", "op": ">", "value": 20})],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step["filter_rows"] == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-step accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestLineageMultiStep:
+    def test_multi_step_each_step_records_only_its_own_drops(self):
+        #  Row 0: Alice 30   — kept through all steps
+        #  Row 1: None  25   — dropped by drop_nulls
+        #  Row 2: Alice 30   — dropped by drop_duplicates (dup of row 0)
+        frame = _make_frame({"name": ["Alice", None, "Alice"], "age": [30, 25, 30]})
+        _, lineage = ar.pipeline(
+            frame,
+            [("drop_nulls",), ("drop_duplicates",)],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step["drop_nulls"] == [1]
+        assert lineage.dropped_by_step["drop_duplicates"] == [2]
+
+    def test_multi_step_indices_refer_to_original_rows(self):
+        """Indices in dropped_by_step are always original-frame row indices."""
+        #  Original: rows 0,1,2,3
+        #  After drop_nulls:  rows 0,2,3 survive (row 1 has null)
+        #  After filter_rows(age>28): from {0,2,3}, row 2 (age=25) is dropped
+        #  So drop_nulls drops original row 1; filter_rows drops original row 2.
+        frame = _make_frame(
+            {"name": ["Alice", None, "Bob", "Charlie"], "age": [30, 25, 25, 35]}
+        )
+        _, lineage = ar.pipeline(
+            frame,
+            [
+                ("drop_nulls",),
+                ("filter_rows", {"column": "age", "op": ">", "value": 28}),
+            ],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step["drop_nulls"] == [1]
+        assert lineage.dropped_by_step["filter_rows"] == [2]
+
+    def test_multi_step_total_dropped_matches_sum(self):
+        frame = _make_frame({"name": ["Alice", None, "Alice"], "age": [30, 25, 30]})
+        _, lineage = ar.pipeline(
+            frame,
+            [("drop_nulls",), ("drop_duplicates",)],
+            track_lineage=True,
+        )
+        expected = sum(len(v) for v in lineage.dropped_by_step.values())
+        assert lineage.total_dropped == expected
+        assert lineage.total_dropped == 2
+
+    def test_three_step_pipeline_accumulates(self):
+        #  Row 0: "Alice" age=30
+        #  Row 1: None    age=25  → dropped by drop_nulls
+        #  Row 2: "Alice" age=30  → dropped by drop_duplicates
+        #  Row 3: " Bob " age=40  → strip_whitespace does NOT drop it
+        frame = _make_frame(
+            {"name": ["Alice", None, "Alice", " Bob "], "age": [30, 25, 30, 40]}
+        )
+        _, lineage = ar.pipeline(
+            frame,
+            [("drop_nulls",), ("strip_whitespace",), ("drop_duplicates",)],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step["drop_nulls"] == [1]
+        assert lineage.dropped_by_step["strip_whitespace"] == []
+        assert lineage.dropped_by_step["drop_duplicates"] == [2]
+        assert lineage.total_dropped == 2
+
+
+# ---------------------------------------------------------------------------
+# Non-dropping step produces empty entry
+# ---------------------------------------------------------------------------
+
+
+class TestLineageNonDroppingStep:
+    def test_non_dropping_step_has_empty_entry(self):
+        frame = _make_frame({"name": ["  Alice  ", "  Bob  "]})
+        _, lineage = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+        assert "strip_whitespace" in lineage.dropped_by_step
+        assert lineage.dropped_by_step["strip_whitespace"] == []
+
+    def test_non_dropping_step_total_dropped_is_zero(self):
+        frame = _make_frame({"name": ["Alice", "Bob"]})
+        _, lineage = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+        assert lineage.total_dropped == 0
+
+    def test_rename_columns_has_empty_entry(self):
+        frame = _make_frame({"old_name": [1, 2, 3]})
+        _, lineage = ar.pipeline(
+            frame,
+            [("rename_columns", {"old_name": "new_name"})],
+            track_lineage=True,
+        )
+        assert lineage.dropped_by_step.get("rename_columns", []) == []
+
+
+# ---------------------------------------------------------------------------
+# LineageReport.total_dropped
+# ---------------------------------------------------------------------------
+
+
+class TestLineageTotalDropped:
+    def test_total_dropped_matches_sum_of_dropped_by_step(self):
+        frame = _make_frame({"x": [1, None, None, 4, None]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        assert lineage.total_dropped == sum(
+            len(v) for v in lineage.dropped_by_step.values()
+        )
+
+    def test_total_dropped_zero_when_nothing_dropped(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        _, lineage = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+        assert lineage.total_dropped == 0
+
+    def test_total_dropped_all_rows(self):
+        frame = _make_frame({"x": [None, None, None]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        assert lineage.total_dropped == 3
+
+
+# ---------------------------------------------------------------------------
+# LineageReport.to_pandas()
+# ---------------------------------------------------------------------------
+
+
+class TestLineageReportToPandas:
+    def test_to_pandas_returns_dataframe(self):
+        frame = _make_frame({"x": [1, None, 3]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        df = lineage.to_pandas()
+        assert isinstance(df, pd.DataFrame)
+
+    def test_to_pandas_schema_has_correct_columns(self):
+        frame = _make_frame({"x": [1, None, 3]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        df = lineage.to_pandas()
+        assert list(df.columns) == ["original_index", "step"]
+
+    def test_to_pandas_correct_rows(self):
+        #  Rows 1 and 2 are null → dropped by drop_nulls
+        frame = _make_frame({"x": [1, None, None, 4]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        df = lineage.to_pandas()
+        assert set(df["original_index"].tolist()) == {1, 2}
+        assert set(df["step"].tolist()) == {"drop_nulls"}
+
+    def test_to_pandas_empty_when_nothing_dropped(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        df = lineage.to_pandas()
+        assert len(df) == 0
+        assert list(df.columns) == ["original_index", "step"]
+
+    def test_to_pandas_multi_step_all_drops_present(self):
+        frame = _make_frame({"name": ["Alice", None, "Alice"], "age": [30, 25, 30]})
+        _, lineage = ar.pipeline(
+            frame,
+            [("drop_nulls",), ("drop_duplicates",)],
+            track_lineage=True,
+        )
+        df = lineage.to_pandas()
+        assert len(df) == 2
+        assert set(df["step"].tolist()) == {"drop_nulls", "drop_duplicates"}
+        null_row = df[df["step"] == "drop_nulls"]
+        assert null_row["original_index"].iloc[0] == 1
+        dup_row = df[df["step"] == "drop_duplicates"]
+        assert dup_row["original_index"].iloc[0] == 2
+
+    def test_to_pandas_row_count_equals_total_dropped(self):
+        frame = _make_frame({"x": [1, None, 3, None, 5]})
+        _, lineage = ar.pipeline(frame, [("drop_nulls",)], track_lineage=True)
+        df = lineage.to_pandas()
+        assert len(df) == lineage.total_dropped
+
+
+# ---------------------------------------------------------------------------
+# Return type
+# ---------------------------------------------------------------------------
+
+
+class TestLineageReturnType:
+    def test_track_lineage_true_returns_tuple(self):
+        frame = _make_frame({"x": [1, 2]})
+        out = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+        assert isinstance(out, tuple)
+        assert len(out) == 2
+
+    def test_track_lineage_true_first_element_is_arframe(self):
+        frame = _make_frame({"x": [1, 2]})
+        result, _ = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+        assert isinstance(result, ar.ArFrame)
+
+    def test_track_lineage_true_second_element_is_lineage_report(self):
+        frame = _make_frame({"x": [1, 2]})
+        _, lineage = ar.pipeline(frame, [("strip_whitespace",)], track_lineage=True)
+        assert isinstance(lineage, LineageReport)
+
+    def test_empty_steps_with_track_lineage_returns_clean_frame(self):
+        frame = _make_frame({"x": [1, 2, 3]})
+        result, lineage = ar.pipeline(frame, [], track_lineage=True)
+        assert isinstance(result, ar.ArFrame)
+        assert lineage.total_dropped == 0
+        df = ar.to_pandas(result)
+        assert "__arnio_lineage_id__" not in df.columns

--- a/website/api.html
+++ b/website/api.html
@@ -89,7 +89,8 @@
         </tbody></table>
 
         <h2 id="pipeline">Pipeline</h2>
-        <div class="api-func"><div class="api-func-header">pipeline(frame, steps, *, verbose=False)</div><div class="api-func-body"><p>Run named cleaning steps or registered Python callables. <code>verbose=True</code> enables lightweight diagnostics through the <code>arnio</code> logger and optional <code>PipelineContext</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">pipeline(frame, steps, *, verbose=False, track_lineage=False)</div><div class="api-func-body"><p>Run named cleaning steps or registered Python callables. <code>verbose=True</code> enables lightweight diagnostics through the <code>arnio</code> logger and optional <code>PipelineContext</code>. Pass <code>track_lineage=True</code> to receive a <code>(ArFrame, LineageReport)</code> tuple that maps every dropped row back to its original index and the step that removed it.</p></div></div>
+        <div class="api-func"><div class="api-func-header">LineageReport</div><div class="api-func-body"><p>Returned by <code>pipeline(..., track_lineage=True)</code>. Attributes: <code>dropped_by_step</code> (dict mapping step name → sorted list of original row indices dropped by that step; steps that dropped no rows have an empty list) and <code>total_dropped</code> (int). Method: <code>to_pandas()</code> returns a flat <code>DataFrame</code> with columns <code>original_index</code> and <code>step</code>.</p></div></div>
         <div class="api-func"><div class="api-func-header">register_step(name, fn, overwrite=False), unregister_step(name), list_steps(), reset_steps(), get_builtin_step_signatures()</div><div class="api-func-body"><p>Manage the step registry and discover available built-in signatures.</p></div></div>
 
         <h2 id="quality">Quality</h2>


### PR DESCRIPTION
## Summary

Implements row lineage metadata tracking through filtering and drop steps for `ar.pipeline()`.

Closes #648

---

## What changed

### `arnio/pipeline.py`
- Added `_LINEAGE_SENTINEL_COL = "__arnio_lineage_id__"` module-level constant
- Added `LineageReport` frozen dataclass with:
  - `dropped_by_step: dict[str, list[int]]` — step name → sorted list of original row indices dropped by that step (empty list for steps that dropped nothing)
  - `total_dropped: int` — total rows dropped across all steps
  - `to_pandas()` — flat `DataFrame` with columns `original_index` and `step`
- Added `track_lineage: bool = False` parameter to `pipeline()` with `isinstance` guard matching the existing `return_metadata` / `dry_run` / `verbose` pattern
- Before the step loop: injects a hidden `int64` sentinel column (`0..n-1`) via `to_pandas → insert → from_pandas` when `track_lineage=True`. The C++ engine treats it as an ordinary column and filters/preserves it correctly through all row-dropping operations
- After each step: diffs surviving sentinel values against the previous set to record which original indices were dropped and by which step name. Non-dropping steps produce an empty diff naturally with no special-casing
- **`drop_duplicates` compatibility fix**: the sentinel assigns a unique value to every row, which would cause `drop_duplicates` to see every row as distinct and drop nothing. Fixed by auto-injecting `subset=<all user columns>` (excluding the sentinel) into its kwargs when `track_lineage=True`, honouring any explicit `subset` the caller already passed
- After the loop: strips sentinel via `drop(columns=[…])`, builds `LineageReport`, returns `(ArFrame, LineageReport)`
- Updated docstring with full parameter docs and return-type variants

### `arnio/__init__.py`
- Imported `LineageReport` from `.pipeline`
- Added `"LineageReport"` to `__all__`

### `website/api.html`
- Updated `pipeline()` entry to include `track_lineage=False` in the signature and describe the `(ArFrame, LineageReport)` return
- Added a new `LineageReport` entry documenting `dropped_by_step`, `total_dropped`, and `to_pandas()`

### `tests/test_pipeline_lineage.py` *(new file)*
41 focused tests across 9 classes:

| Class | What it covers |
|---|---|
| `TestLineageReportImport` | Top-level importability, frozen dataclass immutability |
| `TestTrackLineageTypeValidation` | `TypeError` on `str`, `int`, `None` |
| `TestDefaultBehaviourUnchanged` | `track_lineage=False` returns bare `ArFrame`, no sentinel column leaks |
| `TestSentinelColumnStripped` | Sentinel absent from output frame, column count unchanged |
| `TestLineageDropNulls` | Correct indices for single null, subset, multiple nulls, zero nulls |
| `TestLineageDropDuplicates` | `keep="first"`, `keep="last"`, no-dup case |
| `TestLineageFilterRows` | `>`, `==` operators; no-drop case |
| `TestLineageMultiStep` | Each step records only its own drops; indices always refer to original frame; `total_dropped` arithmetic; three-step chain |
| `TestLineageNonDroppingStep` | `strip_whitespace` and `rename_columns` produce empty entries |
| `TestLineageTotalDropped` | Sum invariant; zero; all rows dropped |
| `TestLineageReportToPandas` | Return type, column schema, correct rows, empty case, multi-step content, row count equals `total_dropped` |
| `TestLineageReturnType` | Tuple length, element types, empty steps case |

---

## Usage

```python
import arnio as ar

frame = ar.from_pandas(df)

result, lineage = ar.pipeline(
    frame,
    [
        ("drop_nulls",),
        ("drop_duplicates",),
    ],
    track_lineage=True,
)

lineage.dropped_by_step
# {"drop_nulls": [1, 4], "drop_duplicates": [7]}

lineage.total_dropped
# 3

lineage.to_pandas()
#    original_index            step
# 0               1      drop_nulls
# 1               4      drop_nulls
# 2               7  drop_duplicates
```

---

## What was not changed

- C++ core / `_core.py` — purely Python layer change
- Any cleaning function internals
- `return_metadata` behaviour — fully backward compatible (`track_lineage=False` default leaves every existing call site untouched)
- All existing CSV, pandas interop, schema, quality, and packaging tests continue to pass (139 existing pipeline tests + 3151 suite-wide)

---

## Test results

<img width="939" height="224" alt="image" src="https://github.com/user-attachments/assets/eb08b0e6-6185-4c88-9cf1-ec0ba4e552a7" />
<img width="955" height="333" alt="image" src="https://github.com/user-attachments/assets/0992d2f7-4c8a-434a-8610-41f9d665f7a8" />


```
tests/test_pipeline_lineage.py   41 passed
tests/test_pipeline.py          139 passed
tests/test_website_api_docs.py    9 passed
```