### PR TITLE
fix: ArFrame.astype leaks pd.NA ambiguous truth-value errors

### DIFF
--- a/arnio/frame.py
+++ b/arnio/frame.py
@@ -230,7 +230,14 @@ class ArFrame:
                     "of column names to dtypes"
                 )
 
-            if value in (object, "object"):
+            if isinstance(value, np.ndarray) and value.size > 1:
+                raise TypeError(
+                    "dtype must be a string, Python type, "
+                    "NumPy/pandas dtype, or mapping "
+                    "of column names to dtypes"
+                )
+
+            if value is object or (isinstance(value, str) and value == "object"):
                 raise TypeError(
                     "dtype must be a string, Python type, "
                     "NumPy/pandas dtype, or mapping "

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1793,3 +1793,33 @@ def test_to_dict_invalid_orient_types():
     # 4. Backward Compatibility: Unsupported string must still raise ValueError
     with pytest.raises(ValueError, match="orient must be one of: list, records, split"):
         frame.to_dict(orient="invalid_string")
+
+
+def test_astype_rejects_pandas_na():
+    import pandas as pd
+    import pytest
+
+    import arnio as ar
+
+    frame = ar.ArFrame.from_records([{"a": "1"}, {"a": "2"}])
+
+    # 1. Scalar pd.NA check
+    with pytest.raises(TypeError, match="dtype must be a string"):
+        frame.astype(pd.NA)
+
+    # 2. Mapping/Dict with pd.NA check
+    with pytest.raises(TypeError, match="dtype must be a string"):
+        frame.astype({"a": pd.NA})
+
+
+def test_astype_rejects_multielement_numpy_array():
+    import numpy as np
+    import pytest
+
+    import arnio as ar
+
+    frame = ar.ArFrame.from_records([{"a": "1"}])
+
+    # 3. Multi-element NumPy array check
+    with pytest.raises(TypeError, match="dtype must be a string"):
+        frame.astype(np.array([1, 2]))


### PR DESCRIPTION
## Summary
Fixed a validation bug in `ArFrame.astype()` where passing `pd.NA` or multi-element NumPy arrays caused Python to raise an ambiguous truth-value error (`TypeError: boolean value of NA is ambiguous`) during the internal tuple-membership check. Replaced the equality/membership check with safe identity (`is`) and string validation.

## Linked issue
Fixes #2461

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Ran focused pytest suite locally in the Codespace environment:
- [x] `python -m pytest tests/test_frame.py -k "test_astype_rejects"`

Result: Both new regression test cases (`test_astype_rejects_pandas_na` and `test_astype_rejects_multielement_numpy_array`) passed successfully.

## Screenshots / Media
N/A

## Performance Impact
No performance regression; optimization completely avoids evaluating arbitrary elementwise equality operations during type filtering.

## GSSoC labels
## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: ArFrame.astype leaks pd.NA ambiguous truth-value errors`).

## Maintainer notes
N/A