### PR TITLE
docs: fix quality reports example

### DIFF
--- a/website/docs.html
+++ b/website/docs.html
@@ -181,6 +181,9 @@ payload = frame.to_dict()</code></pre></div>
         <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python">report = ar.profile(frame, exclude_columns=["private_notes"])
 report.to_markdown()
 report.to_html("quality.html")
+report.to_dict()
+
+report = ar.profile(frame)
 report.to_dict(exclude_columns=["private_notes"])
 report.to_json()
 


### PR DESCRIPTION

Closes #2369

## Summary
Fixes the Quality Reports documentation example that excluded the same column twice.

## Changes
- Kept the profiling-time exclusion example
- Added a valid export-time exclusion example
- Removed the invalid double-exclusion pattern that raised KeyError

## Result
The documentation now demonstrates the two supported privacy-safe workflows:
1. Exclude columns during profiling
2. Profile all columns and exclude during export