### PR TITLE
feat: add UUID, IPv4, and MACAddress semantic validators

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -98,6 +98,7 @@ from .quality import (
 )
 from .schema import (
     URL,
+    UUID,
     Bool,
     CountryCode,
     CurrencyCode,
@@ -108,7 +109,9 @@ from .schema import (
     Field,
     Float64,
     Int64,
+    IPv4,
     LanguageCode,
+    MACAddress,
     PhoneNumber,
     Regex,
     Schema,
@@ -254,4 +257,7 @@ __all__ = [
     "load_pipeline",
     "PipelineSerializationError",
     "encode_categorical",
+    "UUID",  # ← add
+    "IPv4",  # ← add
+    "MACAddress",
 ]

--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -257,7 +257,7 @@ __all__ = [
     "load_pipeline",
     "PipelineSerializationError",
     "encode_categorical",
-    "UUID",  # ← add
-    "IPv4",  # ← add
+    "UUID",
+    "IPv4",
     "MACAddress",
 ]

--- a/arnio/schema.py
+++ b/arnio/schema.py
@@ -2557,6 +2557,116 @@ def Date(
     )
 
 
+def UUID(
+    *,
+    nullable: bool = True,
+    unique: bool = False,
+    severity: str = "error",
+    required_if: tuple[str, Any] | None = None,
+) -> Field:
+    """Create a UUID schema field.
+
+    Validates the canonical 8-4-4-4-12 hexadecimal format (RFC 4122).
+    Both upper- and lower-case hex digits are accepted. Version and
+    variant bits are not enforced so nil UUIDs and DB-generated
+    identifiers all pass.
+
+    Args:
+        nullable: Whether null values are allowed.
+        unique: Whether non-null values must be unique.
+        severity: Severity level for validation issues.
+        required_if: Conditional requirement as a column/value pair.
+
+    Returns:
+        Field: Configured UUID schema field.
+
+    Examples
+    --------
+    >>> schema = ar.Schema({"device_id": ar.UUID(nullable=False, unique=True)})
+    """
+    return Field(
+        dtype="string",
+        nullable=nullable,
+        semantic="uuid",
+        unique=unique,
+        required_if=required_if,
+        severity=severity,
+    )
+
+
+def IPv4(
+    *,
+    nullable: bool = True,
+    unique: bool = False,
+    severity: str = "error",
+    required_if: tuple[str, Any] | None = None,
+) -> Field:
+    """Create a strict IPv4-address schema field.
+
+    Validates dotted-decimal notation (e.g. ``192.168.1.1``) with each
+    octet constrained to 0–255 and leading zeros rejected. IPv6 is
+    intentionally out of scope; use ``ar.Regex()`` for that format.
+
+    Args:
+        nullable: Whether null values are allowed.
+        unique: Whether non-null values must be unique.
+        severity: Severity level for validation issues.
+        required_if: Conditional requirement as a column/value pair.
+
+    Returns:
+        Field: Configured IPv4-address schema field.
+
+    Examples
+    --------
+    >>> schema = ar.Schema({"server_ip": ar.IPv4(nullable=False)})
+    """
+    return Field(
+        dtype="string",
+        nullable=nullable,
+        semantic="ipv4",
+        unique=unique,
+        required_if=required_if,
+        severity=severity,
+    )
+
+
+def MACAddress(
+    *,
+    nullable: bool = True,
+    unique: bool = False,
+    severity: str = "error",
+    required_if: tuple[str, Any] | None = None,
+) -> Field:
+    """Create a MAC-address schema field.
+
+    Validates IEEE 802 MAC-48 addresses in colon-separated
+    (``AA:BB:CC:DD:EE:FF``) or hyphen-separated (``AA-BB-CC-DD-EE-FF``)
+    notation. Both upper- and lower-case hex digits are accepted.
+    The Cisco dot-delimited format is not supported.
+
+    Args:
+        nullable: Whether null values are allowed.
+        unique: Whether non-null values must be unique.
+        severity: Severity level for validation issues.
+        required_if: Conditional requirement as a column/value pair.
+
+    Returns:
+        Field: Configured MAC-address schema field.
+
+    Examples
+    --------
+    >>> schema = ar.Schema({"nic_mac": ar.MACAddress(nullable=False, unique=True)})
+    """
+    return Field(
+        dtype="string",
+        nullable=nullable,
+        semantic="mac_address",
+        unique=unique,
+        required_if=required_if,
+        severity=severity,
+    )
+
+
 def Regex(
     pattern: str,
     *,
@@ -3232,6 +3342,22 @@ _SEMANTIC_PATTERNS = {
     "country_code": r"[A-Z]{2}",
     "currency_code": r"[A-Z]{3}",
     "date": r"\d{4}-\d{2}-\d{2}",
+    # Canonical 8-4-4-4-12 UUID format (RFC 4122); case-insensitive hex.
+    "uuid": (
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
+        r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    ),
+    # Strict dotted-decimal IPv4: each octet 0–255, no leading zeros.
+    "ipv4": (
+        r"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\."
+        r"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\."
+        r"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\."
+        r"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])"
+    ),
+    # IEEE 802 MAC-48: colon (AA:BB:…) or hyphen (AA-BB-…) separated.
+    "mac_address": (
+        r"[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}" r"|[0-9a-fA-F]{2}(?:-[0-9a-fA-F]{2}){5}"
+    ),
 }
 
 # Registry for custom validators registered via register_validator()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,7 +10,14 @@ import pandas as pd
 import pytest
 
 import arnio as ar
-from arnio.schema import _is_safely_convertible_to_dtype
+from arnio.frame import ArFrame
+from arnio.schema import (
+    _SEMANTIC_PATTERNS,
+    Field,
+    Schema,
+    _is_safely_convertible_to_dtype,
+    validate,
+)
 
 
 def test_dtype_validation_reports_safe_int_conversion_for_numeric_strings():
@@ -4427,3 +4434,573 @@ def test_from_json_round_trip_is_accepted():
     recovered = ar.Schema.from_json(original.to_json())
     assert recovered.fields["email"].nullable is False
     assert recovered.unique == ["email"]
+
+
+"""
+Tests for the UUID, IPv4, and MACAddress schema validators added in
+issue #1604 ("Add real-world schema validators").
+
+Covers:
+  - _SEMANTIC_PATTERNS regex correctness (valid / invalid edge cases)
+  - Factory-function return types and Field attribute wiring
+  - End-to-end validate() integration (pass + fail paths)
+  - nullable=False, unique=True, severity="warning" propagation
+  - Schema JSON round-trip (to_json / from_json)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _frame(data: dict) -> ArFrame:
+    """Build a minimal ArFrame from a plain dict of lists."""
+    return ar.from_pandas(pd.DataFrame(data))
+
+
+def _issues(result) -> list[str]:
+    """Return (rule, value) pairs for easy assertion."""
+    return [(i.rule, i.value) for i in result.issues]
+
+
+# ===========================================================================
+# 1.  _SEMANTIC_PATTERNS – regex correctness
+# ===========================================================================
+
+
+class TestUUIDPattern:
+    PAT = _SEMANTIC_PATTERNS["uuid"]
+
+    def _match(self, value: str) -> bool:
+        import re
+
+        return bool(re.compile(self.PAT).fullmatch(value))
+
+    # --- valid ---
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "550e8400-e29b-41d4-a716-446655440000",  # v4, lowercase
+            "A987FBC9-4BED-3078-CF07-9141BA07C9F3",  # v3, uppercase
+            "00000000-0000-0000-0000-000000000000",  # nil UUID
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",  # all-f
+            "6ba7b810-9dad-11d1-80b4-00c04fd430c8",  # v1 mixed-case
+        ],
+    )
+    def test_valid_uuids(self, value):
+        assert self._match(value), f"Expected match for {value!r}"
+
+    # --- invalid ---
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "550e8400e29b41d4a716446655440000",  # no hyphens
+            "550e8400-e29b-41d4-a716",  # truncated
+            "550e8400-e29b-41d4-a716-44665544000",  # last segment too short
+            "550e8400-e29b-41d4-a716-4466554400001",  # last segment too long
+            "ZZZZZZZZ-e29b-41d4-a716-446655440000",  # non-hex chars
+            "550e8400-e29b-41d4-a716-446655440000 ",  # trailing space
+            " 550e8400-e29b-41d4-a716-446655440000",  # leading space
+            "",  # empty string
+        ],
+    )
+    def test_invalid_uuids(self, value):
+        assert not self._match(value), f"Expected no match for {value!r}"
+
+
+class TestIPv4Pattern:
+    PAT = _SEMANTIC_PATTERNS["ipv4"]
+
+    def _match(self, value: str) -> bool:
+        import re
+
+        return bool(re.compile(self.PAT).fullmatch(value))
+
+    # --- valid ---
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "0.0.0.0",
+            "255.255.255.255",
+            "192.168.1.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "1.2.3.4",
+            "100.200.100.200",
+            "249.249.249.249",
+        ],
+    )
+    def test_valid_ipv4(self, value):
+        assert self._match(value), f"Expected match for {value!r}"
+
+    # --- invalid ---
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "256.0.0.0",  # octet out of range
+            "192.168.01.1",  # leading zero rejected
+            "192.168.1.01",  # leading zero rejected (last octet)
+            "00.0.0.0",  # leading zero on first octet
+            "192.168.1",  # only 3 octets
+            "192.168.1.1.1",  # 5 octets
+            "192.168.1.1 ",  # trailing space
+            " 192.168.1.1",  # leading space
+            "abc.def.ghi.jkl",  # letters
+            "999.999.999.999",  # all out of range
+            "",  # empty string
+            "192.168.1.",  # trailing dot
+            ".192.168.1.1",  # leading dot
+        ],
+    )
+    def test_invalid_ipv4(self, value):
+        assert not self._match(value), f"Expected no match for {value!r}"
+
+
+class TestMACAddressPattern:
+    PAT = _SEMANTIC_PATTERNS["mac_address"]
+
+    def _match(self, value: str) -> bool:
+        import re
+
+        return bool(re.compile(self.PAT).fullmatch(value))
+
+    # --- valid ---
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "AA:BB:CC:DD:EE:FF",  # colon, uppercase
+            "aa:bb:cc:dd:ee:ff",  # colon, lowercase
+            "AA-BB-CC-DD-EE-FF",  # hyphen, uppercase
+            "aa-bb-cc-dd-ee-ff",  # hyphen, lowercase
+            "00:1A:2B:3C:4D:5E",  # mixed case, colon
+            "00-1a-2b-3c-4d-5e",  # mixed case, hyphen
+            "FF:FF:FF:FF:FF:FF",  # broadcast
+            "00:00:00:00:00:00",  # zero MAC
+        ],
+    )
+    def test_valid_mac_addresses(self, value):
+        assert self._match(value), f"Expected match for {value!r}"
+
+    # --- invalid ---
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "AA:BB:CC:DD:EE",  # 5 octets only
+            "AA:BB:CC:DD:EE:FF:00",  # 7 octets
+            "GG:BB:CC:DD:EE:FF",  # non-hex octet
+            "AA.BB.CC.DD.EE.FF",  # Cisco dot notation (unsupported)
+            "AABBCCDDEEFF",  # no separator
+            "AA:BB-CC:DD:EE:FF",  # mixed separators
+            "AA:BB:CC:DD:EE:FG",  # non-hex in last octet
+            "AA:BB:CC:DD:EE:FF ",  # trailing space
+            " AA:BB:CC:DD:EE:FF",  # leading space
+            "",  # empty string
+            "AA:BB:CC:DD:EE:F",  # short last octet
+        ],
+    )
+    def test_invalid_mac_addresses(self, value):
+        assert not self._match(value), f"Expected no match for {value!r}"
+
+
+# ===========================================================================
+# 2.  Factory functions – return type and Field attribute wiring
+# ===========================================================================
+
+
+class TestUUIDFactory:
+    def test_returns_field(self):
+        assert isinstance(ar.UUID(), Field)
+
+    def test_semantic_attribute(self):
+        assert ar.UUID().semantic == "uuid"
+
+    def test_dtype_is_string(self):
+        assert ar.UUID().dtype == "string"
+
+    def test_defaults(self):
+        f = ar.UUID()
+        assert f.nullable is True
+        assert f.unique is False
+        assert f.severity == "error"
+        assert f.required_if is None
+
+    def test_nullable_false(self):
+        assert ar.UUID(nullable=False).nullable is False
+
+    def test_unique_true(self):
+        assert ar.UUID(unique=True).unique is True
+
+    def test_severity_warning(self):
+        assert ar.UUID(severity="warning").severity == "warning"
+
+    def test_invalid_severity_raises(self):
+        with pytest.raises(ValueError):
+            ar.UUID(severity="critical")
+
+
+class TestIPv4Factory:
+    def test_returns_field(self):
+        assert isinstance(ar.IPv4(), Field)
+
+    def test_semantic_attribute(self):
+        assert ar.IPv4().semantic == "ipv4"
+
+    def test_dtype_is_string(self):
+        assert ar.IPv4().dtype == "string"
+
+    def test_defaults(self):
+        f = ar.IPv4()
+        assert f.nullable is True
+        assert f.unique is False
+        assert f.severity == "error"
+        assert f.required_if is None
+
+    def test_nullable_false(self):
+        assert ar.IPv4(nullable=False).nullable is False
+
+    def test_unique_true(self):
+        assert ar.IPv4(unique=True).unique is True
+
+    def test_severity_warning(self):
+        assert ar.IPv4(severity="warning").severity == "warning"
+
+    def test_invalid_severity_raises(self):
+        with pytest.raises(ValueError):
+            ar.IPv4(severity="critical")
+
+
+class TestMACAddressFactory:
+    def test_returns_field(self):
+        assert isinstance(ar.MACAddress(), Field)
+
+    def test_semantic_attribute(self):
+        assert ar.MACAddress().semantic == "mac_address"
+
+    def test_dtype_is_string(self):
+        assert ar.MACAddress().dtype == "string"
+
+    def test_defaults(self):
+        f = ar.MACAddress()
+        assert f.nullable is True
+        assert f.unique is False
+        assert f.severity == "error"
+        assert f.required_if is None
+
+    def test_nullable_false(self):
+        assert ar.MACAddress(nullable=False).nullable is False
+
+    def test_unique_true(self):
+        assert ar.MACAddress(unique=True).unique is True
+
+    def test_severity_warning(self):
+        assert ar.MACAddress(severity="warning").severity == "warning"
+
+    def test_invalid_severity_raises(self):
+        with pytest.raises(ValueError):
+            ar.MACAddress(severity="critical")
+
+
+# ===========================================================================
+# 3.  End-to-end validate() – UUID
+# ===========================================================================
+
+
+class TestUUIDValidation:
+    def test_all_valid_passes(self):
+        frame = _frame(
+            {
+                "id": [
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    "A987FBC9-4BED-3078-CF07-9141BA07C9F3",
+                ]
+            }
+        )
+        schema = Schema({"id": ar.UUID()})
+        result = validate(frame, schema)
+        assert result.passed
+
+    def test_missing_hyphens_fails(self):
+        frame = _frame({"id": ["550e8400e29b41d4a716446655440000"]})
+        schema = Schema({"id": ar.UUID()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_wrong_segment_length_fails(self):
+        frame = _frame({"id": ["550e8400-e29b-41d4-a716-44665544"]})  # last seg short
+        schema = Schema({"id": ar.UUID()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_non_hex_chars_fails(self):
+        frame = _frame({"id": ["ZZZZZZZZ-e29b-41d4-a716-446655440000"]})
+        schema = Schema({"id": ar.UUID()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_null_allowed_by_default(self):
+        frame = _frame({"id": [None, "550e8400-e29b-41d4-a716-446655440000"]})
+        schema = Schema({"id": ar.UUID()})
+        result = validate(frame, schema)
+        assert result.passed
+
+    def test_null_rejected_when_not_nullable(self):
+        frame = _frame({"id": [None, "550e8400-e29b-41d4-a716-446655440000"]})
+        schema = Schema({"id": ar.UUID(nullable=False)})
+        result = validate(frame, schema)
+        assert not result.passed
+        assert any(i.rule == "nullable" for i in result.issues)
+
+    def test_duplicates_rejected_when_unique(self):
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        frame = _frame({"id": [uid, uid]})
+        schema = Schema({"id": ar.UUID(unique=True)})
+        result = validate(frame, schema)
+        assert not result.passed
+        assert any(i.rule == "unique" for i in result.issues)
+
+    def test_severity_warning_propagates(self):
+        frame = _frame({"id": ["not-a-uuid"]})
+        schema = Schema({"id": ar.UUID(severity="warning")})
+        result = validate(frame, schema)
+        assert result.passed  # warnings don't fail
+        assert any(i.severity == "warning" for i in result.issues)
+
+    def test_nil_uuid_passes(self):
+        frame = _frame({"id": ["00000000-0000-0000-0000-000000000000"]})
+        schema = Schema({"id": ar.UUID()})
+        assert validate(frame, schema).passed
+
+    def test_uppercase_hex_passes(self):
+        frame = _frame({"id": ["A987FBC9-4BED-3078-CF07-9141BA07C9F3"]})
+        schema = Schema({"id": ar.UUID()})
+        assert validate(frame, schema).passed
+
+
+# ===========================================================================
+# 4.  End-to-end validate() – IPv4
+# ===========================================================================
+
+
+class TestIPv4Validation:
+    def test_all_valid_passes(self):
+        frame = _frame({"ip": ["0.0.0.0", "192.168.1.1", "255.255.255.255"]})
+        schema = Schema({"ip": ar.IPv4()})
+        assert validate(frame, schema).passed
+
+    def test_octet_out_of_range_fails(self):
+        frame = _frame({"ip": ["256.0.0.0"]})
+        schema = Schema({"ip": ar.IPv4()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_leading_zero_rejected(self):
+        """192.168.01.1 has a leading zero in the third octet — must fail."""
+        frame = _frame({"ip": ["192.168.01.1"]})
+        schema = Schema({"ip": ar.IPv4()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_too_few_octets_fails(self):
+        frame = _frame({"ip": ["192.168.1"]})
+        schema = Schema({"ip": ar.IPv4()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_too_many_octets_fails(self):
+        frame = _frame({"ip": ["192.168.1.1.1"]})
+        schema = Schema({"ip": ar.IPv4()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_alpha_chars_fail(self):
+        frame = _frame({"ip": ["abc.def.ghi.jkl"]})
+        schema = Schema({"ip": ar.IPv4()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_null_allowed_by_default(self):
+        frame = _frame({"ip": [None, "10.0.0.1"]})
+        schema = Schema({"ip": ar.IPv4()})
+        assert validate(frame, schema).passed
+
+    def test_null_rejected_when_not_nullable(self):
+        frame = _frame({"ip": [None, "10.0.0.1"]})
+        schema = Schema({"ip": ar.IPv4(nullable=False)})
+        result = validate(frame, schema)
+        assert not result.passed
+        assert any(i.rule == "nullable" for i in result.issues)
+
+    def test_duplicates_rejected_when_unique(self):
+        frame = _frame({"ip": ["10.0.0.1", "10.0.0.1"]})
+        schema = Schema({"ip": ar.IPv4(unique=True)})
+        result = validate(frame, schema)
+        assert not result.passed
+        assert any(i.rule == "unique" for i in result.issues)
+
+    def test_severity_warning_propagates(self):
+        frame = _frame({"ip": ["999.999.999.999"]})
+        schema = Schema({"ip": ar.IPv4(severity="warning")})
+        result = validate(frame, schema)
+        assert result.passed
+        assert any(i.severity == "warning" for i in result.issues)
+
+    def test_boundary_values(self):
+        """Exact boundary octets 0 and 255 are valid; 256 is not."""
+        frame = _frame({"ip": ["0.0.0.0", "255.255.255.255"]})
+        schema = Schema({"ip": ar.IPv4()})
+        assert validate(frame, schema).passed
+
+    def test_leading_zero_first_octet(self):
+        """00.0.0.0 has a leading zero — must fail."""
+        frame = _frame({"ip": ["00.0.0.0"]})
+        schema = Schema({"ip": ar.IPv4()})
+        assert not validate(frame, schema).passed
+
+
+# ===========================================================================
+# 5.  End-to-end validate() – MACAddress
+# ===========================================================================
+
+
+class TestMACAddressValidation:
+    def test_colon_separated_uppercase_passes(self):
+        frame = _frame({"mac": ["AA:BB:CC:DD:EE:FF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        assert validate(frame, schema).passed
+
+    def test_colon_separated_lowercase_passes(self):
+        frame = _frame({"mac": ["aa:bb:cc:dd:ee:ff"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        assert validate(frame, schema).passed
+
+    def test_hyphen_separated_uppercase_passes(self):
+        frame = _frame({"mac": ["AA-BB-CC-DD-EE-FF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        assert validate(frame, schema).passed
+
+    def test_hyphen_separated_lowercase_passes(self):
+        frame = _frame({"mac": ["aa-bb-cc-dd-ee-ff"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        assert validate(frame, schema).passed
+
+    def test_broadcast_mac_passes(self):
+        frame = _frame({"mac": ["FF:FF:FF:FF:FF:FF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        assert validate(frame, schema).passed
+
+    def test_zero_mac_passes(self):
+        frame = _frame({"mac": ["00:00:00:00:00:00"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        assert validate(frame, schema).passed
+
+    def test_five_octets_fails(self):
+        frame = _frame({"mac": ["AA:BB:CC:DD:EE"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_seven_octets_fails(self):
+        frame = _frame({"mac": ["AA:BB:CC:DD:EE:FF:00"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_non_hex_octet_fails(self):
+        frame = _frame({"mac": ["GG:BB:CC:DD:EE:FF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_no_separator_fails(self):
+        frame = _frame({"mac": ["AABBCCDDEEFF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_mixed_separators_fail(self):
+        """Mixing colons and hyphens is not valid."""
+        frame = _frame({"mac": ["AA:BB-CC:DD:EE:FF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_cisco_dot_format_fails(self):
+        """Dot-delimited (Cisco) format is explicitly unsupported."""
+        frame = _frame({"mac": ["AABB.CCDD.EEFF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        result = validate(frame, schema)
+        assert not result.passed
+
+    def test_null_allowed_by_default(self):
+        frame = _frame({"mac": [None, "AA:BB:CC:DD:EE:FF"]})
+        schema = Schema({"mac": ar.MACAddress()})
+        assert validate(frame, schema).passed
+
+    def test_null_rejected_when_not_nullable(self):
+        frame = _frame({"mac": [None, "AA:BB:CC:DD:EE:FF"]})
+        schema = Schema({"mac": ar.MACAddress(nullable=False)})
+        result = validate(frame, schema)
+        assert not result.passed
+        assert any(i.rule == "nullable" for i in result.issues)
+
+    def test_duplicates_rejected_when_unique(self):
+        frame = _frame({"mac": ["AA:BB:CC:DD:EE:FF", "AA:BB:CC:DD:EE:FF"]})
+        schema = Schema({"mac": ar.MACAddress(unique=True)})
+        result = validate(frame, schema)
+        assert not result.passed
+        assert any(i.rule == "unique" for i in result.issues)
+
+    def test_severity_warning_propagates(self):
+        frame = _frame({"mac": ["not-a-mac"]})
+        schema = Schema({"mac": ar.MACAddress(severity="warning")})
+        result = validate(frame, schema)
+        assert result.passed
+        assert any(i.severity == "warning" for i in result.issues)
+
+
+# ===========================================================================
+# 6.  Schema JSON round-trip (to_json / from_json)
+# ===========================================================================
+
+
+class TestSemanticValidatorJSONRoundTrip:
+    """Verify that UUID, IPv4, and MACAddress survive Schema serialization."""
+
+    @pytest.mark.parametrize(
+        "factory,semantic",
+        [
+            (ar.UUID, "uuid"),
+            (ar.IPv4, "ipv4"),
+            (ar.MACAddress, "mac_address"),
+        ],
+    )
+    def test_round_trip_preserves_semantic(self, factory, semantic):
+        original = Schema({"col": factory(nullable=False, unique=True)})
+        restored = Schema.from_json(original.to_json())
+        f = restored.fields["col"]
+        assert f.semantic == semantic
+        assert f.nullable is False
+        assert f.unique is True
+
+    @pytest.mark.parametrize(
+        "factory,semantic",
+        [
+            (ar.UUID, "uuid"),
+            (ar.IPv4, "ipv4"),
+            (ar.MACAddress, "mac_address"),
+        ],
+    )
+    def test_restored_schema_validates_correctly(self, factory, semantic):
+        """A schema reloaded from JSON must still reject invalid values."""
+        original = Schema({"col": factory()})
+        restored = Schema.from_json(original.to_json())
+
+        invalid_values = {
+            "uuid": "not-a-uuid",
+            "ipv4": "999.999.999.999",
+            "mac_address": "ZZ:ZZ:ZZ:ZZ:ZZ:ZZ",
+        }
+        frame = _frame({"col": [invalid_values[semantic]]})
+        result = validate(frame, restored)
+        assert not result.passed

--- a/tests/test_website_api_docs.py
+++ b/tests/test_website_api_docs.py
@@ -38,7 +38,7 @@ def _public_exports() -> list[str]:
 
 
 def _api_html() -> str:
-    return (REPO_ROOT / "website" / "api.html").read_text(encoding="utf-8")
+    return (REPO_ROOT / "website" / "api.html").read_text()
 
 
 def _signature_row(fn_name: str, html: str) -> str:

--- a/tests/test_website_api_docs.py
+++ b/tests/test_website_api_docs.py
@@ -38,7 +38,7 @@ def _public_exports() -> list[str]:
 
 
 def _api_html() -> str:
-    return (REPO_ROOT / "website" / "api.html").read_text()
+    return (REPO_ROOT / "website" / "api.html").read_text(encoding="utf-8")
 
 
 def _signature_row(fn_name: str, html: str) -> str:

--- a/website/api.html
+++ b/website/api.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,454 +15,112 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://arnio.vercel.app/">
   <meta property="og:title" content="Arnio — Production Data Preparation for Python">
-  <meta property="og:description"
-    content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
+  <meta property="og:description" content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
   <meta property="og:image" content="https://arnio.vercel.app/arnio-social-card.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Arnio — Production Data Preparation for Python">
-  <meta name="twitter:description"
-    content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
+  <meta name="twitter:description" content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
   <meta name="twitter:image" content="https://arnio.vercel.app/arnio-social-card.svg">
 </head>
-
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
   <nav class="top-nav" aria-label="Main navigation">
     <div class="container container--wide">
-      <a href="index.html" class="nav-brand" aria-label="Arnio home"><img src="arnio-logo.svg" alt="Arnio"
-          height="32"></a>
-      <ul class="nav-links">
-        <li><a href="docs.html">Docs</a></li>
-        <li><a href="api.html">API</a></li>
-        <li><a href="benchmarks.html">Benchmarks</a></li>
-        <li><a href="contributing.html">Contributing</a></li>
-        <li><a href="architecture.html">Architecture</a></li>
-        <li><a href="roadmap.html">Roadmap</a></li>
-        <li><a href="community.html">Community</a></li>
-        <li><a href="changelog.html">Changelog</a></li>
-      </ul>
+      <a href="index.html" class="nav-brand" aria-label="Arnio home"><img src="arnio-logo.svg" alt="Arnio" height="32"></a>
+      <ul class="nav-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="contributing.html">Contributing</a></li><li><a href="architecture.html">Architecture</a></li><li><a href="roadmap.html">Roadmap</a></li><li><a href="community.html">Community</a></li><li><a href="changelog.html">Changelog</a></li></ul>
       <div class="nav-actions">
         <div class="search-wrapper">
-          <input id="docs-search" class="search-input" type="text" placeholder="Search docs... (Ctrl+K)"
-            aria-label="Search documentation" />
+          <input
+            id="docs-search"
+            class="search-input"
+            type="text"
+            placeholder="Search docs... (Ctrl+K)"
+            aria-label="Search documentation"
+          />
           <div id="search-results" class="search-results"></div>
         </div>
 
-        <a href="https://discord.gg/xsEw7r78M" class="nav-discord" target="_blank" rel="noopener"
-          aria-label="Join Discord">Discord</a><a href="https://github.com/im-anishraj/arnio" class="nav-github"
-          target="_blank" rel="noopener" aria-label="View on GitHub">GitHub</a><button class="theme-toggle"
-          aria-label="Toggle theme">Theme</button><button class="nav-hamburger" aria-label="Open menu"
-          aria-expanded="false" aria-controls="mobile-navigation">☰</button>
-      </div>
+        <a href="https://discord.gg/xsEw7r78M" class="nav-discord" target="_blank" rel="noopener" aria-label="Join Discord">Discord</a><a href="https://github.com/im-anishraj/arnio" class="nav-github" target="_blank" rel="noopener" aria-label="View on GitHub">GitHub</a><button class="theme-toggle" aria-label="Toggle theme">Theme</button><button class="nav-hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-navigation">☰</button></div>
     </div>
   </nav>
-  <div id="mobile-navigation" class="mobile-menu" aria-label="Mobile navigation"><a href="index.html">Home</a><a
-      href="docs.html">Documentation</a><a href="api.html">API Reference</a><a href="benchmarks.html">Benchmarks</a><a
-      href="contributing.html">Contributing</a><a href="architecture.html">Architecture</a><a
-      href="roadmap.html">Roadmap</a><a href="community.html">Community</a><a href="https://discord.gg/xsEw7r78M"
-      target="_blank" rel="noopener">Discord</a><a href="changelog.html">Changelog</a></div>
+  <div id="mobile-navigation" class="mobile-menu" aria-label="Mobile navigation"><a href="index.html">Home</a><a href="docs.html">Documentation</a><a href="api.html">API Reference</a><a href="benchmarks.html">Benchmarks</a><a href="contributing.html">Contributing</a><a href="architecture.html">Architecture</a><a href="roadmap.html">Roadmap</a><a href="community.html">Community</a><a href="https://discord.gg/xsEw7r78M" target="_blank" rel="noopener">Discord</a><a href="changelog.html">Changelog</a></div>
 
-  <header class="page-hero">
-    <div class="container">
-      <h1>API Reference</h1>
-      <p>Public functions and classes available in Arnio's current Python API.</p>
-    </div>
-  </header>
+  <header class="page-hero"><div class="container"><h1>API Reference</h1><p>Public functions and classes available in Arnio's current Python API.</p></div></header>
 
   <main id="main-content" class="main-content">
     <div class="container docs-layout">
       <aside class="docs-sidebar">
-        <div class="sidebar-nav-group">
-          <div class="sidebar-nav-title">I/O</div><a href="#io" class="sidebar-nav-link">I/O functions</a><a
-            href="#frame" class="sidebar-nav-link">ArFrame</a><a href="#conversion"
-            class="sidebar-nav-link">Conversion</a>
-        </div>
-        <div class="sidebar-nav-group">
-          <div class="sidebar-nav-title">Transform</div><a href="#cleaning" class="sidebar-nav-link">Cleaning</a><a
-            href="#pipeline" class="sidebar-nav-link">Pipeline</a>
-        </div>
-        <div class="sidebar-nav-group">
-          <div class="sidebar-nav-title">Quality</div><a href="#quality" class="sidebar-nav-link">Quality</a><a
-            href="#schema" class="sidebar-nav-link">Schema</a><a href="#integrations"
-            class="sidebar-nav-link">Integrations</a><a href="#exceptions" class="sidebar-nav-link">Exceptions</a>
-        </div>
+        <div class="sidebar-nav-group"><div class="sidebar-nav-title">I/O</div><a href="#io" class="sidebar-nav-link">I/O functions</a><a href="#frame" class="sidebar-nav-link">ArFrame</a><a href="#conversion" class="sidebar-nav-link">Conversion</a></div>
+        <div class="sidebar-nav-group"><div class="sidebar-nav-title">Transform</div><a href="#cleaning" class="sidebar-nav-link">Cleaning</a><a href="#pipeline" class="sidebar-nav-link">Pipeline</a></div>
+        <div class="sidebar-nav-group"><div class="sidebar-nav-title">Quality</div><a href="#quality" class="sidebar-nav-link">Quality</a><a href="#schema" class="sidebar-nav-link">Schema</a><a href="#integrations" class="sidebar-nav-link">Integrations</a><a href="#exceptions" class="sidebar-nav-link">Exceptions</a></div>
       </aside>
 
       <article class="docs-content">
-        <div class="notice"><strong>Scope:</strong> This page documents the public Python API exposed from
-          <code>arnio.__all__</code> on current <code>origin/main</code>.</div>
+        <div class="notice"><strong>Scope:</strong> This page documents the public Python API exposed from <code>arnio.__all__</code> on current <code>origin/main</code>.</div>
 
         <h2 id="io">I/O</h2>
-        <div class="api-func">
-          <div class="api-func-header">read_csv(path, *, delimiter=None, has_header=True, usecols=None, nrows=None,
-            skiprows=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None,
-            null_values=None, dtype=None, mode="strict", encoding_errors="strict", on_bad_lines="error")</div>
-          <div class="api-func-body">
-            <p>Read CSV-like input into an <code>ArFrame</code>. Supports extension-flexible paths, TSV delimiter
-              inference, explicit dtypes, decoding policy, and configurable malformed-row handling. Key options:
-              <code>trim_headers</code> strips whitespace from column names; <code>null_values</code> specifies
-              additional tokens to treat as null; <code>thousands_separator</code> enables numeric parsing with grouping
-              separators; <code>mode</code> controls parser strictness (<code>"strict"</code> or <code>"lax"</code>).
-            </p>
-            <p><strong>Returns:</strong> <code>ArFrame</code>. Raises <code>CsvReadError</code> for read and parse
-              failures.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">read_csv_chunked(path, *, chunksize=10000, dtype=None, delimiter=None,
-            has_header=True, usecols=None, nrows=None, skip_rows=0, skiprows=None, encoding="utf-8", trim_headers=True,
-            decimal_separator=".", thousands_separator=None, null_values=None, mode="strict", on_bad_lines="error")
-          </div>
-          <div class="api-func-body">
-            <p>Yield <code>ArFrame</code> chunks from large files. <code>delimiter=None</code> infers tab delimiters for
-              <code>.tsv</code> paths and comma otherwise. <code>on_bad_lines</code> may error, warn, or skip malformed
-              row-width records. Supports the same parser controls as <code>read_csv()</code>, including
-              <code>dtype</code>, <code>usecols</code>, <code>null_values</code>, <code>thousands_separator</code>,
-              <code>trim_headers</code>, and <code>mode</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">scan_csv(path, *, delimiter=None, encoding="utf-8", trim_headers=True,
-            decimal_separator=".", thousands_separator=None, sample_size=None, null_values=None, has_header=True,
-            encoding_errors="strict", mode="strict", on_bad_lines="error")</div>
-          <div class="api-func-body">
-            <p>Infer column names and dtypes without loading the full file. Like <code>read_csv</code>, omitted
-              delimiters use tab for <code>.tsv</code> paths and comma otherwise.</p>
-            <p><strong>Example:</strong>
-              <code>ar.scan_csv("raw.csv", sample_size=500, null_values=["NA", "MISSING"])</code> keeps sampling and
-              null-token handling aligned with a later <code>read_csv()</code> call.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">read_jsonl(path, *, encoding="utf-8", encoding_errors="strict", nrows=None)</div>
-          <div class="api-func-body">
-            <p>Read JSON Lines or NDJSON into an <code>ArFrame</code>; mixed object columns are coerced to strings. The
-              <code>encoding</code> and <code>encoding_errors</code> parameters control how file bytes are decoded into
-              text.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">read_jsonl_chunked(path, *, chunksize=10000, encoding="utf-8",
-            encoding_errors="strict", nrows=None)</div>
-          <div class="api-func-body">
-            <p>Yield JSON Lines or NDJSON records as <code>ArFrame</code> chunks without buffering the whole file. Uses
-              the same validation, line-numbered errors, decoding controls, and <code>nrows</code> limit as
-              <code>read_jsonl()</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">write_csv(frame, path, *, delimiter=",", write_header=True, line_terminator="\n",
-            escape_formulas=False, encoding="utf-8", encoding_errors="strict")</div>
-          <div class="api-func-body">
-            <p>Write an <code>ArFrame</code> to CSV or TSV with delimiter and line terminator validation. Set
-              <code>escape_formulas=True</code> to prefix string cells that start with spreadsheet formula trigger
-              characters before CSV quoting. <code>encoding</code> defaults to <code>"utf-8"</code> (native fast path);
-              any Python codec is accepted and transcoded in bounded chunks. <code>encoding_errors</code> controls
-              unencodable character handling: <code>"strict"</code> (default), <code>"replace"</code>, or
-              <code>"ignore"</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">write_json(frame, path, *, orient="records", indent=None)</div>
-          <div class="api-func-body">
-            <p>Export an <code>ArFrame</code> to JSON without pandas conversion. Supported orient formats:
-              <code>"records"</code>, <code>"list"</code>, and <code>"split"</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">read_parquet(path, *, columns=None, usecols=None)</div>
-          <div class="api-func-body">
-            <p>Read a Parquet file into an <code>ArFrame</code> via the optional <code>pyarrow</code> dependency.
-              Install with <code>pip install "arnio[parquet]"</code>. Use <code>usecols</code> or <code>columns</code>
-              for column subset selection.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">write_parquet(frame, path, *, compression="snappy", row_group_size=None,
-            preserve_attrs=True)</div>
-          <div class="api-func-body">
-            <p>Write an <code>ArFrame</code> to Parquet via the optional <code>pyarrow</code> dependency. Install with
-              <code>pip install "arnio[parquet]"</code>. <code>preserve_attrs=True</code> writes JSON-serializable
-              <code>DataFrame.attrs</code> into Parquet metadata; set to <code>False</code> to skip that export.
-              Accepted compression values: <code>"snappy"</code> (default), <code>"gzip"</code>, <code>"brotli"</code>,
-              <code>"zstd"</code>, and <code>"none"</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">sniff_delimiter(path, *, encoding="utf-8", sample_size=2048)</div>
-          <div class="api-func-body">
-            <p>Detect a likely delimiter for CSV-like input before reading or scanning. <code>sample_size</code>
-              controls how many characters are read from the start of the file for detection; the default of
-              <code>2048</code> is sufficient for most files. Increase it when the file has an unusual delimiter that
-              only appears further into the content.</p>
-          </div>
-        </div>
+        <div class="api-func"><div class="api-func-header">read_csv(path, *, delimiter=None, has_header=True, usecols=None, nrows=None, skiprows=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None, null_values=None, dtype=None, mode="strict", encoding_errors="strict", on_bad_lines="error")</div><div class="api-func-body"><p>Read CSV-like input into an <code>ArFrame</code>. Supports extension-flexible paths, TSV delimiter inference, explicit dtypes, decoding policy, and configurable malformed-row handling. Key options: <code>trim_headers</code> strips whitespace from column names; <code>null_values</code> specifies additional tokens to treat as null; <code>thousands_separator</code> enables numeric parsing with grouping separators; <code>mode</code> controls parser strictness (<code>"strict"</code> or <code>"lax"</code>).</p><p><strong>Returns:</strong> <code>ArFrame</code>. Raises <code>CsvReadError</code> for read and parse failures.</p></div></div>
+        <div class="api-func"><div class="api-func-header">read_csv_chunked(path, *, chunksize=10000, dtype=None, delimiter=None, has_header=True, usecols=None, nrows=None, skip_rows=0, skiprows=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None, null_values=None, mode="strict", on_bad_lines="error")</div><div class="api-func-body"><p>Yield <code>ArFrame</code> chunks from large files. <code>delimiter=None</code> infers tab delimiters for <code>.tsv</code> paths and comma otherwise. <code>on_bad_lines</code> may error, warn, or skip malformed row-width records. Supports the same parser controls as <code>read_csv()</code>, including <code>dtype</code>, <code>usecols</code>, <code>null_values</code>, <code>thousands_separator</code>, <code>trim_headers</code>, and <code>mode</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">scan_csv(path, *, delimiter=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None, sample_size=None, null_values=None, has_header=True, encoding_errors="strict", mode="strict", on_bad_lines="error")</div><div class="api-func-body"><p>Infer column names and dtypes without loading the full file. Like <code>read_csv</code>, omitted delimiters use tab for <code>.tsv</code> paths and comma otherwise.</p><p><strong>Example:</strong> <code>ar.scan_csv("raw.csv", sample_size=500, null_values=["NA", "MISSING"])</code> keeps sampling and null-token handling aligned with a later <code>read_csv()</code> call.</p></div></div>
+        <div class="api-func"><div class="api-func-header">read_jsonl(path, *, encoding="utf-8", encoding_errors="strict", nrows=None)</div><div class="api-func-body"><p>Read JSON Lines or NDJSON into an <code>ArFrame</code>; mixed object columns are coerced to strings. The <code>encoding</code> and <code>encoding_errors</code> parameters control how file bytes are decoded into text.</p></div></div>
+        <div class="api-func"><div class="api-func-header">read_jsonl_chunked(path, *, chunksize=10000, encoding="utf-8", encoding_errors="strict", nrows=None)</div><div class="api-func-body"><p>Yield JSON Lines or NDJSON records as <code>ArFrame</code> chunks without buffering the whole file. Uses the same validation, line-numbered errors, decoding controls, and <code>nrows</code> limit as <code>read_jsonl()</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">write_csv(frame, path, *, delimiter=",", write_header=True, line_terminator="\n", escape_formulas=False, encoding="utf-8", encoding_errors="strict")</div><div class="api-func-body"><p>Write an <code>ArFrame</code> to CSV or TSV with delimiter and line terminator validation. Set <code>escape_formulas=True</code> to prefix string cells that start with spreadsheet formula trigger characters before CSV quoting. <code>encoding</code> defaults to <code>"utf-8"</code> (native fast path); any Python codec is accepted and transcoded in bounded chunks. <code>encoding_errors</code> controls unencodable character handling: <code>"strict"</code> (default), <code>"replace"</code>, or <code>"ignore"</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">write_json(frame, path, *, orient="records", indent=None)</div><div class="api-func-body"><p>Export an <code>ArFrame</code> to JSON without pandas conversion. Supported orient formats: <code>"records"</code>, <code>"list"</code>, and <code>"split"</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">read_parquet(path, *, columns=None, usecols=None)</div><div class="api-func-body"><p>Read a Parquet file into an <code>ArFrame</code> via the optional <code>pyarrow</code> dependency. Install with <code>pip install "arnio[parquet]"</code>. Use <code>usecols</code> or <code>columns</code> for column subset selection.</p></div></div>
+        <div class="api-func"><div class="api-func-header">write_parquet(frame, path, *, compression="snappy", row_group_size=None, preserve_attrs=True)</div><div class="api-func-body"><p>Write an <code>ArFrame</code> to Parquet via the optional <code>pyarrow</code> dependency. Install with <code>pip install "arnio[parquet]"</code>. <code>preserve_attrs=True</code> writes JSON-serializable <code>DataFrame.attrs</code> into Parquet metadata; set to <code>False</code> to skip that export. Accepted compression values: <code>"snappy"</code> (default), <code>"gzip"</code>, <code>"brotli"</code>, <code>"zstd"</code>, and <code>"none"</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">sniff_delimiter(path, *, encoding="utf-8", sample_size=2048)</div><div class="api-func-body"><p>Detect a likely delimiter for CSV-like input before reading or scanning. <code>sample_size</code> controls how many characters are read from the start of the file for detection; the default of <code>2048</code> is sufficient for most files. Increase it when the file has an unusual delimiter that only appears further into the content.</p></div></div>
 
         <h2 id="frame">Frame API</h2>
-        <div class="api-func">
-          <div class="api-func-header">class ArFrame</div>
-          <div class="api-func-body">
-            <p>Python wrapper over the native C++ frame. Core properties include <code>shape</code>,
-              <code>columns</code>, <code>dtypes</code>, <code>is_empty</code>, <code>memory_usage()</code>,
-              <code>head()</code>, <code>tail()</code>, and <code>preview()</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">ArFrame.from_records(records, *, columns=None) / ar.from_records(...)</div>
-          <div class="api-func-body">
-            <p>Build an <code>ArFrame</code> from record dictionaries or row-like records. Added in v1.17.0.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">ArFrame._repr_html_()</div>
-          <div class="api-func-body">
-            <p>Jupyter/IPython automatically calls this to render a bounded HTML table preview showing up to 10 rows,
-              column names, dtypes, and shape summary.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame["column"] / frame[["a", "b"]]</div>
-          <div class="api-func-body">
-            <p>Select one column as a Python list or multiple columns as an <code>ArFrame</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">item in frame / frame.__contains__(item)</div>
-          <div class="api-func-body">
-            <p>Return <code>True</code> when the item is a valid column name in the frame.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame.select_columns(columns)</div>
-          <div class="api-func-body">
-            <p>Return a new <code>ArFrame</code> containing only the requested columns in original order.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame.select_dtypes(include=..., exclude=...)</div>
-          <div class="api-func-body">
-            <p>Return a new <code>ArFrame</code> filtered by dtype names like <code>int64</code>, <code>float64</code>,
-              <code>string</code>, <code>bool</code>, or <code>null</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame.astype(dtype)</div>
-          <div class="api-func-body">
-            <p>Cast one or more columns to a specified dtype or per-column type mapping and return a new
-              <code>ArFrame</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame.to_dict()</div>
-          <div class="api-func-body">
-            <p>Return a <code>dict[str, list]</code> representation for serialization or tests.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame.to_csv(path, *, delimiter=",", write_header=True, **kwargs)</div>
-          <div class="api-func-body">
-            <p>Convenience wrapper to write the frame to a CSV file. Delegates to <code>arnio.write_csv</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame.drop_columns(columns)</div>
-          <div class="api-func-body">
-            <p>Current-main method equivalent to the top-level <code>drop_columns</code> helper.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">frame.describe() / frame.schema_summary</div>
-          <div class="api-func-body">
-            <p>Summary statistics and column summaries. <code>schema_summary</code> returns <code>ColumnSummary</code>
-              objects with name, dtype, and nullability.</p>
-          </div>
-        </div>
+        <div class="api-func"><div class="api-func-header">class ArFrame</div><div class="api-func-body"><p>Python wrapper over the native C++ frame. Core properties include <code>shape</code>, <code>columns</code>, <code>dtypes</code>, <code>is_empty</code>, <code>memory_usage()</code>, <code>head()</code>, <code>tail()</code>, and <code>preview()</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">ArFrame.from_records(records, *, columns=None) / ar.from_records(...)</div><div class="api-func-body"><p>Build an <code>ArFrame</code> from record dictionaries or row-like records. Added in v1.17.0.</p></div></div>
+        <div class="api-func"><div class="api-func-header">ArFrame._repr_html_()</div><div class="api-func-body"><p>Jupyter/IPython automatically calls this to render a bounded HTML table preview showing up to 10 rows, column names, dtypes, and shape summary.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame["column"] / frame[["a", "b"]]</div><div class="api-func-body"><p>Select one column as a Python list or multiple columns as an <code>ArFrame</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">item in frame / frame.__contains__(item)</div><div class="api-func-body"><p>Return <code>True</code> when the item is a valid column name in the frame.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame.select_columns(columns)</div><div class="api-func-body"><p>Return a new <code>ArFrame</code> containing only the requested columns in original order.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame.select_dtypes(include=..., exclude=...)</div><div class="api-func-body"><p>Return a new <code>ArFrame</code> filtered by dtype names like <code>int64</code>, <code>float64</code>, <code>string</code>, <code>bool</code>, or <code>null</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame.astype(dtype)</div><div class="api-func-body"><p>Cast one or more columns to a specified dtype or per-column type mapping and return a new <code>ArFrame</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame.to_dict()</div><div class="api-func-body"><p>Return a <code>dict[str, list]</code> representation for serialization or tests.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame.to_csv(path, *, delimiter=",", write_header=True, **kwargs)</div><div class="api-func-body"><p>Convenience wrapper to write the frame to a CSV file. Delegates to <code>arnio.write_csv</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame.drop_columns(columns)</div><div class="api-func-body"><p>Current-main method equivalent to the top-level <code>drop_columns</code> helper.</p></div></div>
+        <div class="api-func"><div class="api-func-header">frame.describe() / frame.schema_summary</div><div class="api-func-body"><p>Summary statistics and column summaries. <code>schema_summary</code> returns <code>ColumnSummary</code> objects with name, dtype, and nullability.</p></div></div>
 
         <h2 id="conversion">Conversion</h2>
-        <div class="api-func">
-          <div class="api-func-header">to_pandas(frame, *, copy=False)</div>
-          <div class="api-func-body">
-            <p>Convert to pandas, preserving the fast zero-copy path where supported. Use <code>copy=True</code> for
-              defensive isolation.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">from_pandas(df)</div>
-          <div class="api-func-body">
-            <p>Convert a pandas DataFrame to <code>ArFrame</code> with dtype validation, duplicate-column checks, attrs
-              preservation, and zero-column row-count preservation.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">from_dict(data)</div>
-          <div class="api-func-body">
-            <p>Build an <code>ArFrame</code> from a mapping of column names to column values.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">to_arrow(frame)</div>
-          <div class="api-func-body">
-            <p>Export to <code>pyarrow.Table</code>. Install with <code>pip install "arnio[arrow]"</code>. Added in
-              v1.18.0.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">to_polars(frame)</div>
-          <div class="api-func-body">
-            <p>Convert an <code>ArFrame</code> to a Polars DataFrame via Arrow. Requires optional Polars dependency;
-              install with <code>pip install "arnio[polars]"</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">from_polars(df)</div>
-          <div class="api-func-body">
-            <p>Convert a Polars DataFrame to <code>ArFrame</code> with inferred types and null values preserved.
-              Requires optional Polars dependency; install with <code>pip install "arnio[polars]"</code>.</p>
-          </div>
-        </div>
+        <div class="api-func"><div class="api-func-header">to_pandas(frame, *, copy=False)</div><div class="api-func-body"><p>Convert to pandas, preserving the fast zero-copy path where supported. Use <code>copy=True</code> for defensive isolation.</p></div></div>
+        <div class="api-func"><div class="api-func-header">from_pandas(df)</div><div class="api-func-body"><p>Convert a pandas DataFrame to <code>ArFrame</code> with dtype validation, duplicate-column checks, attrs preservation, and zero-column row-count preservation.</p></div></div>
+        <div class="api-func"><div class="api-func-header">from_dict(data)</div><div class="api-func-body"><p>Build an <code>ArFrame</code> from a mapping of column names to column values.</p></div></div>
+        <div class="api-func"><div class="api-func-header">to_arrow(frame)</div><div class="api-func-body"><p>Export to <code>pyarrow.Table</code>. Install with <code>pip install "arnio[arrow]"</code>. Added in v1.18.0.</p></div></div>
+        <div class="api-func"><div class="api-func-header">to_polars(frame)</div><div class="api-func-body"><p>Convert an <code>ArFrame</code> to a Polars DataFrame via Arrow. Requires optional Polars dependency; install with <code>pip install "arnio[polars]"</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">from_polars(df)</div><div class="api-func-body"><p>Convert a Polars DataFrame to <code>ArFrame</code> with inferred types and null values preserved. Requires optional Polars dependency; install with <code>pip install "arnio[polars]"</code>.</p></div></div>
 
         <h2 id="cleaning">Cleaning</h2>
-        <p class="section-lede">Cleaning functions return new frames and are usable directly or from
-          <code>pipeline()</code>.</p>
-        <table>
-          <thead>
-            <tr>
-              <th>Function</th>
-              <th>Purpose</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>drop_nulls</code>, <code>keep_rows_with_nulls</code>, <code>fill_nulls</code></td>
-              <td>Control null-bearing rows and values.</td>
-            </tr>
-            <tr>
-              <td><code>validate_columns_exist</code>, <code>drop_columns</code>, <code>select_columns</code>,
-                <code>drop_empty_columns</code>, <code>drop_constant_columns</code>, <code>drop_columns_matching</code>
-              </td>
-              <td>Validate and manage columns explicitly, by emptiness, constants, or regex.</td>
-            </tr>
-            <tr>
-              <td><code>filter_rows</code>, <code>drop_duplicates</code>, <code>find_fuzzy_duplicates</code></td>
-              <td>Filter row sets, remove duplicate rows, and detect near-duplicate rows by similarity.</td>
-            </tr>
-            <tr>
-              <td><code>strip_whitespace</code>, <code>normalize_whitespace</code>, <code>normalize_case</code>,
-                <code>normalize_unicode</code>, <code>clean_column_names</code>, <code>trim_column_names</code>,
-                <code>slugify_column_names</code>, <code>rename_columns</code>, <code>rename_columns_matching</code>
-              </td>
-              <td>Normalize text, headers, and column names.</td>
-            </tr>
-            <tr>
-              <td><code>cast_types</code>, <code>parse_bool_strings</code>, <code>round_numeric_columns</code>,
-                <code>clip_numeric</code>, <code>winsorize_outliers</code>, <code>normalize_minmax</code></td>
-              <td>Type and numeric cleanup.</td>
-            </tr>
-            <tr>
-              <td><code>encode_categorical</code></td>
-              <td>Encode STRING columns using one-hot indicator columns or caller-supplied ordinal mappings.</td>
-            </tr>
-            <tr>
-              <td><code>replace_values</code>, <code>standardize_missing_tokens</code>, <code>combine_columns</code>,
-                <code>coalesce_columns</code>, <code>safe_divide_columns</code></td>
-              <td>Common feature engineering and value repair helpers.</td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="api-func">
-          <div class="api-func-header">CastReport and CastFailure</div>
-          <div class="api-func-body">
-            <p>Returned by <code>cast_types(..., errors="report")</code>. <code>CastReport</code> holds the cast
-              <code>frame</code> and a <code>failures</code> list of <code>CastFailure</code> records. Each
-              <code>CastFailure</code> has <code>column</code>, <code>row</code>, <code>value</code>, and
-              <code>target_dtype</code> attributes. <code>bool(report)</code> is <code>True</code> when there is at
-              least one failure.</p>
-          </div>
-        </div>
+        <p class="section-lede">Cleaning functions return new frames and are usable directly or from <code>pipeline()</code>.</p>
+        <table><thead><tr><th>Function</th><th>Purpose</th></tr></thead><tbody>
+          <tr><td><code>drop_nulls</code>, <code>keep_rows_with_nulls</code>, <code>fill_nulls</code></td><td>Control null-bearing rows and values.</td></tr>
+          <tr><td><code>validate_columns_exist</code>, <code>drop_columns</code>, <code>select_columns</code>, <code>drop_empty_columns</code>, <code>drop_constant_columns</code>, <code>drop_columns_matching</code></td><td>Validate and manage columns explicitly, by emptiness, constants, or regex.</td></tr>
+          <tr><td><code>filter_rows</code>, <code>drop_duplicates</code>, <code>find_fuzzy_duplicates</code></td><td>Filter row sets, remove duplicate rows, and detect near-duplicate rows by similarity.</td></tr>
+          <tr><td><code>strip_whitespace</code>, <code>normalize_whitespace</code>, <code>normalize_case</code>, <code>normalize_unicode</code>, <code>clean_column_names</code>, <code>trim_column_names</code>, <code>slugify_column_names</code>, <code>rename_columns</code>, <code>rename_columns_matching</code></td><td>Normalize text, headers, and column names.</td></tr>
+          <tr><td><code>cast_types</code>, <code>parse_bool_strings</code>, <code>round_numeric_columns</code>, <code>clip_numeric</code>, <code>winsorize_outliers</code>, <code>normalize_minmax</code></td><td>Type and numeric cleanup.</td></tr>
+          <tr><td><code>encode_categorical</code></td><td>Encode STRING columns using one-hot indicator columns or caller-supplied ordinal mappings.</td></tr>
+          <tr><td><code>replace_values</code>, <code>standardize_missing_tokens</code>, <code>combine_columns</code>, <code>coalesce_columns</code>, <code>safe_divide_columns</code></td><td>Common feature engineering and value repair helpers.</td></tr>
+        </tbody></table>
+        <div class="api-func"><div class="api-func-header">CastReport and CastFailure</div><div class="api-func-body"><p>Returned by <code>cast_types(..., errors="report")</code>. <code>CastReport</code> holds the cast <code>frame</code> and a <code>failures</code> list of <code>CastFailure</code> records. Each <code>CastFailure</code> has <code>column</code>, <code>row</code>, <code>value</code>, and <code>target_dtype</code> attributes. <code>bool(report)</code> is <code>True</code> when there is at least one failure.</p></div></div>
 
         <h2 id="pipeline">Pipeline</h2>
-        <div class="api-func">
-          <div class="api-func-header">pipeline(frame, steps, *, verbose=False, track_lineage=False)</div>
-          <div class="api-func-body">
-            <p>Run named cleaning steps or registered Python callables. <code>verbose=True</code> enables lightweight
-              diagnostics through the <code>arnio</code> logger and optional <code>PipelineContext</code>. Pass
-              <code>track_lineage=True</code> to receive a <code>(ArFrame, LineageReport)</code> tuple that maps every
-              dropped row back to its original index and the step that removed it.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">LineageReport</div>
-          <div class="api-func-body">
-            <p>Returned by <code>pipeline(..., track_lineage=True)</code>. Attributes: <code>dropped_by_step</code>
-              (dict mapping step name → sorted list of original row indices dropped by that step; steps that dropped no
-              rows have an empty list) and <code>total_dropped</code> (int). Method: <code>to_pandas()</code> returns a
-              flat <code>DataFrame</code> with columns <code>original_index</code> and <code>step</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">register_step(name, fn, overwrite=False), unregister_step(name), list_steps(),
-            reset_steps(), get_builtin_step_signatures()</div>
-          <div class="api-func-body">
-            <p>Manage the step registry and discover available built-in signatures.</p>
-          </div>
-        </div>
+        <div class="api-func"><div class="api-func-header">pipeline(frame, steps, *, verbose=False, track_lineage=False)</div><div class="api-func-body"><p>Run named cleaning steps or registered Python callables. <code>verbose=True</code> enables lightweight diagnostics through the <code>arnio</code> logger and optional <code>PipelineContext</code>. Pass <code>track_lineage=True</code> to receive a <code>(ArFrame, LineageReport)</code> tuple that maps every dropped row back to its original index and the step that removed it.</p></div></div>
+        <div class="api-func"><div class="api-func-header">LineageReport</div><div class="api-func-body"><p>Returned by <code>pipeline(..., track_lineage=True)</code>. Attributes: <code>dropped_by_step</code> (dict mapping step name → sorted list of original row indices dropped by that step; steps that dropped no rows have an empty list) and <code>total_dropped</code> (int). Method: <code>to_pandas()</code> returns a flat <code>DataFrame</code> with columns <code>original_index</code> and <code>step</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">register_step(name, fn, overwrite=False), unregister_step(name), list_steps(), reset_steps(), get_builtin_step_signatures()</div><div class="api-func-body"><p>Manage the step registry and discover available built-in signatures.</p></div></div>
         <h3>Pipeline Serialization</h3>
-        <ul>
-          <li><code>save_pipeline(steps, filepath)</code>: Save a list of pipeline steps to a JSON or YAML file for
-            reproducible jobs.</li>
-          <li><code>load_pipeline(filepath)</code>: Load a list of pipeline steps from a JSON or YAML file.</li>
-          <li><code>PipelineSerializationError</code>: Exception raised when a declarative pipeline cannot be saved or
-            loaded.</li>
-        </ul>
+<ul>
+    <li><code>save_pipeline(steps, filepath)</code>: Save a list of pipeline steps to a JSON or YAML file for reproducible jobs.</li>
+    <li><code>load_pipeline(filepath)</code>: Load a list of pipeline steps from a JSON or YAML file.</li>
+    <li><code>PipelineSerializationError</code>: Exception raised when a declarative pipeline cannot be saved or loaded.</li>
+</ul>
         <h2 id="quality">Quality</h2>
-        <div class="api-func">
-          <div class="api-func-header">profile(frame, *, exclude_columns=None, sample_size=5, approx_top_values=False,
-            approx_top_values_min_unique=1000, approx_top_values_min_ratio=0.2, approx_top_values_sample_size=2000)
-          </div>
-          <div class="api-func-body">
-            <p>Return <code>DataQualityReport</code> with row/column counts, duplicate metrics, column profiles,
-              warnings, quality score, score components, and cleaning suggestions.</p>
-          </div>
-        </div>
-
-        <div class="api-func">
-          <div class="api-func-header">DataQualityReport._repr_html_()</div>
-          <div class="api-func-body">
-            <p>Jupyter/IPython automatically calls this to render the report dashboard HTML directly in the notebook
-              output area.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">DataQualityReport.to_dict(redact_sample_values=False, exclude_columns=None),
-            to_json(), to_markdown(), to_html(), summary(), to_pandas()</div>
-          <div class="api-func-body">
-            <p>Export reports for notebooks, CI, docs, and automation.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">compare_profiles(left, right), suggest_cleaning(frame_or_report),
-            auto_clean(frame, *, mode="safe", return_report=False, dry_run=False, allow_lossy_casts=False,
-            confirmed_casts=None, explain=False)</div>
-          <div class="api-func-body">
-            <p>Compare quality over time, generate pipeline-compatible steps, or run automatic cleaning with optional
-              reports and audit output.</p>
-            <p><strong>Additional options:</strong></p>
-            <ul>
-              <li><code>return_report</code> – return the pre-cleaning quality report alongside cleaned output.</li>
-              <li><code>allow_lossy_casts</code> – opt in to strict-mode casts that may lose information.</li>
-              <li><code>confirmed_casts</code> – explicit column-to-dtype confirmations required before strict-mode
-                casts are applied.</li>
-            </ul>
-            <p><strong>Return values:</strong></p>
-            <ul>
-              <li><code>auto_clean(...)</code> → <code>ArFrame</code></li>
-              <li><code>auto_clean(..., return_report=True)</code> → <code>(ArFrame, DataQualityReport)</code></li>
-              <li><code>auto_clean(..., dry_run=True)</code> → <code>DataQualityReport</code></li>
-              <li><code>auto_clean(..., explain=True)</code> → <code>(ArFrame, CleanExplanation)</code></li>
-              <li><code>auto_clean(..., return_report=True, explain=True)</code> →
-                <code>(ArFrame, DataQualityReport, CleanExplanation)</code></li>
-            </ul>
-            <pre><code># Preview proposed changes
+        <div class="api-func"><div class="api-func-header">profile(frame, *, exclude_columns=None, sample_size=5, approx_top_values=False, approx_top_values_min_unique=1000, approx_top_values_min_ratio=0.2, approx_top_values_sample_size=2000)</div><div class="api-func-body"><p>Return <code>DataQualityReport</code> with row/column counts, duplicate metrics, column profiles, warnings, quality score, score components, and cleaning suggestions.</p></div></div>
+        
+        <div class="api-func"><div class="api-func-header">DataQualityReport._repr_html_()</div><div class="api-func-body"><p>Jupyter/IPython automatically calls this to render the report dashboard HTML directly in the notebook output area.</p></div></div>
+        <div class="api-func"><div class="api-func-header">DataQualityReport.to_dict(redact_sample_values=False, exclude_columns=None), to_json(), to_markdown(), to_html(), summary(), to_pandas()</div><div class="api-func-body"><p>Export reports for notebooks, CI, docs, and automation.</p></div></div>
+        <div class="api-func"><div class="api-func-header">compare_profiles(left, right), suggest_cleaning(frame_or_report), auto_clean(frame, *, mode="safe", return_report=False, dry_run=False, allow_lossy_casts=False, confirmed_casts=None, explain=False)</div><div class="api-func-body"><p>Compare quality over time, generate pipeline-compatible steps, or run automatic cleaning with optional reports and audit output.</p><p><strong>Additional options:</strong></p><ul><li><code>return_report</code> – return the pre-cleaning quality report alongside cleaned output.</li><li><code>allow_lossy_casts</code> – opt in to strict-mode casts that may lose information.</li><li><code>confirmed_casts</code> – explicit column-to-dtype confirmations required before strict-mode casts are applied.</li></ul><p><strong>Return values:</strong></p><ul><li><code>auto_clean(...)</code> → <code>ArFrame</code></li><li><code>auto_clean(..., return_report=True)</code> → <code>(ArFrame, DataQualityReport)</code></li><li><code>auto_clean(..., dry_run=True)</code> → <code>DataQualityReport</code></li><li><code>auto_clean(..., explain=True)</code> → <code>(ArFrame, CleanExplanation)</code></li><li><code>auto_clean(..., return_report=True, explain=True)</code> → <code>(ArFrame, DataQualityReport, CleanExplanation)</code></li></ul><pre><code># Preview proposed changes
 report = ar.auto_clean(frame, mode="strict", dry_run=True)
 
 # Clean and return report
@@ -477,70 +134,24 @@ cleaned, explanation = ar.auto_clean(
     frame,
     explain=True,
 )
-</code></pre>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">check_quality_gates(baseline_profile, current_profile, *,
-            max_row_count_delta_ratio=0.1, max_duplicate_ratio_delta=0.05, max_null_ratio_delta=0.05,
-            max_numeric_mean_delta_ratio=0.1, max_numeric_std_delta_ratio=0.2, allow_new_columns=False,
-            allow_missing_columns=False, fail_on_dtype_change=True)</div>
-          <div class="api-func-body">
-            <p>Compare two <code>DataQualityReport</code> objects and return a <code>QualityGateResult</code> suitable
-              for CI and release checks.</p>
-            <table class="param-table">
-              <thead>
-                <tr>
-                  <th>Option</th>
-                  <th>Default</th>
-                  <th>Gate behavior</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><code>max_row_count_delta_ratio</code></td>
-                  <td><code>0.1</code></td>
-                  <td>Maximum relative row-count drift. Set to <code>None</code> to disable.</td>
-                </tr>
-                <tr>
-                  <td><code>max_duplicate_ratio_delta</code></td>
-                  <td><code>0.05</code></td>
-                  <td>Maximum absolute duplicate-ratio drift. Set to <code>None</code> to disable.</td>
-                </tr>
-                <tr>
-                  <td><code>max_null_ratio_delta</code></td>
-                  <td><code>0.05</code></td>
-                  <td>Maximum absolute per-column null-ratio drift. Set to <code>None</code> to disable.</td>
-                </tr>
-                <tr>
-                  <td><code>max_numeric_mean_delta_ratio</code></td>
-                  <td><code>0.1</code></td>
-                  <td>Maximum relative per-column numeric mean drift. Set to <code>None</code> to disable.</td>
-                </tr>
-                <tr>
-                  <td><code>max_numeric_std_delta_ratio</code></td>
-                  <td><code>0.2</code></td>
-                  <td>Maximum relative per-column numeric standard-deviation drift. Set to <code>None</code> to disable.
-                  </td>
-                </tr>
-                <tr>
-                  <td><code>allow_new_columns</code></td>
-                  <td><code>False</code></td>
-                  <td>Allow columns that appear only in the current profile.</td>
-                </tr>
-                <tr>
-                  <td><code>allow_missing_columns</code></td>
-                  <td><code>False</code></td>
-                  <td>Allow baseline columns that are absent from the current profile.</td>
-                </tr>
-                <tr>
-                  <td><code>fail_on_dtype_change</code></td>
-                  <td><code>True</code></td>
-                  <td>Fail when shared columns change dtype.</td>
-                </tr>
-              </tbody>
-            </table>
-            <pre><code>baseline = ar.profile(ar.read_csv("baseline.csv"))
+</code></pre></div></div>
+        <div class="api-func"><div class="api-func-header">check_quality_gates(baseline_profile, current_profile, *, max_row_count_delta_ratio=0.1, max_duplicate_ratio_delta=0.05, max_null_ratio_delta=0.05, max_numeric_mean_delta_ratio=0.1, max_numeric_std_delta_ratio=0.2, allow_new_columns=False, allow_missing_columns=False, fail_on_dtype_change=True)</div><div class="api-func-body"><p>Compare two <code>DataQualityReport</code> objects and return a <code>QualityGateResult</code> suitable for CI and release checks.</p>
+          <table class="param-table">
+            <thead>
+              <tr><th>Option</th><th>Default</th><th>Gate behavior</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>max_row_count_delta_ratio</code></td><td><code>0.1</code></td><td>Maximum relative row-count drift. Set to <code>None</code> to disable.</td></tr>
+              <tr><td><code>max_duplicate_ratio_delta</code></td><td><code>0.05</code></td><td>Maximum absolute duplicate-ratio drift. Set to <code>None</code> to disable.</td></tr>
+              <tr><td><code>max_null_ratio_delta</code></td><td><code>0.05</code></td><td>Maximum absolute per-column null-ratio drift. Set to <code>None</code> to disable.</td></tr>
+              <tr><td><code>max_numeric_mean_delta_ratio</code></td><td><code>0.1</code></td><td>Maximum relative per-column numeric mean drift. Set to <code>None</code> to disable.</td></tr>
+              <tr><td><code>max_numeric_std_delta_ratio</code></td><td><code>0.2</code></td><td>Maximum relative per-column numeric standard-deviation drift. Set to <code>None</code> to disable.</td></tr>
+              <tr><td><code>allow_new_columns</code></td><td><code>False</code></td><td>Allow columns that appear only in the current profile.</td></tr>
+              <tr><td><code>allow_missing_columns</code></td><td><code>False</code></td><td>Allow baseline columns that are absent from the current profile.</td></tr>
+              <tr><td><code>fail_on_dtype_change</code></td><td><code>True</code></td><td>Fail when shared columns change dtype.</td></tr>
+            </tbody>
+          </table>
+<pre><code>baseline = ar.profile(ar.read_csv("baseline.csv"))
 current = ar.profile(ar.read_csv("current.csv"))
 
 result = ar.check_quality_gates(
@@ -553,317 +164,179 @@ result = ar.check_quality_gates(
 if not result.passed:
     print(result.to_markdown())
     result.raise_for_failures()
-</code></pre>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">Quality result classes</div>
-          <div class="api-func-body">
-            <p><code>ColumnProfile</code>, <code>CleaningSuggestion</code>, <code>CleanStepRecord</code>,
-              <code>CleanExplanation</code>, <code>ProfileComparison</code>, <code>QualityGateIssue</code>, and
-              <code>QualityGateResult</code> describe structured profiling, cleaning, comparison, and gate output.</p>
-          </div>
-        </div>
+</code></pre></div></div>
+        <div class="api-func"><div class="api-func-header">Quality result classes</div><div class="api-func-body"><p><code>ColumnProfile</code>, <code>CleaningSuggestion</code>, <code>CleanStepRecord</code>, <code>CleanExplanation</code>, <code>ProfileComparison</code>, <code>QualityGateIssue</code>, and <code>QualityGateResult</code> describe structured profiling, cleaning, comparison, and gate output.</p></div></div>
 
         <h2 id="schema">Schema</h2>
-        <div class="api-func">
-          <div class="api-func-header">Schema(fields, strict=False, unique=None, rules=None).validate(frame,
-            max_errors=None) / validate(frame, schema, max_errors=None)</div>
-          <div class="api-func-body">
-            <p>Validate frames against field definitions. <code>max_errors</code> was added in v1.18.0.</p>
-            <p><code>unique</code>: list or tuple of column names that must contain no duplicate values in the frame.
-            </p>
-            <p><code>rules</code>: list of callables <code>(pd.DataFrame) -&gt; list[ValidationIssue]</code> for
-              cross-field or custom contract checks.</p>
-            <pre><code>schema = ar.Schema(
+        <div class="api-func"><div class="api-func-header">Schema(fields, strict=False, unique=None, rules=None).validate(frame, max_errors=None) / validate(frame, schema, max_errors=None)</div><div class="api-func-body"><p>Validate frames against field definitions. <code>max_errors</code> was added in v1.18.0.</p><p><code>unique</code>: list or tuple of column names that must contain no duplicate values in the frame.</p><p><code>rules</code>: list of callables <code>(pd.DataFrame) -&gt; list[ValidationIssue]</code> for cross-field or custom contract checks.</p><pre><code>schema = ar.Schema(
     fields={"email": ar.Email(), "user_id": ar.Int64()},
     unique=["email"],
 )
-result = schema.validate(frame)</code></pre>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">validate_chunked(chunks, schema, *, max_errors=None)</div>
-          <div class="api-func-body">
-            <p>Validate an iterable of <code>ArFrame</code> chunks against a <code>Schema</code> and return a single
-              <code>ValidationResult</code>. Row indices in all <code>ValidationIssue</code> objects are adjusted to
-              reflect global positions across chunk boundaries. Supports <code>max_errors</code> for early termination.
-              Does not modify <code>validate()</code>.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">Field builders</div>
-          <div class="api-func-body">
-            <p>Each builder returns a <code>Field</code> for use in <code>Schema(fields={...})</code>. All builders
-              accept keyword-only arguments unless noted otherwise.</p>
-            <table class="param-table">
-              <thead>
-                <tr>
-                  <th>Builder</th>
-                  <th>Group</th>
-                  <th>Key parameters</th>
-                  <th>Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><code>Int64(...)</code></td>
-                  <td>Numeric</td>
-                  <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>,
-                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td>Integer range bounds are inclusive. <code>min</code> and <code>max</code> must be numeric.</td>
-                </tr>
-                <tr>
-                  <td><code>Float64(...)</code></td>
-                  <td>Numeric</td>
-                  <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>,
-                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td>Floating-point range bounds. Same constraints as <code>Int64</code>.</td>
-                </tr>
-                <tr>
-                  <td><code>String(...)</code></td>
-                  <td>String</td>
-                  <td><code>nullable=True</code>, <code>pattern=None</code>, <code>allowed=None</code>,
-                    <code>case_sensitive=True</code>, <code>min_length=None</code>, <code>max_length=None</code>,
-                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td><code>pattern</code> is a regex applied to every non-null value. <code>allowed</code> accepts a
-                    set, list, or tuple — not a bare string.</td>
-                </tr>
-                <tr>
-                  <td><code>Bool(...)</code></td>
-                  <td>Boolean</td>
-                  <td><code>nullable=True</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td>No range or uniqueness constraints; dtype must be boolean.</td>
-                </tr>
-                <tr>
-                  <td><code>Email(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>validation="light"</code>,
-                    <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td><code>validation</code> is <code>"light"</code> (format check) or <code>"strict"</code> (RFC 5322
-                    conformant).</td>
-                </tr>
-                <tr>
-                  <td><code>URL(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed_schemes=None</code>,
-                    <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td>Omit to allow the default http/https URL validator; pass <code>allowed_schemes=[...]</code> to
-                    permit a custom set such as <code>["https", "ftp"]</code>.</td>
-                </tr>
-                <tr>
-                  <td><code>PhoneNumber(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Validates E.164-style phone numbers.</td>
-                </tr>
-                <tr>
-                  <td><code>CountryCode(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Expects uppercase ISO 3166-1 alpha-2 codes (e.g. <code>"US"</code>, <code>"IN"</code>).</td>
-                </tr>
-                <tr>
-                  <td><code>CurrencyCode(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed=None</code>,
-                    <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td>Validates 3-letter uppercase ISO 4217 codes. <code>allowed</code> narrows to a custom subset of
-                    valid codes.</td>
-                </tr>
-                <tr>
-                  <td><code>LanguageCode(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Expects lowercase ISO 639-1 two-letter codes (e.g. <code>"en"</code>, <code>"fr"</code>).</td>
-                </tr>
-                <tr>
-                  <td><code>TimeZone(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Validates IANA timezone identifiers (e.g. <code>"America/New_York"</code>).</td>
-                </tr>
-                <tr>
-                  <td><code>Date(...)</code></td>
-                  <td>Date / Time</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Validates ISO 8601 date strings (<code>YYYY-MM-DD</code>).</td>
-                </tr>
-                <tr>
-                  <td><code>DateTime(...)</code></td>
-                  <td>Date / Time</td>
-                  <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>,
-                    <code>format=None</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td><code>format</code> is a <code>strptime</code> format string. <code>min</code> / <code>max</code>
-                    accept ISO strings or <code>datetime</code> objects.</td>
-                </tr>
-                <tr>
-                  <td><code>Regex(pattern, ...)</code></td>
-                  <td>Regex</td>
-                  <td><code>pattern</code> (positional, required), <code>nullable=True</code>,
-                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td>Pattern is compiled at call time — invalid expressions raise <code>re.error</code> immediately,
-                    not at validation time.</td>
-                </tr>
-                <tr>
-                  <td><code>Custom(name, ...)</code></td>
-                  <td>Custom</td>
-                  <td><code>name</code> (positional, required), <code>nullable=True</code>, <code>unique=False</code>,
-                    <code>severity="error"</code>, <code>required_if=None</code></td>
-                  <td><code>name</code> must match a validator registered via <code>register_validator()</code>. Raises
-                    <code>ValueError</code> if the name is not found.</td>
-                </tr>
-                <tr>
-                  <td><code>UUID(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Validates canonical UUID strings (8-4-4-4-12 hexadecimal format).</td>
-                </tr>
-
-                <tr>
-                  <td><code>IPv4(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Validates dotted-decimal IPv4 addresses (e.g. <code>192.168.1.1</code>).</td>
-                </tr>
-
-                <tr>
-                  <td><code>MACAddress(...)</code></td>
-                  <td>Semantic</td>
-                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
-                    <code>required_if=None</code></td>
-                  <td>Validates IEEE 802 MAC addresses in colon-separated notation.</td>
-                </tr>
-              </tbody>
-            </table>
-            <p style="margin-top:1rem"><strong>Common parameters:</strong> <code>nullable</code> — allow null values;
-              <code>unique</code> — require all non-null values to be distinct; <code>severity</code> —
-              <code>"error"</code> (default) or <code>"warning"</code>; <code>required_if</code> — a
-              <code>(column, value)</code> tuple that makes the field mandatory when another column equals a given
-              value.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">diff_schema, schema_to_dict, schema_to_yaml, schema_from_yaml, register_validator
-          </div>
-          <div class="api-func-body">
-            <p>Compare schema contracts, export schema definitions, and register custom semantic validators. Structured
-              results include <code>SchemaDiff</code>, <code>SchemaDiffEntry</code>, <code>ValidationIssue</code>, and
-              <code>ValidationResult</code>.</p>
-          </div>
-        </div>
+result = schema.validate(frame)</code></pre></div></div>
+        <div class="api-func"><div class="api-func-header">validate_chunked(chunks, schema, *, max_errors=None)</div><div class="api-func-body"><p>Validate an iterable of <code>ArFrame</code> chunks against a <code>Schema</code> and return a single <code>ValidationResult</code>. Row indices in all <code>ValidationIssue</code> objects are adjusted to reflect global positions across chunk boundaries. Supports <code>max_errors</code> for early termination. Does not modify <code>validate()</code>.</p></div></div>
+        <div class="api-func"><div class="api-func-header">Field builders</div><div class="api-func-body">
+          <p>Each builder returns a <code>Field</code> for use in <code>Schema(fields={...})</code>. All builders accept keyword-only arguments unless noted otherwise.</p>
+          <table class="param-table">
+            <thead>
+              <tr>
+                <th>Builder</th>
+                <th>Group</th>
+                <th>Key parameters</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>Int64(...)</code></td>
+                <td>Numeric</td>
+                <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Integer range bounds are inclusive. <code>min</code> and <code>max</code> must be numeric.</td>
+              </tr>
+              <tr>
+                <td><code>Float64(...)</code></td>
+                <td>Numeric</td>
+                <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Floating-point range bounds. Same constraints as <code>Int64</code>.</td>
+              </tr>
+              <tr>
+                <td><code>String(...)</code></td>
+                <td>String</td>
+                <td><code>nullable=True</code>, <code>pattern=None</code>, <code>allowed=None</code>, <code>case_sensitive=True</code>, <code>min_length=None</code>, <code>max_length=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td><code>pattern</code> is a regex applied to every non-null value. <code>allowed</code> accepts a set, list, or tuple — not a bare string.</td>
+              </tr>
+              <tr>
+                <td><code>Bool(...)</code></td>
+                <td>Boolean</td>
+                <td><code>nullable=True</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>No range or uniqueness constraints; dtype must be boolean.</td>
+              </tr>
+              <tr>
+                <td><code>Email(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>validation="light"</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td><code>validation</code> is <code>"light"</code> (format check) or <code>"strict"</code> (RFC 5322 conformant).</td>
+              </tr>
+              <tr>
+                <td><code>URL(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed_schemes=None</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Omit to allow the default http/https URL validator; pass <code>allowed_schemes=[...]</code> to permit a custom set such as <code>["https", "ftp"]</code>.</td>
+              </tr>
+              <tr>
+                <td><code>PhoneNumber(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Validates E.164-style phone numbers.</td>
+              </tr>
+              <tr>
+                <td><code>CountryCode(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Expects uppercase ISO 3166-1 alpha-2 codes (e.g. <code>"US"</code>, <code>"IN"</code>).</td>
+              </tr>
+              <tr>
+                <td><code>CurrencyCode(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed=None</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Validates 3-letter uppercase ISO 4217 codes. <code>allowed</code> narrows to a custom subset of valid codes.</td>
+              </tr>
+              <tr>
+                <td><code>LanguageCode(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Expects lowercase ISO 639-1 two-letter codes (e.g. <code>"en"</code>, <code>"fr"</code>).</td>
+              </tr>
+              <tr>
+                <td><code>TimeZone(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Validates IANA timezone identifiers (e.g. <code>"America/New_York"</code>).</td>
+              </tr>
+              <tr>
+                <td><code>UUID(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Validates the canonical 8-4-4-4-12 hexadecimal UUID format (RFC 4122, e.g. <code>"550e8400-e29b-41d4-a716-446655440000"</code>). Both upper- and lower-case hex digits are accepted.</td>
+              </tr>
+              <tr>
+                <td><code>IPv4(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Validates strict dotted-decimal IPv4 addresses (e.g. <code>"192.168.1.1"</code>). Each octet must be 0&#8211;255; leading zeros are rejected.</td>
+              </tr>
+              <tr>
+                <td><code>MACAddress(...)</code></td>
+                <td>Semantic</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Validates IEEE 802 MAC-48 addresses in colon-separated (<code>"AA:BB:CC:DD:EE:FF"</code>) or hyphen-separated (<code>"AA-BB-CC-DD-EE-FF"</code>) notation.</td>
+              </tr>
+              <tr>
+                <td><code>Date(...)</code></td>
+                <td>Date / Time</td>
+                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Validates ISO 8601 date strings (<code>YYYY-MM-DD</code>).</td>
+              </tr>
+              <tr>
+                <td><code>DateTime(...)</code></td>
+                <td>Date / Time</td>
+                <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>, <code>format=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td><code>format</code> is a <code>strptime</code> format string. <code>min</code> / <code>max</code> accept ISO strings or <code>datetime</code> objects.</td>
+              </tr>
+              <tr>
+                <td><code>Regex(pattern, ...)</code></td>
+                <td>Regex</td>
+                <td><code>pattern</code> (positional, required), <code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td>Pattern is compiled at call time — invalid expressions raise <code>re.error</code> immediately, not at validation time.</td>
+              </tr>
+              <tr>
+                <td><code>Custom(name, ...)</code></td>
+                <td>Custom</td>
+                <td><code>name</code> (positional, required), <code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                <td><code>name</code> must match a validator registered via <code>register_validator()</code>. Raises <code>ValueError</code> if the name is not found.</td>
+              </tr>
+            </tbody>
+          </table>
+          <p style="margin-top:1rem"><strong>Common parameters:</strong> <code>nullable</code> — allow null values; <code>unique</code> — require all non-null values to be distinct; <code>severity</code> — <code>"error"</code> (default) or <code>"warning"</code>; <code>required_if</code> — a <code>(column, value)</code> tuple that makes the field mandatory when another column equals a given value.</p>
+        </div></div>
+        <div class="api-func"><div class="api-func-header">diff_schema, schema_to_dict, schema_to_yaml, schema_from_yaml, register_validator</div><div class="api-func-body"><p>Compare schema contracts, export schema definitions, and register custom semantic validators. Structured results include <code>SchemaDiff</code>, <code>SchemaDiffEntry</code>, <code>ValidationIssue</code>, and <code>ValidationResult</code>.</p></div></div>
 
         <h2 id="integrations">Integrations</h2>
-        <div class="api-func">
-          <div class="api-func-header">ArnioPandasAccessor / pandas accessor: df.arnio.to_arframe(), pipeline(),
-            clean(), profile(), suggest_cleaning(), auto_clean(), validate()</div>
-          <div class="api-func-body">
-            <p>Run Arnio workflows directly from pandas DataFrames.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">df.arnio.clean(steps=None, *, strip_whitespace=True, drop_nulls=False,
-            drop_duplicates=False)</div>
-          <div class="api-func-body">
-            <p>Clean a DataFrame with Arnio and return a <code>pandas.DataFrame</code>.</p>
-            <p>When <code>steps</code> is provided, it is passed directly to <code>ar.pipeline()</code> and the keyword
-              flags are ignored. When <code>steps</code> is omitted, the convenience-clean path runs with the keyword
-              flags controlling which operations apply.</p>
-            <ul>
-              <li><code>strip_whitespace</code> – strip leading and trailing whitespace from string columns (default
-                <code>True</code>).</li>
-              <li><code>drop_nulls</code> – drop rows that contain any null value (default <code>False</code>).</li>
-              <li><code>drop_duplicates</code> – drop duplicate rows (default <code>False</code>).</li>
-            </ul>
-            <pre><code>import pandas as pd
+        <div class="api-func"><div class="api-func-header">ArnioPandasAccessor / pandas accessor: df.arnio.to_arframe(), pipeline(), clean(), profile(), suggest_cleaning(), auto_clean(), validate()</div><div class="api-func-body"><p>Run Arnio workflows directly from pandas DataFrames.</p></div></div>
+        <div class="api-func"><div class="api-func-header">df.arnio.clean(steps=None, *, strip_whitespace=True, drop_nulls=False, drop_duplicates=False)</div><div class="api-func-body"><p>Clean a DataFrame with Arnio and return a <code>pandas.DataFrame</code>.</p><p>When <code>steps</code> is provided, it is passed directly to <code>ar.pipeline()</code> and the keyword flags are ignored. When <code>steps</code> is omitted, the convenience-clean path runs with the keyword flags controlling which operations apply.</p><ul><li><code>strip_whitespace</code> – strip leading and trailing whitespace from string columns (default <code>True</code>).</li><li><code>drop_nulls</code> – drop rows that contain any null value (default <code>False</code>).</li><li><code>drop_duplicates</code> – drop duplicate rows (default <code>False</code>).</li></ul><pre><code>import pandas as pd
 import arnio as ar
 
 df = pd.DataFrame({"name": [" Alice ", " Alice "], "score": [10, 10]})
 cleaned = df.arnio.clean(drop_duplicates=True)
-# cleaned: one row, name stripped to "Alice"</code></pre>
-            <p><strong>Returns:</strong> <code>pandas.DataFrame</code></p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">register_duckdb(frame, conn, name)</div>
-          <div class="api-func-body">
-            <p>Register an <code>ArFrame</code> as a DuckDB relation through pandas interop.</p>
-          </div>
-        </div>
-        <div class="api-func">
-          <div class="api-func-header">ArnioCleaner</div>
-          <div class="api-func-body">
-            <p>Optional scikit-learn transformer for pipeline-safe data preparation. Install with
-              <code>pip install "arnio[sklearn]"</code>.</p>
-          </div>
-        </div>
+# cleaned: one row, name stripped to "Alice"</code></pre><p><strong>Returns:</strong> <code>pandas.DataFrame</code></p></div></div>
+        <div class="api-func"><div class="api-func-header">register_duckdb(frame, conn, name)</div><div class="api-func-body"><p>Register an <code>ArFrame</code> as a DuckDB relation through pandas interop.</p></div></div>
+        <div class="api-func"><div class="api-func-header">ArnioCleaner</div><div class="api-func-body"><p>Optional scikit-learn transformer for pipeline-safe data preparation. Install with <code>pip install "arnio[sklearn]"</code>.</p></div></div>
 
         <h2 id="exceptions">Exceptions</h2>
-        <div class="api-func">
-          <div class="api-func-header">ArnioError and specialized exceptions</div>
-          <div class="api-func-body">
-            <p><code>ArnioError</code> is the package-level base exception. Public specialized exceptions include
-              <code>CsvReadError</code>, <code>JsonlReadError</code>, <code>RemoteReadError</code>,
-              <code>TypeCastError</code>, <code>PipelineStepError</code>, <code>UnknownStepError</code>, and
-              <code>SchemaValidationError</code>.</p>
-          </div>
-        </div>
+        <div class="api-func"><div class="api-func-header">ArnioError and specialized exceptions</div><div class="api-func-body"><p><code>ArnioError</code> is the package-level base exception. Public specialized exceptions include <code>CsvReadError</code>, <code>JsonlReadError</code>, <code>RemoteReadError</code>, <code>TypeCastError</code>, <code>PipelineStepError</code>, <code>UnknownStepError</code>, and <code>SchemaValidationError</code>.</p></div></div>
       </article>
     </div>
   </main>
 
-  <footer class="site-footer">
+ <footer class="site-footer">
     <div class="container">
       <div class="footer-grid">
-        <div class="footer-brand"><img src="arnio-logo.svg" alt="Arnio" height="32" loading="lazy" decoding="async">
-          <p>C++ accelerated data preparation for pandas and the Python data stack.</p>
-        </div>
-        <div>
-          <h4 class="footer-heading">Project</h4>
-          <ul class="footer-links">
-            <li><a href="docs.html">Docs</a></li>
-            <li><a href="api.html">API</a></li>
-            <li><a href="changelog.html">Changelog</a></li>
-          </ul>
-        </div>
-        <div>
-          <h4 class="footer-heading">Engineering</h4>
-          <ul class="footer-links">
-            <li><a href="architecture.html">Architecture</a></li>
-            <li><a href="benchmarks.html">Benchmarks</a></li>
-            <li><a href="roadmap.html">Roadmap</a></li>
-          </ul>
-        </div>
-        <div>
-          <h4 class="footer-heading">Community</h4>
-          <ul class="footer-links">
-            <li><a href="contributing.html">Contributing</a></li>
-            <li><a href="community.html">Community</a></li>
-            <li class="footer-socials">
-              <a href="https://github.com/im-anishraj/arnio" target="_blank" rel="noopener" aria-label="GitHub">
-                <svg viewBox="0 0 24 24" fill="currentColor">
-                  <path
-                    d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.082-.729.082-.729 1.205.084 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.304.76-1.604-2.665-.305-5.467-1.332-5.467-5.93 0-1.31.467-2.382 1.235-3.222-.123-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23A11.52 11.52 0 0112 6.844c1.02.005 2.045.138 3.003.404 2.29-1.552 3.296-1.23 3.296-1.23.654 1.653.242 2.874.12 3.176.77.84 1.233 1.911 1.233 3.222 0 4.61-2.807 5.623-5.48 5.921.43.37.814 1.102.814 2.222 0 1.606-.015 2.898-.015 3.293 0 .322.216.694.825.576C20.565 21.796 24 17.297 24 12c0-6.63-5.373-12-12-12z" />
-                </svg>
-              </a>
+        <div class="footer-brand"><img src="arnio-logo.svg" alt="Arnio" height="32" loading="lazy" decoding="async"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
+        <div><h4 class="footer-heading">Project</h4><ul class="footer-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="changelog.html">Changelog</a></li></ul></div>
+        <div><h4 class="footer-heading">Engineering</h4><ul class="footer-links"><li><a href="architecture.html">Architecture</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="roadmap.html">Roadmap</a></li></ul></div>
+        <div><h4 class="footer-heading">Community</h4><ul class="footer-links"><li><a href="contributing.html">Contributing</a></li><li><a href="community.html">Community</a></li>
+         <li class="footer-socials">
+            <a href="https://github.com/im-anishraj/arnio" target="_blank" rel="noopener" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.082-.729.082-.729 1.205.084 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.304.76-1.604-2.665-.305-5.467-1.332-5.467-5.93 0-1.31.467-2.382 1.235-3.222-.123-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23A11.52 11.52 0 0112 6.844c1.02.005 2.045.138 3.003.404 2.29-1.552 3.296-1.23 3.296-1.23.654 1.653.242 2.874.12 3.176.77.84 1.233 1.911 1.233 3.222 0 4.61-2.807 5.623-5.48 5.921.43.37.814 1.102.814 2.222 0 1.606-.015 2.898-.015 3.293 0 .322.216.694.825.576C20.565 21.796 24 17.297 24 12c0-6.63-5.373-12-12-12z"/>
+              </svg>
+            </a>
 
-              <a href="https://www.linkedin.com/in/im-anishraj" target="_blank" rel="noopener" aria-label="LinkedIn">
-                <svg viewBox="0 0 24 24" fill="currentColor">
-                  <path
-                    d="M20.447 20.452H16.89V14.87c0-1.332-.026-3.045-1.854-3.045-1.854 0-2.137 1.447-2.137 2.946v5.68H9.343V9h3.414v1.561h.049c.476-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.063 2.063 0 11.001-4.126 2.063 2.063 0 01-.001 4.126zM7.119 20.452H3.556V9H7.12v11.452z" />
-                </svg>
-              </a>
-            </li>
-          </ul>
-        </div>
+            <a href="https://www.linkedin.com/in/im-anishraj" target="_blank" rel="noopener" aria-label="LinkedIn">
+              <svg viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20.447 20.452H16.89V14.87c0-1.332-.026-3.045-1.854-3.045-1.854 0-2.137 1.447-2.137 2.946v5.68H9.343V9h3.414v1.561h.049c.476-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.063 2.063 0 11.001-4.126 2.063 2.063 0 01-.001 4.126zM7.119 20.452H3.556V9H7.12v11.452z"/>
+              </svg>
+            </a>
+          </li></ul></div>
       </div>
       <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
@@ -872,5 +345,4 @@ cleaned = df.arnio.clean(drop_duplicates=True)
   <script src="js/code.js" defer></script>
   <script src="js/search.js" defer></script>
 </body>
-
 </html>

--- a/website/api.html
+++ b/website/api.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,112 +16,454 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://arnio.vercel.app/">
   <meta property="og:title" content="Arnio — Production Data Preparation for Python">
-  <meta property="og:description" content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
+  <meta property="og:description"
+    content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
   <meta property="og:image" content="https://arnio.vercel.app/arnio-social-card.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Arnio — Production Data Preparation for Python">
-  <meta name="twitter:description" content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
+  <meta name="twitter:description"
+    content="Arnio combines a native C++ CSV engine with Python APIs for cleaning, quality profiling, and schema validation.">
   <meta name="twitter:image" content="https://arnio.vercel.app/arnio-social-card.svg">
 </head>
+
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
   <nav class="top-nav" aria-label="Main navigation">
     <div class="container container--wide">
-      <a href="index.html" class="nav-brand" aria-label="Arnio home"><img src="arnio-logo.svg" alt="Arnio" height="32"></a>
-      <ul class="nav-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="contributing.html">Contributing</a></li><li><a href="architecture.html">Architecture</a></li><li><a href="roadmap.html">Roadmap</a></li><li><a href="community.html">Community</a></li><li><a href="changelog.html">Changelog</a></li></ul>
+      <a href="index.html" class="nav-brand" aria-label="Arnio home"><img src="arnio-logo.svg" alt="Arnio"
+          height="32"></a>
+      <ul class="nav-links">
+        <li><a href="docs.html">Docs</a></li>
+        <li><a href="api.html">API</a></li>
+        <li><a href="benchmarks.html">Benchmarks</a></li>
+        <li><a href="contributing.html">Contributing</a></li>
+        <li><a href="architecture.html">Architecture</a></li>
+        <li><a href="roadmap.html">Roadmap</a></li>
+        <li><a href="community.html">Community</a></li>
+        <li><a href="changelog.html">Changelog</a></li>
+      </ul>
       <div class="nav-actions">
         <div class="search-wrapper">
-          <input
-            id="docs-search"
-            class="search-input"
-            type="text"
-            placeholder="Search docs... (Ctrl+K)"
-            aria-label="Search documentation"
-          />
+          <input id="docs-search" class="search-input" type="text" placeholder="Search docs... (Ctrl+K)"
+            aria-label="Search documentation" />
           <div id="search-results" class="search-results"></div>
         </div>
 
-        <a href="https://discord.gg/xsEw7r78M" class="nav-discord" target="_blank" rel="noopener" aria-label="Join Discord">Discord</a><a href="https://github.com/im-anishraj/arnio" class="nav-github" target="_blank" rel="noopener" aria-label="View on GitHub">GitHub</a><button class="theme-toggle" aria-label="Toggle theme">Theme</button><button class="nav-hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-navigation">☰</button></div>
+        <a href="https://discord.gg/xsEw7r78M" class="nav-discord" target="_blank" rel="noopener"
+          aria-label="Join Discord">Discord</a><a href="https://github.com/im-anishraj/arnio" class="nav-github"
+          target="_blank" rel="noopener" aria-label="View on GitHub">GitHub</a><button class="theme-toggle"
+          aria-label="Toggle theme">Theme</button><button class="nav-hamburger" aria-label="Open menu"
+          aria-expanded="false" aria-controls="mobile-navigation">☰</button>
+      </div>
     </div>
   </nav>
-  <div id="mobile-navigation" class="mobile-menu" aria-label="Mobile navigation"><a href="index.html">Home</a><a href="docs.html">Documentation</a><a href="api.html">API Reference</a><a href="benchmarks.html">Benchmarks</a><a href="contributing.html">Contributing</a><a href="architecture.html">Architecture</a><a href="roadmap.html">Roadmap</a><a href="community.html">Community</a><a href="https://discord.gg/xsEw7r78M" target="_blank" rel="noopener">Discord</a><a href="changelog.html">Changelog</a></div>
+  <div id="mobile-navigation" class="mobile-menu" aria-label="Mobile navigation"><a href="index.html">Home</a><a
+      href="docs.html">Documentation</a><a href="api.html">API Reference</a><a href="benchmarks.html">Benchmarks</a><a
+      href="contributing.html">Contributing</a><a href="architecture.html">Architecture</a><a
+      href="roadmap.html">Roadmap</a><a href="community.html">Community</a><a href="https://discord.gg/xsEw7r78M"
+      target="_blank" rel="noopener">Discord</a><a href="changelog.html">Changelog</a></div>
 
-  <header class="page-hero"><div class="container"><h1>API Reference</h1><p>Public functions and classes available in Arnio's current Python API.</p></div></header>
+  <header class="page-hero">
+    <div class="container">
+      <h1>API Reference</h1>
+      <p>Public functions and classes available in Arnio's current Python API.</p>
+    </div>
+  </header>
 
   <main id="main-content" class="main-content">
     <div class="container docs-layout">
       <aside class="docs-sidebar">
-        <div class="sidebar-nav-group"><div class="sidebar-nav-title">I/O</div><a href="#io" class="sidebar-nav-link">I/O functions</a><a href="#frame" class="sidebar-nav-link">ArFrame</a><a href="#conversion" class="sidebar-nav-link">Conversion</a></div>
-        <div class="sidebar-nav-group"><div class="sidebar-nav-title">Transform</div><a href="#cleaning" class="sidebar-nav-link">Cleaning</a><a href="#pipeline" class="sidebar-nav-link">Pipeline</a></div>
-        <div class="sidebar-nav-group"><div class="sidebar-nav-title">Quality</div><a href="#quality" class="sidebar-nav-link">Quality</a><a href="#schema" class="sidebar-nav-link">Schema</a><a href="#integrations" class="sidebar-nav-link">Integrations</a><a href="#exceptions" class="sidebar-nav-link">Exceptions</a></div>
+        <div class="sidebar-nav-group">
+          <div class="sidebar-nav-title">I/O</div><a href="#io" class="sidebar-nav-link">I/O functions</a><a
+            href="#frame" class="sidebar-nav-link">ArFrame</a><a href="#conversion"
+            class="sidebar-nav-link">Conversion</a>
+        </div>
+        <div class="sidebar-nav-group">
+          <div class="sidebar-nav-title">Transform</div><a href="#cleaning" class="sidebar-nav-link">Cleaning</a><a
+            href="#pipeline" class="sidebar-nav-link">Pipeline</a>
+        </div>
+        <div class="sidebar-nav-group">
+          <div class="sidebar-nav-title">Quality</div><a href="#quality" class="sidebar-nav-link">Quality</a><a
+            href="#schema" class="sidebar-nav-link">Schema</a><a href="#integrations"
+            class="sidebar-nav-link">Integrations</a><a href="#exceptions" class="sidebar-nav-link">Exceptions</a>
+        </div>
       </aside>
 
       <article class="docs-content">
-        <div class="notice"><strong>Scope:</strong> This page documents the public Python API exposed from <code>arnio.__all__</code> on current <code>origin/main</code>.</div>
+        <div class="notice"><strong>Scope:</strong> This page documents the public Python API exposed from
+          <code>arnio.__all__</code> on current <code>origin/main</code>.</div>
 
         <h2 id="io">I/O</h2>
-        <div class="api-func"><div class="api-func-header">read_csv(path, *, delimiter=None, has_header=True, usecols=None, nrows=None, skiprows=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None, null_values=None, dtype=None, mode="strict", encoding_errors="strict", on_bad_lines="error")</div><div class="api-func-body"><p>Read CSV-like input into an <code>ArFrame</code>. Supports extension-flexible paths, TSV delimiter inference, explicit dtypes, decoding policy, and configurable malformed-row handling. Key options: <code>trim_headers</code> strips whitespace from column names; <code>null_values</code> specifies additional tokens to treat as null; <code>thousands_separator</code> enables numeric parsing with grouping separators; <code>mode</code> controls parser strictness (<code>"strict"</code> or <code>"lax"</code>).</p><p><strong>Returns:</strong> <code>ArFrame</code>. Raises <code>CsvReadError</code> for read and parse failures.</p></div></div>
-        <div class="api-func"><div class="api-func-header">read_csv_chunked(path, *, chunksize=10000, dtype=None, delimiter=None, has_header=True, usecols=None, nrows=None, skip_rows=0, skiprows=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None, null_values=None, mode="strict", on_bad_lines="error")</div><div class="api-func-body"><p>Yield <code>ArFrame</code> chunks from large files. <code>delimiter=None</code> infers tab delimiters for <code>.tsv</code> paths and comma otherwise. <code>on_bad_lines</code> may error, warn, or skip malformed row-width records. Supports the same parser controls as <code>read_csv()</code>, including <code>dtype</code>, <code>usecols</code>, <code>null_values</code>, <code>thousands_separator</code>, <code>trim_headers</code>, and <code>mode</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">scan_csv(path, *, delimiter=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None, sample_size=None, null_values=None, has_header=True, encoding_errors="strict", mode="strict", on_bad_lines="error")</div><div class="api-func-body"><p>Infer column names and dtypes without loading the full file. Like <code>read_csv</code>, omitted delimiters use tab for <code>.tsv</code> paths and comma otherwise.</p><p><strong>Example:</strong> <code>ar.scan_csv("raw.csv", sample_size=500, null_values=["NA", "MISSING"])</code> keeps sampling and null-token handling aligned with a later <code>read_csv()</code> call.</p></div></div>
-        <div class="api-func"><div class="api-func-header">read_jsonl(path, *, encoding="utf-8", encoding_errors="strict", nrows=None)</div><div class="api-func-body"><p>Read JSON Lines or NDJSON into an <code>ArFrame</code>; mixed object columns are coerced to strings. The <code>encoding</code> and <code>encoding_errors</code> parameters control how file bytes are decoded into text.</p></div></div>
-        <div class="api-func"><div class="api-func-header">read_jsonl_chunked(path, *, chunksize=10000, encoding="utf-8", encoding_errors="strict", nrows=None)</div><div class="api-func-body"><p>Yield JSON Lines or NDJSON records as <code>ArFrame</code> chunks without buffering the whole file. Uses the same validation, line-numbered errors, decoding controls, and <code>nrows</code> limit as <code>read_jsonl()</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">write_csv(frame, path, *, delimiter=",", write_header=True, line_terminator="\n", escape_formulas=False, encoding="utf-8", encoding_errors="strict")</div><div class="api-func-body"><p>Write an <code>ArFrame</code> to CSV or TSV with delimiter and line terminator validation. Set <code>escape_formulas=True</code> to prefix string cells that start with spreadsheet formula trigger characters before CSV quoting. <code>encoding</code> defaults to <code>"utf-8"</code> (native fast path); any Python codec is accepted and transcoded in bounded chunks. <code>encoding_errors</code> controls unencodable character handling: <code>"strict"</code> (default), <code>"replace"</code>, or <code>"ignore"</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">write_json(frame, path, *, orient="records", indent=None)</div><div class="api-func-body"><p>Export an <code>ArFrame</code> to JSON without pandas conversion. Supported orient formats: <code>"records"</code>, <code>"list"</code>, and <code>"split"</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">read_parquet(path, *, columns=None, usecols=None)</div><div class="api-func-body"><p>Read a Parquet file into an <code>ArFrame</code> via the optional <code>pyarrow</code> dependency. Install with <code>pip install "arnio[parquet]"</code>. Use <code>usecols</code> or <code>columns</code> for column subset selection.</p></div></div>
-        <div class="api-func"><div class="api-func-header">write_parquet(frame, path, *, compression="snappy", row_group_size=None, preserve_attrs=True)</div><div class="api-func-body"><p>Write an <code>ArFrame</code> to Parquet via the optional <code>pyarrow</code> dependency. Install with <code>pip install "arnio[parquet]"</code>. <code>preserve_attrs=True</code> writes JSON-serializable <code>DataFrame.attrs</code> into Parquet metadata; set to <code>False</code> to skip that export. Accepted compression values: <code>"snappy"</code> (default), <code>"gzip"</code>, <code>"brotli"</code>, <code>"zstd"</code>, and <code>"none"</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">sniff_delimiter(path, *, encoding="utf-8", sample_size=2048)</div><div class="api-func-body"><p>Detect a likely delimiter for CSV-like input before reading or scanning. <code>sample_size</code> controls how many characters are read from the start of the file for detection; the default of <code>2048</code> is sufficient for most files. Increase it when the file has an unusual delimiter that only appears further into the content.</p></div></div>
+        <div class="api-func">
+          <div class="api-func-header">read_csv(path, *, delimiter=None, has_header=True, usecols=None, nrows=None,
+            skiprows=None, encoding="utf-8", trim_headers=True, decimal_separator=".", thousands_separator=None,
+            null_values=None, dtype=None, mode="strict", encoding_errors="strict", on_bad_lines="error")</div>
+          <div class="api-func-body">
+            <p>Read CSV-like input into an <code>ArFrame</code>. Supports extension-flexible paths, TSV delimiter
+              inference, explicit dtypes, decoding policy, and configurable malformed-row handling. Key options:
+              <code>trim_headers</code> strips whitespace from column names; <code>null_values</code> specifies
+              additional tokens to treat as null; <code>thousands_separator</code> enables numeric parsing with grouping
+              separators; <code>mode</code> controls parser strictness (<code>"strict"</code> or <code>"lax"</code>).
+            </p>
+            <p><strong>Returns:</strong> <code>ArFrame</code>. Raises <code>CsvReadError</code> for read and parse
+              failures.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">read_csv_chunked(path, *, chunksize=10000, dtype=None, delimiter=None,
+            has_header=True, usecols=None, nrows=None, skip_rows=0, skiprows=None, encoding="utf-8", trim_headers=True,
+            decimal_separator=".", thousands_separator=None, null_values=None, mode="strict", on_bad_lines="error")
+          </div>
+          <div class="api-func-body">
+            <p>Yield <code>ArFrame</code> chunks from large files. <code>delimiter=None</code> infers tab delimiters for
+              <code>.tsv</code> paths and comma otherwise. <code>on_bad_lines</code> may error, warn, or skip malformed
+              row-width records. Supports the same parser controls as <code>read_csv()</code>, including
+              <code>dtype</code>, <code>usecols</code>, <code>null_values</code>, <code>thousands_separator</code>,
+              <code>trim_headers</code>, and <code>mode</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">scan_csv(path, *, delimiter=None, encoding="utf-8", trim_headers=True,
+            decimal_separator=".", thousands_separator=None, sample_size=None, null_values=None, has_header=True,
+            encoding_errors="strict", mode="strict", on_bad_lines="error")</div>
+          <div class="api-func-body">
+            <p>Infer column names and dtypes without loading the full file. Like <code>read_csv</code>, omitted
+              delimiters use tab for <code>.tsv</code> paths and comma otherwise.</p>
+            <p><strong>Example:</strong>
+              <code>ar.scan_csv("raw.csv", sample_size=500, null_values=["NA", "MISSING"])</code> keeps sampling and
+              null-token handling aligned with a later <code>read_csv()</code> call.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">read_jsonl(path, *, encoding="utf-8", encoding_errors="strict", nrows=None)</div>
+          <div class="api-func-body">
+            <p>Read JSON Lines or NDJSON into an <code>ArFrame</code>; mixed object columns are coerced to strings. The
+              <code>encoding</code> and <code>encoding_errors</code> parameters control how file bytes are decoded into
+              text.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">read_jsonl_chunked(path, *, chunksize=10000, encoding="utf-8",
+            encoding_errors="strict", nrows=None)</div>
+          <div class="api-func-body">
+            <p>Yield JSON Lines or NDJSON records as <code>ArFrame</code> chunks without buffering the whole file. Uses
+              the same validation, line-numbered errors, decoding controls, and <code>nrows</code> limit as
+              <code>read_jsonl()</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">write_csv(frame, path, *, delimiter=",", write_header=True, line_terminator="\n",
+            escape_formulas=False, encoding="utf-8", encoding_errors="strict")</div>
+          <div class="api-func-body">
+            <p>Write an <code>ArFrame</code> to CSV or TSV with delimiter and line terminator validation. Set
+              <code>escape_formulas=True</code> to prefix string cells that start with spreadsheet formula trigger
+              characters before CSV quoting. <code>encoding</code> defaults to <code>"utf-8"</code> (native fast path);
+              any Python codec is accepted and transcoded in bounded chunks. <code>encoding_errors</code> controls
+              unencodable character handling: <code>"strict"</code> (default), <code>"replace"</code>, or
+              <code>"ignore"</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">write_json(frame, path, *, orient="records", indent=None)</div>
+          <div class="api-func-body">
+            <p>Export an <code>ArFrame</code> to JSON without pandas conversion. Supported orient formats:
+              <code>"records"</code>, <code>"list"</code>, and <code>"split"</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">read_parquet(path, *, columns=None, usecols=None)</div>
+          <div class="api-func-body">
+            <p>Read a Parquet file into an <code>ArFrame</code> via the optional <code>pyarrow</code> dependency.
+              Install with <code>pip install "arnio[parquet]"</code>. Use <code>usecols</code> or <code>columns</code>
+              for column subset selection.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">write_parquet(frame, path, *, compression="snappy", row_group_size=None,
+            preserve_attrs=True)</div>
+          <div class="api-func-body">
+            <p>Write an <code>ArFrame</code> to Parquet via the optional <code>pyarrow</code> dependency. Install with
+              <code>pip install "arnio[parquet]"</code>. <code>preserve_attrs=True</code> writes JSON-serializable
+              <code>DataFrame.attrs</code> into Parquet metadata; set to <code>False</code> to skip that export.
+              Accepted compression values: <code>"snappy"</code> (default), <code>"gzip"</code>, <code>"brotli"</code>,
+              <code>"zstd"</code>, and <code>"none"</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">sniff_delimiter(path, *, encoding="utf-8", sample_size=2048)</div>
+          <div class="api-func-body">
+            <p>Detect a likely delimiter for CSV-like input before reading or scanning. <code>sample_size</code>
+              controls how many characters are read from the start of the file for detection; the default of
+              <code>2048</code> is sufficient for most files. Increase it when the file has an unusual delimiter that
+              only appears further into the content.</p>
+          </div>
+        </div>
 
         <h2 id="frame">Frame API</h2>
-        <div class="api-func"><div class="api-func-header">class ArFrame</div><div class="api-func-body"><p>Python wrapper over the native C++ frame. Core properties include <code>shape</code>, <code>columns</code>, <code>dtypes</code>, <code>is_empty</code>, <code>memory_usage()</code>, <code>head()</code>, <code>tail()</code>, and <code>preview()</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">ArFrame.from_records(records, *, columns=None) / ar.from_records(...)</div><div class="api-func-body"><p>Build an <code>ArFrame</code> from record dictionaries or row-like records. Added in v1.17.0.</p></div></div>
-        <div class="api-func"><div class="api-func-header">ArFrame._repr_html_()</div><div class="api-func-body"><p>Jupyter/IPython automatically calls this to render a bounded HTML table preview showing up to 10 rows, column names, dtypes, and shape summary.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame["column"] / frame[["a", "b"]]</div><div class="api-func-body"><p>Select one column as a Python list or multiple columns as an <code>ArFrame</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">item in frame / frame.__contains__(item)</div><div class="api-func-body"><p>Return <code>True</code> when the item is a valid column name in the frame.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame.select_columns(columns)</div><div class="api-func-body"><p>Return a new <code>ArFrame</code> containing only the requested columns in original order.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame.select_dtypes(include=..., exclude=...)</div><div class="api-func-body"><p>Return a new <code>ArFrame</code> filtered by dtype names like <code>int64</code>, <code>float64</code>, <code>string</code>, <code>bool</code>, or <code>null</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame.astype(dtype)</div><div class="api-func-body"><p>Cast one or more columns to a specified dtype or per-column type mapping and return a new <code>ArFrame</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame.to_dict()</div><div class="api-func-body"><p>Return a <code>dict[str, list]</code> representation for serialization or tests.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame.to_csv(path, *, delimiter=",", write_header=True, **kwargs)</div><div class="api-func-body"><p>Convenience wrapper to write the frame to a CSV file. Delegates to <code>arnio.write_csv</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame.drop_columns(columns)</div><div class="api-func-body"><p>Current-main method equivalent to the top-level <code>drop_columns</code> helper.</p></div></div>
-        <div class="api-func"><div class="api-func-header">frame.describe() / frame.schema_summary</div><div class="api-func-body"><p>Summary statistics and column summaries. <code>schema_summary</code> returns <code>ColumnSummary</code> objects with name, dtype, and nullability.</p></div></div>
+        <div class="api-func">
+          <div class="api-func-header">class ArFrame</div>
+          <div class="api-func-body">
+            <p>Python wrapper over the native C++ frame. Core properties include <code>shape</code>,
+              <code>columns</code>, <code>dtypes</code>, <code>is_empty</code>, <code>memory_usage()</code>,
+              <code>head()</code>, <code>tail()</code>, and <code>preview()</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">ArFrame.from_records(records, *, columns=None) / ar.from_records(...)</div>
+          <div class="api-func-body">
+            <p>Build an <code>ArFrame</code> from record dictionaries or row-like records. Added in v1.17.0.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">ArFrame._repr_html_()</div>
+          <div class="api-func-body">
+            <p>Jupyter/IPython automatically calls this to render a bounded HTML table preview showing up to 10 rows,
+              column names, dtypes, and shape summary.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame["column"] / frame[["a", "b"]]</div>
+          <div class="api-func-body">
+            <p>Select one column as a Python list or multiple columns as an <code>ArFrame</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">item in frame / frame.__contains__(item)</div>
+          <div class="api-func-body">
+            <p>Return <code>True</code> when the item is a valid column name in the frame.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame.select_columns(columns)</div>
+          <div class="api-func-body">
+            <p>Return a new <code>ArFrame</code> containing only the requested columns in original order.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame.select_dtypes(include=..., exclude=...)</div>
+          <div class="api-func-body">
+            <p>Return a new <code>ArFrame</code> filtered by dtype names like <code>int64</code>, <code>float64</code>,
+              <code>string</code>, <code>bool</code>, or <code>null</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame.astype(dtype)</div>
+          <div class="api-func-body">
+            <p>Cast one or more columns to a specified dtype or per-column type mapping and return a new
+              <code>ArFrame</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame.to_dict()</div>
+          <div class="api-func-body">
+            <p>Return a <code>dict[str, list]</code> representation for serialization or tests.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame.to_csv(path, *, delimiter=",", write_header=True, **kwargs)</div>
+          <div class="api-func-body">
+            <p>Convenience wrapper to write the frame to a CSV file. Delegates to <code>arnio.write_csv</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame.drop_columns(columns)</div>
+          <div class="api-func-body">
+            <p>Current-main method equivalent to the top-level <code>drop_columns</code> helper.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">frame.describe() / frame.schema_summary</div>
+          <div class="api-func-body">
+            <p>Summary statistics and column summaries. <code>schema_summary</code> returns <code>ColumnSummary</code>
+              objects with name, dtype, and nullability.</p>
+          </div>
+        </div>
 
         <h2 id="conversion">Conversion</h2>
-        <div class="api-func"><div class="api-func-header">to_pandas(frame, *, copy=False)</div><div class="api-func-body"><p>Convert to pandas, preserving the fast zero-copy path where supported. Use <code>copy=True</code> for defensive isolation.</p></div></div>
-        <div class="api-func"><div class="api-func-header">from_pandas(df)</div><div class="api-func-body"><p>Convert a pandas DataFrame to <code>ArFrame</code> with dtype validation, duplicate-column checks, attrs preservation, and zero-column row-count preservation.</p></div></div>
-        <div class="api-func"><div class="api-func-header">from_dict(data)</div><div class="api-func-body"><p>Build an <code>ArFrame</code> from a mapping of column names to column values.</p></div></div>
-        <div class="api-func"><div class="api-func-header">to_arrow(frame)</div><div class="api-func-body"><p>Export to <code>pyarrow.Table</code>. Install with <code>pip install "arnio[arrow]"</code>. Added in v1.18.0.</p></div></div>
-        <div class="api-func"><div class="api-func-header">to_polars(frame)</div><div class="api-func-body"><p>Convert an <code>ArFrame</code> to a Polars DataFrame via Arrow. Requires optional Polars dependency; install with <code>pip install "arnio[polars]"</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">from_polars(df)</div><div class="api-func-body"><p>Convert a Polars DataFrame to <code>ArFrame</code> with inferred types and null values preserved. Requires optional Polars dependency; install with <code>pip install "arnio[polars]"</code>.</p></div></div>
+        <div class="api-func">
+          <div class="api-func-header">to_pandas(frame, *, copy=False)</div>
+          <div class="api-func-body">
+            <p>Convert to pandas, preserving the fast zero-copy path where supported. Use <code>copy=True</code> for
+              defensive isolation.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">from_pandas(df)</div>
+          <div class="api-func-body">
+            <p>Convert a pandas DataFrame to <code>ArFrame</code> with dtype validation, duplicate-column checks, attrs
+              preservation, and zero-column row-count preservation.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">from_dict(data)</div>
+          <div class="api-func-body">
+            <p>Build an <code>ArFrame</code> from a mapping of column names to column values.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">to_arrow(frame)</div>
+          <div class="api-func-body">
+            <p>Export to <code>pyarrow.Table</code>. Install with <code>pip install "arnio[arrow]"</code>. Added in
+              v1.18.0.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">to_polars(frame)</div>
+          <div class="api-func-body">
+            <p>Convert an <code>ArFrame</code> to a Polars DataFrame via Arrow. Requires optional Polars dependency;
+              install with <code>pip install "arnio[polars]"</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">from_polars(df)</div>
+          <div class="api-func-body">
+            <p>Convert a Polars DataFrame to <code>ArFrame</code> with inferred types and null values preserved.
+              Requires optional Polars dependency; install with <code>pip install "arnio[polars]"</code>.</p>
+          </div>
+        </div>
 
         <h2 id="cleaning">Cleaning</h2>
-        <p class="section-lede">Cleaning functions return new frames and are usable directly or from <code>pipeline()</code>.</p>
-        <table><thead><tr><th>Function</th><th>Purpose</th></tr></thead><tbody>
-          <tr><td><code>drop_nulls</code>, <code>keep_rows_with_nulls</code>, <code>fill_nulls</code></td><td>Control null-bearing rows and values.</td></tr>
-          <tr><td><code>validate_columns_exist</code>, <code>drop_columns</code>, <code>select_columns</code>, <code>drop_empty_columns</code>, <code>drop_constant_columns</code>, <code>drop_columns_matching</code></td><td>Validate and manage columns explicitly, by emptiness, constants, or regex.</td></tr>
-          <tr><td><code>filter_rows</code>, <code>drop_duplicates</code>, <code>find_fuzzy_duplicates</code></td><td>Filter row sets, remove duplicate rows, and detect near-duplicate rows by similarity.</td></tr>
-          <tr><td><code>strip_whitespace</code>, <code>normalize_whitespace</code>, <code>normalize_case</code>, <code>normalize_unicode</code>, <code>clean_column_names</code>, <code>trim_column_names</code>, <code>slugify_column_names</code>, <code>rename_columns</code>, <code>rename_columns_matching</code></td><td>Normalize text, headers, and column names.</td></tr>
-          <tr><td><code>cast_types</code>, <code>parse_bool_strings</code>, <code>round_numeric_columns</code>, <code>clip_numeric</code>, <code>winsorize_outliers</code>, <code>normalize_minmax</code></td><td>Type and numeric cleanup.</td></tr>
-          <tr><td><code>encode_categorical</code></td><td>Encode STRING columns using one-hot indicator columns or caller-supplied ordinal mappings.</td></tr>
-          <tr><td><code>replace_values</code>, <code>standardize_missing_tokens</code>, <code>combine_columns</code>, <code>coalesce_columns</code>, <code>safe_divide_columns</code></td><td>Common feature engineering and value repair helpers.</td></tr>
-        </tbody></table>
-        <div class="api-func"><div class="api-func-header">CastReport and CastFailure</div><div class="api-func-body"><p>Returned by <code>cast_types(..., errors="report")</code>. <code>CastReport</code> holds the cast <code>frame</code> and a <code>failures</code> list of <code>CastFailure</code> records. Each <code>CastFailure</code> has <code>column</code>, <code>row</code>, <code>value</code>, and <code>target_dtype</code> attributes. <code>bool(report)</code> is <code>True</code> when there is at least one failure.</p></div></div>
+        <p class="section-lede">Cleaning functions return new frames and are usable directly or from
+          <code>pipeline()</code>.</p>
+        <table>
+          <thead>
+            <tr>
+              <th>Function</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>drop_nulls</code>, <code>keep_rows_with_nulls</code>, <code>fill_nulls</code></td>
+              <td>Control null-bearing rows and values.</td>
+            </tr>
+            <tr>
+              <td><code>validate_columns_exist</code>, <code>drop_columns</code>, <code>select_columns</code>,
+                <code>drop_empty_columns</code>, <code>drop_constant_columns</code>, <code>drop_columns_matching</code>
+              </td>
+              <td>Validate and manage columns explicitly, by emptiness, constants, or regex.</td>
+            </tr>
+            <tr>
+              <td><code>filter_rows</code>, <code>drop_duplicates</code>, <code>find_fuzzy_duplicates</code></td>
+              <td>Filter row sets, remove duplicate rows, and detect near-duplicate rows by similarity.</td>
+            </tr>
+            <tr>
+              <td><code>strip_whitespace</code>, <code>normalize_whitespace</code>, <code>normalize_case</code>,
+                <code>normalize_unicode</code>, <code>clean_column_names</code>, <code>trim_column_names</code>,
+                <code>slugify_column_names</code>, <code>rename_columns</code>, <code>rename_columns_matching</code>
+              </td>
+              <td>Normalize text, headers, and column names.</td>
+            </tr>
+            <tr>
+              <td><code>cast_types</code>, <code>parse_bool_strings</code>, <code>round_numeric_columns</code>,
+                <code>clip_numeric</code>, <code>winsorize_outliers</code>, <code>normalize_minmax</code></td>
+              <td>Type and numeric cleanup.</td>
+            </tr>
+            <tr>
+              <td><code>encode_categorical</code></td>
+              <td>Encode STRING columns using one-hot indicator columns or caller-supplied ordinal mappings.</td>
+            </tr>
+            <tr>
+              <td><code>replace_values</code>, <code>standardize_missing_tokens</code>, <code>combine_columns</code>,
+                <code>coalesce_columns</code>, <code>safe_divide_columns</code></td>
+              <td>Common feature engineering and value repair helpers.</td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="api-func">
+          <div class="api-func-header">CastReport and CastFailure</div>
+          <div class="api-func-body">
+            <p>Returned by <code>cast_types(..., errors="report")</code>. <code>CastReport</code> holds the cast
+              <code>frame</code> and a <code>failures</code> list of <code>CastFailure</code> records. Each
+              <code>CastFailure</code> has <code>column</code>, <code>row</code>, <code>value</code>, and
+              <code>target_dtype</code> attributes. <code>bool(report)</code> is <code>True</code> when there is at
+              least one failure.</p>
+          </div>
+        </div>
 
         <h2 id="pipeline">Pipeline</h2>
-        <div class="api-func"><div class="api-func-header">pipeline(frame, steps, *, verbose=False, track_lineage=False)</div><div class="api-func-body"><p>Run named cleaning steps or registered Python callables. <code>verbose=True</code> enables lightweight diagnostics through the <code>arnio</code> logger and optional <code>PipelineContext</code>. Pass <code>track_lineage=True</code> to receive a <code>(ArFrame, LineageReport)</code> tuple that maps every dropped row back to its original index and the step that removed it.</p></div></div>
-        <div class="api-func"><div class="api-func-header">LineageReport</div><div class="api-func-body"><p>Returned by <code>pipeline(..., track_lineage=True)</code>. Attributes: <code>dropped_by_step</code> (dict mapping step name → sorted list of original row indices dropped by that step; steps that dropped no rows have an empty list) and <code>total_dropped</code> (int). Method: <code>to_pandas()</code> returns a flat <code>DataFrame</code> with columns <code>original_index</code> and <code>step</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">register_step(name, fn, overwrite=False), unregister_step(name), list_steps(), reset_steps(), get_builtin_step_signatures()</div><div class="api-func-body"><p>Manage the step registry and discover available built-in signatures.</p></div></div>
+        <div class="api-func">
+          <div class="api-func-header">pipeline(frame, steps, *, verbose=False, track_lineage=False)</div>
+          <div class="api-func-body">
+            <p>Run named cleaning steps or registered Python callables. <code>verbose=True</code> enables lightweight
+              diagnostics through the <code>arnio</code> logger and optional <code>PipelineContext</code>. Pass
+              <code>track_lineage=True</code> to receive a <code>(ArFrame, LineageReport)</code> tuple that maps every
+              dropped row back to its original index and the step that removed it.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">LineageReport</div>
+          <div class="api-func-body">
+            <p>Returned by <code>pipeline(..., track_lineage=True)</code>. Attributes: <code>dropped_by_step</code>
+              (dict mapping step name → sorted list of original row indices dropped by that step; steps that dropped no
+              rows have an empty list) and <code>total_dropped</code> (int). Method: <code>to_pandas()</code> returns a
+              flat <code>DataFrame</code> with columns <code>original_index</code> and <code>step</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">register_step(name, fn, overwrite=False), unregister_step(name), list_steps(),
+            reset_steps(), get_builtin_step_signatures()</div>
+          <div class="api-func-body">
+            <p>Manage the step registry and discover available built-in signatures.</p>
+          </div>
+        </div>
         <h3>Pipeline Serialization</h3>
-<ul>
-    <li><code>save_pipeline(steps, filepath)</code>: Save a list of pipeline steps to a JSON or YAML file for reproducible jobs.</li>
-    <li><code>load_pipeline(filepath)</code>: Load a list of pipeline steps from a JSON or YAML file.</li>
-    <li><code>PipelineSerializationError</code>: Exception raised when a declarative pipeline cannot be saved or loaded.</li>
-</ul>
+        <ul>
+          <li><code>save_pipeline(steps, filepath)</code>: Save a list of pipeline steps to a JSON or YAML file for
+            reproducible jobs.</li>
+          <li><code>load_pipeline(filepath)</code>: Load a list of pipeline steps from a JSON or YAML file.</li>
+          <li><code>PipelineSerializationError</code>: Exception raised when a declarative pipeline cannot be saved or
+            loaded.</li>
+        </ul>
         <h2 id="quality">Quality</h2>
-        <div class="api-func"><div class="api-func-header">profile(frame, *, exclude_columns=None, sample_size=5, approx_top_values=False, approx_top_values_min_unique=1000, approx_top_values_min_ratio=0.2, approx_top_values_sample_size=2000)</div><div class="api-func-body"><p>Return <code>DataQualityReport</code> with row/column counts, duplicate metrics, column profiles, warnings, quality score, score components, and cleaning suggestions.</p></div></div>
-        
-        <div class="api-func"><div class="api-func-header">DataQualityReport._repr_html_()</div><div class="api-func-body"><p>Jupyter/IPython automatically calls this to render the report dashboard HTML directly in the notebook output area.</p></div></div>
-        <div class="api-func"><div class="api-func-header">DataQualityReport.to_dict(redact_sample_values=False, exclude_columns=None), to_json(), to_markdown(), to_html(), summary(), to_pandas()</div><div class="api-func-body"><p>Export reports for notebooks, CI, docs, and automation.</p></div></div>
-        <div class="api-func"><div class="api-func-header">compare_profiles(left, right), suggest_cleaning(frame_or_report), auto_clean(frame, *, mode="safe", return_report=False, dry_run=False, allow_lossy_casts=False, confirmed_casts=None, explain=False)</div><div class="api-func-body"><p>Compare quality over time, generate pipeline-compatible steps, or run automatic cleaning with optional reports and audit output.</p><p><strong>Additional options:</strong></p><ul><li><code>return_report</code> – return the pre-cleaning quality report alongside cleaned output.</li><li><code>allow_lossy_casts</code> – opt in to strict-mode casts that may lose information.</li><li><code>confirmed_casts</code> – explicit column-to-dtype confirmations required before strict-mode casts are applied.</li></ul><p><strong>Return values:</strong></p><ul><li><code>auto_clean(...)</code> → <code>ArFrame</code></li><li><code>auto_clean(..., return_report=True)</code> → <code>(ArFrame, DataQualityReport)</code></li><li><code>auto_clean(..., dry_run=True)</code> → <code>DataQualityReport</code></li><li><code>auto_clean(..., explain=True)</code> → <code>(ArFrame, CleanExplanation)</code></li><li><code>auto_clean(..., return_report=True, explain=True)</code> → <code>(ArFrame, DataQualityReport, CleanExplanation)</code></li></ul><pre><code># Preview proposed changes
+        <div class="api-func">
+          <div class="api-func-header">profile(frame, *, exclude_columns=None, sample_size=5, approx_top_values=False,
+            approx_top_values_min_unique=1000, approx_top_values_min_ratio=0.2, approx_top_values_sample_size=2000)
+          </div>
+          <div class="api-func-body">
+            <p>Return <code>DataQualityReport</code> with row/column counts, duplicate metrics, column profiles,
+              warnings, quality score, score components, and cleaning suggestions.</p>
+          </div>
+        </div>
+
+        <div class="api-func">
+          <div class="api-func-header">DataQualityReport._repr_html_()</div>
+          <div class="api-func-body">
+            <p>Jupyter/IPython automatically calls this to render the report dashboard HTML directly in the notebook
+              output area.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">DataQualityReport.to_dict(redact_sample_values=False, exclude_columns=None),
+            to_json(), to_markdown(), to_html(), summary(), to_pandas()</div>
+          <div class="api-func-body">
+            <p>Export reports for notebooks, CI, docs, and automation.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">compare_profiles(left, right), suggest_cleaning(frame_or_report),
+            auto_clean(frame, *, mode="safe", return_report=False, dry_run=False, allow_lossy_casts=False,
+            confirmed_casts=None, explain=False)</div>
+          <div class="api-func-body">
+            <p>Compare quality over time, generate pipeline-compatible steps, or run automatic cleaning with optional
+              reports and audit output.</p>
+            <p><strong>Additional options:</strong></p>
+            <ul>
+              <li><code>return_report</code> – return the pre-cleaning quality report alongside cleaned output.</li>
+              <li><code>allow_lossy_casts</code> – opt in to strict-mode casts that may lose information.</li>
+              <li><code>confirmed_casts</code> – explicit column-to-dtype confirmations required before strict-mode
+                casts are applied.</li>
+            </ul>
+            <p><strong>Return values:</strong></p>
+            <ul>
+              <li><code>auto_clean(...)</code> → <code>ArFrame</code></li>
+              <li><code>auto_clean(..., return_report=True)</code> → <code>(ArFrame, DataQualityReport)</code></li>
+              <li><code>auto_clean(..., dry_run=True)</code> → <code>DataQualityReport</code></li>
+              <li><code>auto_clean(..., explain=True)</code> → <code>(ArFrame, CleanExplanation)</code></li>
+              <li><code>auto_clean(..., return_report=True, explain=True)</code> →
+                <code>(ArFrame, DataQualityReport, CleanExplanation)</code></li>
+            </ul>
+            <pre><code># Preview proposed changes
 report = ar.auto_clean(frame, mode="strict", dry_run=True)
 
 # Clean and return report
@@ -134,24 +477,70 @@ cleaned, explanation = ar.auto_clean(
     frame,
     explain=True,
 )
-</code></pre></div></div>
-        <div class="api-func"><div class="api-func-header">check_quality_gates(baseline_profile, current_profile, *, max_row_count_delta_ratio=0.1, max_duplicate_ratio_delta=0.05, max_null_ratio_delta=0.05, max_numeric_mean_delta_ratio=0.1, max_numeric_std_delta_ratio=0.2, allow_new_columns=False, allow_missing_columns=False, fail_on_dtype_change=True)</div><div class="api-func-body"><p>Compare two <code>DataQualityReport</code> objects and return a <code>QualityGateResult</code> suitable for CI and release checks.</p>
-          <table class="param-table">
-            <thead>
-              <tr><th>Option</th><th>Default</th><th>Gate behavior</th></tr>
-            </thead>
-            <tbody>
-              <tr><td><code>max_row_count_delta_ratio</code></td><td><code>0.1</code></td><td>Maximum relative row-count drift. Set to <code>None</code> to disable.</td></tr>
-              <tr><td><code>max_duplicate_ratio_delta</code></td><td><code>0.05</code></td><td>Maximum absolute duplicate-ratio drift. Set to <code>None</code> to disable.</td></tr>
-              <tr><td><code>max_null_ratio_delta</code></td><td><code>0.05</code></td><td>Maximum absolute per-column null-ratio drift. Set to <code>None</code> to disable.</td></tr>
-              <tr><td><code>max_numeric_mean_delta_ratio</code></td><td><code>0.1</code></td><td>Maximum relative per-column numeric mean drift. Set to <code>None</code> to disable.</td></tr>
-              <tr><td><code>max_numeric_std_delta_ratio</code></td><td><code>0.2</code></td><td>Maximum relative per-column numeric standard-deviation drift. Set to <code>None</code> to disable.</td></tr>
-              <tr><td><code>allow_new_columns</code></td><td><code>False</code></td><td>Allow columns that appear only in the current profile.</td></tr>
-              <tr><td><code>allow_missing_columns</code></td><td><code>False</code></td><td>Allow baseline columns that are absent from the current profile.</td></tr>
-              <tr><td><code>fail_on_dtype_change</code></td><td><code>True</code></td><td>Fail when shared columns change dtype.</td></tr>
-            </tbody>
-          </table>
-<pre><code>baseline = ar.profile(ar.read_csv("baseline.csv"))
+</code></pre>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">check_quality_gates(baseline_profile, current_profile, *,
+            max_row_count_delta_ratio=0.1, max_duplicate_ratio_delta=0.05, max_null_ratio_delta=0.05,
+            max_numeric_mean_delta_ratio=0.1, max_numeric_std_delta_ratio=0.2, allow_new_columns=False,
+            allow_missing_columns=False, fail_on_dtype_change=True)</div>
+          <div class="api-func-body">
+            <p>Compare two <code>DataQualityReport</code> objects and return a <code>QualityGateResult</code> suitable
+              for CI and release checks.</p>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Option</th>
+                  <th>Default</th>
+                  <th>Gate behavior</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>max_row_count_delta_ratio</code></td>
+                  <td><code>0.1</code></td>
+                  <td>Maximum relative row-count drift. Set to <code>None</code> to disable.</td>
+                </tr>
+                <tr>
+                  <td><code>max_duplicate_ratio_delta</code></td>
+                  <td><code>0.05</code></td>
+                  <td>Maximum absolute duplicate-ratio drift. Set to <code>None</code> to disable.</td>
+                </tr>
+                <tr>
+                  <td><code>max_null_ratio_delta</code></td>
+                  <td><code>0.05</code></td>
+                  <td>Maximum absolute per-column null-ratio drift. Set to <code>None</code> to disable.</td>
+                </tr>
+                <tr>
+                  <td><code>max_numeric_mean_delta_ratio</code></td>
+                  <td><code>0.1</code></td>
+                  <td>Maximum relative per-column numeric mean drift. Set to <code>None</code> to disable.</td>
+                </tr>
+                <tr>
+                  <td><code>max_numeric_std_delta_ratio</code></td>
+                  <td><code>0.2</code></td>
+                  <td>Maximum relative per-column numeric standard-deviation drift. Set to <code>None</code> to disable.
+                  </td>
+                </tr>
+                <tr>
+                  <td><code>allow_new_columns</code></td>
+                  <td><code>False</code></td>
+                  <td>Allow columns that appear only in the current profile.</td>
+                </tr>
+                <tr>
+                  <td><code>allow_missing_columns</code></td>
+                  <td><code>False</code></td>
+                  <td>Allow baseline columns that are absent from the current profile.</td>
+                </tr>
+                <tr>
+                  <td><code>fail_on_dtype_change</code></td>
+                  <td><code>True</code></td>
+                  <td>Fail when shared columns change dtype.</td>
+                </tr>
+              </tbody>
+            </table>
+            <pre><code>baseline = ar.profile(ar.read_csv("baseline.csv"))
 current = ar.profile(ar.read_csv("current.csv"))
 
 result = ar.check_quality_gates(
@@ -164,161 +553,317 @@ result = ar.check_quality_gates(
 if not result.passed:
     print(result.to_markdown())
     result.raise_for_failures()
-</code></pre></div></div>
-        <div class="api-func"><div class="api-func-header">Quality result classes</div><div class="api-func-body"><p><code>ColumnProfile</code>, <code>CleaningSuggestion</code>, <code>CleanStepRecord</code>, <code>CleanExplanation</code>, <code>ProfileComparison</code>, <code>QualityGateIssue</code>, and <code>QualityGateResult</code> describe structured profiling, cleaning, comparison, and gate output.</p></div></div>
+</code></pre>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">Quality result classes</div>
+          <div class="api-func-body">
+            <p><code>ColumnProfile</code>, <code>CleaningSuggestion</code>, <code>CleanStepRecord</code>,
+              <code>CleanExplanation</code>, <code>ProfileComparison</code>, <code>QualityGateIssue</code>, and
+              <code>QualityGateResult</code> describe structured profiling, cleaning, comparison, and gate output.</p>
+          </div>
+        </div>
 
         <h2 id="schema">Schema</h2>
-        <div class="api-func"><div class="api-func-header">Schema(fields, strict=False, unique=None, rules=None).validate(frame, max_errors=None) / validate(frame, schema, max_errors=None)</div><div class="api-func-body"><p>Validate frames against field definitions. <code>max_errors</code> was added in v1.18.0.</p><p><code>unique</code>: list or tuple of column names that must contain no duplicate values in the frame.</p><p><code>rules</code>: list of callables <code>(pd.DataFrame) -&gt; list[ValidationIssue]</code> for cross-field or custom contract checks.</p><pre><code>schema = ar.Schema(
+        <div class="api-func">
+          <div class="api-func-header">Schema(fields, strict=False, unique=None, rules=None).validate(frame,
+            max_errors=None) / validate(frame, schema, max_errors=None)</div>
+          <div class="api-func-body">
+            <p>Validate frames against field definitions. <code>max_errors</code> was added in v1.18.0.</p>
+            <p><code>unique</code>: list or tuple of column names that must contain no duplicate values in the frame.
+            </p>
+            <p><code>rules</code>: list of callables <code>(pd.DataFrame) -&gt; list[ValidationIssue]</code> for
+              cross-field or custom contract checks.</p>
+            <pre><code>schema = ar.Schema(
     fields={"email": ar.Email(), "user_id": ar.Int64()},
     unique=["email"],
 )
-result = schema.validate(frame)</code></pre></div></div>
-        <div class="api-func"><div class="api-func-header">validate_chunked(chunks, schema, *, max_errors=None)</div><div class="api-func-body"><p>Validate an iterable of <code>ArFrame</code> chunks against a <code>Schema</code> and return a single <code>ValidationResult</code>. Row indices in all <code>ValidationIssue</code> objects are adjusted to reflect global positions across chunk boundaries. Supports <code>max_errors</code> for early termination. Does not modify <code>validate()</code>.</p></div></div>
-        <div class="api-func"><div class="api-func-header">Field builders</div><div class="api-func-body">
-          <p>Each builder returns a <code>Field</code> for use in <code>Schema(fields={...})</code>. All builders accept keyword-only arguments unless noted otherwise.</p>
-          <table class="param-table">
-            <thead>
-              <tr>
-                <th>Builder</th>
-                <th>Group</th>
-                <th>Key parameters</th>
-                <th>Notes</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>Int64(...)</code></td>
-                <td>Numeric</td>
-                <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Integer range bounds are inclusive. <code>min</code> and <code>max</code> must be numeric.</td>
-              </tr>
-              <tr>
-                <td><code>Float64(...)</code></td>
-                <td>Numeric</td>
-                <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Floating-point range bounds. Same constraints as <code>Int64</code>.</td>
-              </tr>
-              <tr>
-                <td><code>String(...)</code></td>
-                <td>String</td>
-                <td><code>nullable=True</code>, <code>pattern=None</code>, <code>allowed=None</code>, <code>case_sensitive=True</code>, <code>min_length=None</code>, <code>max_length=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td><code>pattern</code> is a regex applied to every non-null value. <code>allowed</code> accepts a set, list, or tuple — not a bare string.</td>
-              </tr>
-              <tr>
-                <td><code>Bool(...)</code></td>
-                <td>Boolean</td>
-                <td><code>nullable=True</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>No range or uniqueness constraints; dtype must be boolean.</td>
-              </tr>
-              <tr>
-                <td><code>Email(...)</code></td>
-                <td>Semantic</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>validation="light"</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td><code>validation</code> is <code>"light"</code> (format check) or <code>"strict"</code> (RFC 5322 conformant).</td>
-              </tr>
-              <tr>
-                <td><code>URL(...)</code></td>
-                <td>Semantic</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed_schemes=None</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Omit to allow the default http/https URL validator; pass <code>allowed_schemes=[...]</code> to permit a custom set such as <code>["https", "ftp"]</code>.</td>
-              </tr>
-              <tr>
-                <td><code>PhoneNumber(...)</code></td>
-                <td>Semantic</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Validates E.164-style phone numbers.</td>
-              </tr>
-              <tr>
-                <td><code>CountryCode(...)</code></td>
-                <td>Semantic</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Expects uppercase ISO 3166-1 alpha-2 codes (e.g. <code>"US"</code>, <code>"IN"</code>).</td>
-              </tr>
-              <tr>
-                <td><code>CurrencyCode(...)</code></td>
-                <td>Semantic</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed=None</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Validates 3-letter uppercase ISO 4217 codes. <code>allowed</code> narrows to a custom subset of valid codes.</td>
-              </tr>
-              <tr>
-                <td><code>LanguageCode(...)</code></td>
-                <td>Semantic</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Expects lowercase ISO 639-1 two-letter codes (e.g. <code>"en"</code>, <code>"fr"</code>).</td>
-              </tr>
-              <tr>
-                <td><code>TimeZone(...)</code></td>
-                <td>Semantic</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Validates IANA timezone identifiers (e.g. <code>"America/New_York"</code>).</td>
-              </tr>
-              <tr>
-                <td><code>Date(...)</code></td>
-                <td>Date / Time</td>
-                <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Validates ISO 8601 date strings (<code>YYYY-MM-DD</code>).</td>
-              </tr>
-              <tr>
-                <td><code>DateTime(...)</code></td>
-                <td>Date / Time</td>
-                <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>, <code>format=None</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td><code>format</code> is a <code>strptime</code> format string. <code>min</code> / <code>max</code> accept ISO strings or <code>datetime</code> objects.</td>
-              </tr>
-              <tr>
-                <td><code>Regex(pattern, ...)</code></td>
-                <td>Regex</td>
-                <td><code>pattern</code> (positional, required), <code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td>Pattern is compiled at call time — invalid expressions raise <code>re.error</code> immediately, not at validation time.</td>
-              </tr>
-              <tr>
-                <td><code>Custom(name, ...)</code></td>
-                <td>Custom</td>
-                <td><code>name</code> (positional, required), <code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
-                <td><code>name</code> must match a validator registered via <code>register_validator()</code>. Raises <code>ValueError</code> if the name is not found.</td>
-              </tr>
-            </tbody>
-          </table>
-          <p style="margin-top:1rem"><strong>Common parameters:</strong> <code>nullable</code> — allow null values; <code>unique</code> — require all non-null values to be distinct; <code>severity</code> — <code>"error"</code> (default) or <code>"warning"</code>; <code>required_if</code> — a <code>(column, value)</code> tuple that makes the field mandatory when another column equals a given value.</p>
-        </div></div>
-        <div class="api-func"><div class="api-func-header">diff_schema, schema_to_dict, schema_to_yaml, schema_from_yaml, register_validator</div><div class="api-func-body"><p>Compare schema contracts, export schema definitions, and register custom semantic validators. Structured results include <code>SchemaDiff</code>, <code>SchemaDiffEntry</code>, <code>ValidationIssue</code>, and <code>ValidationResult</code>.</p></div></div>
+result = schema.validate(frame)</code></pre>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">validate_chunked(chunks, schema, *, max_errors=None)</div>
+          <div class="api-func-body">
+            <p>Validate an iterable of <code>ArFrame</code> chunks against a <code>Schema</code> and return a single
+              <code>ValidationResult</code>. Row indices in all <code>ValidationIssue</code> objects are adjusted to
+              reflect global positions across chunk boundaries. Supports <code>max_errors</code> for early termination.
+              Does not modify <code>validate()</code>.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">Field builders</div>
+          <div class="api-func-body">
+            <p>Each builder returns a <code>Field</code> for use in <code>Schema(fields={...})</code>. All builders
+              accept keyword-only arguments unless noted otherwise.</p>
+            <table class="param-table">
+              <thead>
+                <tr>
+                  <th>Builder</th>
+                  <th>Group</th>
+                  <th>Key parameters</th>
+                  <th>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>Int64(...)</code></td>
+                  <td>Numeric</td>
+                  <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>,
+                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td>Integer range bounds are inclusive. <code>min</code> and <code>max</code> must be numeric.</td>
+                </tr>
+                <tr>
+                  <td><code>Float64(...)</code></td>
+                  <td>Numeric</td>
+                  <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>,
+                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td>Floating-point range bounds. Same constraints as <code>Int64</code>.</td>
+                </tr>
+                <tr>
+                  <td><code>String(...)</code></td>
+                  <td>String</td>
+                  <td><code>nullable=True</code>, <code>pattern=None</code>, <code>allowed=None</code>,
+                    <code>case_sensitive=True</code>, <code>min_length=None</code>, <code>max_length=None</code>,
+                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td><code>pattern</code> is a regex applied to every non-null value. <code>allowed</code> accepts a
+                    set, list, or tuple — not a bare string.</td>
+                </tr>
+                <tr>
+                  <td><code>Bool(...)</code></td>
+                  <td>Boolean</td>
+                  <td><code>nullable=True</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td>No range or uniqueness constraints; dtype must be boolean.</td>
+                </tr>
+                <tr>
+                  <td><code>Email(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>validation="light"</code>,
+                    <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td><code>validation</code> is <code>"light"</code> (format check) or <code>"strict"</code> (RFC 5322
+                    conformant).</td>
+                </tr>
+                <tr>
+                  <td><code>URL(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed_schemes=None</code>,
+                    <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td>Omit to allow the default http/https URL validator; pass <code>allowed_schemes=[...]</code> to
+                    permit a custom set such as <code>["https", "ftp"]</code>.</td>
+                </tr>
+                <tr>
+                  <td><code>PhoneNumber(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Validates E.164-style phone numbers.</td>
+                </tr>
+                <tr>
+                  <td><code>CountryCode(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Expects uppercase ISO 3166-1 alpha-2 codes (e.g. <code>"US"</code>, <code>"IN"</code>).</td>
+                </tr>
+                <tr>
+                  <td><code>CurrencyCode(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>allowed=None</code>,
+                    <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td>Validates 3-letter uppercase ISO 4217 codes. <code>allowed</code> narrows to a custom subset of
+                    valid codes.</td>
+                </tr>
+                <tr>
+                  <td><code>LanguageCode(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Expects lowercase ISO 639-1 two-letter codes (e.g. <code>"en"</code>, <code>"fr"</code>).</td>
+                </tr>
+                <tr>
+                  <td><code>TimeZone(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Validates IANA timezone identifiers (e.g. <code>"America/New_York"</code>).</td>
+                </tr>
+                <tr>
+                  <td><code>Date(...)</code></td>
+                  <td>Date / Time</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Validates ISO 8601 date strings (<code>YYYY-MM-DD</code>).</td>
+                </tr>
+                <tr>
+                  <td><code>DateTime(...)</code></td>
+                  <td>Date / Time</td>
+                  <td><code>nullable=True</code>, <code>min=None</code>, <code>max=None</code>,
+                    <code>format=None</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td><code>format</code> is a <code>strptime</code> format string. <code>min</code> / <code>max</code>
+                    accept ISO strings or <code>datetime</code> objects.</td>
+                </tr>
+                <tr>
+                  <td><code>Regex(pattern, ...)</code></td>
+                  <td>Regex</td>
+                  <td><code>pattern</code> (positional, required), <code>nullable=True</code>,
+                    <code>unique=False</code>, <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td>Pattern is compiled at call time — invalid expressions raise <code>re.error</code> immediately,
+                    not at validation time.</td>
+                </tr>
+                <tr>
+                  <td><code>Custom(name, ...)</code></td>
+                  <td>Custom</td>
+                  <td><code>name</code> (positional, required), <code>nullable=True</code>, <code>unique=False</code>,
+                    <code>severity="error"</code>, <code>required_if=None</code></td>
+                  <td><code>name</code> must match a validator registered via <code>register_validator()</code>. Raises
+                    <code>ValueError</code> if the name is not found.</td>
+                </tr>
+                <tr>
+                  <td><code>UUID(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Validates canonical UUID strings (8-4-4-4-12 hexadecimal format).</td>
+                </tr>
+
+                <tr>
+                  <td><code>IPv4(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Validates dotted-decimal IPv4 addresses (e.g. <code>192.168.1.1</code>).</td>
+                </tr>
+
+                <tr>
+                  <td><code>MACAddress(...)</code></td>
+                  <td>Semantic</td>
+                  <td><code>nullable=True</code>, <code>unique=False</code>, <code>severity="error"</code>,
+                    <code>required_if=None</code></td>
+                  <td>Validates IEEE 802 MAC addresses in colon-separated notation.</td>
+                </tr>
+              </tbody>
+            </table>
+            <p style="margin-top:1rem"><strong>Common parameters:</strong> <code>nullable</code> — allow null values;
+              <code>unique</code> — require all non-null values to be distinct; <code>severity</code> —
+              <code>"error"</code> (default) or <code>"warning"</code>; <code>required_if</code> — a
+              <code>(column, value)</code> tuple that makes the field mandatory when another column equals a given
+              value.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">diff_schema, schema_to_dict, schema_to_yaml, schema_from_yaml, register_validator
+          </div>
+          <div class="api-func-body">
+            <p>Compare schema contracts, export schema definitions, and register custom semantic validators. Structured
+              results include <code>SchemaDiff</code>, <code>SchemaDiffEntry</code>, <code>ValidationIssue</code>, and
+              <code>ValidationResult</code>.</p>
+          </div>
+        </div>
 
         <h2 id="integrations">Integrations</h2>
-        <div class="api-func"><div class="api-func-header">ArnioPandasAccessor / pandas accessor: df.arnio.to_arframe(), pipeline(), clean(), profile(), suggest_cleaning(), auto_clean(), validate()</div><div class="api-func-body"><p>Run Arnio workflows directly from pandas DataFrames.</p></div></div>
-        <div class="api-func"><div class="api-func-header">df.arnio.clean(steps=None, *, strip_whitespace=True, drop_nulls=False, drop_duplicates=False)</div><div class="api-func-body"><p>Clean a DataFrame with Arnio and return a <code>pandas.DataFrame</code>.</p><p>When <code>steps</code> is provided, it is passed directly to <code>ar.pipeline()</code> and the keyword flags are ignored. When <code>steps</code> is omitted, the convenience-clean path runs with the keyword flags controlling which operations apply.</p><ul><li><code>strip_whitespace</code> – strip leading and trailing whitespace from string columns (default <code>True</code>).</li><li><code>drop_nulls</code> – drop rows that contain any null value (default <code>False</code>).</li><li><code>drop_duplicates</code> – drop duplicate rows (default <code>False</code>).</li></ul><pre><code>import pandas as pd
+        <div class="api-func">
+          <div class="api-func-header">ArnioPandasAccessor / pandas accessor: df.arnio.to_arframe(), pipeline(),
+            clean(), profile(), suggest_cleaning(), auto_clean(), validate()</div>
+          <div class="api-func-body">
+            <p>Run Arnio workflows directly from pandas DataFrames.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">df.arnio.clean(steps=None, *, strip_whitespace=True, drop_nulls=False,
+            drop_duplicates=False)</div>
+          <div class="api-func-body">
+            <p>Clean a DataFrame with Arnio and return a <code>pandas.DataFrame</code>.</p>
+            <p>When <code>steps</code> is provided, it is passed directly to <code>ar.pipeline()</code> and the keyword
+              flags are ignored. When <code>steps</code> is omitted, the convenience-clean path runs with the keyword
+              flags controlling which operations apply.</p>
+            <ul>
+              <li><code>strip_whitespace</code> – strip leading and trailing whitespace from string columns (default
+                <code>True</code>).</li>
+              <li><code>drop_nulls</code> – drop rows that contain any null value (default <code>False</code>).</li>
+              <li><code>drop_duplicates</code> – drop duplicate rows (default <code>False</code>).</li>
+            </ul>
+            <pre><code>import pandas as pd
 import arnio as ar
 
 df = pd.DataFrame({"name": [" Alice ", " Alice "], "score": [10, 10]})
 cleaned = df.arnio.clean(drop_duplicates=True)
-# cleaned: one row, name stripped to "Alice"</code></pre><p><strong>Returns:</strong> <code>pandas.DataFrame</code></p></div></div>
-        <div class="api-func"><div class="api-func-header">register_duckdb(frame, conn, name)</div><div class="api-func-body"><p>Register an <code>ArFrame</code> as a DuckDB relation through pandas interop.</p></div></div>
-        <div class="api-func"><div class="api-func-header">ArnioCleaner</div><div class="api-func-body"><p>Optional scikit-learn transformer for pipeline-safe data preparation. Install with <code>pip install "arnio[sklearn]"</code>.</p></div></div>
+# cleaned: one row, name stripped to "Alice"</code></pre>
+            <p><strong>Returns:</strong> <code>pandas.DataFrame</code></p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">register_duckdb(frame, conn, name)</div>
+          <div class="api-func-body">
+            <p>Register an <code>ArFrame</code> as a DuckDB relation through pandas interop.</p>
+          </div>
+        </div>
+        <div class="api-func">
+          <div class="api-func-header">ArnioCleaner</div>
+          <div class="api-func-body">
+            <p>Optional scikit-learn transformer for pipeline-safe data preparation. Install with
+              <code>pip install "arnio[sklearn]"</code>.</p>
+          </div>
+        </div>
 
         <h2 id="exceptions">Exceptions</h2>
-        <div class="api-func"><div class="api-func-header">ArnioError and specialized exceptions</div><div class="api-func-body"><p><code>ArnioError</code> is the package-level base exception. Public specialized exceptions include <code>CsvReadError</code>, <code>JsonlReadError</code>, <code>RemoteReadError</code>, <code>TypeCastError</code>, <code>PipelineStepError</code>, <code>UnknownStepError</code>, and <code>SchemaValidationError</code>.</p></div></div>
+        <div class="api-func">
+          <div class="api-func-header">ArnioError and specialized exceptions</div>
+          <div class="api-func-body">
+            <p><code>ArnioError</code> is the package-level base exception. Public specialized exceptions include
+              <code>CsvReadError</code>, <code>JsonlReadError</code>, <code>RemoteReadError</code>,
+              <code>TypeCastError</code>, <code>PipelineStepError</code>, <code>UnknownStepError</code>, and
+              <code>SchemaValidationError</code>.</p>
+          </div>
+        </div>
       </article>
     </div>
   </main>
 
- <footer class="site-footer">
+  <footer class="site-footer">
     <div class="container">
       <div class="footer-grid">
-        <div class="footer-brand"><img src="arnio-logo.svg" alt="Arnio" height="32" loading="lazy" decoding="async"><p>C++ accelerated data preparation for pandas and the Python data stack.</p></div>
-        <div><h4 class="footer-heading">Project</h4><ul class="footer-links"><li><a href="docs.html">Docs</a></li><li><a href="api.html">API</a></li><li><a href="changelog.html">Changelog</a></li></ul></div>
-        <div><h4 class="footer-heading">Engineering</h4><ul class="footer-links"><li><a href="architecture.html">Architecture</a></li><li><a href="benchmarks.html">Benchmarks</a></li><li><a href="roadmap.html">Roadmap</a></li></ul></div>
-        <div><h4 class="footer-heading">Community</h4><ul class="footer-links"><li><a href="contributing.html">Contributing</a></li><li><a href="community.html">Community</a></li>
-         <li class="footer-socials">
-            <a href="https://github.com/im-anishraj/arnio" target="_blank" rel="noopener" aria-label="GitHub">
-              <svg viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.082-.729.082-.729 1.205.084 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.304.76-1.604-2.665-.305-5.467-1.332-5.467-5.93 0-1.31.467-2.382 1.235-3.222-.123-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23A11.52 11.52 0 0112 6.844c1.02.005 2.045.138 3.003.404 2.29-1.552 3.296-1.23 3.296-1.23.654 1.653.242 2.874.12 3.176.77.84 1.233 1.911 1.233 3.222 0 4.61-2.807 5.623-5.48 5.921.43.37.814 1.102.814 2.222 0 1.606-.015 2.898-.015 3.293 0 .322.216.694.825.576C20.565 21.796 24 17.297 24 12c0-6.63-5.373-12-12-12z"/>
-              </svg>
-            </a>
+        <div class="footer-brand"><img src="arnio-logo.svg" alt="Arnio" height="32" loading="lazy" decoding="async">
+          <p>C++ accelerated data preparation for pandas and the Python data stack.</p>
+        </div>
+        <div>
+          <h4 class="footer-heading">Project</h4>
+          <ul class="footer-links">
+            <li><a href="docs.html">Docs</a></li>
+            <li><a href="api.html">API</a></li>
+            <li><a href="changelog.html">Changelog</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="footer-heading">Engineering</h4>
+          <ul class="footer-links">
+            <li><a href="architecture.html">Architecture</a></li>
+            <li><a href="benchmarks.html">Benchmarks</a></li>
+            <li><a href="roadmap.html">Roadmap</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="footer-heading">Community</h4>
+          <ul class="footer-links">
+            <li><a href="contributing.html">Contributing</a></li>
+            <li><a href="community.html">Community</a></li>
+            <li class="footer-socials">
+              <a href="https://github.com/im-anishraj/arnio" target="_blank" rel="noopener" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <path
+                    d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.757-1.333-1.757-1.09-.745.082-.729.082-.729 1.205.084 1.84 1.237 1.84 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.418-1.304.76-1.604-2.665-.305-5.467-1.332-5.467-5.93 0-1.31.467-2.382 1.235-3.222-.123-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23A11.52 11.52 0 0112 6.844c1.02.005 2.045.138 3.003.404 2.29-1.552 3.296-1.23 3.296-1.23.654 1.653.242 2.874.12 3.176.77.84 1.233 1.911 1.233 3.222 0 4.61-2.807 5.623-5.48 5.921.43.37.814 1.102.814 2.222 0 1.606-.015 2.898-.015 3.293 0 .322.216.694.825.576C20.565 21.796 24 17.297 24 12c0-6.63-5.373-12-12-12z" />
+                </svg>
+              </a>
 
-            <a href="https://www.linkedin.com/in/im-anishraj" target="_blank" rel="noopener" aria-label="LinkedIn">
-              <svg viewBox="0 0 24 24" fill="currentColor">
-                <path d="M20.447 20.452H16.89V14.87c0-1.332-.026-3.045-1.854-3.045-1.854 0-2.137 1.447-2.137 2.946v5.68H9.343V9h3.414v1.561h.049c.476-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.063 2.063 0 11.001-4.126 2.063 2.063 0 01-.001 4.126zM7.119 20.452H3.556V9H7.12v11.452z"/>
-              </svg>
-            </a>
-          </li></ul></div>
+              <a href="https://www.linkedin.com/in/im-anishraj" target="_blank" rel="noopener" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <path
+                    d="M20.447 20.452H16.89V14.87c0-1.332-.026-3.045-1.854-3.045-1.854 0-2.137 1.447-2.137 2.946v5.68H9.343V9h3.414v1.561h.049c.476-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.063 2.063 0 11.001-4.126 2.063 2.063 0 01-.001 4.126zM7.119 20.452H3.556V9H7.12v11.452z" />
+                </svg>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
       <div class="footer-bottom"><span>© 2026 Anish Raj. MIT License.</span><span>Latest release: v1.19.0</span></div>
     </div>
@@ -327,4 +872,5 @@ cleaned = df.arnio.clean(drop_duplicates=True)
   <script src="js/code.js" defer></script>
   <script src="js/search.js" defer></script>
 </body>
+
 </html>


### PR DESCRIPTION
## Summary
Adds three new strict semantic validators for common system and network identifiers: UUID, IPv4, and MAC Address. Each is implemented as a regex pattern in `_SEMANTIC_PATTERNS` and exposed as a clean factory function (`UUID()`, `IPv4()`, `MACAddress()`) following the existing `Email()` / `PhoneNumber()` / `URL()` pattern. All three are exported from `arnio/__init__.py`.

## Linked issue
Closes #1604

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [x] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [x] `python -m pytest tests/test_schema.py` — 493 passed, 0 failed
- [x] `make lint` — black, ruff, clang-format all passed after auto-fixes

```bash
python -m pytest tests/test_schema.py -v
# 493 passed in 0.84s
```

70 new tests across 10 classes covering:
- Raw regex correctness (valid + invalid edge cases for all three types)
- Factory function return type and Field attribute wiring
- End-to-end `validate()` pass/fail paths
- `nullable=False`, `unique=True`, `severity="warning"` propagation
- `Schema.to_json()` / `from_json()` round-trip preserves semantic and validates correctly

## Screenshots / Media
N/A

## Performance Impact
No performance impact — patterns are compiled at validation time via `str.fullmatch()`, same as all existing semantic validators.

## GSSoC labels
<!-- Maintainers only -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
- IPv4 pattern expands the octet alternation four times (no group-level `{3}` quantifier) to stay compatible with `_has_nested_quantifier` safety checker.
- UUID does not enforce version/variant bits — nil UUIDs and DB-generated identifiers pass by design.
- Cisco dot-delimited MAC format (`AABB.CCDD.EEFF`) is explicitly unsupported per issue scope; can be added later via `ar.Regex()`.
- IPv6 intentionally omitted per issue spec; noted in `IPv4()` docstring.