### PR TITLE
Fix mixed schema export set ordering

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -166,12 +166,19 @@ def _normalize_serializable(value: Any) -> Any:
     # Convert sets into deterministic sorted lists since YAML
     # emission only supports list-like serialized output.
     if isinstance(value, set):
-        return sorted(_normalize_serializable(v) for v in value)
+        return sorted(
+            (_normalize_serializable(v) for v in value),
+            key=_serializable_sort_key,
+        )
 
     if isinstance(value, list):
         return [_normalize_serializable(v) for v in value]
 
     return value
+
+
+def _serializable_sort_key(value: Any) -> tuple[str, str]:
+    return (type(value).__name__, repr(value))
 
 
 def _emit_value(value: Any, depth: int) -> str:
@@ -528,7 +535,7 @@ def schema_from_yaml(source: str | os.PathLike) -> Schema:
 
     if payload is None:
         raise ValueError(
-            "Schema YAML is empty. " "Expected a mapping with at least a 'fields' key."
+            "Schema YAML is empty. Expected a mapping with at least a 'fields' key."
         )
 
     if not isinstance(payload, dict):

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -262,6 +262,18 @@ def test_set_valued_allowed_normalized():
     assert result["fields"]["status"]["allowed"] == ["a", "b", "c"]
 
 
+def test_mixed_scalar_set_valued_allowed_normalized():
+    raw = {"code": {"type": "STRING", "allowed": {1, "1"}}}
+    result = schema_to_dict(raw)
+    assert result["fields"]["code"]["allowed"] == [1, "1"]
+
+
+def test_none_and_string_set_valued_allowed_normalized():
+    raw = {"status": {"type": "STRING", "allowed": {None, "missing"}}}
+    result = schema_to_dict(raw)
+    assert result["fields"]["status"]["allowed"] == [None, "missing"]
+
+
 def test_real_schema_field_dtype():
     schema = ar.Schema({"price": ar.Field(dtype="float64", nullable=False)})
     result = schema_to_dict(schema)
@@ -657,7 +669,7 @@ class TestSchemaFromYaml:
         """A YAML payload with rules_omitted: true must emit a UserWarning."""
         import arnio as ar
 
-        yaml_text = "fields:\n" "  x:\n" "    dtype: string\n" "rules_omitted: true\n"
+        yaml_text = "fields:\n  x:\n    dtype: string\nrules_omitted: true\n"
         with pytest.warns(UserWarning, match="rules_omitted"):
             schema = ar.schema_from_yaml(yaml_text)
 


### PR DESCRIPTION
## Summary
- normalize set-valued schema export fields with a deterministic cross-type sort key
- add regression coverage for mixed scalar and None/string allowed sets

## Tests
- .venv/bin/ruff check .
- .venv/bin/ruff format --check arnio/schema_export.py tests/test_schema_export.py
- .venv/bin/pytest -q tests/test_schema_export.py