### PR TITLE
Validate schema export field names before sorting

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -174,6 +174,13 @@ def _normalize_serializable(value: Any) -> Any:
     return value
 
 
+def _validate_schema_field_names(raw_fields: dict[Any, Any]) -> None:
+    """Require schema field names to be strings before sorting or emitting."""
+    for field_name in raw_fields:
+        if not isinstance(field_name, str):
+            raise TypeError("schema field names must be strings")
+
+
 def _emit_value(value: Any, depth: int) -> str:
     """Recursively emit *value* at the given indentation *depth*."""
     indent = _INDENT * depth
@@ -278,8 +285,11 @@ def schema_to_dict(schema: dict | Any) -> dict:
                 "Remove schema.rules before exporting."
             )
 
+        raw_fields = schema.fields
+        _validate_schema_field_names(raw_fields)
+
         normalised: dict = {}
-        for name, field in schema.fields.items():
+        for name, field in raw_fields.items():
             if isinstance(field, dict):
                 raw_field = field
             elif hasattr(field, "dtype"):
@@ -320,6 +330,7 @@ def schema_to_dict(schema: dict | Any) -> dict:
             raw_fields = schema
             metadata = {}
 
+        _validate_schema_field_names(raw_fields)
         normalised = {}
 
         for field_name in sorted(raw_fields.keys()):

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -79,6 +79,28 @@ class TestSchemaToDict:
         with pytest.raises(TypeError, match="Expected a dict"):
             schema_to_dict(42)
 
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            {1: "INT64"},
+            {"fields": {1: "INT64"}},
+            {"name": "STRING", 1: "INT64"},
+            {"fields": {"name": "STRING", 1: "INT64"}},
+        ],
+    )
+    def test_non_string_field_names_raise_typeerror(self, raw):
+        with pytest.raises(TypeError, match="schema field names must be strings"):
+            schema_to_dict(raw)
+
+        with pytest.raises(TypeError, match="schema field names must be strings"):
+            schema_to_yaml(raw)
+
+    def test_schema_object_non_string_field_name_raises_typeerror(self):
+        schema = _FakeSchema({1: _FakeField(type="INT64")})
+
+        with pytest.raises(TypeError, match="schema field names must be strings"):
+            schema_to_dict(schema)
+
 
 class TestSchemaToYamlOutput:
     def test_basic_output(self):


### PR DESCRIPTION
## Summary
- validate schema export field names before sorting raw field mappings
- raise a clear TypeError for non-string field names in flat, structured, and Schema-like inputs
- add regression coverage for all-non-string and mixed field-name mappings

Fixes #2470

## Tests
- uv run pytest -q tests/test_schema_export.py
- uv run ruff check .
- uv run pytest -q

## Notes
- uv run pyright fails in this environment because pyright is not installed: Failed to spawn: pyright; No such file or directory.
- uv run ruff format --check . reports pre-existing formatting drift across 32 files unrelated to this change. A focused ruff format diff for arnio/schema_export.py and tests/test_schema_export.py only shows older unrelated lines.