### PR TITLE
ci: add path filters to heavy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [ "main" ]
+
   pull_request:
     branches: [ "main" ]
+    paths:
+      - ".github/workflows/ci.yml"
+      - "arnio/**"
+      - "bindings/**"
+      - "cpp/**"
+      - "tests/**"
+      - "examples/**"
+      - "scripts/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - "mypy.ini"
+      - "CMakeLists.txt"
+      - ".pre-commit-config.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,8 +4,18 @@ name: "CodeQL Security Scan"
 on:
   push:
     branches: [ "main" ]
+
   pull_request:
     branches: [ "main" ]
+    paths:
+      - ".github/workflows/codeql.yml"
+      - "arnio/**"
+      - "bindings/**"
+      - "cpp/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - "CMakeLists.txt"
 
 jobs:
   analyze:

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -3,8 +3,17 @@ name: Examples Smoke
 on:
   push:
     branches: [main]
+
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/examples-smoke.yml"
+      - "examples/**"
+      - "arnio/**"
+      - "bindings/**"
+      - "cpp/**"
+      - "pyproject.toml"
+      - "setup.py"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Audited all GitHub Actions workflows and found that most specialized workflows already used path-based triggers.

Added pull request path filters to the remaining heavy unfiltered workflows:

* CI (`ci.yml`)
* CodeQL Security Scan (`codeql.yml`)
* Examples Smoke (`examples-smoke.yml`)

This prevents expensive jobs from running on docs-only or website-only changes while preserving validation for source code, tests, packaging/configuration, and workflow updates.

## Linked issue

Fixes #2235

## Type of change

* [ ] Bug fix
* [ ] Feature
* [x] Performance improvement
* [ ] Documentation
* [ ] Tests
* [ ] Refactor
* [x] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [ ] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [x] Developer tooling

## Testing

* [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [ ] `make lint`
* [ ] optionally `python -m pytest tests -v --tb=short -x`
* [x] Other:

Performed workflow audit and verified:

* Existing specialized workflows already use path filters where appropriate.
* Source, test, packaging/configuration, and workflow-file changes continue to trigger the relevant workflows.
* Docs-only and website-only changes no longer trigger the modified heavy workflows.

## Screenshots / Media

N/A

## Performance Impact

Reduces unnecessary CI execution for documentation-only pull requests by preventing heavy workflows from running when no code-related files are modified.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [ ] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Most workflows already had path-based triggers. This PR only updates the remaining unfiltered heavy workflows (`ci.yml`, `codeql.yml`, and `examples-smoke.yml`) to align with the existing workflow strategy.
