### PR TITLE
fix: restore public exports and main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           cache: 'pip'
 
       - name: Install lint dependencies
-        run: pip install "black>=24.0" "ruff>=0.4.0" "mypy>=1.0" pandas-stubs types-setuptools
+        run: pip install "black>=24.0" "ruff>=0.4.0" "mypy>=1.0,<2.0" pandas-stubs types-PyYAML types-setuptools
 
       - name: Documentation UTF-8 check
         run: python scripts/check_docs_utf8.py

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'pip'
 
       - name: Install audit tools
-        run: pip install pip-audit
+        run: python -m pip install --upgrade pip pip-audit
 
       - name: Install full dependency tree
         run: pip install -e ".[dev,arrow,sklearn,parquet]"

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -25,6 +25,7 @@ from .cleaning import (
     find_fuzzy_duplicates,
     keep_rows_with_nulls,
     normalize_case,
+    normalize_minmax,
     normalize_unicode,
     normalize_whitespace,
     parse_bool_strings,
@@ -42,6 +43,7 @@ from .cleaning import (
     winsorize_outliers,
 )
 from .convert import from_dict, from_pandas, from_polars, to_arrow, to_pandas, to_polars
+from .encode_categorical import encode_categorical
 from .exceptions import (
     ArnioError,
     CsvReadError,
@@ -120,7 +122,7 @@ from .schema import (
     register_validator,
     validate,
 )
-from .schema_export import schema_to_dict, schema_to_yaml
+from .schema_export import schema_from_yaml, schema_to_dict, schema_to_yaml
 
 from_records = ArFrame.from_records
 
@@ -156,6 +158,7 @@ __all__ = [
     "clean_column_names",
     "clip_numeric",
     "winsorize_outliers",
+    "normalize_minmax",
     "coalesce_columns",
     "combine_columns",
     "rename_columns_matching",
@@ -242,9 +245,11 @@ __all__ = [
     "Custom",
     "register_validator",
     "Date",
+    "schema_from_yaml",
     "schema_to_dict",
     "schema_to_yaml",
     "save_pipeline",
     "load_pipeline",
     "PipelineSerializationError",
+    "encode_categorical",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,9 @@ dev = [
     "PyYAML>=6.0",
     "duckdb>=1.0",
     "tomli; python_version < '3.11'",
-    "mypy>=1.0",
+    "mypy>=1.0,<2.0",
     "pandas-stubs",
+    "types-PyYAML",
     "types-setuptools",
 ]
 sklearn = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,4 +94,3 @@ def csv_with_empty_columns(tmp_path):
     path = tmp_path / "empty_columns.csv"
     path.write_text(csv_content)
     return str(path)
-

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -891,7 +891,7 @@ class TestDropColumns:
             )
 
 
-class TestDropEmptyColumns:
+class TestDropEmptyColumnsPipeline:
     def test_drop_empty_columns_all_empty(self, csv_with_empty_columns):
         frame = ar.read_csv(csv_with_empty_columns)
         result = ar.drop_empty_columns(frame)

--- a/tests/test_encode_categorical.py
+++ b/tests/test_encode_categorical.py
@@ -6,6 +6,12 @@ import pytest
 import arnio as ar
 from arnio.encode_categorical import encode_categorical
 
+
+def test_encode_categorical_is_exported():
+    assert ar.encode_categorical is encode_categorical
+    assert "encode_categorical" in ar.__all__
+
+
 # ── fixtures ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- restore the accidentally removed top-level exports for `normalize_minmax`, `schema_from_yaml`, and `encode_categorical`
- fix the Black and Ruff blockers currently hidden in the main lint job
- keep mypy compatible with Arnio's Python 3.9 target and install the missing PyYAML stubs
- add regression coverage for the `encode_categorical` public export

## Root cause
PR #2104 replaced parts of `arnio/__init__.py` while adding pipeline serialization, unintentionally dropping three existing public exports. The latest main run consequently failed 39 tests across every OS/Python job. The lint job also stopped at a trailing blank line before reaching a duplicate test-class name and dependency-version issues.

## Verification
- `black --check --diff` over all tracked Python files
- `ruff check .` (excluding local untracked QA artifacts)
- `mypy --config-file mypy.ini` in an isolated Python 3.12 environment matching CI dependencies
- `python scripts/check_docs_utf8.py`
- AST public-export smoke check
- pre-commit hooks: Black and Ruff passed

Local pytest execution could not build the C++ extension because this Windows host does not have MSVC/NMake installed. GitHub Actions provides the authoritative native build and full test matrix.