### PR TITLE
fix: initialize MSVC in windows wheel smoke workflow

### DIFF
--- a/.github/workflows/windows-msvc-wheel-smoke.yml
+++ b/.github/workflows/windows-msvc-wheel-smoke.yml
@@ -37,6 +37,10 @@ jobs:
           python-version: "3.12"
           cache: 'pip'
 
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+
       - name: Upgrade pip and setuptools
         run: python -m pip install --upgrade pip setuptools wheel
 


### PR DESCRIPTION
## Summary

Initialize the Visual Studio developer environment before building wheels in the dedicated Windows MSVC wheel smoke workflow.

## Changes

* add the same pinned `ilammy/msvc-dev-cmd` setup step already used by the Windows native CI workflow
* initialize the MSVC build environment before invoking `pip wheel`
* preserve the existing wheel install and smoke-test flow

Closes #2482
