### PR TITLE
Add exclude_columns support to DataQualityReport.to_markdown

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -9,6 +9,7 @@ import html
 import json
 import math
 import os
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -547,7 +548,8 @@ class DataQualityReport:
             if not reason or not exclude_columns:
                 return reason
             for col in exclude_columns:
-                reason = reason.replace(f"'{col}'", "'[REDACTED]'")
+                pattern = rf"\b{re.escape(col)}\b"
+                reason = re.sub(pattern, "[REDACTED]", reason)
             return reason
 
         lines: list[str] = []
@@ -609,8 +611,6 @@ class DataQualityReport:
             for step in rendered_suggestions:
                 filtered_kwargs: dict[str, Any] = {}
                 for key, value in sorted(dict(step[1]).items()):
-                    if key in exclude_columns:
-                        continue
                     if key in {"subset", "columns"} and isinstance(value, list):
                         filtered_kwargs[key] = [
                             item for item in value if item not in exclude_columns
@@ -621,6 +621,8 @@ class DataQualityReport:
                             for col_name, col_type in value.items()
                             if col_name not in exclude_columns
                         }
+                    elif isinstance(value, str) and value in exclude_columns:
+                        filtered_kwargs[key] = "[REDACTED]"
                     else:
                         filtered_kwargs[key] = value
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -10,7 +10,7 @@ import json
 import math
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Sequence, Set
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -611,10 +611,17 @@ class DataQualityReport:
             for step in rendered_suggestions:
                 filtered_kwargs: dict[str, Any] = {}
                 for key, value in sorted(dict(step[1]).items()):
-                    if key in {"subset", "columns"} and isinstance(value, list):
-                        filtered_kwargs[key] = [
-                            item for item in value if item not in exclude_columns
-                        ]
+                    if key in {"subset", "columns"}:
+                        if isinstance(value, Sequence) and not isinstance(value, str):
+                            filtered_kwargs[key] = [
+                                item for item in value if item not in exclude_columns
+                            ]
+                        elif isinstance(value, Set):
+                            filtered_kwargs[key] = sorted(
+                                item for item in value if item not in exclude_columns
+                            )
+                        else:
+                            filtered_kwargs[key] = value
                     elif key == "cast_types" and isinstance(value, dict):
                         filtered_kwargs[key] = {
                             col_name: col_type

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -633,13 +633,9 @@ class DataQualityReport:
                     else:
                         filtered_kwargs[key] = value
 
-                kwargs_str = json.dumps(
-                    filtered_kwargs, sort_keys=True, default=str
-                )
+                kwargs_str = json.dumps(filtered_kwargs, sort_keys=True, default=str)
                 conf_score = getattr(step, "confidence_score", None)
-                conf_reason = _redact_reason(
-                    getattr(step, "confidence_reason", None)
-                )
+                conf_reason = _redact_reason(getattr(step, "confidence_reason", None))
                 if conf_score is not None and conf_reason is not None:
                     lines.append(
                         f"- `{step[0]}`: `{kwargs_str}` "

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -521,9 +521,34 @@ class DataQualityReport:
         self,
         output: Any | None = None,
         max_suggestions: int | None = None,
+        exclude_columns: list[str] | set[str] | tuple[str, ...] | None = None,
     ) -> str | None:
         """Return a GitHub-friendly Markdown report."""
         max_suggestions = self._validate_max_suggestions(max_suggestions)
+
+        if exclude_columns is None:
+            exclude_columns = set()
+        elif not isinstance(exclude_columns, (list, tuple, set)):
+            raise TypeError("exclude_columns must be a list, tuple, set, or None")
+        else:
+            if not all(isinstance(column, str) for column in exclude_columns):
+                raise TypeError("exclude_columns must contain only string column names")
+            exclude_columns = set(exclude_columns)
+
+        unknown_exclude_columns = sorted(exclude_columns - set(self.columns))
+        if unknown_exclude_columns:
+            available_columns = ", ".join(self.columns) or "<none>"
+            raise KeyError(
+                "Unknown exclude_columns: "
+                f"{unknown_exclude_columns}. Available columns: {available_columns}"
+            )
+
+        def _redact_reason(reason: str | None) -> str | None:
+            if not reason or not exclude_columns:
+                return reason
+            for col in exclude_columns:
+                reason = reason.replace(f"'{col}'", "'[REDACTED]'")
+            return reason
 
         lines: list[str] = []
 
@@ -552,6 +577,8 @@ class DataQualityReport:
             lines.append("|---|---|---|---|---|---|---|")
 
             for name in sorted(self.columns):
+                if name in exclude_columns:
+                    continue
                 column = self.columns[name]
 
                 warnings = ", ".join(column.warnings) if column.warnings else "-"
@@ -580,9 +607,30 @@ class DataQualityReport:
                 rendered_suggestions = self.suggestions[:max_suggestions]
 
             for step in rendered_suggestions:
-                kwargs_str = json.dumps(step[1], sort_keys=True, default=str)
+                filtered_kwargs: dict[str, Any] = {}
+                for key, value in sorted(dict(step[1]).items()):
+                    if key in exclude_columns:
+                        continue
+                    if key in {"subset", "columns"} and isinstance(value, list):
+                        filtered_kwargs[key] = [
+                            item for item in value if item not in exclude_columns
+                        ]
+                    elif key == "cast_types" and isinstance(value, dict):
+                        filtered_kwargs[key] = {
+                            col_name: col_type
+                            for col_name, col_type in value.items()
+                            if col_name not in exclude_columns
+                        }
+                    else:
+                        filtered_kwargs[key] = value
+
+                kwargs_str = json.dumps(
+                    filtered_kwargs, sort_keys=True, default=str
+                )
                 conf_score = getattr(step, "confidence_score", None)
-                conf_reason = getattr(step, "confidence_reason", None)
+                conf_reason = _redact_reason(
+                    getattr(step, "confidence_reason", None)
+                )
                 if conf_score is not None and conf_reason is not None:
                     lines.append(
                         f"- `{step[0]}`: `{kwargs_str}` "

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1667,6 +1667,80 @@ def test_report_to_markdown_includes_uniqueness_metrics(tmp_path):
     assert "66.67%" in md
 
 
+def test_report_to_markdown_exclude_columns_filters_columns_and_suggestions():
+    report = ar.DataQualityReport(
+        row_count=2,
+        column_count=2,
+        memory_usage=128,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=100.0,
+        score_components={},
+        columns={
+            "ssn": ar.ColumnProfile(
+                name="ssn",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=2,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=2,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+            "age": ar.ColumnProfile(
+                name="age",
+                dtype="int64",
+                semantic_type="numeric",
+                row_count=2,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=2,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+        },
+        suggestions=[
+            ar.CleaningSuggestion(
+                "strip_whitespace",
+                {"subset": ["ssn", "age"], "columns": ["ssn"]},
+                0.95,
+                "Column 'ssn' has leading whitespace",
+            )
+        ],
+    )
+
+    md = report.to_markdown(exclude_columns=["ssn"])
+
+    assert "ssn" not in md
+    assert "age" in md
+    assert "[REDACTED]" in md
+
+
+def test_report_to_markdown_exclude_columns_unknown_raises_keyerror():
+    report = ar.profile(ar.from_dict({"a": [1]}))
+
+    with pytest.raises(KeyError):
+        report.to_markdown(exclude_columns=["nope"])
+
+
+@pytest.mark.parametrize("exclude_columns", [{"ssn"}, ("ssn",)])
+def test_report_to_markdown_accepts_set_and_tuple_exclude_columns(exclude_columns):
+    report = ar.profile(ar.from_dict({"ssn": ["123-45-6789"], "age": [30]}))
+
+    md = report.to_markdown(exclude_columns=exclude_columns)
+
+    assert "ssn" not in md
+    assert "age" in md
+
+
+def test_report_to_markdown_exclude_columns_invalid_type_raises_typeerror():
+    report = ar.profile(ar.from_dict({"a": [1]}))
+
+    with pytest.raises(TypeError):
+        report.to_markdown(exclude_columns=123)
+
+
 def test_unique_ratio_empty_column(tmp_path):
     path = tmp_path / "empty_unique.csv"
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1840,6 +1840,55 @@ def test_report_to_markdown_redacts_unquoted_confidence_reason():
     assert "[REDACTED]" in md
 
 
+def test_report_to_markdown_filters_tuple_and_set_suggestion_columns():
+    report = ar.DataQualityReport(
+        row_count=2,
+        column_count=2,
+        memory_usage=128,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=100.0,
+        score_components={},
+        columns={
+            "secret": ar.ColumnProfile(
+                name="secret",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=2,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=2,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+            "visible": ar.ColumnProfile(
+                name="visible",
+                dtype="string",
+                semantic_type="text",
+                row_count=2,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=2,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+        },
+        suggestions=[
+            ar.CleaningSuggestion(
+                "example",
+                {"subset": ("secret", "visible"), "columns": {"secret", "visible"}},
+                0.90,
+                "Example suggestion for secret and visible",
+            )
+        ],
+    )
+
+    md = report.to_markdown(exclude_columns=["secret"])
+
+    assert "secret" not in md
+    assert "visible" in md
+
+
 def test_unique_ratio_empty_column(tmp_path):
     path = tmp_path / "empty_unique.csv"
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1741,6 +1741,105 @@ def test_report_to_markdown_exclude_columns_invalid_type_raises_typeerror():
         report.to_markdown(exclude_columns=123)
 
 
+def test_report_to_markdown_exclude_columns_preserves_kwarg_named_columns():
+    report = ar.DataQualityReport(
+        row_count=3,
+        column_count=3,
+        memory_usage=256,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=100.0,
+        score_components={},
+        columns={
+            "columns": ar.ColumnProfile(
+                name="columns",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=3,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=3,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+            "visible": ar.ColumnProfile(
+                name="visible",
+                dtype="string",
+                semantic_type="text",
+                row_count=3,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=3,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+            "secret": ar.ColumnProfile(
+                name="secret",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=3,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=3,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+        },
+        suggestions=[
+            ar.CleaningSuggestion(
+                "example",
+                {"columns": ["secret", "visible"], "subset": ["columns", "secret"]},
+                0.90,
+                "Example suggestion for secret and columns",
+            )
+        ],
+    )
+
+    md = report.to_markdown(exclude_columns=["secret"])
+
+    assert "secret" not in md
+    assert "visible" in md
+    assert '"columns"' in md
+
+
+def test_report_to_markdown_redacts_unquoted_confidence_reason():
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=1,
+        memory_usage=64,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=100.0,
+        score_components={},
+        columns={
+            "ssn": ar.ColumnProfile(
+                name="ssn",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=1,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=1,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+        },
+        suggestions=[
+            ar.CleaningSuggestion(
+                "example",
+                {},
+                0.90,
+                "Column ssn contains whitespace",
+            )
+        ],
+    )
+
+    md = report.to_markdown(exclude_columns=["ssn"])
+
+    assert "ssn" not in md
+    assert "[REDACTED]" in md
+
+
 def test_unique_ratio_empty_column(tmp_path):
     path = tmp_path / "empty_unique.csv"
 


### PR DESCRIPTION
## Summary
Added `exclude_columns` support to `DataQualityReport.to_markdown()` to match the behavior already available in `to_dict()` and `to_json()`.

The Markdown report now:
- Excludes specified columns from the column summary table
- Removes excluded columns from rendered cleaning suggestions
- Redacts excluded column names from confidence reasons
- Validates input types and unknown column names

Added regression tests covering filtering, validation, and supported input types.

## Linked issue
Fixes #1915

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] Data quality / profiling

## Testing
- [ ] `make test`
- [ ] `make lint`
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:

powershell
python -m py_compile arnio/quality.py