### PR TITLE
fix: safe import fallback for missing C++ extension

### DIFF
--- a/arnio/__init__.py
+++ b/arnio/__init__.py
@@ -5,127 +5,6 @@ import arnio as ar
 """
 
 from ._version import __version__ as __version__
-from .cleaning import (
-    CastFailure,
-    CastReport,
-    cast_types,
-    clean,
-    clean_column_names,
-    clip_numeric,
-    coalesce_columns,
-    combine_columns,
-    drop_columns,
-    drop_columns_matching,
-    drop_constant_columns,
-    drop_duplicates,
-    drop_empty_columns,
-    drop_nulls,
-    fill_nulls,
-    filter_rows,
-    find_fuzzy_duplicates,
-    keep_rows_with_nulls,
-    normalize_case,
-    normalize_minmax,
-    normalize_unicode,
-    normalize_whitespace,
-    parse_bool_strings,
-    rename_columns,
-    rename_columns_matching,
-    replace_values,
-    round_numeric_columns,
-    safe_divide_columns,
-    select_columns,
-    slugify_column_names,
-    standardize_missing_tokens,
-    strip_whitespace,
-    trim_column_names,
-    validate_columns_exist,
-    winsorize_outliers,
-)
-from .convert import from_dict, from_pandas, from_polars, to_arrow, to_pandas, to_polars
-from .encode_categorical import encode_categorical
-from .exceptions import (
-    ArnioError,
-    CsvReadError,
-    JsonlReadError,
-    PipelineSerializationError,
-    PipelineStepError,
-    RemoteReadError,
-    SchemaValidationError,
-    TypeCastError,
-    UnknownStepError,
-)
-from .frame import ArFrame, ColumnSummary
-from .integrations import ArnioPandasAccessor, register_duckdb
-from .io import (
-    read_csv,
-    read_csv_chunked,
-    read_jsonl,
-    read_jsonl_chunked,
-    read_parquet,
-    scan_csv,
-    sniff_delimiter,
-    write_csv,
-    write_json,
-    write_parquet,
-)
-from .pipeline import (
-    LineageReport,
-    PipelineContext,
-    get_builtin_step_signatures,
-    list_steps,
-    load_pipeline,
-    pipeline,
-    register_step,
-    reset_steps,
-    save_pipeline,
-    unregister_step,
-)
-from .quality import (
-    CleanExplanation,
-    CleaningSuggestion,
-    CleanStepRecord,
-    ColumnProfile,
-    DataQualityReport,
-    ProfileComparison,
-    QualityGateIssue,
-    QualityGateResult,
-    auto_clean,
-    check_quality_gates,
-    compare_profiles,
-    profile,
-    suggest_cleaning,
-)
-from .schema import (
-    URL,
-    Bool,
-    CountryCode,
-    CurrencyCode,
-    Custom,
-    Date,
-    DateTime,
-    Email,
-    Field,
-    Float64,
-    Int64,
-    LanguageCode,
-    PhoneNumber,
-    Regex,
-    Schema,
-    SchemaDiff,
-    SchemaDiffEntry,
-    String,
-    TimeZone,
-    ValidationIssue,
-    ValidationResult,
-    diff_schema,
-    register_validator,
-    validate,
-    validate_chunked,
-)
-from .schema_export import schema_from_yaml, schema_to_dict, schema_to_yaml
-
-from_records = ArFrame.from_records
 
 __all__ = [
     # Core class
@@ -255,3 +134,143 @@ __all__ = [
     "PipelineSerializationError",
     "encode_categorical",
 ]
+
+try:
+    from .cleaning import (
+        CastFailure,
+        CastReport,
+        cast_types,
+        clean,
+        clean_column_names,
+        clip_numeric,
+        coalesce_columns,
+        combine_columns,
+        drop_columns,
+        drop_columns_matching,
+        drop_constant_columns,
+        drop_duplicates,
+        drop_empty_columns,
+        drop_nulls,
+        fill_nulls,
+        filter_rows,
+        find_fuzzy_duplicates,
+        keep_rows_with_nulls,
+        normalize_case,
+        normalize_minmax,
+        normalize_unicode,
+        normalize_whitespace,
+        parse_bool_strings,
+        rename_columns,
+        rename_columns_matching,
+        replace_values,
+        round_numeric_columns,
+        safe_divide_columns,
+        select_columns,
+        slugify_column_names,
+        standardize_missing_tokens,
+        strip_whitespace,
+        trim_column_names,
+        validate_columns_exist,
+        winsorize_outliers,
+    )
+    from .convert import from_dict, from_pandas, from_polars, to_arrow, to_pandas, to_polars
+    from .encode_categorical import encode_categorical
+    from .exceptions import (
+        ArnioError,
+        CsvReadError,
+        JsonlReadError,
+        PipelineSerializationError,
+        PipelineStepError,
+        RemoteReadError,
+        SchemaValidationError,
+        TypeCastError,
+        UnknownStepError,
+    )
+    from .frame import ArFrame, ColumnSummary
+    from .integrations import ArnioPandasAccessor, register_duckdb
+    from .io import (
+        read_csv,
+        read_csv_chunked,
+        read_jsonl,
+        read_jsonl_chunked,
+        read_parquet,
+        scan_csv,
+        sniff_delimiter,
+        write_csv,
+        write_json,
+        write_parquet,
+    )
+    from .pipeline import (
+        LineageReport,
+        PipelineContext,
+        get_builtin_step_signatures,
+        list_steps,
+        load_pipeline,
+        pipeline,
+        register_step,
+        reset_steps,
+        save_pipeline,
+        unregister_step,
+    )
+    from .quality import (
+        CleanExplanation,
+        CleaningSuggestion,
+        CleanStepRecord,
+        ColumnProfile,
+        DataQualityReport,
+        ProfileComparison,
+        QualityGateIssue,
+        QualityGateResult,
+        auto_clean,
+        check_quality_gates,
+        compare_profiles,
+        profile,
+        suggest_cleaning,
+    )
+    from .schema import (
+        URL,
+        Bool,
+        CountryCode,
+        CurrencyCode,
+        Custom,
+        Date,
+        DateTime,
+        Email,
+        Field,
+        Float64,
+        Int64,
+        LanguageCode,
+        PhoneNumber,
+        Regex,
+        Schema,
+        SchemaDiff,
+        SchemaDiffEntry,
+        String,
+        TimeZone,
+        ValidationIssue,
+        ValidationResult,
+        diff_schema,
+        register_validator,
+        validate,
+        validate_chunked,
+    )
+    from .schema_export import schema_from_yaml, schema_to_dict, schema_to_yaml
+
+    from_records = ArFrame.from_records
+
+except ImportError as e:
+    _import_err = e
+
+    class _DummyPlaceholder:
+        def __init__(self, *args, **kwargs):
+            raise _import_err
+        def __call__(self, *args, **kwargs):
+            raise _import_err
+        def __getattr__(self, name):
+            raise _import_err
+
+    _placeholder = _DummyPlaceholder()
+    for _name in __all__:
+        if _name != "from_records":
+            globals()[_name] = _placeholder
+    from_records = _placeholder


### PR DESCRIPTION
Fixes #2462. Wraps the eager module imports in __init__.py with a try-except fallback to dummy/placeholder objects if the C++ extension is missing, allowing the CLI to load and run --help successfully on unbuilt checkouts.