### PR TITLE
fix: preserve empty pandas int64 dtype in from_pandas

### DIFF
--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -349,6 +349,8 @@ def to_arrow(frame: ArFrame) -> pa.Table:
 def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
     if dtype == pd.Int64Dtype():
         return _DType.INT64
+    if str(dtype) == "int64":
+        return _DType.INT64
     if dtype == pd.Float64Dtype():
         return _DType.FLOAT64
     if str(dtype) == "float64":
@@ -356,7 +358,6 @@ def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
     if dtype == pd.BooleanDtype() or str(dtype) == "bool":
         return _DType.BOOL
     return None
-
 
 def _validate_unique_column_labels(labels: pd.Index) -> None:
     seen: set[object] = set()

--- a/arnio/convert.py
+++ b/arnio/convert.py
@@ -359,6 +359,7 @@ def _pandas_dtype_to_arnio(dtype: object) -> _DType | None:
         return _DType.BOOL
     return None
 
+
 def _validate_unique_column_labels(labels: pd.Index) -> None:
     seen: set[object] = set()
     dupes: list[object] = []

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1463,6 +1463,7 @@ def test_from_arrow_table_missing_pyarrow_raises_helpful_import_error():
     assert "_from_arrow_table() requires pyarrow." in str(exc_info.value)
     assert "pip install arnio[arrow]" in str(exc_info.value)
 
+
 # ---------------------------------------------------------------------------
 # Issue #1960 — preserve empty pandas int64 dtype in from_pandas
 # ---------------------------------------------------------------------------
@@ -1514,12 +1515,14 @@ class TestEmptyInt64DtypePreservation:
         assert len(result) == 0
 
     def test_empty_mixed_schema_roundtrip(self):
-        df = pd.DataFrame({
-            "id": pd.Series([], dtype="int64"),
-            "score": pd.Series([], dtype="float64"),
-            "active": pd.Series([], dtype="bool"),
-            "name": pd.Series([], dtype="string"),
-        })
+        df = pd.DataFrame(
+            {
+                "id": pd.Series([], dtype="int64"),
+                "score": pd.Series([], dtype="float64"),
+                "active": pd.Series([], dtype="bool"),
+                "name": pd.Series([], dtype="string"),
+            }
+        )
         frame = ar.from_pandas(df)
         assert frame.dtypes["id"] == "int64"
         assert frame.dtypes["score"] == "float64"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1462,3 +1462,68 @@ def test_from_arrow_table_missing_pyarrow_raises_helpful_import_error():
             _from_arrow_table(None)
     assert "_from_arrow_table() requires pyarrow." in str(exc_info.value)
     assert "pip install arnio[arrow]" in str(exc_info.value)
+
+# ---------------------------------------------------------------------------
+# Issue #1960 — preserve empty pandas int64 dtype in from_pandas
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInt64DtypePreservation:
+    """Regression tests for from_pandas() with zero-row DataFrames.
+
+    Covers: regular int64, nullable Int64, float64, bool, string columns.
+    """
+
+    def test_empty_numpy_int64_roundtrip(self):
+        df = pd.DataFrame({"id": pd.Series([], dtype="int64")})
+        frame = ar.from_pandas(df)
+        assert frame.dtypes["id"] == "int64"
+        result = ar.to_pandas(frame)
+        assert str(result["id"].dtype) == "Int64"
+        assert len(result) == 0
+
+    def test_empty_nullable_int64_roundtrip(self):
+        df = pd.DataFrame({"id": pd.Series([], dtype=pd.Int64Dtype())})
+        frame = ar.from_pandas(df)
+        assert frame.dtypes["id"] == "int64"
+        result = ar.to_pandas(frame)
+        assert str(result["id"].dtype) == "Int64"
+        assert len(result) == 0
+
+    def test_empty_float64_roundtrip(self):
+        df = pd.DataFrame({"score": pd.Series([], dtype="float64")})
+        frame = ar.from_pandas(df)
+        assert frame.dtypes["score"] == "float64"
+        result = ar.to_pandas(frame)
+        assert str(result["score"].dtype) == "float64"
+        assert len(result) == 0
+
+    def test_empty_bool_roundtrip(self):
+        df = pd.DataFrame({"active": pd.Series([], dtype="bool")})
+        frame = ar.from_pandas(df)
+        assert frame.dtypes["active"] == "bool"
+        result = ar.to_pandas(frame)
+        assert str(result["active"].dtype) == "boolean"
+        assert len(result) == 0
+
+    def test_empty_string_roundtrip(self):
+        df = pd.DataFrame({"name": pd.Series([], dtype="string")})
+        frame = ar.from_pandas(df)
+        result = ar.to_pandas(frame)
+        assert str(result["name"].dtype) == "string"
+        assert len(result) == 0
+
+    def test_empty_mixed_schema_roundtrip(self):
+        df = pd.DataFrame({
+            "id": pd.Series([], dtype="int64"),
+            "score": pd.Series([], dtype="float64"),
+            "active": pd.Series([], dtype="bool"),
+            "name": pd.Series([], dtype="string"),
+        })
+        frame = ar.from_pandas(df)
+        assert frame.dtypes["id"] == "int64"
+        assert frame.dtypes["score"] == "float64"
+        assert frame.dtypes["active"] == "bool"
+        result = ar.to_pandas(frame)
+        assert len(result) == 0
+        assert list(result.columns) == ["id", "score", "active", "name"]


### PR DESCRIPTION
## Summary

Fixes the bug where `from_pandas()` loses regular numpy `int64` dtype information for zero-row DataFrames. An empty `int64` column was being converted to an Arnio `string` column, causing `to_pandas()` to return it as `string` instead of `Int64`.

## Root cause

`_pandas_dtype_to_arnio()` in `arnio/convert.py` handled nullable `pd.Int64Dtype()` but did not handle regular numpy `int64`. With no values present, the native frame could not infer the dtype from data, so the column fell back to `string`.

## Fix

Added `str(dtype) == "int64"` check to `_pandas_dtype_to_arnio()` so the dtype hint is correctly passed to `_Frame.from_dict()` for empty columns.

## Tests

Added `TestEmptyInt64DtypePreservation` in `tests/test_convert.py` covering:
- empty numpy `int64` roundtrip
- empty nullable `Int64` roundtrip
- empty `float64` roundtrip
- empty `bool` roundtrip
- empty `string` roundtrip
- empty mixed schema roundtrip

Closes #1960