### PR TITLE
test: cover combine_columns mixed null semantics

### DIFF
--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -45,32 +45,6 @@ class TestDropNulls:
 
         assert result.shape[0] == 2
 
-    def test_mixed_null_and_non_null_columns(self):
-        import pandas as pd
-
-        df = pd.DataFrame(
-            {
-                "a": ["hello", None, "foo", None],
-                "b": [None, "world", "bar", None],
-            }
-        )
-
-        frame = ar.from_pandas(df)
-
-        result = ar.combine_columns(
-            frame,
-            subset=["a", "b"],
-            separator=" ",
-            output_column="combined",
-        )
-
-        result_df = ar.to_pandas(result)
-
-        assert result_df["combined"].iloc[0] == "hello "
-        assert result_df["combined"].iloc[1] == " world"
-        assert result_df["combined"].iloc[2] == "foo bar"
-        assert pd.isna(result_df["combined"].iloc[3])
-
 
 class TestKeepRowsWithNulls:
     def test_pandas_input_empty_subset_raises(self):
@@ -3705,6 +3679,35 @@ class TestCombineColumns:
 
         assert pd.isna(result_df["combined"]).iloc[0]
         assert result_df["combined"].iloc[1] == "hello world"
+
+    def test_combine_columns_mixed_null_and_non_null_columns(self):
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "a": ["hello", None, "foo", None],
+                "b": [None, "world", "bar", None],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+
+        result = ar.combine_columns(
+            frame,
+            subset=["a", "b"],
+            separator=" ",
+            output_column="combined",
+        )
+
+        result_df = ar.to_pandas(result)
+
+        assert result_df["combined"].iloc[0] == "hello "
+        assert result_df["combined"].iloc[1] == " world"
+        assert result_df["combined"].iloc[2] == "foo bar"
+        assert pd.isna(result_df["combined"].iloc[3])
+
+        # dtype contract
+        assert str(result_df["combined"].dtype) == "string"
 
     def test_missing_subset_column_raises(self):
         import pandas as pd

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -45,6 +45,32 @@ class TestDropNulls:
 
         assert result.shape[0] == 2
 
+    def test_mixed_null_and_non_null_columns(self):
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {
+                "a": ["hello", None, "foo", None],
+                "b": [None, "world", "bar", None],
+            }
+        )
+
+        frame = ar.from_pandas(df)
+
+        result = ar.combine_columns(
+            frame,
+            subset=["a", "b"],
+            separator=" ",
+            output_column="combined",
+        )
+
+        result_df = ar.to_pandas(result)
+
+        assert result_df["combined"].iloc[0] == "hello "
+        assert result_df["combined"].iloc[1] == " world"
+        assert result_df["combined"].iloc[2] == "foo bar"
+        assert pd.isna(result_df["combined"].iloc[3])
+
 
 class TestKeepRowsWithNulls:
     def test_pandas_input_empty_subset_raises(self):


### PR DESCRIPTION
### Fixes #618 

## Summary

Adds regression coverage for combine_columns when input columns contain a mix of null and non-null values.

## Changes

- Added test for mixed null/non-null column combinations
- Verified combined output preserves expected null semantics
- Ensures rows with all-null inputs still return NA

