### PR TITLE
fix: sort mixed-type sets deterministically during schema export

### DIFF
--- a/arnio/schema_export.py
+++ b/arnio/schema_export.py
@@ -166,7 +166,8 @@ def _normalize_serializable(value: Any) -> Any:
     # Convert sets into deterministic sorted lists since YAML
     # emission only supports list-like serialized output.
     if isinstance(value, set):
-        return sorted(_normalize_serializable(v) for v in value)
+        normalized_elements = [_normalize_serializable(v) for v in value]
+        return sorted(normalized_elements, key=lambda x: (type(x).__name__, repr(x)))
 
     if isinstance(value, list):
         return [_normalize_serializable(v) for v in value]

--- a/tests/test_schema_export.py
+++ b/tests/test_schema_export.py
@@ -284,6 +284,12 @@ def test_set_valued_allowed_normalized():
     assert result["fields"]["status"]["allowed"] == ["a", "b", "c"]
 
 
+def test_mixed_scalar_set_normalized():
+    raw = {"code": {"type": "STRING", "allowed": {1, "1"}}}
+    result = schema_to_dict(raw)
+    assert result["fields"]["code"]["allowed"] == [1, "1"]
+
+
 def test_real_schema_field_dtype():
     schema = ar.Schema({"price": ar.Field(dtype="float64", nullable=False)})
     result = schema_to_dict(schema)


### PR DESCRIPTION
This PR resolves issue #2460: 'Bug: schema_to_dict fails mixed scalar sets with raw sort TypeError' by sorting set elements using a tuple key of (type(x).__name__, repr(x)) instead of direct element comparisons, preventing TypeErrors when set elements are mutually incomparable (e.g. str and int), and adds unit tests.