### PR TITLE
fix: expose active nav link with aria-current

### DIFF
--- a/tests/test_website_nav_accessibility.py
+++ b/tests/test_website_nav_accessibility.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MAIN_JS = REPO_ROOT / "website" / "js" / "main.js"
+
+
+def test_active_nav_links_expose_current_page_state():
+    main_js = MAIN_JS.read_text(encoding="utf-8")
+
+    assert "link.classList.add('active');" in main_js
+    assert "link.setAttribute('aria-current', 'page');" in main_js
+    assert "link.removeAttribute('aria-current');" in main_js

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -74,6 +74,9 @@
       const href = link.getAttribute('href');
       if (href === currentPage || (currentPage === '' && href === 'index.html')) {
         link.classList.add('active');
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
       }
     });
 


### PR DESCRIPTION
## Summary
- set `aria-current="page"` when the website script marks the current top/mobile nav link active
- clear stale `aria-current` from non-current nav links during the same pass
- add a static regression test for the nav accessibility behavior

Fixes #2442

## Root Cause
The website already applied a visual `.active` class to current-page navigation links, but it did not expose that same state to assistive technologies.

## Testing
- `python3 -m pytest tests/test_website_nav_accessibility.py tests/test_website_assets.py -q`
- `git diff --check`
