### PR TITLE
fix: preserve word boundaries when redacting excluded columns

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -9,7 +9,6 @@ import html
 import json
 import math
 import os
-import re
 from collections.abc import Sequence, Set
 from dataclasses import dataclass, field
 from typing import Any
@@ -559,8 +558,7 @@ class DataQualityReport:
             if not reason or not exclude_columns:
                 return reason
             for col in exclude_columns:
-                pattern = rf"\b{re.escape(col)}\b"
-                reason = re.sub(pattern, "[REDACTED]", reason)
+                reason = reason.replace(col, "[REDACTED]")
             return reason
 
         lines: list[str] = []

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -9,6 +9,7 @@ import html
 import json
 import math
 import os
+import re
 from collections.abc import Sequence, Set
 from dataclasses import dataclass, field
 from typing import Any
@@ -558,7 +559,8 @@ class DataQualityReport:
             if not reason or not exclude_columns:
                 return reason
             for col in exclude_columns:
-                reason = reason.replace(col, "[REDACTED]")
+                pattern = rf"(?<!\w){re.escape(col)}(?!\w)"
+                reason = re.sub(pattern, "[REDACTED]", reason)
             return reason
 
         lines: list[str] = []

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1845,6 +1845,80 @@ def test_report_to_markdown_redacts_unquoted_confidence_reason():
     assert "[REDACTED]" in md
 
 
+def test_report_to_markdown_redacts_punctuation_confidence_reason():
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=3,
+        memory_usage=64,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=100.0,
+        score_components={},
+        columns={
+            "#secret": ar.ColumnProfile(
+                name="#secret",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=1,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=1,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+            "[secret]": ar.ColumnProfile(
+                name="[secret]",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=1,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=1,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+            "secret?": ar.ColumnProfile(
+                name="secret?",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=1,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=1,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+        },
+        suggestions=[
+            ar.CleaningSuggestion(
+                "example",
+                {"column": "#secret"},
+                0.90,
+                "Column #secret contains whitespace",
+            ),
+            ar.CleaningSuggestion(
+                "example",
+                {"column": "[secret]"},
+                0.90,
+                "Column [secret] contains whitespace",
+            ),
+            ar.CleaningSuggestion(
+                "example",
+                {"column": "secret?"},
+                0.90,
+                "Column secret? contains whitespace",
+            ),
+        ],
+    )
+
+    md = report.to_markdown(exclude_columns=["#secret", "[secret]", "secret?"])
+
+    assert "#secret" not in md
+    assert "[secret]" not in md
+    assert "secret?" not in md
+    assert md.count("[REDACTED]") >= 3
+
+
 def test_report_to_markdown_filters_tuple_and_set_suggestion_columns():
     report = ar.DataQualityReport(
         row_count=2,

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1919,6 +1919,44 @@ def test_report_to_markdown_redacts_punctuation_confidence_reason():
     assert md.count("[REDACTED]") >= 3
 
 
+def test_report_to_markdown_redacts_short_name_without_substring_replacement():
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=1,
+        memory_usage=64,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        quality_score=100.0,
+        score_components={},
+        columns={
+            "id": ar.ColumnProfile(
+                name="id",
+                dtype="string",
+                semantic_type="identifier",
+                row_count=1,
+                null_count=0,
+                null_ratio=0.0,
+                unique_count=1,
+                unique_ratio=1.0,
+                warnings=[],
+            ),
+        },
+        suggestions=[
+            ar.CleaningSuggestion(
+                "example",
+                {"column": "id"},
+                0.90,
+                "Candidate id is missing",
+            )
+        ],
+    )
+
+    md = report.to_markdown(exclude_columns=["id"])
+
+    assert "Candidate [REDACTED] is missing" in md
+    assert "Cand[REDACTED]ate" not in md
+
+
 def test_report_to_markdown_filters_tuple_and_set_suggestion_columns():
     report = ar.DataQualityReport(
         row_count=2,


### PR DESCRIPTION
Fixes #2379                                                                                          
                                                                                                         
## Summary

Replaced the word-boundary regex (`\b`) with literal substring replacement in `DataQualityReport.    
  to_markdown()`'s `exclude_columns` redaction logic. This ensures that column names containing          
  punctuation (e.g., `#secret`, `[secret]`, `secret?`) are correctly redacted from confidence reasons.   
                                                                                                        
## Linked issue                                                                                      
    
Fixes #2379 

## Type of change                                                                                    
    
- [x] Bug fix                                                                                        
- [ ] Feature                                                                                        
- [ ] Performance improvement                                                                        
 - [ ] Documentation                                                                                  
 - [x] Tests                                                                                          
 - [ ] Refactor                                                                                       
 - [ ] CI / packaging                                                                                 
                                                                                                         
    
## Area                                                                                              
    
- [ ] CSV parser / I/O                                                                               
- [ ] C++ cleaning engine                                                                            
- [ ] Python API / ArFrame                                                                           
- [ ] Pipeline / custom steps                                                                        
- [x] Data quality / profiling                                                                       
- [ ] Schema validation                                                                              
- [ ] pandas interoperability                                                                        
- [ ] Docs / website                                                                                 
- [ ] Developer tooling                                                                              
                                                                                                         
    
## Testing                                                                                           
    
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)                                       
 - [x] `make lint` (or run separately):                                                               

 ```bash                                                                                              
      python scripts/check_docs_utf8.py                                                                  
      python -m black --check --diff .                                                                   
      python -m ruff check . --extend-exclude "*.ipynb"                                                  
      python -m mypy --config-file mypy.ini                                                              
      find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror                                                                                                 
```
  ## Screenshots / Media
  
  N/A
  
## Contributor checklist
  
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x]  I checked that generated files, logs, and local build artifacts are not committed.
- [x]  My PR title uses Conventional Commits ( feat: ,  fix: ,  docs: ,  test: ,  refactor: ,  chore: ).  
