### PR TITLE
perf: optimize Frame::describe() direct storage access

### DIFF
--- a/benchmarks/benchmark_describe.py
+++ b/benchmarks/benchmark_describe.py
@@ -1,0 +1,51 @@
+import statistics
+import time
+
+import pandas as pd
+
+import arnio as ar
+
+ROWS = 100_000
+RUNS = 5
+
+
+def build_frame():
+    df = pd.DataFrame(
+        {
+            "id": range(ROWS),
+            "score": [i * 0.5 for i in range(ROWS)],
+            "label": [f"group_{i % 100}" for i in range(ROWS)],
+            "active": [i % 2 == 0 for i in range(ROWS)],
+        }
+    )
+    return ar.from_pandas(df)
+
+
+def main():
+    frame = build_frame()
+
+    # Warm-up run so the measured runs are a little more stable.
+    frame.describe()
+
+    timings = []
+
+    for _ in range(RUNS):
+        start = time.perf_counter()
+        stats = frame.describe()
+        elapsed = time.perf_counter() - start
+        timings.append(elapsed)
+
+    assert stats["id"]["count"] == float(ROWS)
+    assert stats["score"]["count"] == float(ROWS)
+    assert stats["label"]["unique"] == 100.0
+    assert stats["active"]["count"] == float(ROWS)
+
+    print(f"Frame.describe() benchmark on {ROWS:,} mixed rows")
+    print(f"runs: {RUNS}")
+    print(f"min: {min(timings):.6f}s")
+    print(f"mean: {statistics.mean(timings):.6f}s")
+    print(f"max: {max(timings):.6f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -188,160 +188,158 @@ void Frame::rebuild_index() {
 
 std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>> Frame::describe()
     const {
-  std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>> summary;
+    std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>> summary;
 
-  for (const auto& col : columns_) {
-    std::string col_name = col.name();
-    std::vector<std::pair<std::string, double>> stats;
+    for (const auto& col : columns_) {
+        std::string col_name = col.name();
+        std::vector<std::pair<std::string, double>> stats;
 
-    const size_t total_rows = col.size();
-    size_t null_count = 0;
-    size_t valid_count = 0;
+        const size_t total_rows = col.size();
+        size_t null_count = 0;
+        size_t valid_count = 0;
 
-    const DType dtype = col.dtype();
+        const DType dtype = col.dtype();
 
-    if (dtype == DType::INT64) {
-      const auto& values = std::get<std::vector<int64_t>>(col.data());
+        if (dtype == DType::INT64) {
+            const auto& values = std::get<std::vector<int64_t>>(col.data());
 
-      double sum = 0.0;
-      double min_val = std::numeric_limits<double>::infinity();
-      double max_val = -std::numeric_limits<double>::infinity();
-      size_t finite_count = 0;
+            double sum = 0.0;
+            double min_val = std::numeric_limits<double>::infinity();
+            double max_val = -std::numeric_limits<double>::infinity();
+            size_t finite_count = 0;
 
-      for (size_t i = 0; i < total_rows; ++i) {
-        if (col.is_null(i)) {
-          null_count++;
-          continue;
+            for (size_t i = 0; i < total_rows; ++i) {
+                if (col.is_null(i)) {
+                    null_count++;
+                    continue;
+                }
+
+                valid_count++;
+
+                const double val = static_cast<double>(values[i]);
+                finite_count++;
+                sum += val;
+
+                if (val < min_val) min_val = val;
+                if (val > max_val) max_val = val;
+            }
+
+            stats.push_back({"count", static_cast<double>(valid_count)});
+            stats.push_back({"nulls", static_cast<double>(null_count)});
+            stats.push_back({"non_finite", 0.0});
+
+            if (finite_count > 0) {
+                stats.push_back({"mean", sum / finite_count});
+                stats.push_back({"min", min_val});
+                stats.push_back({"max", max_val});
+            } else {
+                stats.push_back({"mean", 0.0});
+                stats.push_back({"min", 0.0});
+                stats.push_back({"max", 0.0});
+            }
+
+            summary.push_back({col_name, stats});
+        } else if (dtype == DType::FLOAT64) {
+            const auto& values = std::get<std::vector<double>>(col.data());
+
+            double sum = 0.0;
+            double min_val = std::numeric_limits<double>::infinity();
+            double max_val = -std::numeric_limits<double>::infinity();
+            size_t finite_count = 0;
+            size_t non_finite_count = 0;
+
+            for (size_t i = 0; i < total_rows; ++i) {
+                if (col.is_null(i)) {
+                    null_count++;
+                    continue;
+                }
+
+                valid_count++;
+
+                const double val = values[i];
+
+                if (!std::isfinite(val)) {
+                    non_finite_count++;
+                    continue;
+                }
+
+                finite_count++;
+                sum += val;
+
+                if (val < min_val) min_val = val;
+                if (val > max_val) max_val = val;
+            }
+
+            stats.push_back({"count", static_cast<double>(valid_count)});
+            stats.push_back({"nulls", static_cast<double>(null_count)});
+            stats.push_back({"non_finite", static_cast<double>(non_finite_count)});
+
+            if (finite_count > 0) {
+                stats.push_back({"mean", sum / finite_count});
+                stats.push_back({"min", min_val});
+                stats.push_back({"max", max_val});
+            } else {
+                stats.push_back({"mean", 0.0});
+                stats.push_back({"min", 0.0});
+                stats.push_back({"max", 0.0});
+            }
+
+            summary.push_back({col_name, stats});
+        } else if (dtype == DType::BOOL) {
+            size_t true_count = 0;
+            size_t false_count = 0;
+
+            const auto& values = std::get<std::vector<bool>>(col.data());
+
+            for (size_t i = 0; i < total_rows; ++i) {
+                if (col.is_null(i)) {
+                    null_count++;
+                    continue;
+                }
+
+                valid_count++;
+
+                if (values[i]) {
+                    true_count++;
+                } else {
+                    false_count++;
+                }
+            }
+
+            stats.push_back({"count", static_cast<double>(valid_count)});
+            stats.push_back({"nulls", static_cast<double>(null_count)});
+            stats.push_back({"true", static_cast<double>(true_count)});
+            stats.push_back({"false", static_cast<double>(false_count)});
+            stats.push_back({"true_ratio", valid_count > 0 ? static_cast<double>(true_count) /
+                                                                 static_cast<double>(valid_count)
+                                                           : 0.0});
+
+            summary.push_back({col_name, stats});
+        } else if (dtype == DType::STRING) {
+            const auto& values = std::get<std::vector<std::string>>(col.data());
+
+            std::unordered_set<std::string_view> unique_values;
+            unique_values.reserve(total_rows);
+
+            for (size_t i = 0; i < total_rows; ++i) {
+                if (col.is_null(i)) {
+                    null_count++;
+                    continue;
+                }
+
+                valid_count++;
+                unique_values.insert(std::string_view(values[i]));
+            }
+
+            stats.push_back({"count", static_cast<double>(valid_count)});
+            stats.push_back({"nulls", static_cast<double>(null_count)});
+            stats.push_back({"unique", static_cast<double>(unique_values.size())});
+
+            summary.push_back({col_name, stats});
         }
-
-        valid_count++;
-
-        const double val = static_cast<double>(values[i]);
-        finite_count++;
-        sum += val;
-
-        if (val < min_val) min_val = val;
-        if (val > max_val) max_val = val;
-      }
-
-      stats.push_back({"count", static_cast<double>(valid_count)});
-      stats.push_back({"nulls", static_cast<double>(null_count)});
-      stats.push_back({"non_finite", 0.0});
-
-      if (finite_count > 0) {
-        stats.push_back({"mean", sum / finite_count});
-        stats.push_back({"min", min_val});
-        stats.push_back({"max", max_val});
-      } else {
-        stats.push_back({"mean", 0.0});
-        stats.push_back({"min", 0.0});
-        stats.push_back({"max", 0.0});
-      }
-
-      summary.push_back({col_name, stats});
-    } else if (dtype == DType::FLOAT64) {
-      const auto& values = std::get<std::vector<double>>(col.data());
-
-      double sum = 0.0;
-      double min_val = std::numeric_limits<double>::infinity();
-      double max_val = -std::numeric_limits<double>::infinity();
-      size_t finite_count = 0;
-      size_t non_finite_count = 0;
-
-      for (size_t i = 0; i < total_rows; ++i) {
-        if (col.is_null(i)) {
-          null_count++;
-          continue;
-        }
-
-        valid_count++;
-
-        const double val = values[i];
-
-        if (!std::isfinite(val)) {
-          non_finite_count++;
-          continue;
-        }
-
-        finite_count++;
-        sum += val;
-
-        if (val < min_val) min_val = val;
-        if (val > max_val) max_val = val;
-      }
-
-      stats.push_back({"count", static_cast<double>(valid_count)});
-      stats.push_back({"nulls", static_cast<double>(null_count)});
-      stats.push_back({"non_finite", static_cast<double>(non_finite_count)});
-
-      if (finite_count > 0) {
-        stats.push_back({"mean", sum / finite_count});
-        stats.push_back({"min", min_val});
-        stats.push_back({"max", max_val});
-      } else {
-        stats.push_back({"mean", 0.0});
-        stats.push_back({"min", 0.0});
-        stats.push_back({"max", 0.0});
-      }
-
-      summary.push_back({col_name, stats});
-    } else if (dtype == DType::BOOL) {
-      size_t true_count = 0;
-      size_t false_count = 0;
-
-      const auto& values = std::get<std::vector<bool>>(col.data());
-
-      for (size_t i = 0; i < total_rows; ++i) {
-        if (col.is_null(i)) {
-          null_count++;
-          continue;
-        }
-
-        valid_count++;
-
-        if (values[i]) {
-          true_count++;
-        } else {
-          false_count++;
-        }
-      }
-
-      stats.push_back({"count", static_cast<double>(valid_count)});
-      stats.push_back({"nulls", static_cast<double>(null_count)});
-      stats.push_back({"true", static_cast<double>(true_count)});
-      stats.push_back({"false", static_cast<double>(false_count)});
-      stats.push_back({"true_ratio",
-                       valid_count > 0
-                           ? static_cast<double>(true_count) /
-                                 static_cast<double>(valid_count)
-                           : 0.0});
-
-      summary.push_back({col_name, stats});
-    } else if (dtype == DType::STRING) {
-      const auto& values = std::get<std::vector<std::string>>(col.data());
-
-      std::unordered_set<std::string_view> unique_values;
-      unique_values.reserve(total_rows);
-
-      for (size_t i = 0; i < total_rows; ++i) {
-        if (col.is_null(i)) {
-          null_count++;
-          continue;
-        }
-
-        valid_count++;
-        unique_values.insert(std::string_view(values[i]));
-      }
-
-      stats.push_back({"count", static_cast<double>(valid_count)});
-      stats.push_back({"nulls", static_cast<double>(null_count)});
-      stats.push_back({"unique", static_cast<double>(unique_values.size())});
-
-      summary.push_back({col_name, stats});
     }
-  }
 
-  return summary;
+    return summary;
 }
 
 }  // namespace arnio

--- a/cpp/src/frame.cpp
+++ b/cpp/src/frame.cpp
@@ -1,7 +1,10 @@
 #include "arnio/frame.h"
 
 #include <cmath>
+#include <limits>
 #include <stdexcept>
+#include <string_view>
+#include <unordered_set>
 
 namespace arnio {
 
@@ -185,111 +188,160 @@ void Frame::rebuild_index() {
 
 std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>> Frame::describe()
     const {
-    std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>> summary;
+  std::vector<std::pair<std::string, std::vector<std::pair<std::string, double>>>> summary;
 
-    for (const auto& col : columns_) {
-        std::string col_name = col.name();
-        std::vector<std::pair<std::string, double>> stats;
+  for (const auto& col : columns_) {
+    std::string col_name = col.name();
+    std::vector<std::pair<std::string, double>> stats;
 
-        size_t total_rows = col.size();
-        size_t null_count = 0;
-        size_t valid_count = 0;
-        std::string type_str = dtype_to_string(col.dtype());
+    const size_t total_rows = col.size();
+    size_t null_count = 0;
+    size_t valid_count = 0;
 
-        if (type_str == "int64" || type_str == "float64") {
-            double sum = 0.0;
-            double min_val = std::numeric_limits<double>::infinity();
-            double max_val = -std::numeric_limits<double>::infinity();
-            size_t finite_count = 0;
-            size_t non_finite_count = 0;
+    const DType dtype = col.dtype();
 
-            for (size_t i = 0; i < total_rows; ++i) {
-                if (col.is_null(i)) {
-                    null_count++;
-                    continue;
-                }
-                valid_count++;
+    if (dtype == DType::INT64) {
+      const auto& values = std::get<std::vector<int64_t>>(col.data());
 
-                double val = 0.0;
-                if (col.dtype() == DType::INT64) {
-                    val = static_cast<double>(std::get<int64_t>(col.at(i)));
-                } else {
-                    val = std::get<double>(col.at(i));
-                }
+      double sum = 0.0;
+      double min_val = std::numeric_limits<double>::infinity();
+      double max_val = -std::numeric_limits<double>::infinity();
+      size_t finite_count = 0;
 
-                if (!std::isfinite(val)) {
-                    non_finite_count++;
-                    continue;
-                }
-
-                finite_count++;
-                sum += val;
-                if (val < min_val) min_val = val;
-                if (val > max_val) max_val = val;
-            }
-
-            stats.push_back({"count", static_cast<double>(valid_count)});
-            stats.push_back({"nulls", static_cast<double>(null_count)});
-            stats.push_back({"non_finite", static_cast<double>(non_finite_count)});
-            if (finite_count > 0) {
-                stats.push_back({"mean", sum / finite_count});
-                stats.push_back({"min", min_val});
-                stats.push_back({"max", max_val});
-            } else {
-                stats.push_back({"mean", 0.0});
-                stats.push_back({"min", 0.0});
-                stats.push_back({"max", 0.0});
-            }
-
-            summary.push_back({col_name, stats});
-        } else if (col.dtype() == DType::BOOL) {
-            size_t true_count = 0;
-            size_t false_count = 0;
-            const auto& values = std::get<std::vector<bool>>(col.data());
-
-            for (size_t i = 0; i < total_rows; ++i) {
-                if (col.is_null(i)) {
-                    null_count++;
-                    continue;
-                }
-                valid_count++;
-                if (values[i]) {
-                    true_count++;
-                } else {
-                    false_count++;
-                }
-            }
-
-            stats.push_back({"count", static_cast<double>(valid_count)});
-            stats.push_back({"nulls", static_cast<double>(null_count)});
-            stats.push_back({"true", static_cast<double>(true_count)});
-            stats.push_back({"false", static_cast<double>(false_count)});
-            stats.push_back({"true_ratio", valid_count > 0 ? static_cast<double>(true_count) /
-                                                                 static_cast<double>(valid_count)
-                                                           : 0.0});
-
-            summary.push_back({col_name, stats});
-        } else if (type_str == "string") {
-            std::unordered_set<std::string> unique_values;
-
-            for (size_t i = 0; i < total_rows; ++i) {
-                if (col.is_null(i)) {
-                    null_count++;
-                    continue;
-                }
-                valid_count++;
-                unique_values.insert(std::get<std::string>(col.at(i)));
-            }
-
-            stats.push_back({"count", static_cast<double>(valid_count)});
-            stats.push_back({"nulls", static_cast<double>(null_count)});
-            stats.push_back({"unique", static_cast<double>(unique_values.size())});
-
-            summary.push_back({col_name, stats});
+      for (size_t i = 0; i < total_rows; ++i) {
+        if (col.is_null(i)) {
+          null_count++;
+          continue;
         }
-    }
 
-    return summary;
+        valid_count++;
+
+        const double val = static_cast<double>(values[i]);
+        finite_count++;
+        sum += val;
+
+        if (val < min_val) min_val = val;
+        if (val > max_val) max_val = val;
+      }
+
+      stats.push_back({"count", static_cast<double>(valid_count)});
+      stats.push_back({"nulls", static_cast<double>(null_count)});
+      stats.push_back({"non_finite", 0.0});
+
+      if (finite_count > 0) {
+        stats.push_back({"mean", sum / finite_count});
+        stats.push_back({"min", min_val});
+        stats.push_back({"max", max_val});
+      } else {
+        stats.push_back({"mean", 0.0});
+        stats.push_back({"min", 0.0});
+        stats.push_back({"max", 0.0});
+      }
+
+      summary.push_back({col_name, stats});
+    } else if (dtype == DType::FLOAT64) {
+      const auto& values = std::get<std::vector<double>>(col.data());
+
+      double sum = 0.0;
+      double min_val = std::numeric_limits<double>::infinity();
+      double max_val = -std::numeric_limits<double>::infinity();
+      size_t finite_count = 0;
+      size_t non_finite_count = 0;
+
+      for (size_t i = 0; i < total_rows; ++i) {
+        if (col.is_null(i)) {
+          null_count++;
+          continue;
+        }
+
+        valid_count++;
+
+        const double val = values[i];
+
+        if (!std::isfinite(val)) {
+          non_finite_count++;
+          continue;
+        }
+
+        finite_count++;
+        sum += val;
+
+        if (val < min_val) min_val = val;
+        if (val > max_val) max_val = val;
+      }
+
+      stats.push_back({"count", static_cast<double>(valid_count)});
+      stats.push_back({"nulls", static_cast<double>(null_count)});
+      stats.push_back({"non_finite", static_cast<double>(non_finite_count)});
+
+      if (finite_count > 0) {
+        stats.push_back({"mean", sum / finite_count});
+        stats.push_back({"min", min_val});
+        stats.push_back({"max", max_val});
+      } else {
+        stats.push_back({"mean", 0.0});
+        stats.push_back({"min", 0.0});
+        stats.push_back({"max", 0.0});
+      }
+
+      summary.push_back({col_name, stats});
+    } else if (dtype == DType::BOOL) {
+      size_t true_count = 0;
+      size_t false_count = 0;
+
+      const auto& values = std::get<std::vector<bool>>(col.data());
+
+      for (size_t i = 0; i < total_rows; ++i) {
+        if (col.is_null(i)) {
+          null_count++;
+          continue;
+        }
+
+        valid_count++;
+
+        if (values[i]) {
+          true_count++;
+        } else {
+          false_count++;
+        }
+      }
+
+      stats.push_back({"count", static_cast<double>(valid_count)});
+      stats.push_back({"nulls", static_cast<double>(null_count)});
+      stats.push_back({"true", static_cast<double>(true_count)});
+      stats.push_back({"false", static_cast<double>(false_count)});
+      stats.push_back({"true_ratio",
+                       valid_count > 0
+                           ? static_cast<double>(true_count) /
+                                 static_cast<double>(valid_count)
+                           : 0.0});
+
+      summary.push_back({col_name, stats});
+    } else if (dtype == DType::STRING) {
+      const auto& values = std::get<std::vector<std::string>>(col.data());
+
+      std::unordered_set<std::string_view> unique_values;
+      unique_values.reserve(total_rows);
+
+      for (size_t i = 0; i < total_rows; ++i) {
+        if (col.is_null(i)) {
+          null_count++;
+          continue;
+        }
+
+        valid_count++;
+        unique_values.insert(std::string_view(values[i]));
+      }
+
+      stats.push_back({"count", static_cast<double>(valid_count)});
+      stats.push_back({"nulls", static_cast<double>(null_count)});
+      stats.push_back({"unique", static_cast<double>(unique_values.size())});
+
+      summary.push_back({col_name, stats});
+    }
+  }
+
+  return summary;
 }
 
 }  // namespace arnio

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1076,6 +1076,65 @@ def test_describe_boolean_columns_with_nulls():
     assert stats["flag"]["true_ratio"] == pytest.approx(2.0 / 3.0)
 
 
+def test_describe_preserves_mixed_column_outputs():
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "score": [1.5, 2.5, 3.5, 4.5],
+            "label": ["a", "b", "a", "c"],
+            "active": [True, False, True, True],
+        }
+    )
+
+    frame = ar.from_pandas(df)
+    stats = frame.describe()
+
+    assert stats["id"]["count"] == 4.0
+    assert stats["id"]["nulls"] == 0.0
+    assert stats["id"]["non_finite"] == 0.0
+    assert stats["id"]["mean"] == 2.5
+    assert stats["id"]["min"] == 1.0
+    assert stats["id"]["max"] == 4.0
+
+    assert stats["score"]["count"] == 4.0
+    assert stats["score"]["nulls"] == 0.0
+    assert stats["score"]["non_finite"] == 0.0
+    assert stats["score"]["mean"] == 3.0
+    assert stats["score"]["min"] == 1.5
+    assert stats["score"]["max"] == 4.5
+
+    assert stats["label"]["count"] == 4.0
+    assert stats["label"]["nulls"] == 0.0
+    assert stats["label"]["unique"] == 3.0
+
+    assert stats["active"]["count"] == 4.0
+    assert stats["active"]["nulls"] == 0.0
+    assert stats["active"]["true"] == 3.0
+    assert stats["active"]["false"] == 1.0
+    assert stats["active"]["true_ratio"] == pytest.approx(0.75)
+
+
+def test_describe_preserves_null_and_non_finite_float_handling():
+    import io
+
+    frame = ar.read_csv(
+        io.StringIO("value,name\n" "1.0,a\n" "inf,b\n" "3.0,\n" ",c\n" "-inf,a\n")
+    )
+
+    stats = frame.describe()
+
+    assert stats["value"]["count"] == 4.0
+    assert stats["value"]["nulls"] == 1.0
+    assert stats["value"]["non_finite"] == 2.0
+    assert stats["value"]["mean"] == 2.0
+    assert stats["value"]["min"] == 1.0
+    assert stats["value"]["max"] == 3.0
+
+    assert stats["name"]["count"] == 4.0
+    assert stats["name"]["nulls"] == 1.0
+    assert stats["name"]["unique"] == 3.0
+
+
 # ── non-finite describe regression tests ─────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Optimizes the existing C++ Frame::describe() implementation by removing col.at(i) from the numeric/string hot paths and using direct typed vector access instead.

This keeps the public API, return shape, bindings, and Python-facing behavior unchanged while improving the internal describe path.

## Linked issue
Fixes #1035 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately):
```bash
  python scripts/check_docs_utf8.py
  python -m black --check --diff .
  python -m ruff check . --extend-exclude "*.ipynb"
  python -m mypy --config-file mypy.ini
  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
  ```
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
  - [x] python -m black --check --target-version py311 tests/test_frame.py benchmarks/benchmark_describe.py 
  - [x] python -m ruff check tests/test_frame.py benchmarks/benchmark_describe.py 
  - [x] python -m pytest tests/test_frame.py -v -k describe 
  - [x] python benchmarks/benchmark_describe.py git diff --check -- cpp/src/frame.cpp

- Results:

python -m black --check --target-version py311 tests/test_frame.py benchmarks/benchmark_describe.py
All done! 2 files would be left unchanged.

python -m ruff check tests/test_frame.py benchmarks/benchmark_describe.py
All checks passed!

python -m pytest tests/test_frame.py -v -k describe
15 passed, 171 deselected

python benchmarks/benchmark_describe.py
Frame.describe() benchmark on 100,000 mixed rows
runs: 5
min: 0.002753s
mean: 0.002952s
max: 0.003404s

git diff --check -- cpp/src/frame.cpp
passed

## Screenshots / Media
N/A — no UI, README visual, or terminal UI change.

## Performance Impact
Added benchmarks/benchmark_describe.py with a deterministic 100,000-row mixed-frame benchmark.

Local result:
Frame.describe() benchmark on 100,000 mixed rows
runs: 5
min: 0.002753s
mean: 0.002952s
max: 0.003404s

Implementation notes:
- `INT64` columns now read directly from `std::vector<int64_t>`.
- `FLOAT64` columns now read directly from `std::vector<double>`.
- `STRING `unique counting now uses local `std::unordered_set<std::string_view>`.
- `std::string_view` values remain local to `Frame::describe()` and do not outlive the backing string vector.
- Existing null and non-finite float behavior is preserved.

## GSSoC labels
Maintainers only.
Suggested applicable labels based on the issue scope: `type:performance`, `area:cpp-core`, and the appropriate GSSoC approval/level labels after review.


## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
No public API, binding, return-shape, or Python-facing behavior changes were made, so docs/examples were not updated.