### PR TITLE
Fix read_jsonl_chunked path type validation

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1600,6 +1600,10 @@ def read_jsonl_chunked(
     """
     _validate_jsonl_encoding(encoding)
 
+    if not isinstance(path, (str, os.PathLike)):
+        raise TypeError(
+            f"read_jsonl_chunked expected a filesystem path, got {type(path).__name__!r}"
+        )
     path = os.fspath(path)
     encoding_errors = _validate_encoding_errors(encoding_errors)
     nrows = _validate_jsonl_nrows(nrows)

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -596,3 +596,14 @@ class TestReadJsonlInvalidPathType:
             match="read_jsonl expected a filesystem path",
         ):
             ar.read_jsonl(bad_input)
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [123, 3.14, None, object(), ["a.jsonl"]],
+    )
+    def test_chunked_raises_type_error(self, bad_input):
+        with pytest.raises(
+            TypeError,
+            match="read_jsonl_chunked expected a filesystem path",
+        ):
+            list(ar.read_jsonl_chunked(bad_input))


### PR DESCRIPTION
## Summary
- Validate read_jsonl_chunked path inputs before calling os.fspath
- Match the clearer TypeError contract already used by read_jsonl
- Add regression coverage for invalid path input types

Fixes #2458

## Tests
- uv run --extra dev pytest tests/test_jsonl.py -q
- uv run ruff check .
- uv run pytest -q