### PR TITLE
Fix lint ci

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -128,7 +128,7 @@ def test_remove_special_chars(sample_csv):
 4. If you've added code that should be tested, add tests.
 5. If you've changed public behavior, update documentation or examples.
 6. Ensure the test suite passes (`make test`).
-7. Ensure your code passes linting (`make lint`). This is a required pre-PR step.
+7. Ensure your code passes linting (`make lint`). This checks docs encoding, formatting (`black`, `ruff`), types (`mypy`), and C++ styling (`clang-format`). This is a required pre-PR step.
 8. Open the pull request and link the issue with `Fixes #issue-number` when complete.
 9. Ensure your PR title follows **Conventional Commits**.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,10 +29,14 @@
 ## Testing
 <!-- Paste commands you ran and summarize the result. -->
 - [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
+```markdown
 - [ ] `make lint` (or run separately:
-  ```powershell
-  python -m ruff check .
-  python -m black --check .
+  ```bash
+  python scripts/check_docs_utf8.py
+  python -m black --check --diff .
+  python -m ruff check . --extend-exclude "*.ipynb"
+  python -m mypy --config-file mypy.ini
+  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
   ```
 )
 - [ ] optionally `python -m pytest tests -v --tb=short -x`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,16 +29,13 @@
 ## Testing
 <!-- Paste commands you ran and summarize the result. -->
 - [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
-```markdown
-- [ ] `make lint` (or run separately:
+- [ ] `make lint` (or run separately):
   ```bash
   python scripts/check_docs_utf8.py
   python -m black --check --diff .
   python -m ruff check . --extend-exclude "*.ipynb"
   python -m mypy --config-file mypy.ini
   find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
-  ```
-)
 - [ ] optionally `python -m pytest tests -v --tb=short -x`
 - [ ] Other:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,7 @@
   python -m ruff check . --extend-exclude "*.ipynb"
   python -m mypy --config-file mypy.ini
   find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
+  ```
 - [ ] optionally `python -m pytest tests -v --tb=short -x`
 - [ ] Other:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@
 <!-- Paste commands you ran and summarize the result. -->
 - [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
 - [ ] `make lint` (or run separately):
-  ```bash
+```bash
   python scripts/check_docs_utf8.py
   python -m black --check --diff .
   python -m ruff check . --extend-exclude "*.ipynb"

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ test-quick: ## Run tests without coverage (fast, pass/fail only)
 	pytest tests/ -v
 
 lint: ## Check linting
-	ruff check .
-	black --check .
+	python scripts/check_docs_utf8.py
+	black --check --diff .
+	ruff check . --extend-exclude "*.ipynb"
+	mypy --config-file mypy.ini
+	find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
 
 format: ## Format code
 	black .


### PR DESCRIPTION
## Summary
This PR aligns the local `make lint` target with the CI linting job, preventing the issue where local lint checks pass but CI fails. 

Specifically, I updated the `Makefile` and PR template to include the exact flags and missing checks from `.github/workflows/ci.yml`:
- `python scripts/check_docs_utf8.py`
- `black --check --diff .`
- `ruff check . --extend-exclude "*.ipynb"`
- `mypy --config-file mypy.ini`
- `clang-format --dry-run --Werror` on `cpp/` and `bindings/`

I also updated `CONTRIBUTING.md` and the PR template to reflect these newly synced requirements.

**Local Verification:** I ran `make lint` locally and confirmed that it executes all 5 checks in sequence successfully, behaving exactly like the CI environment. 

Fixes #1877