### PR TITLE
fix(csv-parser): prioritize structural consistency over raw frequency…

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1734,8 +1734,9 @@ def sniff_delimiter(
             counts[c].pop()
 
     # 5. Score Candidates and Detect Ties/Ambiguity
-    best_candidates = []
-    best_score = -1.0
+    best_candidates: list[str] = []
+    best_consistency = -1.0
+    best_mode = -1
 
     from collections import Counter
 
@@ -1748,16 +1749,26 @@ def sniff_delimiter(
         counter = Counter(non_zero_counts)
         mode, mode_freq = counter.most_common(1)[0]
 
+        # Primary score: fraction of ALL lines that show the modal count
         consistency = mode_freq / len(line_counts)
-        score = consistency * 10.0 + (mode * 0.1)
 
-        if score > best_score:
-            best_score = score
+        if consistency > best_consistency + 1e-9:
+            # Strictly better consistency → new sole leader
+            best_consistency = consistency
+            best_mode = mode
             best_candidates = [delimiter]
-        elif abs(score - best_score) < 1e-9:
-            best_candidates.append(delimiter)
+        elif abs(consistency - best_consistency) < 1e-9:
+            # Consistency tied → apply secondary tie-breaker (mode)
+            if mode > best_mode:
+                # Higher per-line count wins the tie
+                best_mode = mode
+                best_candidates = [delimiter]
+            elif mode == best_mode:
+                # Both scores identical → ambiguous; keep both
+                best_candidates.append(delimiter)
+            # mode < best_mode: current leader keeps its position
 
-    if not best_candidates or best_score <= 0.0:
+    if not best_candidates or best_consistency <= 0.0:
         raise ValueError(
             f"Could not determine CSV delimiter from sample: no candidate delimiters found in {path!r}"
         )

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -261,8 +261,7 @@ def _validate_dtype_mapping(dtype: dict[str, str]) -> dict[str, str]:
 
         if dtype_name not in allowed:
             raise ValueError(
-                f"Unsupported dtype {dtype_name!r}. "
-                f"Expected one of: {sorted(allowed)}"
+                f"Unsupported dtype {dtype_name!r}. Expected one of: {sorted(allowed)}"
             )
 
         validated[column] = dtype_name
@@ -663,7 +662,7 @@ def _validate_encoding_errors(value: str) -> str:
 
     if value not in _VALID_ENCODING_ERRORS:
         raise ValueError(
-            "encoding_errors must be one of " "'strict', 'replace', or 'ignore'"
+            "encoding_errors must be one of 'strict', 'replace', or 'ignore'"
         )
 
     return value
@@ -1514,7 +1513,7 @@ def read_jsonl(
 
     if not isinstance(path, (str, os.PathLike)):
         raise TypeError(
-            f"read_jsonl expected a filesystem path, " f"got {type(path).__name__!r}"
+            f"read_jsonl expected a filesystem path, got {type(path).__name__!r}"
         )
     path = os.fspath(path)
     encoding_errors = _validate_encoding_errors(encoding_errors)
@@ -1655,8 +1654,7 @@ def sniff_delimiter(
     """
     if not isinstance(path, (str, os.PathLike)):
         raise TypeError(
-            f"sniff_delimiter expected a filesystem path, "
-            f"got {type(path).__name__!r}"
+            f"sniff_delimiter expected a filesystem path, got {type(path).__name__!r}"
         )
     path = os.fspath(path)
 

--- a/tests/test_sniff_delimiter.py
+++ b/tests/test_sniff_delimiter.py
@@ -169,6 +169,43 @@ class TestSniffDelimiter:
         result = sniff_delimiter(path)
         assert result == ","
 
+    def test_issue_1928_comma_wins_over_high_frequency_pipe_in_quoted_field(
+        self, tmp_path
+    ):
+        """Regression test for issue #1928 — quoted-field variant.
+
+        Exact minimal reproduction from the issue report: a 2-column
+        comma-delimited CSV where col1 is a quoted field containing 25
+        pipe characters (a|b|c|...|z).  Before the fix the old scoring
+        formula (consistency * 10.0 + mode * 0.1) returned '|' because
+        the raw pipe frequency inflated its score above the perfectly
+        consistent comma.  The fixed two-phase scoring returns ','.
+        """
+        path = tmp_path / "issue_1928_quoted.csv"
+        path.write_text(
+            'col1,col2\n"a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z",1\n'
+        )
+        result = sniff_delimiter(path)
+        assert result == ","
+
+    def test_issue_1928_comma_wins_over_high_frequency_pipe_in_unquoted_field(
+        self, tmp_path
+    ):
+        """Regression test for issue #1928 — unquoted-field variant.
+
+        The unquoted form is the strongest trigger of the bug: 25 raw
+        pipe characters per data row while the true delimiter ',' appears
+        on every line including the header.  The old formula
+        misidentified '|'; the new two-phase scoring (consistency as
+        the primary metric, mode only as tie-breaker) correctly returns
+        ','.
+        """
+        path = tmp_path / "issue_1928_unquoted.csv"
+        data = "a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z"
+        path.write_text(f"col1,col2\n{data},1\n{data},2\n{data},3\n")
+        result = sniff_delimiter(path)
+        assert result == ","
+
 
 class TestReadCsvDelimiterDetection:
     """Test suite for CSV delimiter auto-detection through read_csv/scan_csv."""


### PR DESCRIPTION
… in sniff_delimiter

## Summary
Prioritized structural consistency over raw frequency in the sniff_delimiter logic.

Previously, sniff_delimiter combined consistency and mode into a single mathematical score (consistency * 10.0 + (mode * 0.1)). This allowed a very high delimiter count on a few lines to artificially outweigh structural consistency across all lines. Now, the logic evaluates consistency first, and only uses mode as a secondary tie-breaker if consistency is identical. This results in much more accurate and predictable CSV delimiter detection, particularly for messy files.

## Linked issue
Fixes #1928

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
   Ran pytest tests/ -v, all tests passed successfully with 100% pass rate.
- [x] `make lint` (or run separately:
  Ran ruff check . and black --check ., reported All checks passed!
)
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
N/A (Backend parser logic update only)

## Performance Impact
No significant negative performance impact; it's just a scoring logic update in the Python parser step. Negligible difference in time complexity.

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
N/A
