### PR TITLE
Validate schema severity type before allowed-value checks

### DIFF
--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -196,6 +196,8 @@ _ALLOWED_SCHEMA_KEYS = {
 
 def _validate_severity(severity: str) -> None:
     """Raise ValueError if severity is not 'error' or 'warning'."""
+    if not isinstance(severity, str):
+        raise TypeError("severity must be a string")
     if severity not in _VALID_SEVERITIES:
         raise ValueError("severity must be 'error' or 'warning'")
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,6 +3,7 @@
 import io
 import json
 import warnings
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -1943,6 +1944,38 @@ def test_int64_rejects_impossible_bounds():
 def test_invalid_severity_raises():
     with pytest.raises(ValueError, match="severity must be"):
         ar.Int64(severity="warn")
+
+
+def test_field_constructors_reject_non_string_severity():
+    list_severity: Any = ["error"]
+    int_severity: Any = 1
+    none_severity: Any = None
+
+    with pytest.raises(TypeError, match="severity must be a string"):
+        ar.Email(severity=list_severity)
+
+    with pytest.raises(TypeError, match="severity must be a string"):
+        ar.Int64(severity=int_severity)
+
+    with pytest.raises(TypeError, match="severity must be a string"):
+        ar.Int64(severity=none_severity)
+
+
+def test_field_constructors_accept_valid_severities():
+    assert ar.Int64(severity="error").severity == "error"
+    assert ar.Email(severity="warning").severity == "warning"
+
+
+def test_validation_issue_rejects_non_string_severity():
+    list_severity: Any = ["error"]
+
+    with pytest.raises(TypeError, match="severity must be a string"):
+        ar.ValidationIssue(
+            column="score",
+            rule="custom",
+            message="bad",
+            severity=list_severity,
+        )
 
 
 def test_float64_rejects_impossible_bounds():


### PR DESCRIPTION
## Summary
- validate schema severity values are strings before checking allowed values
- preserve the existing ValueError for unsupported severity strings
- add regression coverage for field constructors and ValidationIssue non-string severities

Fixes #1790

## Tests
- uv run pytest -q tests/test_schema.py
- uv run ruff check .
- uv run pytest -q

Note: uv run pyright could not be run locally because pyright is not installed in the project environment. uv run ruff format --check . reports pre-existing formatting differences across unrelated files on current upstream/main, so the PR avoids broad formatting churn.