### PR TITLE
Preserve ArFrame attrs in Arrow metadata

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import copy as copylib
 import decimal
+import json
 import math
 from typing import TYPE_CHECKING, Any
 
@@ -303,31 +304,47 @@ def to_arrow(frame: ArFrame) -> pa.Table:
 
     if cpp_frame.num_cols() == 0:
         empty = pd.DataFrame(index=pd.RangeIndex(cpp_frame.num_rows()))
-        return pa.Table.from_pandas(empty)
+        table = pa.Table.from_pandas(empty)
+    else:
 
-    for i in range(cpp_frame.num_cols()):
-        col = cpp_frame.column_by_index(i)
-        name = col.name()
-        dtype = col.dtype()
-        mask = col.get_null_mask()
+        for i in range(cpp_frame.num_cols()):
+            col = cpp_frame.column_by_index(i)
+            name = col.name()
+            dtype = col.dtype()
+            mask = col.get_null_mask()
 
-        if dtype == _DType.INT64:
-            arr = col.to_numpy_int()
-            pa_arr = pa.array(arr, mask=mask, type=pa.int64())
-        elif dtype == _DType.FLOAT64:
-            arr = col.to_numpy_float()
-            pa_arr = pa.array(arr, mask=mask, type=pa.float64())
-        elif dtype == _DType.BOOL:
-            arr = col.to_numpy_bool()
-            pa_arr = pa.array(arr, mask=mask, type=pa.bool_())
-        else:
-            values = col.to_python_list()
-            pa_arr = pa.array(values, type=pa.string())
+            if dtype == _DType.INT64:
+                arr = col.to_numpy_int()
+                pa_arr = pa.array(arr, mask=mask, type=pa.int64())
+            elif dtype == _DType.FLOAT64:
+                arr = col.to_numpy_float()
+                pa_arr = pa.array(arr, mask=mask, type=pa.float64())
+            elif dtype == _DType.BOOL:
+                arr = col.to_numpy_bool()
+                pa_arr = pa.array(arr, mask=mask, type=pa.bool_())
+            else:
+                values = col.to_python_list()
+                pa_arr = pa.array(values, type=pa.string())
 
-        arrays.append(pa_arr)
-        names.append(name)
+            arrays.append(pa_arr)
+            names.append(name)
 
-    return pa.Table.from_arrays(arrays, names=names)
+        table = pa.Table.from_arrays(arrays, names=names)
+
+    if frame._attrs:
+        try:
+            attrs_json = json.dumps(frame._attrs)
+        except TypeError as e:
+            raise TypeError(
+                "to_arrow() only supports JSON-serializable attrs metadata"
+            ) from e
+
+        metadata = dict(table.schema.metadata or {})
+        metadata[b"arnio.attrs"] = attrs_json.encode("utf-8")
+
+        table = table.replace_schema_metadata(metadata)
+
+    return table
 
 
 def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -306,7 +306,6 @@ def to_arrow(frame: ArFrame) -> pa.Table:
         empty = pd.DataFrame(index=pd.RangeIndex(cpp_frame.num_rows()))
         table = pa.Table.from_pandas(empty)
     else:
-
         for i in range(cpp_frame.num_cols()):
             col = cpp_frame.column_by_index(i)
             name = col.name()

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1039,6 +1039,64 @@ class TestToArrow:
         assert table.column(0).type == pyarrow.int64()
         assert table.column(0).to_pylist() == [1, 2, 3]
 
+    def test_to_arrow_preserves_attrs_metadata(self):
+        df = pd.DataFrame({"x": [1]})
+        df.attrs = {"source": "test"}
+
+        frame = ar.from_pandas(df)
+        table = ar.to_arrow(frame)
+
+        metadata = table.schema.metadata or {}
+
+        assert b"arnio.attrs" in metadata
+
+    def test_to_arrow_preserves_nested_attrs_metadata(self):
+        df = pd.DataFrame({"x": [1]})
+        df.attrs = {"config": {"version": 1}}
+
+        frame = ar.from_pandas(df)
+        table = ar.to_arrow(frame)
+
+        metadata = table.schema.metadata or {}
+
+        assert b"arnio.attrs" in metadata
+
+    def test_to_arrow_skips_empty_attrs_metadata(self):
+        df = pd.DataFrame({"x": [1]})
+        df.attrs = {}
+
+        frame = ar.from_pandas(df)
+        table = ar.to_arrow(frame)
+
+        metadata = table.schema.metadata or {}
+
+        assert b"arnio.attrs" not in metadata
+
+    def test_to_arrow_zero_column_frame_preserves_attrs(self):
+        df = pd.DataFrame({"a": [None, None]})
+        df.attrs = {"source": "zero-column"}
+
+        frame = ar.from_pandas(df)
+        frame = ar.drop_empty_columns(frame)
+
+        table = ar.to_arrow(frame)
+
+        metadata = table.schema.metadata or {}
+
+        assert b"arnio.attrs" in metadata
+
+    def test_to_arrow_non_serializable_attrs_raise(self):
+        df = pd.DataFrame({"x": [1]})
+        df.attrs = {"bad": {1, 2, 3}}
+
+        frame = ar.from_pandas(df)
+
+        with pytest.raises(
+            TypeError,
+            match="JSON-serializable attrs metadata",
+        ):
+            ar.to_arrow(frame)
+
     def test_float64_columns(self):
         import pyarrow
 


### PR DESCRIPTION
## Summary

* preserve ArFrame attrs metadata in `to_arrow`
* add JSON serialization validation for attrs metadata
* add tests for Arrow metadata preservation and zero-column edge cases

Fixes #1906
