### PR TITLE
fix: validate SchemaDiff and SchemaDiffEntry inputs

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1175,8 +1175,7 @@ class ValidationIssue:
                 )
             if self.row_index < 0:
                 raise ValueError(
-                    f"ValidationIssue 'row_index' must be >= 0, "
-                    f"got {self.row_index}"
+                    f"ValidationIssue 'row_index' must be >= 0, got {self.row_index}"
                 )
         _validate_severity(self.severity)
 
@@ -1430,19 +1429,15 @@ class SchemaDiff:
     """Result of comparing two schema contracts."""
 
     differences: list[SchemaDiffEntry]
-    
+
     def __post_init__(self) -> None:
         if not isinstance(self.differences, list):
-            raise TypeError(
-                "differences must be a list of SchemaDiffEntry instances"
-            )
+            raise TypeError("differences must be a list of SchemaDiffEntry instances")
 
         for i, diff in enumerate(self.differences):
             if not isinstance(diff, SchemaDiffEntry):
-                raise TypeError(
-                    f"differences[{i}] must be a SchemaDiffEntry instance"
-                )
-        
+                raise TypeError(f"differences[{i}] must be a SchemaDiffEntry instance")
+
     @property
     def changed(self) -> bool:
         """Whether the two schemas differ."""
@@ -2555,7 +2550,6 @@ def _validate_column(
 
     if field_def.dtype is not None and actual_dtype != field_def.dtype:
         if not (field_def.dtype == "datetime" and actual_dtype == "string"):
-
             message = (
                 f"Column {name!r} has dtype {actual_dtype!r}; "
                 f"expected {field_def.dtype!r}"
@@ -2569,9 +2563,7 @@ def _validate_column(
                     name,
                 )
             ):
-                message += (
-                    f". Values appear safely convertible " f"to '{field_def.dtype}'"
-                )
+                message += f". Values appear safely convertible to '{field_def.dtype}'"
 
             issues.append(
                 ValidationIssue(

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -1404,6 +1404,16 @@ class SchemaDiffEntry:
     expected: Any = None
     observed: Any = None
 
+    def __post_init__(self) -> None:
+        if self.column is not None and not isinstance(self.column, str):
+            raise TypeError("column must be a str or None")
+
+        if self.attribute is not None and not isinstance(self.attribute, str):
+            raise TypeError("attribute must be a str or None")
+
+        if not isinstance(self.change, str) or not self.change.strip():
+            raise TypeError("change must be a non-empty string")
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly dictionary."""
         return {
@@ -1420,7 +1430,19 @@ class SchemaDiff:
     """Result of comparing two schema contracts."""
 
     differences: list[SchemaDiffEntry]
+    
+    def __post_init__(self) -> None:
+        if not isinstance(self.differences, list):
+            raise TypeError(
+                "differences must be a list of SchemaDiffEntry instances"
+            )
 
+        for i, diff in enumerate(self.differences):
+            if not isinstance(diff, SchemaDiffEntry):
+                raise TypeError(
+                    f"differences[{i}] must be a SchemaDiffEntry instance"
+                )
+        
     @property
     def changed(self) -> bool:
         """Whether the two schemas differ."""

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -1,6 +1,7 @@
 """Tests for diff_schema function in arnio.schema."""
+import pytest
 
-from arnio.schema import Field, Schema, diff_schema
+from arnio.schema import ( Field, Schema, SchemaDiff, SchemaDiffEntry, diff_schema, )
 
 
 def _rule_alpha(df):
@@ -307,3 +308,34 @@ class TestDiffSchema:
         assert diff.changed is True
         assert diff.difference_count == 1
         assert diff.differences[0].attribute == "severity"
+    
+    def test_schemadiffentry_rejects_invalid_column_type(self):
+        with pytest.raises(TypeError):
+            SchemaDiffEntry(column=1, change="missing_column")
+
+
+    def test_schemadiffentry_rejects_invalid_attribute_type(self):
+        with pytest.raises(TypeError):
+            SchemaDiffEntry(
+                column="age",
+                change="changed_field",
+                attribute=123,
+            )
+
+
+    def test_schemadiffentry_rejects_invalid_change_type(self):
+        with pytest.raises(TypeError):
+            SchemaDiffEntry(
+                column="age",
+                change=123,
+            )
+
+
+    def test_schemadiff_rejects_non_list_differences(self):
+        with pytest.raises(TypeError):
+            SchemaDiff("abc")
+
+
+    def test_schemadiff_rejects_non_entry_objects(self):
+        with pytest.raises(TypeError):
+            SchemaDiff([1, 2, 3])

--- a/tests/test_diff_schema.py
+++ b/tests/test_diff_schema.py
@@ -1,7 +1,14 @@
 """Tests for diff_schema function in arnio.schema."""
+
 import pytest
 
-from arnio.schema import ( Field, Schema, SchemaDiff, SchemaDiffEntry, diff_schema, )
+from arnio.schema import (
+    Field,
+    Schema,
+    SchemaDiff,
+    SchemaDiffEntry,
+    diff_schema,
+)
 
 
 def _rule_alpha(df):
@@ -308,11 +315,10 @@ class TestDiffSchema:
         assert diff.changed is True
         assert diff.difference_count == 1
         assert diff.differences[0].attribute == "severity"
-    
+
     def test_schemadiffentry_rejects_invalid_column_type(self):
         with pytest.raises(TypeError):
             SchemaDiffEntry(column=1, change="missing_column")
-
 
     def test_schemadiffentry_rejects_invalid_attribute_type(self):
         with pytest.raises(TypeError):
@@ -322,7 +328,6 @@ class TestDiffSchema:
                 attribute=123,
             )
 
-
     def test_schemadiffentry_rejects_invalid_change_type(self):
         with pytest.raises(TypeError):
             SchemaDiffEntry(
@@ -330,11 +335,9 @@ class TestDiffSchema:
                 change=123,
             )
 
-
     def test_schemadiff_rejects_non_list_differences(self):
         with pytest.raises(TypeError):
             SchemaDiff("abc")
-
 
     def test_schemadiff_rejects_non_entry_objects(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Closes #1685

## Summary
- Added validation for SchemaDiffEntry inputs
- Added validation for SchemaDiff inputs
- Added unit tests for invalid constructor arguments

## Changes
- Validate column type
- Validate attribute type
- Validate change type
- Validate differences list type
- Validate SchemaDiffEntry objects inside differences