### PR TITLE
Fix Quality Reports exclude_columns docs example

### DIFF
--- a/website/docs.html
+++ b/website/docs.html
@@ -181,8 +181,11 @@ payload = frame.to_dict()</code></pre></div>
         <div class="code-block"><div class="code-block-header">Python</div><pre><code class="language-python">report = ar.profile(frame, exclude_columns=["private_notes"])
 report.to_markdown()
 report.to_html("quality.html")
-report.to_dict(exclude_columns=["private_notes"])
+report.to_dict()
 report.to_json()
+
+full_report = ar.profile(frame)
+full_report.to_dict(exclude_columns=["private_notes"])
 
 baseline = ar.profile(old_frame)
 current = ar.profile(new_frame)


### PR DESCRIPTION
## Summary
- update the Quality Reports docs snippet to avoid excluding private_notes twice
- show the alternate export-time exclude_columns pattern separately

Fixes #2369

## Tests
- uv run pytest -q tests/test_website_api_docs.py tests/test_website_assets.py tests/test_docs_utf8_check.py
- uv run ruff check .
- uv run pytest -q

## Notes
- uv run pyright fails in this environment because pyright is not installed: Failed to spawn: pyright; No such file or directory.
- uv run ruff format --check . reports pre-existing formatting drift across 32 files unrelated to this docs-only change.