### PR TITLE
docs: add encoding_errors to read_jsonl docstring and smoke parity check

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1683,7 +1683,8 @@ def read_jsonl_chunked(
     ------
     ValueError
         If the file extension is not ``.jsonl`` or ``.ndjson``, if
-        ``chunksize`` is not positive, or if ``nrows`` is not non-negative.
+        ``chunksize`` is not positive, or if ``nrows`` is not non-negative, or if
+        ``encoding_errors`` is not one of ``"strict"``, ``"replace"``, or ``"ignore"``.
     JsonlReadError
         If the file is empty (no data rows), or if a line contains invalid
         JSON or unsupported nested values. The error message includes the

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1586,6 +1586,11 @@ def read_jsonl(
         Path to the ``.jsonl`` or ``.ndjson`` file.
     encoding : str, default ``"utf-8"``
         File encoding.
+    encoding_errors : str, default ``"strict"``
+        How encoding errors are handled while decoding file bytes.
+        One of ``"strict"`` (raise on invalid bytes), ``"replace"``
+        (substitute the Unicode replacement character), or ``"ignore"``
+        (drop invalid bytes silently).
     nrows : int, optional
         Maximum number of data rows to read.  If ``None``, all rows are read.
 
@@ -1597,8 +1602,9 @@ def read_jsonl(
     Raises
     ------
     ValueError
-        If the file extension is not ``.jsonl`` or ``.ndjson``, or if
-        ``nrows`` is not a non-negative integer.
+        If the file extension is not ``.jsonl`` or ``.ndjson``, if
+        ``nrows`` is not a non-negative integer, or if ``encoding_errors``
+        is not one of ``"strict"``, ``"replace"``, or ``"ignore"``.
     JsonlReadError
         If the file is empty (no data rows), or if a line contains invalid
         JSON or unsupported nested values. The error message includes the
@@ -1608,6 +1614,7 @@ def read_jsonl(
     --------
     >>> frame = ar.read_jsonl("events.jsonl")
     >>> frame = ar.read_jsonl("data.ndjson", nrows=1000)
+    >>> frame = ar.read_jsonl("data.jsonl", encoding_errors="replace")
     """
     _validate_jsonl_encoding(encoding)
 

--- a/tests/smoke_wheel_install.py
+++ b/tests/smoke_wheel_install.py
@@ -104,7 +104,7 @@ def main() -> int:
 
         import_check = (
             "import arnio as ar; "
-            "import tempfile, pathlib; "
+            "import inspect, tempfile, pathlib; "
             "print('arnio import ok:', ar.__version__); "
             "assert hasattr(ar, 'read_csv'); "
             "assert hasattr(ar, 'pipeline'); "
@@ -114,7 +114,14 @@ def main() -> int:
             "csv.write_text('name,age\\nAlice,30\\nBob,25\\n'); "
             "frame = ar.read_csv(str(csv)); "
             "assert frame is not None; "
-            "print('read_csv smoke test passed')"
+            "print('read_csv smoke test passed'); "
+            "sig = inspect.signature(ar.read_jsonl); "
+            "params = sig.parameters; "
+            "assert 'encoding_errors' in params, 'read_jsonl is missing encoding_errors parameter'; "
+            "assert params['encoding_errors'].default == 'strict', 'read_jsonl encoding_errors default must be strict'; "
+            "sig2 = inspect.signature(ar.read_jsonl_chunked); "
+            "assert 'encoding_errors' in sig2.parameters, 'read_jsonl_chunked is missing encoding_errors parameter'; "
+            "print('read_jsonl signature parity check passed')"
         )
 
         run([str(python), "-c", import_check], cwd=tmp_dir)


### PR DESCRIPTION
## Summary
Add `encoding_errors` to the `read_jsonl` docstring and add a signature parity check to the wheel smoke test. The parameter was already wired into the implementation but was missing from the docstring and had no wheel-level regression guard.

## Linked issue
Closes #2364

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [x] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [x] Developer tooling

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately):
```bash
  python scripts/check_docs_utf8.py
  python -m black --check --diff .
  python -m ruff check . --extend-exclude "*.ipynb"
  python -m mypy --config-file mypy.ini
  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
```
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
N/A

## Performance Impact
None.

## GSSoC labels
<!-- Maintainers only -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
Another contributor submitted overlapping work on this issue. I resolved the merge conflicts and scoped this PR to only the two remaining gaps: the `read_jsonl` docstring and the smoke test parity check. No implementation changes were made.