### PR TITLE
fix: validate importable arnio core in check_env

### DIFF
--- a/examples/check_env.py
+++ b/examples/check_env.py
@@ -253,7 +253,11 @@ def main():
 
     _, core_available = detect_core_status()
 
-    if not core_available and not build_tools["all_required_found"]:
+    required_build_tools_available = all(
+        check.available for check in build_tools if check.required
+    )
+
+    if not core_available and not required_build_tools_available:
         sys.exit(1)
 
 

--- a/examples/check_env.py
+++ b/examples/check_env.py
@@ -131,20 +131,24 @@ def check_build_tools():
 
 
 def detect_core_status():
-    """Detect the native extension without importing the full arnio package."""
+    """Detect the native extension for the actually importable arnio package."""
+    import importlib.util
+
     if "arnio._core" in sys.modules:
         if sys.modules["arnio._core"] is None:
             return "Not Compiled (arnio._core unavailable)", False
         return "Available (C++ Accelerated)", True
 
-    for entry in sys.path:
-        package_dir = Path(entry or ".") / "arnio"
-        if not package_dir.is_dir():
-            continue
+    spec = importlib.util.find_spec("arnio")
 
-        for suffix in EXTENSION_SUFFIXES:
-            if (package_dir / f"_arnio_cpp{suffix}").exists():
-                return "Available (C++ Accelerated)", True
+    if spec is None or spec.origin is None:
+        return "Not Installed (arnio package not found)", False
+
+    package_dir = Path(spec.origin).parent
+
+    for suffix in EXTENSION_SUFFIXES:
+        if (package_dir / f"_arnio_cpp{suffix}").exists():
+            return "Available (C++ Accelerated)", True
 
     return "Not Compiled (_arnio_cpp extension file not found)", False
 
@@ -229,15 +233,28 @@ def print_dashboard(results, build_tools=None):
         print("\n[TIP] To install all missing optional dependencies, run:")
         print(f"  pip install {' '.join(missing)}")
     else:
+        print("\nAll optional dependencies are successfully installed!")
+
+    if core_available:
+        print("Native Arnio core is available. You are ready to go.")
+    else:
         print(
-            "\nAll optional dependencies are successfully installed! You are ready to go."
+            "Native Arnio core is not available. "
+            "Build the extension before running Arnio examples locally."
         )
     print("=" * 70)
 
 
 def main():
     results = check_dependencies()
-    print_dashboard(results)
+    build_tools = check_build_tools()
+
+    print_dashboard(results, build_tools)
+
+    _, core_available = detect_core_status()
+
+    if not core_available and not build_tools["all_required_found"]:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_check_env.py
+++ b/tests/test_check_env.py
@@ -155,9 +155,12 @@ def test_detect_core_status_uses_importable_package_path(
 
     (installed_package / "_arnio_cpp.pyd").write_text("compiled extension")
 
-    with patch(
-        "importlib.util.find_spec",
-        return_value=MagicMock(origin=str(init_file)),
+    with (
+        patch.dict(sys.modules, {"arnio._core": None}, clear=False),
+        patch(
+            "importlib.util.find_spec",
+            return_value=MagicMock(origin=str(init_file)),
+        ),
     ):
         status, available = detect_core_status()
 

--- a/tests/test_check_env.py
+++ b/tests/test_check_env.py
@@ -1,6 +1,7 @@
 """Unit tests for examples/check_env.py environment dashboard."""
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ from examples.check_env import (
     EXAMPLES,
     BuildToolCheck,
     check_dependencies,
+    detect_core_status,
     print_dashboard,
 )
 from examples.example_registry import check_env_examples
@@ -114,6 +116,53 @@ def test_check_env_all_available(capsys: pytest.CaptureFixture[str]) -> None:
             if "arnio_with_duckdb.py" in line:
                 assert "[Ready]" in line
         assert "All optional dependencies are successfully installed!" in output
+        assert "Native Arnio core is available. You are ready to go." in output
+
+
+def test_check_env_reports_missing_native_core_readiness(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch.dict(sys.modules, {"arnio._core": None}):
+        results = {
+            "numpy": (True, "Installed"),
+            "pandas": (True, "Installed"),
+            "duckdb": (True, "Installed"),
+            "sklearn": (True, "Installed"),
+            "pyarrow": (True, "Installed"),
+            "pytest": (True, "Installed"),
+        }
+
+        print_dashboard(results, build_tools=MISSING_BUILD_TOOLS)
+
+        captured = capsys.readouterr()
+        output = captured.out
+
+        assert "All optional dependencies are successfully installed!" in output
+        assert "Native Arnio core is not available." in output
+
+
+def test_detect_core_status_uses_importable_package_path(
+    tmp_path: Path,
+) -> None:
+    source_package = tmp_path / "source" / "arnio"
+    source_package.mkdir(parents=True)
+
+    init_file = source_package / "__init__.py"
+    init_file.write_text("# source package")
+
+    installed_package = tmp_path / "site-packages" / "arnio"
+    installed_package.mkdir(parents=True)
+
+    (installed_package / "_arnio_cpp.pyd").write_text("compiled extension")
+
+    with patch(
+        "importlib.util.find_spec",
+        return_value=MagicMock(origin=str(init_file)),
+    ):
+        status, available = detect_core_status()
+
+    assert available is False
+    assert "Not Compiled" in status
 
 
 def test_check_dependencies_reports_broken_import() -> None:

--- a/tests/test_check_env.py
+++ b/tests/test_check_env.py
@@ -119,6 +119,29 @@ def test_check_env_all_available(capsys: pytest.CaptureFixture[str]) -> None:
         assert "Native Arnio core is available. You are ready to go." in output
 
 
+def test_main_exits_when_core_and_required_build_tools_missing() -> None:
+    with (
+        patch(
+            "examples.check_env.check_dependencies",
+            return_value={},
+        ),
+        patch(
+            "examples.check_env.check_build_tools",
+            return_value=MISSING_BUILD_TOOLS,
+        ),
+        patch(
+            "examples.check_env.detect_core_status",
+            return_value=("Not Compiled", False),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        from examples.check_env import main
+
+        main()
+
+    assert exc_info.value.code == 1
+
+
 def test_check_env_reports_missing_native_core_readiness(
     capsys: pytest.CaptureFixture[str],
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes incorrect native-core detection in `examples/check_env.py` when a source checkout shadows an installed wheel containing `_arnio_cpp`.

## Changes

* resolve the actually importable `arnio` package path using `importlib.util.find_spec`
* validate `_arnio_cpp` only under the resolved package path instead of scanning arbitrary `sys.path` entries
* separate optional dependency readiness from native-core readiness messaging
* return a non-zero exit code when the native core is unavailable and required build tools are missing
* add regression coverage for source-checkout shadowing of an installed wheel

Fixes #2349
