### PR TITLE
feat: add normalize_minmax cleaning primitive

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -25,6 +25,7 @@ from .cleaning import (
     find_fuzzy_duplicates,
     keep_rows_with_nulls,
     normalize_case,
+    normalize_minmax,
     normalize_unicode,
     normalize_whitespace,
     parse_bool_strings,
@@ -40,7 +41,6 @@ from .cleaning import (
     trim_column_names,
     validate_columns_exist,
     winsorize_outliers,
-    normalize_minmax,
 )
 from .convert import from_dict, from_pandas, from_polars, to_arrow, to_pandas, to_polars
 from .exceptions import (

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -37,6 +37,7 @@ from .cleaning import (
     trim_column_names,
     validate_columns_exist,
     winsorize_outliers,
+    normalize_minmax,
 )
 from .convert import from_dict, from_pandas, from_polars, to_arrow, to_pandas, to_polars
 from .exceptions import (
@@ -147,6 +148,7 @@ __all__ = [
     "clean_column_names",
     "clip_numeric",
     "winsorize_outliers",
+    "normalize_minmax",
     "coalesce_columns",
     "combine_columns",
     "rename_columns_matching",

--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -821,6 +821,138 @@ def winsorize_outliers(
     return from_pandas(df)
 
 
+def normalize_minmax(
+    frame: ArFrame,
+    *,
+    subset: list[str] | None = None,
+    feature_range: tuple[float, float] = (0.0, 1.0),
+) -> ArFrame:
+    """Scale numeric columns to a target range using min-max normalization.
+
+    Null values are preserved and excluded from min/max computation.
+    Constant columns (all non-null values identical) map to the lower bound
+    of ``feature_range`` without raising or producing NaN.
+
+    Parameters
+    ----------
+    frame : ArFrame
+        Input data frame.
+    subset : list[str], optional
+        Numeric columns to normalize. If None, applies to all int64/float64 columns.
+    feature_range : tuple[float, float], default (0.0, 1.0)
+        Target output range as (min, max). Both bounds must be finite and min < max.
+
+    Returns
+    -------
+    ArFrame
+        New frame with normalized numeric columns.
+
+    Raises
+    ------
+    TypeError
+        If feature_range is not a tuple or list of two numbers.
+    ValueError
+        If feature_range bounds are not finite, or min >= max.
+        If subset contains non-numeric columns.
+        If any column in subset does not exist in the frame.
+
+    Examples
+    --------
+    >>> import arnio as ar
+    >>> frame = ar.read_csv("data.csv")
+    >>> scaled = ar.normalize_minmax(frame, subset=["price", "age"])
+    >>> scaled = ar.normalize_minmax(frame, feature_range=(-1.0, 1.0))
+    >>> # Pipeline usage
+    >>> cleaned = ar.pipeline(frame, [
+    ...     ("normalize_minmax", {"subset": ["price"], "feature_range": (0.0, 1.0)}),
+    ... ])
+    """
+    frame, _ = _validate_frame(frame)
+
+    # --- validate feature_range ---
+    if not isinstance(feature_range, (tuple, list)):
+        raise TypeError(
+            f"feature_range must be a tuple or list of two numbers, got {type(feature_range).__name__!r}"
+        )
+
+    if len(feature_range) != 2:
+        raise ValueError(
+            f"feature_range must contain exactly 2 elements, got {len(feature_range)}"
+        )
+    lo, hi = feature_range
+
+    if isinstance(lo, bool) or isinstance(hi, bool):
+        raise TypeError("feature_range bounds must be numeric (int or float), not bool")
+    if not isinstance(lo, (int, float)) or not isinstance(hi, (int, float)):
+        raise TypeError(
+            f"feature_range bounds must be numeric (int or float), "
+            f"got {type(lo).__name__!r} and {type(hi).__name__!r}"
+        )
+    if not math.isfinite(lo) or not math.isfinite(hi):
+        raise ValueError("feature_range bounds must be finite")
+    if lo >= hi:
+        raise ValueError(
+            f"feature_range min ({lo}) must be strictly less than max ({hi})"
+        )
+
+    # --- resolve target columns  ---
+    dtypes = frame.dtypes
+
+    numeric_columns = [
+        col for col, dtype in dtypes.items() if dtype in ("int64", "float64")
+    ]
+
+    if subset is not None:
+        subset = _validate_existing_column_sequence(
+            subset,
+            available_columns=frame.columns,
+            argument_name="subset",
+            missing_error=ValueError,
+            missing_message=lambda missing, available: (
+                f"Unknown columns in subset: {missing}. Available: {available}"
+            ),
+        )
+        non_numeric = [
+            col
+            for col in subset
+            if dtypes.get(col) not in ("int64", "float64")
+            and not to_pandas(frame)[col].isna().all()
+        ]
+        if non_numeric:
+            raise ValueError(
+                f"normalize_minmax only supports numeric columns: {non_numeric}"
+            )
+        target_columns = subset
+    else:
+        target_columns = numeric_columns
+
+    if not target_columns:
+        return from_pandas(to_pandas(frame))
+
+    # --- scale  ---
+    df = to_pandas(frame).copy(deep=False)
+    lo_f = float(lo)
+    hi_f = float(hi)
+    scale = hi_f - lo_f
+
+    for col in target_columns:
+        series = df[col].astype("float64")
+        col_min = series.min(skipna=True)
+        col_max = series.max(skipna=True)
+
+        if pd.isna(col_min):
+            # All-null column — leave unchanged
+            continue
+
+        if col_min == col_max:
+            # Constant column — map to lower bound, preserve nulls
+            df[col] = series.where(series.isna(), lo_f)
+        else:
+            df[col] = lo_f + (series - col_min) / (col_max - col_min) * scale
+
+    return from_pandas(df)
+
+
 def strip_whitespace(
     frame: ArFrame,
     *,

--- a/arnio/pipeline.py
+++ b/arnio/pipeline.py
@@ -38,6 +38,7 @@ _STEP_REGISTRY: dict[str, Callable] = {
     "drop_empty_columns": cleaning.drop_empty_columns,
     "clip_numeric": cleaning.clip_numeric,
     "winsorize_outliers": cleaning.winsorize_outliers,
+    "normalize_minmax": cleaning.normalize_minmax,
     "strip_whitespace": cleaning.strip_whitespace,
     "parse_bool_strings": cleaning.parse_bool_strings,
     "normalize_case": cleaning.normalize_case,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4622,3 +4622,203 @@ class TestRenameColumnsMatching:
         frame = ar.from_pandas(pd.DataFrame({"temp_": [1]}))
         with pytest.raises(ValueError):
             ar.rename_columns_matching(frame, "^temp_$", "   ")
+
+
+class TestNormalizeMinmax:
+    def test_basic_scale_to_unit_range(self):
+        frame = ar.from_pandas(pd.DataFrame({"price": [0.0, 50.0, 100.0]}))
+        result = ar.normalize_minmax(frame, subset=["price"])
+        df = ar.to_pandas(result)
+        assert df["price"].tolist() == pytest.approx([0.0, 0.5, 1.0])
+
+    def test_returns_arframe(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        assert isinstance(result, ar.ArFrame)
+
+    def test_custom_feature_range(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [0.0, 100.0]}))
+        result = ar.normalize_minmax(frame, subset=["x"], feature_range=(-1.0, 1.0))
+        df = ar.to_pandas(result)
+        assert df["x"].tolist() == pytest.approx([-1.0, 1.0])
+
+    def test_nulls_preserved_and_excluded_from_computation(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [0.0, None, 100.0]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert df["x"].iloc[0] == pytest.approx(0.0)
+        assert df["x"].iloc[2] == pytest.approx(1.0)
+        assert pd.isna(df["x"].iloc[1])
+
+    def test_all_null_column_left_unchanged(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [None, None, None]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert df["x"].isna().all()
+
+    def test_constant_column_maps_to_lower_bound(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [5.0, 5.0, 5.0]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert all(v == pytest.approx(0.0) for v in df["x"].dropna())
+
+    def test_constant_column_preserves_nulls(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [5.0, None, 5.0]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert df["x"].iloc[0] == pytest.approx(0.0)
+        assert pd.isna(df["x"].iloc[1])
+        assert df["x"].iloc[2] == pytest.approx(0.0)
+
+    def test_non_numeric_subset_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"name": ["a", "b"]}))
+        with pytest.raises(ValueError, match="only supports numeric columns"):
+            ar.normalize_minmax(frame, subset=["name"])
+
+    def test_missing_subset_column_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(ValueError, match="Unknown columns in subset"):
+            ar.normalize_minmax(frame, subset=["nonexistent"])
+
+    def test_feature_range_min_ge_max_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(ValueError, match="strictly less than max"):
+            ar.normalize_minmax(frame, feature_range=(1.0, 0.0))
+
+    def test_feature_range_equal_bounds_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(ValueError):
+            ar.normalize_minmax(frame, feature_range=(1.0, 1.0))
+
+    def test_feature_range_non_finite_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(ValueError, match="finite"):
+            ar.normalize_minmax(frame, feature_range=(float("-inf"), 1.0))
+
+    def test_feature_range_wrong_type_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(TypeError):
+            ar.normalize_minmax(frame, feature_range="bad")
+
+    def test_feature_range_bool_bounds_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(TypeError):
+            ar.normalize_minmax(frame, feature_range=(True, False))
+
+    def test_no_subset_applies_to_all_numeric_columns(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": [0.0, 100.0],
+                    "b": [0.0, 50.0],
+                    "label": ["x", "y"],
+                }
+            )
+        )
+        result = ar.normalize_minmax(frame)
+        df = ar.to_pandas(result)
+        assert df["a"].tolist() == pytest.approx([0.0, 1.0])
+        assert df["b"].tolist() == pytest.approx([0.0, 1.0])
+        assert df["label"].tolist() == ["x", "y"]
+
+    def test_int64_column_normalized(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [0, 50, 100]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert df["x"].tolist() == pytest.approx([0.0, 0.5, 1.0])
+
+    def test_no_numeric_columns_returns_frame_unchanged(self):
+        frame = ar.from_pandas(pd.DataFrame({"label": ["a", "b"]}))
+        result = ar.normalize_minmax(frame)
+        df = ar.to_pandas(result)
+        assert list(df.columns) == ["label"]
+        assert df["label"].tolist() == ["a", "b"]
+
+    def test_output_is_float64(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [0, 1, 2]}))
+        result = ar.normalize_minmax(frame)
+        df = ar.to_pandas(result)
+        assert df["x"].dtype in ("float64", "float")
+
+    def test_pipeline_step_registered(self):
+        frame = ar.from_pandas(pd.DataFrame({"price": [0.0, 100.0]}))
+        result = ar.pipeline(frame, [("normalize_minmax", {"subset": ["price"]})])
+        df = ar.to_pandas(result)
+        assert df["price"].tolist() == pytest.approx([0.0, 1.0])
+
+    def test_pipeline_with_custom_feature_range(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [0.0, 50.0, 100.0]}))
+        result = ar.pipeline(
+            frame,
+            [
+                ("normalize_minmax", {"subset": ["x"], "feature_range": (-1.0, 1.0)}),
+            ],
+        )
+        df = ar.to_pandas(result)
+        assert df["x"].tolist() == pytest.approx([-1.0, 0.0, 1.0])
+
+    def test_pipeline_chained_with_other_steps(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "price": [0.0, None, 100.0],
+                    "label": ["  a  ", "b", "c"],
+                }
+            )
+        )
+        result = ar.pipeline(
+            frame,
+            [
+                ("strip_whitespace",),
+                ("normalize_minmax", {"subset": ["price"]}),
+            ],
+        )
+        df = ar.to_pandas(result)
+        assert df["price"].iloc[0] == pytest.approx(0.0)
+        assert pd.isna(df["price"].iloc[1])
+        assert df["price"].iloc[2] == pytest.approx(1.0)
+        assert df["label"].iloc[0] == "a"
+
+
+class TestNormalizeMinmaxExtra:
+    def test_single_row_maps_to_lower_bound(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [42.0]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert df["x"].iloc[0] == pytest.approx(0.0)
+
+    def test_empty_frame_returns_empty(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": pd.Series(dtype="float64")}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert df.empty
+
+    def test_negative_values_scaled_correctly(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [-100.0, 0.0, 100.0]}))
+        result = ar.normalize_minmax(frame, subset=["x"])
+        df = ar.to_pandas(result)
+        assert df["x"].tolist() == pytest.approx([0.0, 0.5, 1.0])
+
+    def test_non_subset_columns_untouched(self):
+        frame = ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "price": [0.0, 100.0],
+                    "qty": [10.0, 20.0],
+                }
+            )
+        )
+        result = ar.normalize_minmax(frame, subset=["price"])
+        df = ar.to_pandas(result)
+        assert df["price"].tolist() == pytest.approx([0.0, 1.0])
+        assert df["qty"].tolist() == [10.0, 20.0]
+
+    def test_feature_range_single_element_tuple_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(ValueError):
+            ar.normalize_minmax(frame, feature_range=(0.0,))
+
+    def test_feature_range_three_elements_raises(self):
+        frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
+        with pytest.raises(ValueError):
+            ar.normalize_minmax(frame, feature_range=(0.0, 0.5, 1.0))

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4951,6 +4951,8 @@ class TestNormalizeMinmaxExtra:
         frame = ar.from_pandas(pd.DataFrame({"x": [1.0, 2.0]}))
         with pytest.raises(ValueError):
             ar.normalize_minmax(frame, feature_range=(0.0, 0.5, 1.0))
+
+
 class TestPublicHelpersValidateArFrame:
     @pytest.mark.parametrize("obj", [object(), None, 123, pd.DataFrame()])
     def test_cleaning_helpers_reject_invalid_frame(self, obj):

--- a/website/api.html
+++ b/website/api.html
@@ -86,7 +86,7 @@
           <tr><td><code>validate_columns_exist</code>, <code>drop_columns</code>, <code>select_columns</code>, <code>drop_empty_columns</code>, <code>drop_constant_columns</code>, <code>drop_columns_matching</code></td><td>Validate and manage columns explicitly, by emptiness, constants, or regex.</td></tr>
           <tr><td><code>filter_rows</code>, <code>drop_duplicates</code></td><td>Filter row sets and remove duplicate rows.</td></tr>
           <tr><td><code>strip_whitespace</code>, <code>normalize_whitespace</code>, <code>normalize_case</code>, <code>normalize_unicode</code>, <code>clean_column_names</code>, <code>trim_column_names</code>, <code>slugify_column_names</code>, <code>rename_columns</code>, <code>rename_columns_matching</code></td><td>Normalize text, headers, and column names.</td></tr>
-          <tr><td><code>cast_types</code>, <code>parse_bool_strings</code>, <code>round_numeric_columns</code>, <code>clip_numeric</code>, <code>winsorize_outliers</code></td><td>Type and numeric cleanup.</td></tr>
+          <tr><td><code>cast_types</code>, <code>parse_bool_strings</code>, <code>round_numeric_columns</code>, <code>clip_numeric</code>, <code>winsorize_outliers</code>, <code>normalize_minmax</code></td><td>Type and numeric cleanup.</td></tr>
           <tr><td><code>replace_values</code>, <code>standardize_missing_tokens</code>, <code>combine_columns</code>, <code>coalesce_columns</code>, <code>safe_divide_columns</code></td><td>Common feature engineering and value repair helpers.</td></tr>
         </tbody></table>
 


### PR DESCRIPTION
## Summary
Adds normalize_minmax(), a min-max normalization cleaning primitive for numeric columns. Scales int64 and float64 columns to a configurable feature_range, preserves nulls, handles constant columns deterministically, and registers as a pipeline step.

## Linked issue
Fixes #1634

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [x] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
python -m pytest tests/test_cleaning.py -v -k "Minmax"
27 passed

ruff check arnio/cleaning.py arnio/pipeline.py tests/test_cleaning.py
All checks passed!

black arnio/cleaning.py arnio/pipeline.py tests/test_cleaning.py
All done!

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [ x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
