### PR TITLE
fix: validate DateTime format directives at construction time

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -5,6 +5,7 @@ Production data contracts and validation.
 
 from __future__ import annotations
 
+from datetime import datetime
 import json
 import math
 import re
@@ -2486,7 +2487,14 @@ def DateTime(
     """Create a datetime schema field for validating string timestamps."""
     if format is not None and not isinstance(format, str):
         raise TypeError("DateTime format must be a string or None")
-
+    if format is not None:
+        try:
+            datetime.strptime("2000-01-01", format)
+        except ValueError as exc:
+            raise ValueError(
+                f"DateTime format {format!r} contains an invalid or unsupported directive: {exc}"
+            ) from exc
+        
     min_val = _parse_datetime_bound(min, "min")
     max_val = _parse_datetime_bound(max, "max")
     if min_val is not None and max_val is not None and min_val > max_val:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2469,6 +2469,16 @@ def test_datetime_rejects_invalid_format_type():
     with pytest.raises(TypeError, match="format must be a string or None"):
         ar.DateTime(format=123)
 
+        
+def test_datetime_rejects_invalid_format_directive():
+    with pytest.raises(ValueError, match="invalid or unsupported directive"):
+        ar.DateTime(format="bad-%Q")
+
+
+def test_datetime_accepts_valid_custom_format():
+    field = ar.DateTime(format="%Y-%m-%d")
+    assert field.format == "%Y-%m-%d"        
+
 
 def test_datetime_rejects_invalid_boundary_values():
     with pytest.raises(ValueError, match="min must be a parseable datetime scalar"):


### PR DESCRIPTION
## Summary
Adds fail-fast validation of the `format` argument in `DateTime()`. Previously, invalid directives like `bad-%Q` were accepted at construction time and only raised a confusing pandas-origin `ValueError` later during validation. Now `DateTime(format=...)` validates the format string immediately using `datetime.strptime` and raises a clear `ValueError` at construction time.

## Linked issue
Fixes #1825 

## Type of change
- [x] Bug fix
- [x] Tests

## Area
- [x] Schema validation
- [x] Python API / ArFrame

## Testing

```bash
python3 -m pytest arnio/tests/test_schema.py -k "datetime_rejects_invalid_format or datetime_accepts_valid_custom" -v
```

All 3 tests passed:
- `test_datetime_rejects_invalid_format_type` (existing)
- `test_datetime_rejects_invalid_format_directive` (new)
- `test_datetime_accepts_valid_custom_format` (new)

- [x] `python -m pytest tests -v --tb=short -x`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: validate DateTime format directives at construction time`).