### PR TITLE
fix: validate form type in normalize_unicode

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1133,7 +1133,7 @@ def normalize_unicode(
     """
     _validate_arframe(frame)
     valid_forms = {"NFC", "NFD", "NFKC", "NFKD"}
-    if not isinstance(form,str):
+    if not isinstance(form, str):
         raise TypeError("form must be a string")
     if form not in valid_forms:
         raise ValueError(f"Unsupported Unicode normalization form: {form}")

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -1133,6 +1133,8 @@ def normalize_unicode(
     """
     _validate_arframe(frame)
     valid_forms = {"NFC", "NFD", "NFKC", "NFKD"}
+    if not isinstance(form,str):
+        raise TypeError("form must be a string")
     if form not in valid_forms:
         raise ValueError(f"Unsupported Unicode normalization form: {form}")
     if subset is not None:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1748,15 +1748,15 @@ class TestNormalizeUnicode:
         assert result_df["text"].iloc[0] == unicodedata.normalize("NFC", "cafe\u0301")
 
     def test_normalize_unicode_non_string_form_raises(self):
-        import pandas as pd 
+        import pandas as pd
 
         import arnio as ar
         import pytest
-        
-        df=pd.DataFrame({"text":["hello"]})
-        frame=ar.from_pandas(df)
-        with pytest.raises(TypeError,match="form must be a string"):
-            ar.normalize_unicode(frame,form=["NFC"])
+
+        df = pd.DataFrame({"text": ["hello"]})
+        frame = ar.from_pandas(df)
+        with pytest.raises(TypeError, match="form must be a string"):
+            ar.normalize_unicode(frame, form=["NFC"])
 
     def test_normalize_unicode_no_pandas_roundtrip(self):
         import pandas as pd

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1747,6 +1747,17 @@ class TestNormalizeUnicode:
         result_df = ar.to_pandas(result)
         assert result_df["text"].iloc[0] == unicodedata.normalize("NFC", "cafe\u0301")
 
+    def test_normalize_unicode_non_string_form_raises(self):
+        import pandas as pd 
+
+        import arnio as ar
+        import pytest
+        
+        df=pd.DataFrame({"text":["hello"]})
+        frame=ar.from_pandas(df)
+        with pytest.raises(TypeError,match="form must be a string"):
+            ar.normalize_unicode(frame,form=["NFC"])
+
     def test_normalize_unicode_no_pandas_roundtrip(self):
         import pandas as pd
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1749,9 +1749,9 @@ class TestNormalizeUnicode:
 
     def test_normalize_unicode_non_string_form_raises(self):
         import pandas as pd
+        import pytest
 
         import arnio as ar
-        import pytest
 
         df = pd.DataFrame({"text": ["hello"]})
         frame = ar.from_pandas(df)


### PR DESCRIPTION
## Summary
Added validation for the `form` parameter in `normalize_unicode()` to ensure it is a string before checking supported normalization forms. Also added a regression test for non-string input.

## Linked issue
Fixes #1669

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] Python API / ArFrame

## Testing
- [ ] `make test`
- [ ] `make lint`
- [x] Other:

```powershell
python -m pytest tests/test_cleaning.py
