### PR TITLE
fix(csv): format double fields with to_chars

### DIFF
--- a/cpp/src/csv_writer.cpp
+++ b/cpp/src/csv_writer.cpp
@@ -1,13 +1,14 @@
 #include "arnio/csv_writer.h"
 
+#include <charconv>
+#include <cstdio>
 #ifdef _WIN32
 #include <filesystem>
 #endif
 #include <fstream>
-#include <iomanip>
 #include <limits>
-#include <sstream>
 #include <stdexcept>
+#include <system_error>
 #include <variant>
 
 #include "arnio/frame.h"
@@ -20,6 +21,28 @@ inline void open_binary_output(std::ofstream& file, const std::string& path) {
     file.open(std::filesystem::u8path(path), std::ios::binary);
 #else
     file.open(path, std::ios::binary);
+#endif
+}
+
+inline std::string format_double(double value) {
+    char num_buffer[64];
+
+#if defined(__APPLE__) && defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
+    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130300
+    const int written = std::snprintf(num_buffer, sizeof(num_buffer), "%.*g",
+                                      std::numeric_limits<double>::max_digits10, value);
+    if (written < 0 || static_cast<size_t>(written) >= sizeof(num_buffer)) {
+        throw std::runtime_error("Failed to format floating-point CSV value");
+    }
+    return std::string(num_buffer, static_cast<size_t>(written));
+#else
+    const auto [ptr, ec] =
+        std::to_chars(num_buffer, num_buffer + sizeof(num_buffer), value,
+                      std::chars_format::general, std::numeric_limits<double>::max_digits10);
+    if (ec != std::errc()) {
+        throw std::runtime_error("Failed to format floating-point CSV value");
+    }
+    return std::string(num_buffer, ptr);
 #endif
 }
 }  // namespace
@@ -75,10 +98,7 @@ std::string CsvWriter::cell_to_string(const Frame& frame, size_t row, size_t col
         return std::to_string(std::get<int64_t>(cell));
     }
     if (std::holds_alternative<double>(cell)) {
-        std::ostringstream oss;
-        oss << std::setprecision(std::numeric_limits<double>::max_digits10)
-            << std::get<double>(cell);
-        return oss.str();
+        return format_double(std::get<double>(cell));
     }
     if (std::holds_alternative<bool>(cell)) {
         return std::get<bool>(cell) ? "true" : "false";

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -99,6 +99,14 @@ class TestWriteCsv:
         df = ar.to_pandas(frame2)
         assert abs(df["val"].iloc[0] - 1.23456789012345678) < 1e-15
 
+    def test_high_precision_float_writes_max_digits10(self, tmp_path):
+        frame = ar.from_pandas(pd.DataFrame({"val": [1.2345678901234567]}))
+        out = tmp_path / "float.csv"
+
+        ar.write_csv(frame, out)
+
+        assert out.read_text(encoding="utf-8") == "val\n1.2345678901234567\n"
+
     def test_invalid_delimiter(self, tmp_path):
         frame = ar.from_pandas(pd.DataFrame({"a": [1]}))
         with pytest.raises(ValueError, match="delimiter must be a single character"):


### PR DESCRIPTION
## Summary
Fixes #1034

This PR keeps the change scoped to the maintainer-approved `cell_to_string()` double-formatting path. The writer still returns a string for each cell, so existing CSV quoting, delimiter handling, and line terminator behavior stay on the same path.

What changed:
- replaced the `std::ostringstream` double formatting branch with `std::to_chars`;
- kept `std::chars_format::general` with `max_digits10` so high-precision values keep the existing round-trip-oriented precision contract;
- added a stack-buffer `snprintf("%.17g")` fallback only for older macOS deployment targets where AppleClang marks floating-point `std::to_chars` unavailable;
- handle `std::errc` explicitly and fail with a clear runtime error if formatting fails;
- added raw output regression coverage for a high-precision float value.

## Linked issue
Fixes #1034

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately):
```bash
  python scripts/check_docs_utf8.py
  python -m black --check --diff .
  python -m ruff check . --extend-exclude "*.ipynb"
  python -m mypy --config-file mypy.ini
  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
  ```
- [x] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:

Validation I ran:
- `.venv/bin/python -m pytest tests/test_write_csv.py` - 82 passed
- `.venv/bin/python -m pytest` - 3494 passed, 106 skipped
- `.venv/bin/python -m ruff check tests/test_write_csv.py` - passed
- `.venv/bin/clang-format --dry-run --Werror cpp/src/csv_writer.cpp` - passed
- `/usr/bin/clang++ -std=gnu++17 -arch arm64 -mmacosx-version-min=11.0 -Icpp/include -c cpp/src/csv_writer.cpp -o /private/tmp/arnio_csv_writer_macos11.o` - passed
- `git diff --check` - passed

Note: the first full pytest run inside the restricted shell failed only because local loopback socket binding was blocked for `tests/test_remote_csv.py`. Re-running the same command with loopback permission passed the full suite.

## Screenshots / Media
Not applicable.

## Performance Impact
This removes the `std::ostringstream` construction from double cell formatting and uses a fixed stack buffer for the conversion. On macOS deployment targets below 13.3, AppleClang exposes floating-point `std::to_chars` as unavailable, so that path uses stack-buffer `snprintf` to keep the wheel build compatible without going back to stream formatting. I did not run benchmarks because the PR is intentionally limited to the approved writer formatting path.

## GSSoC labels
This is for GSSoC 2026 and stays scoped to the assigned issue. Please add the appropriate GSSoC approval/scoring labels if this matches the maintainer-approved scope.

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
I did not rewrite the row writer into a direct `out.write()` pipeline. The change stays inside the existing `cell_to_string()` contract as requested.

No docs/examples were changed because this does not add a public API option or new user-facing parameter.
