### PR TITLE
fix: validate winsorize bounds before comparisons

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -847,6 +847,14 @@ def winsorize_outliers(
     >>> clean = ar.winsorize_outliers(frame, lower=0.01, upper=0.99, subset=["revenue"])
     """
     _validate_arframe(frame)
+
+    for name, value in (("lower", lower), ("upper", upper)):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"'{name}' must be an int or float")
+
+        if not math.isfinite(value):
+            raise ValueError(f"'{name}' must be finite")
+
     if lower < 0 or upper > 1:
         raise ValueError("lower and upper must be between 0 and 1")
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -309,6 +309,32 @@ class TestWinsorizeOutliers:
         with pytest.raises(ValueError):
             ar.winsorize_outliers(frame, lower=lower, upper=upper)
 
+    def test_winsorize_outliers_rejects_boolean_bounds(self):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(TypeError, match="'lower' must be an int or float"):
+            ar.winsorize_outliers(frame, lower=True)
+
+        with pytest.raises(TypeError, match="'upper' must be an int or float"):
+            ar.winsorize_outliers(frame, upper=False)
+
+    @pytest.mark.parametrize("value", ["0.1", None, object()])
+    def test_winsorize_outliers_rejects_non_numeric_bounds(self, value):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(TypeError, match="'lower' must be an int or float"):
+            ar.winsorize_outliers(frame, lower=value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [float("nan"), float("inf"), float("-inf")],
+    )
+    def test_winsorize_outliers_rejects_non_finite_bounds(self, value):
+        frame = ar.from_pandas(pd.DataFrame({"value": [1, 2, 3]}))
+
+        with pytest.raises(ValueError, match="finite"):
+            ar.winsorize_outliers(frame, lower=value)
+
     def test_winsorize_outliers_identical_values_noop(self):
         frame = ar.from_pandas(pd.DataFrame({"value": [5, 5, 5]}))
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? Keep this short but specific. -->

Adds explicit validation for `winsorize_outliers()` bounds before percentile comparisons and range checks.

* Rejects boolean bounds with a clear `TypeError`
* Rejects non-numeric bounds with a clear `TypeError`
* Rejects non-finite bounds (`NaN`, `inf`, `-inf`) with a clear `ValueError`
* Preserves existing valid percentile behavior
* Adds focused regression tests for each invalid bound category

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue

<!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->

Closes #2457

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

<!-- Paste commands you ran and summarize the result. -->

* [x] `make test` (or `python -m pytest tests -v --cov=arnio`)

Result:

```text
3538 passed, 107 skipped, 4 warnings in 142.96s
Coverage: 92%
```

* [ ] `make lint` (or run separately)

Ran:

```bash
python -m mypy --config-file mypy.ini
```

Result:

```text
Success: no issues found in 20 source files
```

Pre-commit hooks executed during commit:

* black (reformatted files successfully)

* ruff (passed)

* [x] optionally `python -m pytest tests -v --tb=short -x`

Result:

```text
3538 passed, 107 skipped, 4 warnings in 133.67s
```

* [x] Other:

```bash
python -m pytest tests/test_cleaning.py
```

Result:

```text
567 passed in 6.96s
```

```bash
python -m pytest tests/test_cleaning.py -k winsorize
```

Result:

```text
22 passed, 545 deselected
```

## Screenshots / Media

<!-- If this PR changes the UI, README visuals, or terminal output, add a screenshot or GIF. -->

N/A

## Performance Impact

<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

N/A

## GSSoC labels

<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

Keeps the change scoped to winsorize_outliers() bound validation and associated regression tests only.