### PR TITLE
Fix native cleaning ops dropping ArFrame._attrs (#1459)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -33,6 +33,14 @@ from .exceptions import TypeCastError
 from .frame import ArFrame
 
 
+def _wrap(cpp_result, source: ArFrame) -> ArFrame:
+    """Wrap a C++ frame result, carrying over a deep copy of source attrs."""
+    return ArFrame(
+        cpp_result,
+        attrs=copy.deepcopy(source._attrs),
+    )
+
+
 def validate_columns_exist(
     frame: ArFrame,
     columns: Sequence[str],
@@ -238,7 +246,7 @@ def drop_nulls(
             ),
         )
     result = _drop_nulls(frame._frame, subset=subset)
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def drop_columns(frame: ArFrame, columns: Sequence[str]) -> ArFrame:
@@ -443,7 +451,7 @@ def fill_nulls(
             f"got {type(value).__name__!r}"
         )
     result = _fill_nulls(frame._frame, value, subset=subset)
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def drop_duplicates(
@@ -501,7 +509,7 @@ def drop_duplicates(
 
         return ArFrame(_Frame.from_dict({}, {}, frame.shape[0]))
     result = _drop_duplicates(frame._frame, subset=subset, keep=keep_arg)
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def drop_constant_columns(
@@ -737,7 +745,7 @@ def clip_numeric(
         upper=float(upper) if upper is not None else None,
         subset=subset,
     )
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def winsorize_outliers(
@@ -857,7 +865,7 @@ def strip_whitespace(
             ),
         )
     result = _strip_whitespace(frame._frame, subset=subset)
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def normalize_whitespace(frame, columns=None):
@@ -1090,7 +1098,7 @@ def normalize_case(
             ),
         )
     result = _normalize_case(frame._frame, subset=subset, case_type=case_type)
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def normalize_unicode(
@@ -1173,10 +1181,7 @@ def normalize_unicode(
             new_columns[name] = col.to_python_list()
             dtype_hints[name] = dtype
     new_cpp_frame = _Frame.from_dict(new_columns, dtype_hints, frame.shape[0])
-    return ArFrame(
-        new_cpp_frame,
-        attrs=copy.deepcopy(frame._attrs) if frame._attrs is not None else None,
-    )
+    return _wrap(new_cpp_frame, frame)
 
 
 def rename_columns(
@@ -1229,7 +1234,7 @@ def rename_columns(
         )
 
     result = _rename_columns(frame._frame, mapping)
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def trim_column_names(frame: ArFrame) -> ArFrame:
@@ -1267,7 +1272,7 @@ def trim_column_names(frame: ArFrame) -> ArFrame:
         if original != updated
     }
     result = _rename_columns(frame._frame, mapping)
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def cast_types(
@@ -1325,7 +1330,7 @@ def cast_types(
             )
     except ValueError as e:
         raise TypeCastError(str(e)) from e
-    return ArFrame(result)
+    return _wrap(result, frame)
 
 
 def _append_clean_step(
@@ -1613,7 +1618,7 @@ def combine_columns(
         result = _combine_columns(
             frame._frame, subset_columns, separator, output_column
         )
-        return ArFrame(result)
+        return _wrap(result, frame)
 
     # Pandas fallback
     df = frame.copy(deep=False)

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -564,7 +564,7 @@ def drop_duplicates(
     if frame.shape[1] == 0:
         from ._core import _Frame
 
-        return ArFrame(_Frame.from_dict({}, {}, frame.shape[0]))
+        return _wrap(_Frame.from_dict({}, {}, frame.shape[0]), frame)
     result = _drop_duplicates(frame._frame, subset=subset, keep=keep_arg)
     return _wrap(result, frame)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1909,6 +1909,72 @@ class TestNormalizeUnicode:
         assert frame_3_0_attrs._attrs["key"] == "value"
 
 
+class TestAttrsPreservation:
+    """Native cleaning wrappers must carry over ArFrame._attrs via deep copy."""
+
+    def _base_frame(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"name": [" Alice ", " Bob "], "age": [20, 30], "score": [1.5, 2.5]})
+        frame = ar.from_pandas(df)
+        frame._attrs = {"source": "crm", "meta": {"version": 1}}
+        return frame
+
+    @pytest.mark.parametrize(
+        "op_name, fn",
+        [
+            ("drop_nulls", lambda f: ar.drop_nulls(f)),
+            ("fill_nulls", lambda f: ar.fill_nulls(f, 0)),
+            ("drop_duplicates", lambda f: ar.drop_duplicates(f)),
+            ("strip_whitespace", lambda f: ar.strip_whitespace(f)),
+            ("normalize_case", lambda f: ar.normalize_case(f, subset=["name"], case_type="lower")),
+            ("clip_numeric", lambda f: ar.clip_numeric(f, subset=["age"], lower=0, upper=99)),
+            ("rename_columns", lambda f: ar.rename_columns(f, {"score": "score2"})),
+            ("trim_column_names", lambda f: ar.trim_column_names(f)),
+            ("cast_types", lambda f: ar.cast_types(f, {"age": "float64"})),
+            ("normalize_unicode", lambda f: ar.normalize_unicode(f, subset=["name"])),
+        ],
+    )
+    def test_attrs_propagated(self, op_name, fn):
+        frame = self._base_frame()
+        result = fn(frame)
+        assert result._attrs == {"source": "crm", "meta": {"version": 1}}, (
+            f"{op_name} dropped _attrs"
+        )
+
+    @pytest.mark.parametrize(
+        "op_name, fn",
+        [
+            ("drop_nulls", lambda f: ar.drop_nulls(f)),
+            ("fill_nulls", lambda f: ar.fill_nulls(f, 0)),
+            ("drop_duplicates", lambda f: ar.drop_duplicates(f)),
+            ("strip_whitespace", lambda f: ar.strip_whitespace(f)),
+            ("normalize_case", lambda f: ar.normalize_case(f, subset=["name"], case_type="lower")),
+            ("clip_numeric", lambda f: ar.clip_numeric(f, subset=["age"], lower=0, upper=99)),
+            ("rename_columns", lambda f: ar.rename_columns(f, {"score": "score2"})),
+            ("trim_column_names", lambda f: ar.trim_column_names(f)),
+            ("cast_types", lambda f: ar.cast_types(f, {"age": "float64"})),
+            ("normalize_unicode", lambda f: ar.normalize_unicode(f, subset=["name"])),
+        ],
+    )
+    def test_attrs_deep_copy_isolated(self, op_name, fn):
+        frame = self._base_frame()
+        result = fn(frame)
+        result._attrs["meta"]["version"] = 999
+        assert frame._attrs["meta"]["version"] == 1, (
+            f"{op_name} shared _attrs by reference instead of deep copying"
+        )
+
+    def test_empty_attrs_not_propagated(self):
+        """When source frame has no attrs, result attrs should also be empty."""
+        frame = ar.from_pandas(
+            __import__("pandas").DataFrame({"name": ["Alice"], "age": [20]})
+        )
+        assert frame._attrs == {}
+        result = ar.strip_whitespace(frame)
+        assert result._attrs == {}
+
+
 class TestParseBoolStrings:
     def test_parse_basic_bool_strings(self):
         import pandas as pd

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1989,6 +1989,42 @@ class TestAttrsPreservation:
             frame._attrs["meta"]["version"] == 1
         ), f"{op_name} shared _attrs by reference instead of deep copying"
 
+    def test_drop_duplicates_zero_columns_preserves_attrs(self):
+        """drop_duplicates zero-column early return must propagate attrs."""
+        import pandas as pd
+
+        from arnio._core import _Frame
+
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+        # Build a genuine zero-column frame with rows intact
+        frame._frame = _Frame.from_dict({}, {}, 3)
+        frame._attrs = {"source": "crm", "meta": {"version": 1}}
+        assert frame.shape == (3, 0)
+
+        result = ar.drop_duplicates(frame)
+
+        assert result._attrs == {
+            "source": "crm",
+            "meta": {"version": 1},
+        }, "drop_duplicates zero-column path dropped _attrs"
+
+    def test_drop_duplicates_zero_columns_attrs_deep_copy_isolated(self):
+        """drop_duplicates zero-column result attrs must be a deep copy."""
+        import pandas as pd
+
+        from arnio._core import _Frame
+
+        frame = ar.from_pandas(pd.DataFrame({"a": [1, 2, 3]}))
+        frame._frame = _Frame.from_dict({}, {}, 3)
+        frame._attrs = {"source": "crm", "meta": {"version": 1}}
+
+        result = ar.drop_duplicates(frame)
+        result._attrs["meta"]["version"] = 999
+
+        assert (
+            frame._attrs["meta"]["version"] == 1
+        ), "drop_duplicates zero-column path shared _attrs by reference instead of deep copying"
+
     def test_empty_attrs_not_propagated(self):
         """When source frame has no attrs, result attrs should also be empty."""
         frame = ar.from_pandas(


### PR DESCRIPTION
## Summary
- Add `_wrap()` helper in `cleaning.py` that deep-copies `source._attrs` onto every C++-backed result frame
- Apply `_wrap()` to `drop_nulls`, `fill_nulls`, `drop_duplicates`, `clip_numeric`, `strip_whitespace`, `normalize_case`, `normalize_unicode`, `rename_columns`, `trim_column_names`, `cast_types`, and `combine_columns`
- Add `TestAttrsPreservation` test class covering attrs propagation and deep-copy isolation across all affected operations
- Standardize attrs preservation behavior across native cleaning wrappers to match existing behavior in conversion APIs and `normalize_unicode`

## Test plan
- [ ] `test_attrs_propagated` — verifies all affected operations preserve `_attrs`
- [ ] `test_attrs_deep_copy_isolated` — verifies result attrs are deep-copied and isolated from source mutations
- [ ] `test_empty_attrs_not_propagated` — verifies empty attrs remain empty after transformations

Closes #1459

@im-anishraj please review the PR.