### PR TITLE
Validate slugify_column_names input frame

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -2493,6 +2493,8 @@ def clean_column_names(
 def slugify_column_names(frame, on_duplicates="raise"):
     import re
 
+    import pandas as pd
+
     from .convert import from_pandas, to_pandas
     from .frame import ArFrame
 
@@ -2500,6 +2502,9 @@ def slugify_column_names(frame, on_duplicates="raise"):
         raise ValueError("on_duplicates must be 'raise'")
 
     is_arframe = isinstance(frame, ArFrame)
+    if not is_arframe and not isinstance(frame, pd.DataFrame):
+        raise TypeError("frame must be an ArFrame or pandas.DataFrame")
+
     df = to_pandas(frame) if is_arframe else frame
 
     new_cols = []

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4795,6 +4795,13 @@ class TestSlugifyColumnNames:
         with pytest.raises(ValueError):
             ar.slugify_column_names(frame, on_duplicates="ignore")
 
+    @pytest.mark.parametrize("frame", [None, [], {"a": [1]}])
+    def test_non_frame_input_raises_typeerror(self, frame):
+        with pytest.raises(
+            TypeError, match="frame must be an ArFrame or pandas.DataFrame"
+        ):
+            ar.slugify_column_names(frame)
+
 
 class TestRenameColumnsMatching:
     def test_basic_rename(self):


### PR DESCRIPTION
## Summary
- validate slugify_column_names input before accessing .columns
- raise a clear TypeError for non-ArFrame and non-pandas DataFrame inputs
- add regression coverage for None, list, and dict inputs

Fixes #2466

## Tests
- uv run pytest -q tests/test_cleaning.py -k slugify
- uv run ruff check .
- uv run pytest -q

## Notes
- uv run pyright fails in this environment because pyright is not installed: Failed to spawn: pyright; No such file or directory.
- uv run ruff format --check . reports pre-existing formatting drift across 32 files unrelated to this change. A focused ruff format diff for tests/test_cleaning.py only shows older unrelated lines.