### PR TITLE
fix: validate orient type in ArFrame.to_dict

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -461,6 +461,10 @@ class ArFrame:
         >>> frame.to_dict()
         {'name': ['Alice', 'Bob'], 'age': [25, 30]}
         """
+        # STEP 1: Validate orient is strictly a string to prevent unhashable raw leaks
+        if not isinstance(orient, str):
+            raise TypeError("orient must be a string")
+
         col_names = self.columns
         num_cols = self.shape[1]
         data = {

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1713,3 +1713,24 @@ def test_from_records_dict_explicit_valid_columns_subset():
     assert frame.shape == (2, 1)
     assert frame.columns == ["a"]
     assert frame["a"] == [1, 3]
+
+
+def test_to_dict_invalid_orient_types():
+    data = {"name": ["Alice", "Bob"], "age": [25, 30]}
+    frame = ar.from_dict(data)
+
+    # 1. Unhashable list input must raise TypeError cleanly
+    with pytest.raises(TypeError, match="orient must be a string"):
+        frame.to_dict(orient=["list"])
+
+    # 2. Unhashable dict input must raise TypeError cleanly
+    with pytest.raises(TypeError, match="orient must be a string"):
+        frame.to_dict(orient={"mode": "list"})
+
+    # 3. Hashable non-string input (like int) must also raise TypeError cleanly
+    with pytest.raises(TypeError, match="orient must be a string"):
+        frame.to_dict(orient=1)
+
+    # 4. Backward Compatibility: Unsupported string must still raise ValueError
+    with pytest.raises(ValueError, match="orient must be one of: list, records, split"):
+        frame.to_dict(orient="invalid_string")


### PR DESCRIPTION
## Summary
- Added an explicit `isinstance(orient, str)` type check in `ArFrame.to_dict()` before evaluating set membership to safely prevent raw Python `TypeError: unhashable type` leaks when users pass mutable objects like lists or dictionaries.
- Preserved the existing `ValueError` contract for invalid/unsupported string inputs and maintained backward compatibility for all valid orientations.
- Added comprehensive regression tests covering unhashable lists, unhashable dictionaries, hashable non-strings (integers), and invalid strings.

## Linked issue
Fixes #2472

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Ran focused pytest targeting the new regression tests along with formatting checks locally:
```bash
pytest tests/test_frame.py -k test_to_dict_invalid_orient_types
python -m ruff check --fix arnio/frame.py tests/test_frame.py
python -m black arnio/frame.py tests/test_frame.py