### PR TITLE
Fix: Improving invalid utf-8 error reporting along with regression tests

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -720,7 +720,7 @@ def _enrich_csv_runtime_error(
     """
     if "Invalid UTF-8 sequence encountered" in msg:
         return CsvReadError(
-            f"Could not read CSV file {path!r} using encoding " f"{encoding!r}: {msg}"
+            f"Could not read CSV file {path} using encoding " f"{encoding}: {msg}"
         )
 
     return _enrich_row_width_error(exc, delimiter)

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -714,10 +714,10 @@ def _enrich_csv_runtime_error(
     """Add path/encoding context to selected native CSV errors."""
 
     msg = str(exc)
-    """Native CSV parsing currently reports malformed UTF-8 using the message below. 
-    We match it here so we can attach file path and encoding context at the Python API boundary. 
-    If the native wording changes, this enrichment may need updating.
-    """
+    # Native CSV parsing currently reports malformed UTF-8 using the message below.
+    # We match it here so we can attach file path and encoding context at the Python API boundary.
+    # If the native wording changes, this enrichment may need updating.
+
     if "Invalid UTF-8 sequence encountered" in msg:
         return CsvReadError(
             f"Could not read CSV file {path} using encoding " f"{encoding}: {msg}"
@@ -1653,6 +1653,8 @@ def scan_csv(
     except RuntimeError as e:
         assert delimiter is not None
         raise _enrich_csv_runtime_error(e, native_path, encoding, delimiter) from None
+    except Exception as e:
+        raise CsvReadError(str(e)) from None
     finally:
         if should_cleanup and os.path.exists(native_path):
             try:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -708,6 +708,24 @@ def _enrich_row_width_error(exc: Exception, delimiter: str) -> CsvReadError:
     return CsvReadError(msg)
 
 
+def _enrich_csv_runtime_error(
+    exc: RuntimeError, path: str, encoding: str, delimiter: str
+) -> CsvReadError:
+    """Add path/encoding context to selected native CSV errors."""
+
+    msg = str(exc)
+    """Native CSV parsing currently reports malformed UTF-8 using the message below. 
+    We match it here so we can attach file path and encoding context at the Python API boundary. 
+    If the native wording changes, this enrichment may need updating.
+    """
+    if "Invalid UTF-8 sequence encountered" in msg:
+        return CsvReadError(
+            f"Could not read CSV file {path!r} using encoding " f"{encoding!r}: {msg}"
+        )
+
+    return _enrich_row_width_error(exc, delimiter)
+
+
 # Candidate delimiters to probe during delimiter-mismatch detection.
 # Checked only when the parse produced exactly one column, which is the
 # signature of a delimiter mismatch.
@@ -1038,10 +1056,9 @@ def read_csv(
             except (ValueError, TypeError):
                 raise
             except RuntimeError as e:
-                # The C++ backend raises RuntimeError for row-width mismatches.
-                # Enrich only confirmed row-width messages; re-raise everything
-                # else as CsvReadError with the original message intact.
-                raise _enrich_row_width_error(e, delimiter) from None
+                raise _enrich_csv_runtime_error(
+                    e, native_path, encoding, delimiter
+                ) from None
 
         if on_bad_lines == "warn" and bad_rows:
             _warn_bad_rows(bad_rows)
@@ -1633,8 +1650,9 @@ def scan_csv(
         raise
     except CsvReadError:
         raise
-    except Exception as e:
-        raise CsvReadError(str(e)) from None
+    except RuntimeError as e:
+        assert delimiter is not None
+        raise _enrich_csv_runtime_error(e, native_path, encoding, delimiter) from None
     finally:
         if should_cleanup and os.path.exists(native_path):
             try:

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -839,6 +839,74 @@ class TestReadCsv:
         assert "name" in schema
         assert "\ufeffname" not in schema
 
+    def test_invalid_utf8_read_csv_raises_with_path_and_encoding(self, tmp_path):
+        csv_path = tmp_path / "bad_utf8.csv"
+        csv_path.write_bytes(b"name\n\xff\n")
+
+        with pytest.raises(ar.CsvReadError) as exc_info:
+            ar.read_csv(csv_path, encoding="utf-8")
+
+        msg = str(exc_info.value)
+        assert "utf-8" in msg.lower()
+        assert str(csv_path) in msg
+        # This checks that the underlying UTF-8 validation failure remains
+        # visible to callers. The match comes from the native parser message,
+        # not the wrapper-injected encoding context.
+        assert "invalid utf-8" in msg.lower()
+
+    def test_invalid_utf8_scan_csv_raises_with_path_and_encoding(self, tmp_path):
+        csv_path = tmp_path / "bad_utf8.csv"
+        csv_path.write_bytes(b"name\n\xff\n")
+
+        with pytest.raises(ar.CsvReadError) as exc_info:
+            ar.scan_csv(csv_path, encoding="utf-8")
+
+        msg = str(exc_info.value)
+
+        assert "utf-8" in msg.lower()
+        assert str(csv_path) in msg
+        assert "invalid utf-8" in msg.lower()
+
+    def test_invalid_utf8_read_csv_utf8_alias_also_raises(self, tmp_path):
+        csv_path = tmp_path / "bad_utf8.csv"
+        csv_path.write_bytes(b"name\n\xff\n")
+
+        with pytest.raises(ar.CsvReadError) as exc_info:
+            ar.read_csv(csv_path, encoding="utf8")
+
+        msg = str(exc_info.value)
+
+        assert str(csv_path) in msg
+        assert "utf8" in msg.lower() or "utf-8" in msg.lower()
+        assert "invalid utf-8" in msg.lower()
+
+    def test_valid_utf8_still_reads(self, tmp_path):
+        csv_path = tmp_path / "utf8.csv"
+        csv_path.write_text("name\ncafé\n", encoding="utf-8")
+
+        frame = ar.read_csv(csv_path, encoding="utf-8")
+
+        assert frame.shape == (1, 1)
+
+    def test_utf8_sig_still_reads(self, tmp_path):
+        csv_path = tmp_path / "utf8sig.csv"
+        csv_path.write_bytes(b"\xef\xbb\xbfname\nalice\n")
+
+        frame = ar.read_csv(csv_path, encoding="utf-8")
+        df = ar.to_pandas(frame)
+
+        assert list(df.columns) == ["name"]
+        assert "\ufeff" not in df.columns[0]
+        assert df.iloc[0]["name"] == "alice"
+
+    def test_latin1_transcoding_still_works(self, tmp_path):
+        csv_path = tmp_path / "latin1.csv"
+        csv_path.write_bytes("name\ncafé\n".encode("latin-1"))
+
+        frame = ar.read_csv(csv_path, encoding="latin-1")
+        df = ar.to_pandas(frame)
+        assert df["name"].iloc[0] == "café"
+
     def test_pathlike_input(self, sample_csv):
         frame = ar.read_csv(Path(sample_csv))
         assert frame.shape == (3, 4)


### PR DESCRIPTION
## Summary
The native UTF-8 validation already exists in the C++ parser through `handle_utf8_errors()`. This PR adds regression tests for the following functionality:

- Verifying that invalid UTF-8 input raises CsvReadError during both read_csv() and scan_csv(), rather than failing later during to_pandas() conversion.
- Coverage for the utf8 encoding alias in addition to utf-8.
- Ensuring valid UTF-8 input continues to work.
- Ensuring UTF-8 BOM (UTF-8-SIG) handling remains correct.
- Ensuring explicit non-UTF-8 encodings such as latin-1 continue to be transcoded and parsed correctly.

The error reporting at the Python API boundary is improved by re-raising native UTF-8 validation failures as CsvReadError with file path and encoding context.

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
Fixes #712 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [x] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately):
```bash
  python scripts/check_docs_utf8.py
  python -m black --check --diff .
  python -m ruff check . --extend-exclude "*.ipynb"
  python -m mypy --config-file mypy.ini
  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
  ```
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other: 

## Screenshots / Media
To reproduce the issue:
```bash
from pathlib import Path
import tempfile
import arnio as ar

with tempfile.TemporaryDirectory() as td:
    path = Path(td) / "bad_utf8.csv"
    path.write_bytes(b"name\n\xff\n")

    try:
        ar.read_csv(path, encoding="utf-8")
        print("Unexpected success")
    except ar.CsvReadError as e:
        print(type(e).__name__)
        print(e)
```
Output:
<img width="2690" height="112" alt="image" src="https://github.com/user-attachments/assets/3d2f509a-1db9-47f4-a62b-f6766da03f5c" />

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
