### PR TITLE
chore: align local make lint command with CI checks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -128,7 +128,7 @@ def test_remove_special_chars(sample_csv):
 4. If you've added code that should be tested, add tests.
 5. If you've changed public behavior, update documentation or examples.
 6. Ensure the test suite passes (`make test`).
-7. Ensure your code passes linting (`make lint`). This is a required pre-PR step.
+7. Ensure your code passes linting (`make lint`). This checks docs encoding, formatting (`black`, `ruff`), types (`mypy`), and C++ styling (`clang-format`). This is a required pre-PR step.
 8. Open the pull request and link the issue with `Fixes #issue-number` when complete.
 9. Ensure your PR title follows **Conventional Commits**.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,10 +29,14 @@
 ## Testing
 <!-- Paste commands you ran and summarize the result. -->
 - [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
+```markdown
 - [ ] `make lint` (or run separately:
-  ```powershell
-  python -m ruff check .
-  python -m black --check .
+  ```bash
+  python scripts/check_docs_utf8.py
+  python -m black --check --diff .
+  python -m ruff check . --extend-exclude "*.ipynb"
+  python -m mypy --config-file mypy.ini
+  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
   ```
 )
 - [ ] optionally `python -m pytest tests -v --tb=short -x`

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ test-quick: ## Run tests without coverage (fast, pass/fail only)
 	pytest tests/ -v
 
 lint: ## Check linting
-	ruff check .
-	black --check .
+	python scripts/check_docs_utf8.py
+	black --check --diff .
+	ruff check . --extend-exclude "*.ipynb"
+	mypy --config-file mypy.ini
+	find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
 
 format: ## Format code
 	black .


### PR DESCRIPTION
## Summary
This PR aligns the local `make lint` target with the CI linting job, preventing the issue where local lint checks pass but CI fails. I updated the `Makefile` and PR template to include the exact flags and missing checks from `.github/workflows/ci.yml` (docs encoding, `black`, `ruff`, `mypy`, and `clang-format`).

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #1877

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [x] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [x] Developer tooling

## Testing
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately:
```bash
  python scripts/check_docs_utf8.py
  python -m black --check --diff .
  python -m ruff check . --extend-exclude "*.ipynb"
  python -m mypy --config-file mypy.ini
  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror