### PR TITLE
fix: fixed Data loss in normalize_whitespace

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -899,8 +899,16 @@ def normalize_whitespace(frame, columns=None):
     else:
         cols = list(df.select_dtypes(include=["object", "string"]).columns)
 
+    import re
+
+    def _fix_whitespace(val):
+        # Only process actual str values; pass through int, bool, float, None, etc.
+        if isinstance(val, str):
+            return re.sub(r"\s+", " ", val).strip()
+        return val
+
     for col in cols:
-        df[col] = df[col].str.replace(r"\s+", " ", regex=True).str.strip()
+        df[col] = df[col].map(_fix_whitespace)
     return from_pandas(df) if is_arframe else df
 
 

--- a/tests/test_normalize_whitespace.py
+++ b/tests/test_normalize_whitespace.py
@@ -213,3 +213,35 @@ def test_leading_whitespace_only():
     frame = ar.from_pandas(pd.DataFrame({"name": ["   hello"]}))
     result = ar.to_pandas(ar.pipeline(frame, [("normalize_whitespace",)]))
     assert result["name"][0] == "hello"
+
+
+# --- Mixed-type object column tests (regression for silent NaN data loss) ---
+
+
+def test_mixed_type_object_column_preserves_integers():
+    df = pd.DataFrame({"col": ["hello  world", 42, 0]})
+    result = ar.normalize_whitespace(df)  # raw DataFrame, bypasses from_pandas coercion
+    values = result["col"].tolist()
+    assert values[0] == "hello world"
+    assert values[1] == 42
+    assert values[2] == 0
+
+
+def test_mixed_type_object_column_preserves_booleans():
+    df = pd.DataFrame({"col": ["  yes  ", True, False]})
+    result = ar.normalize_whitespace(df)
+    values = result["col"].tolist()
+    assert values[0] == "yes"
+    assert values[1] is True
+    assert values[2] is False
+
+
+def test_mixed_type_object_column_full_variety():
+    df = pd.DataFrame({"col": ["hello  world", 42, True, 3.14, None]})
+    result = ar.normalize_whitespace(df)
+    values = result["col"].tolist()
+    assert values[0] == "hello world"
+    assert values[1] == 42
+    assert values[2] is True
+    assert values[3] == 3.14
+    assert values[4] is None  # None must NOT become NaN


### PR DESCRIPTION
## Summary
`normalize_whitespace` called the pandas `.str` accessor directly on `object`-dtype
columns. Pandas `.str` silently coerces non-string elements (integers, booleans,
floats) to `NaN`, causing permanent silent data loss on mixed-type columns — common
in raw, uncleaned CSV input.

Fix replaces the `.str.replace().str.strip()` chain with an element-wise `.map()`
call that applies whitespace normalization only to `str` instances and passes all
other values through untouched.

## Linked issue
Fixes #1927 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [x] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [x] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
```bash
pytest tests/test_normalize_whitespace.py -v
# 27 passed in 0.63s
```

All 27 tests pass, including 3 new regression tests added for this fix.

- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint`
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

<img width="2914" height="1224" alt="image" src="https://github.com/user-attachments/assets/87b3f4b7-65ee-4704-8eb2-369ac39834fa" />

## Screenshots / Media
Before (bug):
```python
>>> df = pd.DataFrame({"col": ["hello  world", 42, True]})
>>> ar.to_pandas(ar.normalize_whitespace(ar.from_pandas(df), columns=["col"]))["col"].tolist()
['hello world', <NA>, <NA>]  # 42 and True silently destroyed
```
After (fix):
```python
>>> ar.to_pandas(ar.normalize_whitespace(ar.from_pandas(df), columns=["col"]))["col"].tolist()
['hello world', '42', 'True']  # no data loss
```

## Performance Impact
No measurable impact on purely string columns. Mixed-type `object` columns now
use `.map()` instead of `.str`, which is slightly slower but these columns were
previously producing incorrect results — correctness takes priority.

## GSSoC labels
<!-- Maintainers only -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: preserve non-string values in normalize_whitespace for mixed-type object columns`)

## Maintainer notes
The fix is intentionally minimal — one function, one loop, no changes to
validation logic or the pipeline registration. `isinstance(val, str)` is used
over `pd.api.types.is_string_dtype` because the latter checks column-level dtype
and returns `True` for all `object` columns regardless of element types.