### PR TITLE
test: exercise cloud-scheme rejection through public API (#2360)

### DIFF
--- a/tests/smoke_wheel_install.py
+++ b/tests/smoke_wheel_install.py
@@ -119,6 +119,51 @@ def main() -> int:
 
         run([str(python), "-c", import_check], cwd=tmp_dir)
 
+        # Verify that cloud-scheme rejection is present in the installed wheel.
+        # The ValueError must be raised by Python before the C++ extension is
+        # reached, so no real network access or cloud credentials are needed.
+        # Write to a temp script file to avoid shell quoting complexity.
+        cloud_scheme_script = (
+            "import arnio as ar\n"
+            "schemes = ['s3', 'gs', 'az', 'abfs', 'abfss']\n"
+            "errors = []\n"
+            "for scheme in schemes:\n"
+            "    url = f'{scheme}://bucket/file.csv'\n"
+            "    for fn in [ar.read_csv, ar.scan_csv]:\n"
+            "        try:\n"
+            "            fn(url)\n"
+            "            errors.append(f'{fn.__name__}({url}): expected ValueError, got no exception')\n"
+            "        except ValueError as exc:\n"
+            "            if 'pip install' not in str(exc):\n"
+            "                errors.append(f'{fn.__name__}({url}): missing pip hint — {exc}')\n"
+            "        except Exception as exc:\n"
+            "            errors.append(f'{fn.__name__}({url}): wrong exception type {type(exc).__name__} — {exc}')\n"
+            "    # read_csv_chunked must be iterated to trigger the guard\n"
+            "    try:\n"
+            "        next(iter(ar.read_csv_chunked(url)))\n"
+            "        errors.append(f'read_csv_chunked({url}): expected ValueError, got no exception')\n"
+            "    except ValueError as exc:\n"
+            "        if 'pip install' not in str(exc):\n"
+            "            errors.append(f'read_csv_chunked({url}): missing pip hint — {exc}')\n"
+            "    except Exception as exc:\n"
+            "        errors.append(f'read_csv_chunked({url}): wrong exception type {type(exc).__name__} — {exc}')\n"
+            "if errors:\n"
+            "    raise SystemExit('Cloud scheme smoke test FAILED:\\n' + '\\n'.join(errors))\n"
+            "print('cloud scheme smoke test passed')\n"
+        )
+
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            delete=False,
+            dir=tmp_dir,
+            encoding="utf-8",
+        ) as script_file:
+            script_file.write(cloud_scheme_script)
+            script_path = script_file.name
+
+        run([str(python), script_path], cwd=tmp_dir)
+
     print("Wheel install smoke test passed.")
     return 0
 

--- a/tests/test_remote_csv.py
+++ b/tests/test_remote_csv.py
@@ -475,14 +475,47 @@ class TestReadCsvChunkedHttpUrl:
 # but the ValueError is raised in Python before C++ is reached)
 # ---------------------------------------------------------------------------
 
+# All five planned cloud schemes must be covered.
+_ALL_CLOUD_SCHEMES = ["s3", "gs", "az", "abfs", "abfss"]
+
 
 class TestCloudSchemeRejectionPublicApi:
-    @pytest.mark.parametrize("scheme", ["s3", "gs", "az", "abfs"])
-    def test_read_csv_cloud_scheme_raises_value_error(self, scheme):
-        with pytest.raises(ValueError, match="pip install"):
-            # No C++ needed — ValueError from _materialize_csv_input
-            _materialize_csv_input(f"{scheme}://bucket/file.csv")
+    """Public API functions must reject cloud schemes with actionable errors.
 
-    def test_scan_csv_cloud_scheme_raises_value_error(self):
+    These tests call ar.read_csv / ar.scan_csv / ar.read_csv_chunked directly
+    (not the internal _materialize_csv_input helper) so a regression in the
+    Python-before-C++ guard is caught regardless of where the hook lives.
+    The ValueError is raised before the C++ extension is invoked, so no
+    compiled extension is required for these tests to run.
+    """
+
+    @pytest.mark.parametrize("scheme", _ALL_CLOUD_SCHEMES)
+    def test_read_csv_raises_value_error_for_cloud_scheme(self, scheme):
         with pytest.raises(ValueError, match="pip install"):
-            _materialize_csv_input("s3://bucket/file.csv")
+            ar.read_csv(f"{scheme}://bucket/file.csv")
+
+    @pytest.mark.parametrize("scheme", _ALL_CLOUD_SCHEMES)
+    def test_read_csv_error_contains_scheme_name(self, scheme):
+        with pytest.raises(ValueError, match=scheme):
+            ar.read_csv(f"{scheme}://bucket/file.csv")
+
+    @pytest.mark.parametrize("scheme", _ALL_CLOUD_SCHEMES)
+    def test_scan_csv_raises_value_error_for_cloud_scheme(self, scheme):
+        with pytest.raises(ValueError, match="pip install"):
+            ar.scan_csv(f"{scheme}://bucket/file.csv")
+
+    @pytest.mark.parametrize("scheme", _ALL_CLOUD_SCHEMES)
+    def test_scan_csv_error_contains_scheme_name(self, scheme):
+        with pytest.raises(ValueError, match=scheme):
+            ar.scan_csv(f"{scheme}://bucket/file.csv")
+
+    @pytest.mark.parametrize("scheme", _ALL_CLOUD_SCHEMES)
+    def test_read_csv_chunked_raises_value_error_for_cloud_scheme(self, scheme):
+        # Must iterate the generator to trigger the guard.
+        with pytest.raises(ValueError, match="pip install"):
+            next(iter(ar.read_csv_chunked(f"{scheme}://bucket/file.csv")))
+
+    @pytest.mark.parametrize("scheme", _ALL_CLOUD_SCHEMES)
+    def test_read_csv_chunked_error_contains_scheme_name(self, scheme):
+        with pytest.raises(ValueError, match=scheme):
+            next(iter(ar.read_csv_chunked(f"{scheme}://bucket/file.csv")))


### PR DESCRIPTION
## Summary

Fixes the regression described in #2360: `TestCloudSchemeRejectionPublicApi` was calling the internal `_materialize_csv_input` helper directly instead of the three public functions, so a bug in the Python-before-C++ guard inside `read_csv`, `scan_csv`, or `read_csv_chunked` would pass CI while users hit a generic `CsvReadError` from the published wheel.

No changes to `arnio/io.py` — the cloud-scheme `ValueError` guard is already correct in `main`.

## Changes

**`tests/test_remote_csv.py`**
- Rewrote `TestCloudSchemeRejectionPublicApi` to call `ar.read_csv`, `ar.scan_csv`, and `ar.read_csv_chunked` directly through the public API
- Added `abfss` to the scheme list (`_ALL_CLOUD_SCHEMES`) — it was in `_CLOUD_SCHEME_HINTS` but missing from this class
- Added a `read_csv_chunked` parametrized pair — calls `next(iter(...))` to trigger the guard inside the generator
- Added a second assertion per function checking the scheme name itself appears in the error message (matches the documented format)
- Result: 30 parametrized cases covering 3 functions × 5 schemes × 2 assertions

**`tests/smoke_wheel_install.py`**
- Added a `cloud_scheme_script` block that runs after the existing import check
- Exercises all five schemes against `read_csv`, `scan_csv`, and `read_csv_chunked` on the installed wheel
- Checks for correct exception type (`ValueError`) and presence of the `pip install` hint
- Written to a temp `.py` file to avoid shell-quoting issues; makes no network calls

## Testing
pytest tests/ -v   → 3369 passed, 113 skipped
black              → unchanged
ruff check         → all checks passed

## Closes

Closes #2360