### PR TITLE
fix: make CSV transcoding writes atomic

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1224,6 +1224,7 @@ def write_csv(
     _CHUNK_SIZE = 1 << 20  # 1 MiB per chunk
 
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+    output_tmp_path: str | None = None
     try:
         os.close(tmp_fd)
         try:
@@ -1231,25 +1232,46 @@ def write_csv(
         except RuntimeError as e:
             raise RuntimeError(str(e)) from e
 
-        # newline="" on both sides preserves the line_terminator written by
-        # the C++ backend exactly — no platform newline translation.
-        with (
-            open(tmp_path, encoding="utf-8", newline="") as src,
-            open(
-                path, "w", encoding=encoding, errors=encoding_errors, newline=""
-            ) as dst,
-        ):
-            while True:
-                chunk = src.read(_CHUNK_SIZE)
-                if not chunk:
-                    break
-                try:
+        try:
+            output_fd, output_tmp_path = tempfile.mkstemp(
+                dir=os.path.dirname(os.path.abspath(path)),
+                prefix=f".{os.path.basename(path)}.",
+                suffix=".tmp",
+            )
+            os.close(output_fd)
+
+            # newline="" on both sides preserves the line_terminator written by
+            # the C++ backend exactly — no platform newline translation.
+            with (
+                open(tmp_path, encoding="utf-8", newline="") as src,
+                open(
+                    output_tmp_path,
+                    "w",
+                    encoding=encoding,
+                    errors=encoding_errors,
+                    newline="",
+                ) as dst,
+            ):
+                while True:
+                    chunk = src.read(_CHUNK_SIZE)
+                    if not chunk:
+                        break
                     dst.write(chunk)
-                except UnicodeEncodeError as exc:
-                    raise ValueError(
-                        f"write_csv: character cannot be encoded in {encoding!r}: {exc}"
-                    ) from exc
+
+            os.replace(output_tmp_path, path)
+            output_tmp_path = None
+        except UnicodeEncodeError as exc:
+            raise ValueError(
+                f"write_csv: character cannot be encoded in {encoding!r}: {exc}"
+            ) from exc
+        except OSError as exc:
+            raise RuntimeError(str(exc)) from exc
     finally:
+        if output_tmp_path is not None:
+            try:
+                os.unlink(output_tmp_path)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_path)
         except OSError:

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -551,6 +551,47 @@ class TestWriteCsvEncoding:
         with pytest.raises(ValueError, match="cannot be encoded"):
             ar.write_csv(frame, str(out), encoding="latin-1", encoding_errors="strict")
 
+    def test_unencodable_character_strict_preserves_existing_file(self, tmp_path):
+        """Strict transcoding failures do not replace an existing destination."""
+        frame = ar.from_pandas(pd.DataFrame({"val": ["こんにちは"]}))
+        out = tmp_path / "out.csv"
+        out.write_bytes(b"sentinel")
+
+        with pytest.raises(ValueError, match="cannot be encoded"):
+            ar.write_csv(frame, str(out), encoding="latin-1", encoding_errors="strict")
+
+        assert out.read_bytes() == b"sentinel"
+
+    def test_missing_destination_parent_raises_runtimeerror(self, tmp_path):
+        """Destination filesystem errors use the public RuntimeError contract."""
+        frame = self._simple_frame()
+        out = tmp_path / "missing" / "out.csv"
+
+        with pytest.raises(RuntimeError) as exc_info:
+            ar.write_csv(frame, str(out), encoding="latin-1")
+
+        assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+    def test_replace_error_preserves_existing_file_and_cleans_temp(
+        self, tmp_path, monkeypatch
+    ):
+        """Atomic replacement errors preserve the destination and clean the output temp."""
+        frame = self._simple_frame()
+        out = tmp_path / "out.csv"
+        out.write_bytes(b"sentinel")
+
+        def fail_replace(_src, _dst):
+            raise PermissionError("replace denied")
+
+        monkeypatch.setattr(os, "replace", fail_replace)
+
+        with pytest.raises(RuntimeError, match="replace denied") as exc_info:
+            ar.write_csv(frame, str(out), encoding="latin-1")
+
+        assert isinstance(exc_info.value.__cause__, PermissionError)
+        assert out.read_bytes() == b"sentinel"
+        assert list(tmp_path.iterdir()) == [out]
+
     def test_unencodable_character_replace_writes_file(self, tmp_path):
         """encoding_errors="replace" writes replacement characters instead of raising."""
         frame = ar.from_pandas(pd.DataFrame({"val": ["こんにちは"]}))


### PR DESCRIPTION
Fixes #2487

This PR keeps the change scoped to the non-UTF-8 transcoding path in `write_csv()`.

The previous flow wrote the UTF-8 intermediate output directly to the destination before transcoding it in place. If transcoding failed, an existing destination could be replaced or left partially written, and some destination filesystem errors escaped the public `RuntimeError` contract.

What changed:
- write transcoded output to a temporary file beside the destination
- replace the destination atomically only after transcoding closes successfully
- preserve an existing destination when encoding fails
- wrap destination filesystem failures as `RuntimeError`
- add regression coverage for failed transcoding, existing destinations, cleanup, and filesystem errors

Validation:
- `pytest tests/test_write_csv.py -q` - 81 passed
- `pytest tests/ -q` - 3315 passed, 106 skipped
- `ruff check . --extend-exclude "*.ipynb"`
- `black --check --diff .`
- `mypy --config-file mypy.ini`
- `python scripts/check_docs_utf8.py`

This is for GSSoC 2026 and stays scoped to the assigned CSV write atomicity issue.
