### PR TITLE
perf: pre-allocate Column vectors in from_dict when row_count is known

### DIFF
--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -182,6 +182,15 @@ PYBIND11_MODULE(_arnio_cpp, m) {
                 Frame frame =
                     row_count_obj.is_none() ? Frame() : Frame(row_count_obj.cast<size_t>());
 
+                // Extract the row count once so we can pre-allocate each column's
+                // internal vectors before the push_back loop.  This eliminates the
+                // O(log N) heap-reallocation cascade that occurs when vectors grow
+                // from zero capacity.
+                std::optional<size_t> row_count;
+                if (!row_count_obj.is_none()) {
+                    row_count = row_count_obj.cast<size_t>();
+                }
+
                 for (auto item : cols_dict) {
                     std::string name = py::cast<std::string>(item.first);
                     py::list values = py::cast<py::list>(item.second);
@@ -211,6 +220,13 @@ PYBIND11_MODULE(_arnio_cpp, m) {
                     }
 
                     Column col(name, dtype);
+
+                    // Pre-allocate to the known row count to avoid repeated
+                    // vector growth reallocations during the push_back loop below.
+                    if (row_count.has_value()) {
+                        col.reserve(*row_count);
+                    }
+
                     for (auto val : values) {
                         if (val.is_none()) {
                             col.push_null();

--- a/cpp/include/arnio/column.h
+++ b/cpp/include/arnio/column.h
@@ -26,6 +26,12 @@ class Column {
     void push_null();
     void set_name(const std::string& name);
 
+    // Internal capacity pre-allocation.  Called by the binding layer when the
+    // final row count is known upfront (e.g. Frame::from_dict with row_count).
+    // Not registered in the pybind11 wrapper — this is an implementation detail,
+    // not part of the public Python API.
+    void reserve(size_t capacity);
+
     // Data access
     const ColumnData& data() const;
     const std::vector<bool>& null_mask() const;

--- a/cpp/src/column.cpp
+++ b/cpp/src/column.cpp
@@ -204,6 +204,18 @@ void Column::push_null() {
 void Column::set_name(const std::string& name) { name_ = name; }
 void Column::set_dtype(DType dtype) { dtype_ = dtype; }
 
+void Column::reserve(size_t capacity) {
+    null_mask_.reserve(capacity);
+    std::visit(
+        [capacity](auto& vec) {
+            using T = std::decay_t<decltype(vec)>;
+            if constexpr (!std::is_same_v<T, std::monostate>) {
+                vec.reserve(capacity);
+            }
+        },
+        data_);
+}
+
 void Column::assert_type_consistency() const {
     bool consistent = false;
     switch (dtype_) {

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -799,6 +799,110 @@ class TestFromPandas:
             ar.from_dict({"a": b"abc"})
 
 
+class TestFromPandasReservePreallocation:
+    """Regression tests for the Column::reserve() internal preallocation path.
+
+    Frame::from_dict calls col.reserve(row_count) when the row count is
+    supplied.  These tests verify that the optimised and unoptimised paths
+    produce identical frames — same shape, column names, dtypes, values, and
+    null masks — across all supported column types.
+    """
+
+    def _build_cols_dict(self):
+        return {
+            "col_int": [1, 2, None, 4, 5],
+            "col_float": [1.1, None, 3.3, 4.4, 5.5],
+            "col_bool": [True, False, None, True, False],
+            "col_str": ["alpha", "beta", None, "delta", "epsilon"],
+        }
+
+    def test_from_dict_with_row_count_matches_without(self):
+        """from_dict with row_count supplied must produce the same frame as without."""
+        cols = self._build_cols_dict()
+        from arnio._arnio_cpp import DType, Frame
+
+        dtype_hints = {
+            "col_int": DType.INT64,
+            "col_float": DType.FLOAT64,
+            "col_bool": DType.BOOL,
+            "col_str": DType.STRING,
+        }
+
+        frame_without = Frame.from_dict(cols, dtype_hints)
+        frame_with = Frame.from_dict(cols, dtype_hints, row_count=5)
+
+        assert frame_without.shape() == frame_with.shape()
+        assert frame_without.column_names() == frame_with.column_names()
+
+        for idx in range(frame_without.num_cols()):
+            col_a = frame_without.column_by_index(idx)
+            col_b = frame_with.column_by_index(idx)
+            assert col_a.dtype() == col_b.dtype(), f"dtype mismatch on column {idx}"
+            assert col_a.size() == col_b.size(), f"size mismatch on column {idx}"
+            for row in range(col_a.size()):
+                assert col_a.is_null(row) == col_b.is_null(
+                    row
+                ), f"null mask mismatch at col={idx}, row={row}"
+                if not col_a.is_null(row):
+                    assert col_a.at(row) == col_b.at(
+                        row
+                    ), f"value mismatch at col={idx}, row={row}"
+
+    def test_from_pandas_reserve_preallocation_roundtrip(self):
+        """from_pandas on a mixed-type DataFrame must roundtrip correctly
+        regardless of whether the internal reserve path is exercised."""
+        df = pd.DataFrame(
+            {
+                "col_int": pd.array([1, 2, None, 4, 5], dtype=pd.Int64Dtype()),
+                "col_float": [1.1, float("nan"), 3.3, 4.4, 5.5],
+                "col_bool": [True, False, True, False, True],
+                "col_str": ["alpha", "beta", "gamma", "delta", "epsilon"],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+
+        assert list(result.columns) == list(df.columns)
+        assert result.shape == df.shape
+        # Non-null int values must round-trip exactly.
+        assert result["col_int"].dropna().tolist() == [1, 2, 4, 5]
+
+        assert frame.shape == (5, 4)
+
+    def test_from_dict_large_row_count_correctness(self):
+        """Reserve path must not corrupt values or null masks at scale."""
+        n = 10_000
+        cols = {
+            "ints": list(range(n)),
+            "floats": [float(i) + 0.5 for i in range(n)],
+            "bools": [i % 2 == 0 for i in range(n)],
+            "strs": [str(i) for i in range(n)],
+        }
+        from arnio._arnio_cpp import DType, Frame
+
+        dtype_hints = {
+            "ints": DType.INT64,
+            "floats": DType.FLOAT64,
+            "bools": DType.BOOL,
+            "strs": DType.STRING,
+        }
+
+        frame_without = Frame.from_dict(cols, dtype_hints)
+        frame_with = Frame.from_dict(cols, dtype_hints, row_count=n)
+
+        assert frame_without.shape() == frame_with.shape()
+        # Spot-check a sample of rows to keep the test fast.
+        sample_indices = [0, 1, n // 2, n - 2, n - 1]
+        for col_idx in range(frame_without.num_cols()):
+            col_a = frame_without.column_by_index(col_idx)
+            col_b = frame_with.column_by_index(col_idx)
+            for row in sample_indices:
+                assert col_a.is_null(row) == col_b.is_null(row)
+                if not col_a.is_null(row):
+                    assert col_a.at(row) == col_b.at(row)
+
+
 class TestAttrsPreservation:
     def test_attrs_roundtrip(self):
         """attrs set on input DataFrame survive from_pandas -> to_pandas."""


### PR DESCRIPTION
# Closes #1264

## Summary

Preallocates internal `Column` storage when the final row count is already known during `Frame::from_dict()` ingestion.

Currently, each `Column` starts with zero-capacity storage and grows incrementally via repeated `push_back()` operations. This change introduces an internal `Column::reserve()` helper and uses the existing `row_count` information to reserve storage upfront before ingestion begins.

The change is entirely internal and does not introduce any new Python or pybind11 API.

---

## Changes

| File | Change |
|------|--------|
| `cpp/include/arnio/column.h` | Added internal `void reserve(size_t capacity)` declaration |
| `cpp/src/column.cpp` | Implemented `Column::reserve()` for `null_mask_` and typed storage vectors |
| `bindings/bind_arnio.cpp` | Extracts `row_count` once and calls `col.reserve(*row_count)` before value insertion |
| `tests/test_convert.py` | Added focused regression tests covering reserve and non-reserve paths |

### Implementation

Added an internal helper:

```cpp
void Column::reserve(size_t capacity);
```

The implementation reserves:

- `null_mask_`
- underlying typed storage vector

while skipping `std::monostate` storage used by `NULL_TYPE` columns.

Inside `Frame::from_dict()`:

```cpp
if (row_count.has_value()) {
    col.reserve(*row_count);
}
```

No pybind11 bindings were added.

---

## Benchmark

Benchmark command:

```bash
python benchmarks/benchmark_from_pandas_memory.py
```

| Row Count | Before (main) | After (patched) |
|------------|--------------|----------------|
| 10,000 | 0.9406 MB | 0.9407 MB |
| 100,000 | 9.0848 MB | 9.0847 MB |
| 1,000,000 | 92.4912 MB | 92.4911 MB |

### Notes

Peak Python-side memory is effectively unchanged.

This is expected because the benchmark uses `tracemalloc`, which only observes Python heap allocations. The optimization targets C++ vector preallocation and growth behavior, which is outside the visibility of Python-level memory profiling.

---

## Testing

### Full Test Suite

```text
120 passed, 17 skipped
```

### Added Regression Tests

```text
TestFromPandasReservePreallocation::test_from_dict_with_row_count_matches_without
TestFromPandasReservePreallocation::test_from_pandas_reserve_preallocation_roundtrip
TestFromPandasReservePreallocation::test_from_dict_large_row_count_correctness
```

Result:

```text
3 passed
```

These tests verify that:

- Reserve and non-reserve paths produce identical output
- Round-trip conversion behaviour is unchanged
- Large row-count ingestion remains correct

---

## Validation


![Benchmark Output](https://github.com/user-attachments/assets/cd89b3ba-9214-4521-9eac-34d856ff7839)


![Full Test Suite](https://github.com/user-attachments/assets/741fda04-8f04-4dd1-8221-1f0ae45266f4)


![Regression Tests](https://github.com/user-attachments/assets/94f4a08d-8a97-48fb-ac17-05a758f9a1bb)


![Build Validation](https://github.com/user-attachments/assets/5b459623-23ea-4859-b5df-cafb6dd25d2e)

---

## Checklist

- [x] Added internal-only `Column::reserve()`
- [x] No new public Python API
- [x] No pybind11 registration required
- [x] Row-count preallocation enabled in `Frame::from_dict()`
- [x] Added focused regression tests
- [x] Benchmarked before and after implementation
- [x] Full test suite passes