### PR TITLE
docs: add auto_clean dry-run and explain workflow examples

### DIFF
--- a/website/docs.html
+++ b/website/docs.html
@@ -180,17 +180,19 @@ gate = ar.check_quality_gates(baseline, current)</code></pre></div>
         <h3>Safe auto_clean Workflow</h3>
         <p><code>auto_clean()</code> is powerful and safety-sensitive. Use <code>dry_run=True</code> and <code>explain=True</code> to audit changes before applying them to real data.</p>
         <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python"># Step 1 — Preview what would change, without touching the data
-report = ar.auto_clean(frame, dry_run=True, return_report=True)
-print(report)
+# Step 1 — Preview what would change, without touching the data
+report = ar.auto_clean(frame, mode="strict", dry_run=True)
+casts = report.confirmed_casts
 
-# Step 2 — Understand why each change is suggested
-report = ar.auto_clean(frame, dry_run=True, explain=True, return_report=True)
+# Step 2 — Inspect explanations separately (cannot combine with dry_run)
+clean, explanation = ar.auto_clean(frame, explain=True)
 
-# Step 3 — Apply intentionally once you have reviewed the suggestions
+# Step 3 — Apply intentionally using the previewed casts
 clean = ar.auto_clean(
     frame,
-    allow_lossy_casts=False,
-    confirmed_casts={"price": "FLOAT64"},
+    mode="strict",
+    allow_lossy_casts=True,
+    confirmed_casts=casts,
 )
 df = ar.to_pandas(clean)</code></pre></div>
 

--- a/website/docs.html
+++ b/website/docs.html
@@ -177,6 +177,24 @@ baseline = ar.profile(old_frame)
 current = ar.profile(new_frame)
 gate = ar.check_quality_gates(baseline, current)</code></pre></div>
 
+        <h3>Safe auto_clean Workflow</h3>
+        <p><code>auto_clean()</code> is powerful and safety-sensitive. Use <code>dry_run=True</code> and <code>explain=True</code> to audit changes before applying them to real data.</p>
+        <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python"># Step 1 — Preview what would change, without touching the data
+report = ar.auto_clean(frame, dry_run=True, return_report=True)
+print(report)
+
+# Step 2 — Understand why each change is suggested
+report = ar.auto_clean(frame, dry_run=True, explain=True, return_report=True)
+
+# Step 3 — Apply intentionally once you have reviewed the suggestions
+clean = ar.auto_clean(
+    frame,
+    allow_lossy_casts=False,
+    confirmed_casts={"price": "FLOAT64"},
+)
+df = ar.to_pandas(clean)</code></pre></div>
+
+
         <h2 id="schema">Schema Validation</h2>
         <p>Schemas validate the shape and semantics of a dataset. v1.18.0 added <code>max_errors</code>; v1.17.0 added URL scheme restrictions and YAML export helpers.</p>
         <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python">ar.register_validator("positive", lambda value: value > 0)

--- a/website/docs.html
+++ b/website/docs.html
@@ -179,10 +179,10 @@ gate = ar.check_quality_gates(baseline, current)</code></pre></div>
 
         <h3>Safe auto_clean Workflow</h3>
         <p><code>auto_clean()</code> is powerful and safety-sensitive. Use <code>dry_run=True</code> and <code>explain=True</code> to audit changes before applying them to real data.</p>
-        <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python"># Step 1 — Preview what would change, without touching the data
+        <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python">
 # Step 1 — Preview what would change, without touching the data
 report = ar.auto_clean(frame, mode="strict", dry_run=True)
-casts = report.confirmed_casts
+casts = dict(report.suggestions).get("cast_types")
 
 # Step 2 — Inspect explanations separately (cannot combine with dry_run)
 clean, explanation = ar.auto_clean(frame, explain=True)


### PR DESCRIPTION
## Summary
Adds a safe `auto_clean()` workflow example to the Quality Reports section of `website/docs.html`.

## Changes
- Added a 3-step code example showing `dry_run=True`, `explain=True`, and intentional application with `confirmed_casts`

## Related Issue
fixes #2168