### PR TITLE
Replace 404 page exception wording with user-friendly copy

### DIFF
--- a/tests/test_website_assets.py
+++ b/tests/test_website_assets.py
@@ -47,3 +47,16 @@ def test_website_asset_references_match_display_context():
 
     index_html = (WEBSITE_DIR / "index.html").read_text(encoding="utf-8")
     assert 'src="arnio-icon.svg" alt="" width="92" height="92"' in index_html
+
+
+def test_404_page_has_no_exception_wording():
+    html = (WEBSITE_DIR / "404.html").read_text(encoding="utf-8")
+    assert "Python Exception" not in html
+    assert "FileNotFoundError" not in html
+
+
+def test_404_page_has_user_friendly_copy_and_navigation():
+    html = (WEBSITE_DIR / "404.html").read_text(encoding="utf-8")
+    assert "Page not found" in html
+    assert "Go Home" in html
+    assert "View Docs" in html

--- a/website/404.html
+++ b/website/404.html
@@ -37,21 +37,10 @@
   <div class="container">
     <article class="docs-content" style="max-width: 800px; margin: 0 auto; text-align: center; padding: 0;">      <h2 style="font-size: 4rem; margin-bottom: 1rem;">404</h2>
 
-      <div class="code-block">
-        <div class="code-block-header">Python Exception</div>
-        <pre><code>FileNotFoundError: Route not found
+      <p style="margin-top: 1rem; font-size: 1.25rem; font-weight: 600;">Page not found</p>
 
-The requested resource could not be located.
-
-Possible causes:
-- The URL was typed incorrectly
-- The page has been moved
-- The link is outdated
-Please use one of the navigation options below.</code></pre>
-      </div>
-
-      <p style="margin-top: 2rem;">
-        Looks like you've wandered outside the Arnio documentation.
+      <p style="margin-top: 1rem;">
+        The page may have moved, or the link may be outdated.
       </p>
 
       <div style="display:flex;justify-content:center;gap:1rem;flex-wrap:wrap;margin-top:2rem;">


### PR DESCRIPTION
## Summary

Fixes #2356. The `website/404.html` page displayed a `code-block` div
styled as a Python exception — `Python Exception` as the header,
`FileNotFoundError: Route not found` in the `<pre><code>` body — making
missing routes look like a backend crash rather than a normal 404.

## Changes

**`website/404.html`**
- Removed the `<div class="code-block">` exception block entirely
- Replaced it with `<p>Page not found</p>` and `<p>The page may have
  moved, or the link may be outdated.</p>`
- All existing nav bar, nav actions (Go Home, View Docs), footer, and
  CSS classes are unchanged

**`tests/test_website_assets.py`**
- `test_404_page_has_no_exception_wording` — asserts `Python Exception`
  and `FileNotFoundError` are absent from `404.html`
- `test_404_page_has_user_friendly_copy_and_navigation` — asserts
  `Page not found`, `Go Home`, and `View Docs` are present

## Verification

HTTP 404 status is unaffected — Vercel serves `404.html` automatically
with status 404 via its static routing config. No `vercel.json` changes
needed.

## Closes

Closes #2356