### PR TITLE
Feature: Add compressed CSV support for .csv.gz files

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -513,6 +513,7 @@ def _materialize_csv_input(
     """
     if isinstance(source, (str, os.PathLike)):
         raw = os.fspath(source)
+        is_temp = False
 
         # Only inspect scheme for plain strings — PathLike objects are
         # always local filesystem paths.
@@ -530,9 +531,54 @@ def _materialize_csv_input(
 
             # HTTP/HTTPS — fetch via stdlib urllib, no new dependencies.
             if scheme in _SUPPORTED_URL_SCHEMES:
-                tmp_path = _fetch_url_to_tempfile(raw)
-                return tmp_path, True, True
+                raw = _fetch_url_to_tempfile(raw)
+                is_temp = True
 
+        is_gz = False
+        if isinstance(source, str) and source.lower().endswith(".gz"):
+            is_gz = True
+        elif not isinstance(source, str) and raw.lower().endswith(".gz"):
+            is_gz = True
+            
+        if is_gz:
+            import gzip
+            import shutil
+            import tempfile
+            tmp = tempfile.NamedTemporaryFile(
+                mode="wb",
+                suffix=".csv",
+                delete=False,
+            )
+            try:
+                with gzip.open(raw, "rb") as gz_file:
+                    shutil.copyfileobj(gz_file, tmp, length=_FILE_LIKE_COPY_CHUNK_SIZE)
+                tmp.close()
+                if is_temp:
+                    try:
+                        os.unlink(raw)
+                    except OSError:
+                        pass
+                return tmp.name, True, False
+            except Exception:
+                try:
+                    tmp.close()
+                except OSError:
+                    pass
+                try:
+                    os.unlink(tmp.name)
+                except OSError:
+                    pass
+                if is_temp:
+                    try:
+                        os.unlink(raw)
+                    except OSError:
+                        pass
+                raise
+
+        # If it was an HTTP fetch but not a .gz, it's materialized text
+        if is_temp:
+            return raw, True, True
+            
         return raw, False, False
 
     if isinstance(source, io.StringIO) or (
@@ -648,7 +694,8 @@ def read_csv(
     ----------
     path : str or file-like object
         Filesystem path or text file-like object containing CSV data.
-        Any file extension is accepted. For ``.tsv`` files, the delimiter
+        Any file extension is accepted, including compressed ``.csv.gz`` files.
+        For ``.tsv`` files, the delimiter
         is automatically set to ``'\t'`` when ``delimiter`` is omitted.
     delimiter : str or None, default None
         Field delimiter character.  When ``None`` (the default) the
@@ -857,7 +904,7 @@ def read_csv_chunked(
     Parameters
     ----------
     path : str or file-like object
-        Path to the CSV file. Supports .csv, .txt, and .tsv extensions.
+        Path to the CSV file. Supports .csv, .txt, .tsv, and compressed .csv.gz extensions.
         Text file-like objects are copied to a temporary file in bounded
         chunks before native parsing.  For ``.tsv`` paths the delimiter is
         automatically set to ``'\\t'`` when ``delimiter`` is omitted.
@@ -1147,7 +1194,8 @@ def scan_csv(
     ----------
     path : str or file-like object
         Filesystem path or text file-like object containing CSV data.
-        Any file extension is accepted. For ``.tsv`` files, the delimiter
+        Any file extension is accepted, including compressed ``.csv.gz`` files.
+        For ``.tsv`` files, the delimiter
         is automatically set to ``'\t'`` when ``delimiter`` is omitted.
     delimiter : str or None, default None
         Field delimiter character.  When ``None`` (the default) the

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -542,6 +542,7 @@ def _materialize_csv_input(
 
         if is_gz:
             import gzip
+
             tmp = tempfile.NamedTemporaryFile(
                 mode="wb",
                 suffix=".csv",
@@ -995,7 +996,7 @@ def read_csv_chunked(
                 orig_path_lower = path.lower()
             else:
                 orig_path_lower = os.fspath(path).lower()
-                
+
             if not (
                 orig_path_lower.endswith(".csv")
                 or orig_path_lower.endswith(".txt")

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -542,9 +542,6 @@ def _materialize_csv_input(
 
         if is_gz:
             import gzip
-            import shutil
-            import tempfile
-
             tmp = tempfile.NamedTemporaryFile(
                 mode="wb",
                 suffix=".csv",
@@ -802,12 +799,13 @@ def read_csv(
     >>> df = ar.read_csv("data.tsv", delimiter=",")  # explicit comma honoured
     >>> df = ar.read_csv("data.dat")              # non-standard extension accepted
     """
-    path, should_cleanup, is_materialized_text = _materialize_csv_input(path)
+    native_path, should_cleanup, is_materialized_text = _materialize_csv_input(path)
 
     try:
-        _validate_csv_path(path, encoding)
+        # Explicitly validate the decompressed temp file (or local path) rather than the compressed bytes
+        _validate_csv_path(native_path, encoding)
 
-        path_lower = path.lower()
+        path_lower = native_path.lower()
 
         # Resolve the sentinel: auto-detect tab for .tsv only when the caller
         # truly omitted delimiter (None).  An explicit delimiter="," is always
@@ -846,19 +844,19 @@ def read_csv(
 
         reader = _CsvReader(config)
     except Exception:
-        if should_cleanup and os.path.exists(path):
-            os.unlink(path)
+        if should_cleanup and os.path.exists(native_path):
+            os.unlink(native_path)
         raise
 
     try:
         effective_encoding = "utf-8" if is_materialized_text else encoding
         with _utf8_csv_path(
-            path,
+            native_path,
             effective_encoding,
             encoding_errors=encoding_errors,
             delimiter=delimiter,
-        ) as native_path:
-            cpp_frame, bad_rows = reader.read(native_path, on_bad_lines)
+        ) as native_csv_path:
+            cpp_frame, bad_rows = reader.read(native_csv_path, on_bad_lines)
 
         # on_bad_lines == "error" will raise RuntimeError then converted to CsvReadError as before
         if on_bad_lines == "warn" and bad_rows:
@@ -874,8 +872,8 @@ def read_csv(
         raise CsvReadError(str(e)) from None
 
     finally:
-        if should_cleanup and os.path.exists(path):
-            os.unlink(path)
+        if should_cleanup and os.path.exists(native_path):
+            os.unlink(native_path)
 
 
 def read_csv_chunked(
@@ -986,23 +984,31 @@ def read_csv_chunked(
     ...     process(chunk)
     """
     is_path_input = isinstance(path, (str, os.PathLike))
-    path, should_cleanup, is_materialized_text = _materialize_csv_input(
+    native_path, should_cleanup, is_materialized_text = _materialize_csv_input(
         path, caller="read_csv_chunked"
     )
     try:
-        path_lower = path.lower()
+        path_lower = native_path.lower()
         if is_path_input:
+            # We check the original path extension if it was passed as a path
+            if isinstance(path, str):
+                orig_path_lower = path.lower()
+            else:
+                orig_path_lower = os.fspath(path).lower()
+                
             if not (
-                path_lower.endswith(".csv")
-                or path_lower.endswith(".txt")
-                or path_lower.endswith(".tsv")
+                orig_path_lower.endswith(".csv")
+                or orig_path_lower.endswith(".txt")
+                or orig_path_lower.endswith(".tsv")
+                or orig_path_lower.endswith(".gz")
             ):
                 raise ValueError(
                     f"Unsupported file format: {path}. "
-                    "Only .csv, .txt, and .tsv are supported."
+                    "Only .csv, .txt, .tsv, and compressed .csv.gz are supported."
                 )
 
-        _validate_csv_path(path, encoding, reject_utf8_nul_bytes=False)
+        # Explicitly validate the decompressed temp file (or local path) rather than the compressed bytes
+        _validate_csv_path(native_path, encoding, reject_utf8_nul_bytes=False)
 
         # Resolve the sentinel: auto-detect tab for .tsv only when the caller
         # truly omitted delimiter (None).  An explicit delimiter="," is always
@@ -1062,15 +1068,15 @@ def read_csv_chunked(
 
         reader = _CsvChunkReader(config)
     except Exception:
-        if should_cleanup and os.path.exists(path):
-            os.unlink(path)
+        if should_cleanup and os.path.exists(native_path):
+            os.unlink(native_path)
         raise
     try:
         effective_encoding = "utf-8" if is_materialized_text else encoding
         with _utf8_csv_path(
-            path, effective_encoding, delimiter=delimiter
-        ) as native_path:
-            reader.open(native_path)
+            native_path, effective_encoding, delimiter=delimiter
+        ) as native_csv_path:
+            reader.open(native_csv_path)
             yielded_nonempty_chunk = False
             while True:
                 chunk = reader.next_chunk(chunksize, on_bad_lines)
@@ -1097,8 +1103,8 @@ def read_csv_chunked(
         raise CsvReadError(str(e)) from None
     finally:
         reader.close()
-        if should_cleanup and os.path.exists(path):
-            os.unlink(path)
+        if should_cleanup and os.path.exists(native_path):
+            os.unlink(native_path)
 
 
 def write_csv(
@@ -1271,12 +1277,12 @@ def scan_csv(
     >>> schema = ar.scan_csv("data.dat")              # non-standard extension accepted
     """
 
-    path, should_cleanup, _ = _materialize_csv_input(path, caller="scan_csv")
+    native_path, should_cleanup, _ = _materialize_csv_input(path, caller="scan_csv")
 
     try:
-        _validate_csv_path(path, encoding, reject_utf8_nul_bytes=False)
+        _validate_csv_path(native_path, encoding, reject_utf8_nul_bytes=False)
 
-        path_lower = path.lower()
+        path_lower = native_path.lower()
 
         # Resolve the sentinel: auto-detect tab for .tsv only when the caller
         # truly omitted delimiter (None).  An explicit delimiter="," is always
@@ -1314,16 +1320,17 @@ def scan_csv(
 
         reader = _CsvReader(config)
         # Schema inference only needs a sample, avoiding full-file transcode.
+        # For scan_csv, if sample_rows is specified, we use that for sniffing the schema.
         # sample_rows is passed so _utf8_csv_path uses record-aware sampling
         # without rewriting decoded CSV text before native parsing.
         with _utf8_csv_path(
-            path,
+            native_path,
             encoding,
             encoding_errors=encoding_errors,
             delimiter=delimiter,
             sample_rows=100 if sample_size is None else sample_size,
-        ) as native_path:
-            schema, bad_row_msgs = reader.scan_schema(native_path, on_bad_lines)
+        ) as native_csv_path:
+            schema, bad_row_msgs = reader.scan_schema(native_csv_path, on_bad_lines)
             if on_bad_lines == "warn" and bad_row_msgs:
                 warnings.warn(
                     f"{len(bad_row_msgs)} malformed CSV row(s) skipped during schema inference:\n"
@@ -1335,9 +1342,9 @@ def scan_csv(
     except RuntimeError as e:
         raise CsvReadError(str(e)) from None
     finally:
-        if should_cleanup and os.path.exists(path):
+        if should_cleanup and os.path.exists(native_path):
             try:
-                os.unlink(path)
+                os.unlink(native_path)
             except OSError:
                 pass
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -583,7 +583,7 @@ def _materialize_csv_input(
     if isinstance(source, io.StringIO) or (
         hasattr(source, "read") and callable(source.read)
     ):
-        tmp = tempfile.NamedTemporaryFile(
+        text_tmp = tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
             suffix=".csv",
@@ -599,16 +599,16 @@ def _materialize_csv_input(
                     raise TypeError(
                         "read_csv file-like objects must return text, not bytes"
                     )
-                tmp.write(chunk)
-            tmp.close()
-            return tmp.name, True, True
+                text_tmp.write(chunk)
+            text_tmp.close()
+            return text_tmp.name, True, True
         except Exception:
             try:
-                tmp.close()
+                text_tmp.close()
             except OSError:
                 pass
             try:
-                os.unlink(tmp.name)
+                os.unlink(text_tmp.name)
             except OSError:
                 pass
             raise
@@ -994,8 +994,10 @@ def read_csv_chunked(
             # We check the original path extension if it was passed as a path
             if isinstance(path, str):
                 orig_path_lower = path.lower()
-            else:
+            elif isinstance(path, os.PathLike):
                 orig_path_lower = os.fspath(path).lower()
+            else:
+                orig_path_lower = ""
 
             if not (
                 orig_path_lower.endswith(".csv")

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -539,11 +539,12 @@ def _materialize_csv_input(
             is_gz = True
         elif not isinstance(source, str) and raw.lower().endswith(".gz"):
             is_gz = True
-            
+
         if is_gz:
             import gzip
             import shutil
             import tempfile
+
             tmp = tempfile.NamedTemporaryFile(
                 mode="wb",
                 suffix=".csv",
@@ -578,7 +579,7 @@ def _materialize_csv_input(
         # If it was an HTTP fetch but not a .gz, it's materialized text
         if is_temp:
             return raw, True, True
-            
+
         return raw, False, False
 
     if isinstance(source, io.StringIO) or (

--- a/examples/arnio_with_pandas.ipynb
+++ b/examples/arnio_with_pandas.ipynb
@@ -39,8 +39,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import arnio as ar\n",
     "import pandas as pd\n",
+    "\n",
+    "import arnio as ar\n",
     "\n",
     "df = pd.DataFrame({\n",
     "    'name': [' Alice ', 'Bob', 'CHARLIE', None],\n",

--- a/examples/dataset_profile_comparison.ipynb
+++ b/examples/dataset_profile_comparison.ipynb
@@ -24,6 +24,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "\n",
     "import arnio as ar\n",
     "\n",
     "# 1. Creating baseline and current ArFrame datasets\n",

--- a/examples/schema_validation.ipynb
+++ b/examples/schema_validation.ipynb
@@ -41,6 +41,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "\n",
     "import arnio as ar\n",
     "\n",
     "frame = ar.from_pandas(pd.DataFrame([\n",

--- a/tests/test_csv_gz.py
+++ b/tests/test_csv_gz.py
@@ -8,7 +8,7 @@ import arnio as ar
 def test_read_csv_gz_parity():
     # Create a temporary uncompressed CSV
     with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".csv", delete=False
+        mode="w", suffix=".csv", encoding="utf-8", delete=False
     ) as uncompressed:
         uncompressed.write("id,name,value\n")
         uncompressed.write("1,alice,10.5\n")

--- a/tests/test_csv_gz.py
+++ b/tests/test_csv_gz.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+import gzip
+import pytest
+import arnio as ar
+
+def test_read_csv_gz_parity():
+    # Create a temporary uncompressed CSV
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as uncompressed:
+        uncompressed.write("id,name,value\n")
+        uncompressed.write("1,alice,10.5\n")
+        uncompressed.write("2,bob,20.0\n")
+        uncompressed.write("3,charlie,30.2\n")
+        uncompressed_path = uncompressed.name
+        
+    # Create a compressed version of it
+    compressed_path = uncompressed_path + ".gz"
+    with open(uncompressed_path, "rb") as f_in:
+        with gzip.open(compressed_path, "wb") as f_out:
+            f_out.writelines(f_in)
+            
+    try:
+        # 1. Test read_csv
+        df_uncompressed = ar.read_csv(uncompressed_path)
+        df_compressed = ar.read_csv(compressed_path)
+        
+        # Compare columns and rows
+        assert df_uncompressed.column_names == df_compressed.column_names
+        assert len(df_uncompressed) == len(df_compressed)
+        for col in df_uncompressed.column_names:
+            assert list(df_uncompressed[col]) == list(df_compressed[col])
+            
+        # 2. Test read_csv_chunked
+        chunks_uncompressed = list(ar.read_csv_chunked(uncompressed_path, chunksize=2))
+        chunks_compressed = list(ar.read_csv_chunked(compressed_path, chunksize=2))
+        
+        assert len(chunks_uncompressed) == len(chunks_compressed)
+        for chunk_un, chunk_comp in zip(chunks_uncompressed, chunks_compressed):
+            assert len(chunk_un) == len(chunk_comp)
+            for col in chunk_un.column_names:
+                assert list(chunk_un[col]) == list(chunk_comp[col])
+                
+        # 3. Test scan_csv
+        # scan_csv might be in arnio
+        if hasattr(ar, "scan_csv"):
+            schema_uncompressed = ar.scan_csv(uncompressed_path)
+            schema_compressed = ar.scan_csv(compressed_path)
+            assert schema_uncompressed == schema_compressed
+            
+    finally:
+        if os.path.exists(uncompressed_path):
+            os.remove(uncompressed_path)
+        if os.path.exists(compressed_path):
+            os.remove(compressed_path)

--- a/tests/test_csv_gz.py
+++ b/tests/test_csv_gz.py
@@ -4,49 +4,52 @@ import gzip
 import pytest
 import arnio as ar
 
+
 def test_read_csv_gz_parity():
     # Create a temporary uncompressed CSV
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as uncompressed:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".csv", delete=False
+    ) as uncompressed:
         uncompressed.write("id,name,value\n")
         uncompressed.write("1,alice,10.5\n")
         uncompressed.write("2,bob,20.0\n")
         uncompressed.write("3,charlie,30.2\n")
         uncompressed_path = uncompressed.name
-        
+
     # Create a compressed version of it
     compressed_path = uncompressed_path + ".gz"
     with open(uncompressed_path, "rb") as f_in:
         with gzip.open(compressed_path, "wb") as f_out:
             f_out.writelines(f_in)
-            
+
     try:
         # 1. Test read_csv
         df_uncompressed = ar.read_csv(uncompressed_path)
         df_compressed = ar.read_csv(compressed_path)
-        
+
         # Compare columns and rows
         assert df_uncompressed.column_names == df_compressed.column_names
         assert len(df_uncompressed) == len(df_compressed)
         for col in df_uncompressed.column_names:
             assert list(df_uncompressed[col]) == list(df_compressed[col])
-            
+
         # 2. Test read_csv_chunked
         chunks_uncompressed = list(ar.read_csv_chunked(uncompressed_path, chunksize=2))
         chunks_compressed = list(ar.read_csv_chunked(compressed_path, chunksize=2))
-        
+
         assert len(chunks_uncompressed) == len(chunks_compressed)
         for chunk_un, chunk_comp in zip(chunks_uncompressed, chunks_compressed):
             assert len(chunk_un) == len(chunk_comp)
             for col in chunk_un.column_names:
                 assert list(chunk_un[col]) == list(chunk_comp[col])
-                
+
         # 3. Test scan_csv
         # scan_csv might be in arnio
         if hasattr(ar, "scan_csv"):
             schema_uncompressed = ar.scan_csv(uncompressed_path)
             schema_compressed = ar.scan_csv(compressed_path)
             assert schema_uncompressed == schema_compressed
-            
+
     finally:
         if os.path.exists(uncompressed_path):
             os.remove(uncompressed_path)

--- a/tests/test_csv_gz.py
+++ b/tests/test_csv_gz.py
@@ -1,7 +1,7 @@
+import gzip
 import os
 import tempfile
-import gzip
-import pytest
+
 import arnio as ar
 
 
@@ -28,9 +28,9 @@ def test_read_csv_gz_parity():
         df_compressed = ar.read_csv(compressed_path)
 
         # Compare columns and rows
-        assert df_uncompressed.column_names == df_compressed.column_names
+        assert df_uncompressed.columns == df_compressed.columns
         assert len(df_uncompressed) == len(df_compressed)
-        for col in df_uncompressed.column_names:
+        for col in df_uncompressed.columns:
             assert list(df_uncompressed[col]) == list(df_compressed[col])
 
         # 2. Test read_csv_chunked
@@ -40,7 +40,7 @@ def test_read_csv_gz_parity():
         assert len(chunks_uncompressed) == len(chunks_compressed)
         for chunk_un, chunk_comp in zip(chunks_uncompressed, chunks_compressed):
             assert len(chunk_un) == len(chunk_comp)
-            for col in chunk_un.column_names:
+            for col in chunk_un.columns:
                 assert list(chunk_un[col]) == list(chunk_comp[col])
 
         # 3. Test scan_csv


### PR DESCRIPTION
Fixes #642. Implemented scoped materialization/decompression path that preserves the C++ parser contract for ead_csv, ead_csv_chunked, and scan_csv. Parity tests added.