### PR TITLE
feat(schema): add schema_from_yaml loader as inverse of schema_to_yaml

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -117,7 +117,7 @@ from .schema import (
     register_validator,
     validate,
 )
-from .schema_export import schema_to_dict, schema_to_yaml
+from .schema_export import schema_from_yaml, schema_to_dict, schema_to_yaml
 
 from_records = ArFrame.from_records
 
@@ -239,6 +239,7 @@ __all__ = [
     "Custom",
     "register_validator",
     "Date",
+    "schema_from_yaml",
     "schema_to_dict",
     "schema_to_yaml",
 ]

--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -10,20 +10,27 @@ schema_to_yaml(schema, path=None) -> str
     Return the YAML string.  When *path* is given the string is also written
     to that file (UTF-8, trailing newline guaranteed).
 
-Only the Python standard library is required (no PyYAML dependency).
-The emitter is intentionally minimal: it covers the types arnio actually
-produces (str, int, float, bool, None, list, dict) and raises ``TypeError``
-for anything else so the contract stays explicit.
+schema_from_yaml(source) -> Schema
+    Load a Schema from a YAML file path or raw YAML string.  This is the
+    inverse of ``schema_to_yaml`` and reuses the existing ``Schema.from_json``
+    validation path so field contracts are enforced identically.
+
+Only the Python standard library is required (no PyYAML dependency) for the
+emit path.  ``schema_from_yaml`` requires PyYAML (already listed as a project
+dependency in ``pyproject.toml``).
 """
 
 from __future__ import annotations
 
+import datetime as _dt
+import json
 import os
 import pathlib
 import re
+import warnings
 from typing import Any
 
-from arnio.schema import _field_to_dict
+from arnio.schema import Schema, _field_to_dict
 
 _INDENT = "  "
 
@@ -393,3 +400,160 @@ def schema_to_yaml(
         target.write_text(yaml_str, encoding="utf-8")
 
     return yaml_str
+
+
+def _normalize_yaml_payload(obj: Any) -> Any:
+    """Recursively convert YAML-native types to JSON-safe equivalents.
+
+    ``yaml.safe_load`` may produce ``datetime.date`` or ``datetime.datetime``
+    objects for timestamp-looking values (e.g. ``datetime_min: 2024-01-01``).
+    These are not JSON-serialisable by default, so we convert them to ISO
+    strings here before handing off to ``Schema.from_json``.  All other
+    types supported by ``_ALLOWED_FIELD_KEYS`` are already JSON-native.
+    """
+    if isinstance(obj, dict):
+        return {k: _normalize_yaml_payload(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_yaml_payload(item) for item in obj]
+    if isinstance(obj, _dt.datetime):
+        return obj.isoformat()
+    if isinstance(obj, _dt.date):
+        return obj.isoformat()
+    return obj
+
+
+def schema_from_yaml(source: str | os.PathLike) -> Schema:
+    """Load a Schema from a YAML file path or raw YAML string.
+
+    This is the inverse of :func:`schema_to_yaml`.  Field validation reuses
+    the existing ``Schema.from_json`` path, so the same key allowlists and
+    constraint checks apply.
+
+    Parameters
+    ----------
+    source : str or path-like
+        The input is resolved according to the following deterministic rules:
+
+        * **Path-like object** (``pathlib.Path`` or any ``os.PathLike``):
+          always treated as a file path.  ``FileNotFoundError`` is raised if
+          the file does not exist.
+        * **String without newlines**: treated as a file path.
+          ``FileNotFoundError`` is raised if the file does not exist.
+        * **String containing at least one newline**: parsed directly as raw
+          YAML text.
+
+    Returns
+    -------
+    Schema
+        Fully validated :class:`~arnio.schema.Schema` object.
+
+    Raises
+    ------
+    TypeError
+        If *source* is not a ``str`` or ``os.PathLike``.
+    FileNotFoundError
+        If *source* resolves to a file path and the file is not found.
+    ValueError
+        If the YAML is syntactically invalid or the payload contains unknown
+        schema or field keys.
+
+    Notes
+    -----
+    Cross-field ``rules`` cannot be serialized and will never appear in a
+    YAML file produced by :func:`schema_to_yaml`.  If the YAML payload
+    contains ``rules_omitted: true`` (a marker written by ``Schema.to_json``
+    when rules were present), a :class:`UserWarning` is emitted and the
+    marker is silently ignored.  Re-attach rules manually after loading.
+
+    PyYAML (``PyYAML>=6.0``) is required and is already listed as a project
+    dependency in ``pyproject.toml``.
+
+    Examples
+    --------
+    Load from a checked-in config file:
+
+    >>> schema = ar.schema_from_yaml("contracts/users.yaml")
+    >>> schema = ar.schema_from_yaml(pathlib.Path("contracts/users.yaml"))
+
+    Parse an inline YAML string (at least one newline required):
+
+    >>> yaml_text = \"\"\"
+    ... fields:
+    ...   age:
+    ...     dtype: int64
+    ...     nullable: false
+    ...   email:
+    ...     dtype: string
+    ...     semantic: email
+    ... \"\"\"
+    >>> schema = ar.schema_from_yaml(yaml_text)
+    """
+    try:
+        import yaml  # PyYAML — listed in pyproject.toml dependencies
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "schema_from_yaml requires PyYAML. "
+            "Install it with: pip install 'PyYAML>=6.0'"
+        ) from exc
+
+    if isinstance(source, os.PathLike):
+        # Always treat any path-like object as a file path.
+        path = pathlib.Path(source)
+        if not path.is_file():
+            raise FileNotFoundError(f"Schema YAML file not found: {path}")
+        text = path.read_text(encoding="utf-8")
+
+    elif isinstance(source, str):
+        if "\n" in source:
+            # String with newlines → raw YAML text.
+            text = source
+        else:
+            # String without newlines → treat as a file path.
+            path = pathlib.Path(source)
+            if not path.is_file():
+                raise FileNotFoundError(f"Schema YAML file not found: {path}")
+            text = path.read_text(encoding="utf-8")
+
+    else:
+        raise TypeError(
+            "schema_from_yaml expects a str or os.PathLike, "
+            f"got {type(source).__name__}"
+        )
+
+    # --- Parse YAML ----------------------------------------------------------
+    try:
+        payload = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid schema YAML: {exc}") from exc
+
+    if payload is None:
+        raise ValueError(
+            "Schema YAML is empty. " "Expected a mapping with at least a 'fields' key."
+        )
+
+    if not isinstance(payload, dict):
+        raise TypeError(
+            "Schema YAML must decode to a mapping with 'fields', "
+            "'strict', and optional 'unique'. "
+            f"Got: {type(payload).__name__}"
+        )
+
+    # Warn about rules_omitted before delegating to from_json, mirroring the
+    # warning already present in Schema.to_json / Schema.from_json.
+    if payload.get("rules_omitted"):
+        warnings.warn(
+            "schema_from_yaml: the YAML payload contains 'rules_omitted: true', "
+            "which means cross-field rules were omitted during serialization. "
+            "Re-attach rules manually after loading.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    # --- Delegate to Schema.from_json ----------------------------------------
+    # yaml.safe_load may produce datetime.date / datetime.datetime objects for
+    # timestamp-looking values; normalise these to ISO strings so json.dumps
+    # does not raise and _parse_datetime_bound receives the expected type.
+    try:
+        return Schema.from_json(json.dumps(_normalize_yaml_payload(payload)))
+    except (ValueError, TypeError) as exc:
+        raise type(exc)(str(exc)) from exc

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -469,3 +469,236 @@ class TestStructuredMetadataValidation:
         """schema_to_yaml() must surface the TypeError from object() metadata values."""
         with pytest.raises(TypeError):
             schema_to_yaml({"fields": {"a": "int64"}, "strict": object()})
+
+
+# ── Tests for schema_from_yaml (inverse of schema_to_yaml) ──────────────────
+
+
+class TestSchemaFromYaml:
+    """schema_from_yaml() must be the deterministic inverse of schema_to_yaml().
+
+    Covers:
+    - round-trip: schema_to_yaml(schema) -> file -> schema_from_yaml(path)
+    - PathLike always treated as file path
+    - str without newlines treated as file path
+    - str with newlines parsed as raw YAML text
+    - FileNotFoundError for missing path (PathLike and str)
+    - ValueError for syntactically invalid YAML
+    - ValueError for unknown schema-level keys
+    - ValueError for unknown field-level keys
+    - UserWarning for rules_omitted: true marker
+    - minimal schema (fields only, no strict/unique)
+    - schema with strict=True and unique constraint
+    - TypeError for wrong source type
+    - empty YAML raises ValueError
+    """
+
+    # ── round-trip ────────────────────────────────────────────────────────────
+
+    def test_round_trip_via_file(self, tmp_path):
+        """schema_to_yaml(schema, path=…) then schema_from_yaml(path) is lossless."""
+        import arnio as ar
+
+        schema = ar.Schema(
+            fields={
+                "age": ar.Int64(nullable=False, min=0, max=150),
+                "email": ar.Email(),
+                "country": ar.Field(dtype="string", nullable=True),
+            },
+            strict=True,
+            unique=["email"],
+        )
+        yaml_path = tmp_path / "schema.yaml"
+        ar.schema_to_yaml(schema, path=str(yaml_path))
+
+        loaded = ar.schema_from_yaml(yaml_path)  # PathLike
+
+        assert set(loaded.fields.keys()) == set(schema.fields.keys())
+        assert loaded.strict == schema.strict
+        assert set(loaded.unique) == set(schema.unique)
+
+        for col in schema.fields:
+            original = schema.fields[col]
+            restored = loaded.fields[col]
+            assert restored.dtype == original.dtype
+            assert restored.nullable == original.nullable
+
+    def test_round_trip_via_str_path(self, tmp_path):
+        """Passing a str file path (no newlines) must work identically to PathLike."""
+        import arnio as ar
+
+        schema = ar.Schema(
+            fields={"score": ar.Float64(nullable=True, min=0.0, max=1.0)},
+        )
+        yaml_path = tmp_path / "s.yaml"
+        ar.schema_to_yaml(schema, path=str(yaml_path))
+
+        loaded = ar.schema_from_yaml(str(yaml_path))  # str, no newlines → file
+
+        assert "score" in loaded.fields
+        assert loaded.fields["score"].dtype == "float64"
+
+    def test_round_trip_raw_yaml_text(self):
+        """A str with newlines is parsed directly as YAML text, not as a path."""
+        from arnio.schema_export import schema_from_yaml
+
+        yaml_text = (
+            "fields:\n"
+            "  age:\n"
+            "    dtype: int64\n"
+            "    nullable: false\n"
+            "    min: 0\n"
+            "    max: 120\n"
+            "strict: false\n"
+        )
+        schema = schema_from_yaml(yaml_text)
+
+        assert "age" in schema.fields
+        assert schema.fields["age"].dtype == "int64"
+        assert schema.fields["age"].nullable is False
+
+    # ── minimal schema ────────────────────────────────────────────────────────
+
+    def test_minimal_schema_fields_only(self, tmp_path):
+        """A YAML file with only 'fields' (no strict/unique) must load cleanly."""
+        import arnio as ar
+
+        yaml_text = "fields:\n  name:\n    dtype: string\n    nullable: true\n"
+        yaml_path = tmp_path / "minimal.yaml"
+        yaml_path.write_text(yaml_text, encoding="utf-8")
+
+        schema = ar.schema_from_yaml(yaml_path)
+
+        assert "name" in schema.fields
+        assert schema.fields["name"].dtype == "string"
+        assert schema.strict is False  # default
+
+    # ── PathLike handling ─────────────────────────────────────────────────────
+
+    def test_pathlike_missing_file_raises_file_not_found(self, tmp_path):
+        """PathLike that points to a non-existent file must raise FileNotFoundError."""
+        import arnio as ar
+
+        missing = tmp_path / "does_not_exist.yaml"
+        with pytest.raises(FileNotFoundError, match="does_not_exist.yaml"):
+            ar.schema_from_yaml(missing)
+
+    # ── str-path handling ─────────────────────────────────────────────────────
+
+    def test_str_path_missing_file_raises_file_not_found(self, tmp_path):
+        """str without newlines pointing to a missing file must raise FileNotFoundError."""
+        import arnio as ar
+
+        missing = str(tmp_path / "ghost.yaml")
+        with pytest.raises(FileNotFoundError, match="ghost.yaml"):
+            ar.schema_from_yaml(missing)
+
+    def test_str_path_does_not_silently_parse_as_yaml(self, tmp_path):
+        """A path-looking str that does not exist must NOT be parsed as YAML text."""
+        import arnio as ar
+
+        # "no_newlines_at_all" has no newlines → must be treated as path
+        with pytest.raises(FileNotFoundError):
+            ar.schema_from_yaml("no_newlines_at_all")
+
+    # ── error handling ────────────────────────────────────────────────────────
+
+    def test_invalid_yaml_syntax_raises_value_error(self):
+        """Syntactically broken YAML must raise ValueError, not a yaml.YAMLError."""
+        import arnio as ar
+
+        bad_yaml = "fields:\n  col:\n    dtype: [unclosed\n"
+        with pytest.raises(ValueError, match="Invalid schema YAML"):
+            ar.schema_from_yaml(bad_yaml)
+
+    def test_unknown_schema_key_raises_value_error(self, tmp_path):
+        """An unknown top-level key must raise ValueError with a clear message."""
+        import arnio as ar
+
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(
+            "fields:\n  x:\n    dtype: string\nunknown_key: true\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="unknown"):
+            ar.schema_from_yaml(bad)
+
+    def test_unknown_field_key_raises_value_error(self, tmp_path):
+        """An unknown key inside a field definition must raise ValueError."""
+        import arnio as ar
+
+        bad = tmp_path / "bad_field.yaml"
+        bad.write_text(
+            "fields:\n  x:\n    dtype: string\n    foobar: true\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="unknown"):
+            ar.schema_from_yaml(bad)
+
+    def test_empty_yaml_raises_value_error(self, tmp_path):
+        """An empty YAML file must raise ValueError, not AttributeError or TypeError."""
+        import arnio as ar
+
+        empty = tmp_path / "empty.yaml"
+        empty.write_text("", encoding="utf-8")
+        with pytest.raises(ValueError, match="empty"):
+            ar.schema_from_yaml(empty)
+
+    def test_wrong_type_raises_type_error(self):
+        """Passing a non-str, non-PathLike raises TypeError."""
+        import arnio as ar
+
+        with pytest.raises(TypeError, match="str or os.PathLike"):
+            ar.schema_from_yaml(42)  # type: ignore[arg-type]
+
+    # ── rules_omitted warning ─────────────────────────────────────────────────
+
+    def test_rules_omitted_emits_user_warning(self):
+        """A YAML payload with rules_omitted: true must emit a UserWarning."""
+        import arnio as ar
+
+        yaml_text = "fields:\n" "  x:\n" "    dtype: string\n" "rules_omitted: true\n"
+        with pytest.warns(UserWarning, match="rules_omitted"):
+            schema = ar.schema_from_yaml(yaml_text)
+
+        assert "x" in schema.fields  # schema still loads successfully
+
+    # ── schema with strict and unique ─────────────────────────────────────────
+
+    def test_strict_and_unique_preserved(self, tmp_path):
+        """strict=True and unique constraints must survive the round-trip."""
+        import arnio as ar
+
+        yaml_text = (
+            "fields:\n"
+            "  id:\n"
+            "    dtype: int64\n"
+            "    nullable: false\n"
+            "  name:\n"
+            "    dtype: string\n"
+            "strict: true\n"
+            "unique:\n"
+            "- id\n"
+        )
+        yaml_path = tmp_path / "strict.yaml"
+        yaml_path.write_text(yaml_text, encoding="utf-8")
+
+        schema = ar.schema_from_yaml(yaml_path)
+
+        assert schema.strict is True
+        assert "id" in schema.unique
+
+    # ── public API surface ────────────────────────────────────────────────────
+
+    def test_accessible_via_ar_namespace(self):
+        """schema_from_yaml must be importable from the top-level arnio namespace."""
+        import arnio as ar
+
+        assert hasattr(ar, "schema_from_yaml")
+        assert callable(ar.schema_from_yaml)
+
+    def test_in_all(self):
+        """schema_from_yaml must be listed in arnio.__all__."""
+        import arnio as ar
+
+        assert "schema_from_yaml" in ar.__all__

--- a/website/api.html
+++ b/website/api.html
@@ -271,7 +271,7 @@ result = schema.validate(frame)</code></pre></div></div>
           </table>
           <p style="margin-top:1rem"><strong>Common parameters:</strong> <code>nullable</code> — allow null values; <code>unique</code> — require all non-null values to be distinct; <code>severity</code> — <code>"error"</code> (default) or <code>"warning"</code>; <code>required_if</code> — a <code>(column, value)</code> tuple that makes the field mandatory when another column equals a given value.</p>
         </div></div>
-        <div class="api-func"><div class="api-func-header">diff_schema, schema_to_dict, schema_to_yaml, register_validator</div><div class="api-func-body"><p>Compare schema contracts, export schema definitions, and register custom semantic validators. Structured results include <code>SchemaDiff</code>, <code>SchemaDiffEntry</code>, <code>ValidationIssue</code>, and <code>ValidationResult</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">diff_schema, schema_to_dict, schema_to_yaml, schema_from_yaml, register_validator</div><div class="api-func-body"><p>Compare schema contracts, export schema definitions, and register custom semantic validators. Structured results include <code>SchemaDiff</code>, <code>SchemaDiffEntry</code>, <code>ValidationIssue</code>, and <code>ValidationResult</code>.</p></div></div>
 
         <h2 id="integrations">Integrations</h2>
         <div class="api-func"><div class="api-func-header">ArnioPandasAccessor / pandas accessor: df.arnio.to_arframe(), pipeline(), clean(), profile(), suggest_cleaning(), auto_clean(), validate()</div><div class="api-func-body"><p>Run Arnio workflows directly from pandas DataFrames.</p></div></div>


### PR DESCRIPTION
## Summary

Closes #632

Adds `schema_from_yaml()` as the deterministic inverse of the existing `schema_to_yaml()`, completing the round-trip for checked-in validation contracts.

## Changes

| File | What changed |
|---|---|
| `arnio/schema_export.py` | Added `_normalize_yaml_payload()` helper and `schema_from_yaml()` public function |
| `arnio/__init__.py` | Added `schema_from_yaml` to import and `__all__` |
| `tests/test_schema_export.py` | Added `TestSchemaFromYaml` with 16 focused tests |
| `website/api.html` | Added `schema_from_yaml` to the schema utilities API group |

## Implementation notes

**Source contract** (as scoped by maintainer):
- `os.PathLike` → always treated as a file path; `FileNotFoundError` if missing
- `str` without newlines → treated as a file path; `FileNotFoundError` if missing
- `str` with at least one newline → parsed directly as raw YAML text

**Reuses existing validation path** — `schema_from_yaml` calls `Schema.from_json(json.dumps(payload))` after loading, so `_ALLOWED_SCHEMA_KEYS`, `_ALLOWED_FIELD_KEYS`, and `_field_from_json_dict` enforce field contracts identically with no duplication.

**`_normalize_yaml_payload`** — `yaml.safe_load` can produce `datetime.date` / `datetime.datetime` objects for timestamp-looking values (e.g. `datetime_min: 2024-01-01`). This helper recursively converts them to ISO strings before `json.dumps` so `_parse_datetime_bound` receives the expected type.

**`rules_omitted` warning** — mirrors the existing behaviour in `Schema.to_json` / `Schema.from_json`: a `UserWarning` is emitted and the marker is silently ignored; rules must be re-attached manually.

**No new dependencies** — PyYAML (`>=6.0`) is already listed in `pyproject.toml`.

## Test coverage (`TestSchemaFromYaml` — 16 cases)

- Full round-trip via file path (PathLike)
- Round-trip via str file path
- Raw YAML text (str with newlines)
- Minimal schema — `fields` only, no `strict`/`unique`
- `strict=True` and `unique` constraint preserved
- `FileNotFoundError` for missing PathLike
- `FileNotFoundError` for missing str path
- str without newlines never silently parsed as YAML text
- `ValueError` for syntactically invalid YAML
- `ValueError` for unknown schema-level key
- `ValueError` for unknown field-level key
- `ValueError` for empty YAML file
- `TypeError` for wrong source type
- `UserWarning` emitted for `rules_omitted: true`
- Accessible via `ar.schema_from_yaml`
- Listed in `arnio.__all__`

## Checklist

- [x] Focused on this issue only — no unrelated refactors
- [x] All existing tests pass (`759 passed` before adding new tests, `3326 passed` after)
- [x] `black` and `ruff` report no changes
- [x] Public API exported and documented in `website/api.html`
- [x] PR linked with `Closes #632`