### PR TITLE
Validate write_parquet preserve_attrs type

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1954,8 +1954,8 @@ def write_parquet(
     ImportError
         If ``pyarrow`` is not installed.
     TypeError
-        If ``preserve_attrs`` is ``True`` and ``DataFrame.attrs``
-        contains non-JSON-serializable values.
+        If ``preserve_attrs`` is not a boolean, or if ``preserve_attrs`` is
+        ``True`` and ``DataFrame.attrs`` contains non-JSON-serializable values.
     ValueError
         If the file extension is not ``.parquet`` or ``.pq``, if
         ``compression`` is not a recognised codec, or if
@@ -2000,6 +2000,9 @@ def write_parquet(
             raise TypeError("row_group_size must be an integer")
         if row_group_size <= 0:
             raise ValueError("row_group_size must be a positive integer")
+
+    if not isinstance(preserve_attrs, bool):
+        raise TypeError("preserve_attrs must be a bool")
 
     try:
         import pyarrow  # noqa: F401 — presence check only

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -252,6 +252,21 @@ class TestWriteParquetErrors:
                 compression=compression,
             )
 
+    @pytest.mark.parametrize(
+        "preserve_attrs",
+        ["False", 0, 1, None, [], {}, object()],
+    )
+    def test_non_bool_preserve_attrs_raises_type_error(self, tmp_path, preserve_attrs):
+        # preserve_attrs validation happens before the pyarrow import check.
+        frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
+
+        with pytest.raises(TypeError, match="preserve_attrs must be a bool"):
+            ar.write_parquet(
+                frame,
+                tmp_path / "out.parquet",
+                preserve_attrs=preserve_attrs,
+            )
+
     def test_missing_pyarrow_raises_import_error(self, tmp_path):
         # This test mocks pyarrow away and must run even without pyarrow.
         frame = ar.from_pandas(pd.DataFrame({"a": [1]}))


### PR DESCRIPTION
## Summary
- Reject non-boolean preserve_attrs values before Parquet export
- Document the preserve_attrs TypeError contract
- Add regression coverage for common non-bool inputs

Fixes #2459

## Tests
- uv run --extra dev pytest tests/test_parquet.py -q
- uv run ruff format --check arnio/io.py tests/test_parquet.py
- uv run ruff check .
- uv run pytest -q