### PR TITLE
Feature: add append mode to write_csv (Fixes #644)

### DIFF
--- a/arnio/_arnio_cpp.pyi
+++ b/arnio/_arnio_cpp.pyi
@@ -136,6 +136,7 @@ class CsvWriteConfig:
     write_header: bool
     line_terminator: str
     escape_formulas: bool
+    append: bool
 
     def __init__(self) -> None: ...
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1355,6 +1355,8 @@ def write_csv(
         If ``encoding`` is an unknown codec, ``encoding_errors`` is not one of
         ``"strict"``, ``"replace"``, or ``"ignore"``, or if a character cannot
         be encoded in the requested encoding with ``encoding_errors="strict"``.
+        Also raised if appending to a file that lacks a trailing newline, or
+        if appending with a schema that doesn't match the existing CSV.
     RuntimeError
         If the file cannot be opened or written.
 
@@ -1363,6 +1365,10 @@ def write_csv(
     >>> ar.write_csv(frame, "output.csv")
     >>> ar.write_csv(frame, "output.tsv", delimiter="\\t")
     >>> ar.write_csv(frame, "output_latin1.csv", encoding="latin-1")
+    
+    Append to an existing file (headers are omitted if the file exists):
+    
+    >>> ar.write_csv(new_frame, "output.csv", append=True)
     """
     if not isinstance(frame, ArFrame):
         raise TypeError("frame must be an ArFrame")
@@ -1399,6 +1405,12 @@ def write_csv(
     is_empty = file_exists and os.path.getsize(path) == 0
 
     if append and file_exists and not is_empty:
+        with open(path, "rb") as f:
+            f.seek(-1, os.SEEK_END)
+            last_byte = f.read(1)
+            if last_byte not in (b"\n", b"\r"):
+                raise ValueError("Cannot append to a CSV file that lacks a final line terminator.")
+
         try:
             schema = scan_csv(
                 path,
@@ -1459,13 +1471,21 @@ def write_csv(
             )
             os.close(output_fd)
 
+            if append and file_exists and not is_empty:
+                import shutil
+
+                shutil.copy2(path, output_tmp_path)
+                mode = "a"
+            else:
+                mode = "w"
+
             # newline="" on both sides preserves the line_terminator written by
             # the C++ backend exactly — no platform newline translation.
             with (
                 open(tmp_path, encoding="utf-8", newline="") as src,
                 open(
                     output_tmp_path,
-                    "w",
+                    mode,
                     encoding=encoding,
                     errors=encoding_errors,
                     newline="",

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1407,7 +1407,9 @@ def write_csv(
                 encoding_errors=encoding_errors,
             )
         except Exception as e:
-            raise ValueError(f"Could not scan existing CSV to validate schema: {e}") from e
+            raise ValueError(
+                f"Could not scan existing CSV to validate schema: {e}"
+            ) from e
 
         existing_cols = list(schema.keys())
         if existing_cols != frame.columns:

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1311,6 +1311,7 @@ def write_csv(
     frame: ArFrame,
     path: str | os.PathLike[str],
     *,
+    append: bool = False,
     delimiter: str = ",",
     write_header: bool = True,
     line_terminator: str = "\n",
@@ -1393,11 +1394,35 @@ def write_csv(
     _validate_jsonl_encoding(encoding)
     _validate_encoding_errors(encoding_errors)
 
+    append = _validate_bool_option(append, "append")
+    file_exists = os.path.exists(path)
+    is_empty = file_exists and os.path.getsize(path) == 0
+
+    if append and file_exists and not is_empty:
+        try:
+            schema = scan_csv(
+                path,
+                delimiter=delimiter,
+                encoding=encoding,
+                encoding_errors=encoding_errors,
+            )
+        except Exception as e:
+            raise ValueError(f"Could not scan existing CSV to validate schema: {e}") from e
+
+        existing_cols = list(schema.keys())
+        if existing_cols != frame.columns:
+            raise ValueError(
+                f"Schema mismatch: Cannot append to {path}. "
+                f"Expected columns {existing_cols}, got {frame.columns}."
+            )
+        write_header = False
+
     config = _CsvWriteConfig()
     config.delimiter = delimiter
     config.write_header = _validate_bool_option(write_header, "write_header")
     config.line_terminator = line_terminator
     config.escape_formulas = _validate_bool_option(escape_formulas, "escape_formulas")
+    config.append = append
 
     writer = _CsvWriter(config)
 

--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1365,9 +1365,9 @@ def write_csv(
     >>> ar.write_csv(frame, "output.csv")
     >>> ar.write_csv(frame, "output.tsv", delimiter="\\t")
     >>> ar.write_csv(frame, "output_latin1.csv", encoding="latin-1")
-    
+
     Append to an existing file (headers are omitted if the file exists):
-    
+
     >>> ar.write_csv(new_frame, "output.csv", append=True)
     """
     if not isinstance(frame, ArFrame):
@@ -1409,7 +1409,9 @@ def write_csv(
             f.seek(-1, os.SEEK_END)
             last_byte = f.read(1)
             if last_byte not in (b"\n", b"\r"):
-                raise ValueError("Cannot append to a CSV file that lacks a final line terminator.")
+                raise ValueError(
+                    "Cannot append to a CSV file that lacks a final line terminator."
+                )
 
         try:
             schema = scan_csv(

--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -338,7 +338,8 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def_readwrite("delimiter", &CsvWriteConfig::delimiter)
         .def_readwrite("write_header", &CsvWriteConfig::write_header)
         .def_readwrite("line_terminator", &CsvWriteConfig::line_terminator)
-        .def_readwrite("escape_formulas", &CsvWriteConfig::escape_formulas);
+        .def_readwrite("escape_formulas", &CsvWriteConfig::escape_formulas)
+        .def_readwrite("append", &CsvWriteConfig::append);
 
     py::class_<CsvWriter>(m, "CsvWriter")
         .def(py::init<const CsvWriteConfig&>(), py::arg("config") = CsvWriteConfig{})

--- a/cpp/include/arnio/csv_writer.h
+++ b/cpp/include/arnio/csv_writer.h
@@ -12,6 +12,7 @@ struct CsvWriteConfig {
     bool write_header = true;
     std::string line_terminator = "\n";
     bool escape_formulas = false;
+    bool append = false;
 };
 
 class CsvWriter {

--- a/cpp/src/csv_writer.cpp
+++ b/cpp/src/csv_writer.cpp
@@ -15,11 +15,17 @@
 namespace arnio {
 
 namespace {
-inline void open_binary_output(std::ofstream& file, const std::string& path) {
+inline void open_binary_output(std::ofstream& file, const std::string& path, bool append) {
+    auto mode = std::ios::binary | std::ios::out;
+    if (append) {
+        mode |= std::ios::app;
+    } else {
+        mode |= std::ios::trunc;
+    }
 #ifdef _WIN32
-    file.open(std::filesystem::u8path(path), std::ios::binary);
+    file.open(std::filesystem::u8path(path), mode);
 #else
-    file.open(path, std::ios::binary);
+    file.open(path, mode);
 #endif
 }
 }  // namespace
@@ -93,7 +99,7 @@ void CsvWriter::write(const Frame& frame, const std::string& path) const {
     // corrupting any line_terminator that already contains '\r'
     // (e.g. "\r\n" → "\r\r\n").
     std::ofstream out;
-    open_binary_output(out, path);
+    open_binary_output(out, path, config_.append);
     if (!out.is_open()) {
         throw std::runtime_error("Could not open file for writing: " + path);
     }

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -661,8 +661,9 @@ def test_write_csv_append(tmp_path):
     # Append to existing
     ar.write_csv(frame2, path, append=True)
     res2 = ar.read_csv(path)
-    assert len(res2) == 4
-    assert res2.column("A").to_list() == [1, 2, 3, 4]
+    res2_df = ar.to_pandas(res2)
+    assert len(res2_df) == 4
+    assert res2_df["A"].tolist() == [1, 2, 3, 4]
 
     # Schema mismatch
     frame3 = ar.from_pandas(pd.DataFrame({"A": [5], "C": ["diff"]}))

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -648,11 +648,9 @@ class TestWriteCsvEncoding:
         assert after - before == {str(out)}
 
 def test_write_csv_append(tmp_path):
-    import arnio as ar
-    import pytest
     path = str(tmp_path / 'test_append.csv')
-    frame1 = ar.ArFrame({'A': [1, 2], 'B': ['x', 'y']})
-    frame2 = ar.ArFrame({'A': [3, 4], 'B': ['z', 'w']})
+    frame1 = ar.from_pandas(pd.DataFrame({'A': [1, 2], 'B': ['x', 'y']}))
+    frame2 = ar.from_pandas(pd.DataFrame({'A': [3, 4], 'B': ['z', 'w']}))
 
     # Append to empty
     ar.write_csv(frame1, path, append=True)
@@ -666,6 +664,6 @@ def test_write_csv_append(tmp_path):
     assert res2.column('A').to_list() == [1, 2, 3, 4]
 
     # Schema mismatch
-    frame3 = ar.ArFrame({'A': [5], 'C': ['diff']})
+    frame3 = ar.from_pandas(pd.DataFrame({'A': [5], 'C': ['diff']}))
     with pytest.raises(ValueError, match='Schema mismatch'):
         ar.write_csv(frame3, path, append=True)

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -648,24 +648,66 @@ class TestWriteCsvEncoding:
         assert after - before == {str(out)}
 
 
-def test_write_csv_append(tmp_path):
-    path = str(tmp_path / "test_append.csv")
-    frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}))
-    frame2 = ar.from_pandas(pd.DataFrame({"A": [3, 4], "B": ["z", "w"]}))
+class TestWriteCsvAppend:
+    def test_append_to_empty(self, tmp_path):
+        path = str(tmp_path / "test_append_empty.csv")
+        frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}))
+        
+        ar.write_csv(frame1, path, append=True)
+        res1 = ar.to_pandas(ar.read_csv(path))
+        assert len(res1) == 2
+        assert list(res1.columns) == ["A", "B"]
 
-    # Append to empty
-    ar.write_csv(frame1, path, append=True)
-    res1 = ar.read_csv(path)
-    assert len(res1) == 2
+    def test_append_to_existing(self, tmp_path):
+        path = str(tmp_path / "test_append_existing.csv")
+        frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}))
+        frame2 = ar.from_pandas(pd.DataFrame({"A": [3, 4], "B": ["z", "w"]}))
 
-    # Append to existing
-    ar.write_csv(frame2, path, append=True)
-    res2 = ar.read_csv(path)
-    res2_df = ar.to_pandas(res2)
-    assert len(res2_df) == 4
-    assert res2_df["A"].tolist() == [1, 2, 3, 4]
+        ar.write_csv(frame1, path)
+        ar.write_csv(frame2, path, append=True)
+        
+        res = ar.to_pandas(ar.read_csv(path))
+        assert len(res) == 4
+        assert list(res["A"]) == [1, 2, 3, 4]
+        assert list(res["B"]) == ["x", "y", "z", "w"]
 
-    # Schema mismatch
-    frame3 = ar.from_pandas(pd.DataFrame({"A": [5], "C": ["diff"]}))
-    with pytest.raises(ValueError, match="Schema mismatch"):
-        ar.write_csv(frame3, path, append=True)
+    def test_append_schema_mismatch(self, tmp_path):
+        path = str(tmp_path / "test_schema_mismatch.csv")
+        frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}))
+        frame3 = ar.from_pandas(pd.DataFrame({"A": [5], "C": ["diff"]}))
+        
+        ar.write_csv(frame1, path)
+        with pytest.raises(ValueError, match="Schema mismatch"):
+            ar.write_csv(frame3, path, append=True)
+
+    def test_append_missing_newline(self, tmp_path):
+        path = tmp_path / "test_missing_newline.csv"
+        path.write_bytes(b"A,B\n1,x\n2,y")  # No trailing newline
+        
+        frame2 = ar.from_pandas(pd.DataFrame({"A": [3], "B": ["z"]}))
+        with pytest.raises(ValueError, match="lacks a final line terminator"):
+            ar.write_csv(frame2, str(path), append=True)
+
+    def test_append_non_utf8(self, tmp_path):
+        path = str(tmp_path / "test_append_non_utf8.csv")
+        frame1 = ar.from_pandas(pd.DataFrame({"city": ["München"]}))
+        frame2 = ar.from_pandas(pd.DataFrame({"city": ["Zürich"]}))
+        
+        ar.write_csv(frame1, path, encoding="latin-1")
+        ar.write_csv(frame2, path, encoding="latin-1", append=True)
+        
+        res = ar.to_pandas(ar.read_csv(path, encoding="latin-1"))
+        assert len(res) == 2
+        assert list(res["city"]) == ["München", "Zürich"]
+
+    def test_append_false_overwrites(self, tmp_path):
+        path = str(tmp_path / "test_append_false.csv")
+        frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2]}))
+        frame2 = ar.from_pandas(pd.DataFrame({"A": [3, 4]}))
+        
+        ar.write_csv(frame1, path)
+        ar.write_csv(frame2, path, append=False)  # default is False
+        
+        res = ar.to_pandas(ar.read_csv(path))
+        assert len(res) == 2
+        assert list(res["A"]) == [3, 4]

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -647,10 +647,11 @@ class TestWriteCsvEncoding:
         after = set(glob.glob(str(tmp_path / "*.csv")))
         assert after - before == {str(out)}
 
+
 def test_write_csv_append(tmp_path):
-    path = str(tmp_path / 'test_append.csv')
-    frame1 = ar.from_pandas(pd.DataFrame({'A': [1, 2], 'B': ['x', 'y']}))
-    frame2 = ar.from_pandas(pd.DataFrame({'A': [3, 4], 'B': ['z', 'w']}))
+    path = str(tmp_path / "test_append.csv")
+    frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}))
+    frame2 = ar.from_pandas(pd.DataFrame({"A": [3, 4], "B": ["z", "w"]}))
 
     # Append to empty
     ar.write_csv(frame1, path, append=True)
@@ -661,9 +662,9 @@ def test_write_csv_append(tmp_path):
     ar.write_csv(frame2, path, append=True)
     res2 = ar.read_csv(path)
     assert len(res2) == 4
-    assert res2.column('A').to_list() == [1, 2, 3, 4]
+    assert res2.column("A").to_list() == [1, 2, 3, 4]
 
     # Schema mismatch
-    frame3 = ar.from_pandas(pd.DataFrame({'A': [5], 'C': ['diff']}))
-    with pytest.raises(ValueError, match='Schema mismatch'):
+    frame3 = ar.from_pandas(pd.DataFrame({"A": [5], "C": ["diff"]}))
+    with pytest.raises(ValueError, match="Schema mismatch"):
         ar.write_csv(frame3, path, append=True)

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -646,3 +646,26 @@ class TestWriteCsvEncoding:
         ar.write_csv(frame, str(out), encoding="latin-1")
         after = set(glob.glob(str(tmp_path / "*.csv")))
         assert after - before == {str(out)}
+
+def test_write_csv_append(tmp_path):
+    import arnio as ar
+    import pytest
+    path = str(tmp_path / 'test_append.csv')
+    frame1 = ar.ArFrame({'A': [1, 2], 'B': ['x', 'y']})
+    frame2 = ar.ArFrame({'A': [3, 4], 'B': ['z', 'w']})
+
+    # Append to empty
+    ar.write_csv(frame1, path, append=True)
+    res1 = ar.read_csv(path)
+    assert len(res1) == 2
+
+    # Append to existing
+    ar.write_csv(frame2, path, append=True)
+    res2 = ar.read_csv(path)
+    assert len(res2) == 4
+    assert res2.column('A').to_list() == [1, 2, 3, 4]
+
+    # Schema mismatch
+    frame3 = ar.ArFrame({'A': [5], 'C': ['diff']})
+    with pytest.raises(ValueError, match='Schema mismatch'):
+        ar.write_csv(frame3, path, append=True)

--- a/tests/test_write_csv.py
+++ b/tests/test_write_csv.py
@@ -652,7 +652,7 @@ class TestWriteCsvAppend:
     def test_append_to_empty(self, tmp_path):
         path = str(tmp_path / "test_append_empty.csv")
         frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}))
-        
+
         ar.write_csv(frame1, path, append=True)
         res1 = ar.to_pandas(ar.read_csv(path))
         assert len(res1) == 2
@@ -665,7 +665,7 @@ class TestWriteCsvAppend:
 
         ar.write_csv(frame1, path)
         ar.write_csv(frame2, path, append=True)
-        
+
         res = ar.to_pandas(ar.read_csv(path))
         assert len(res) == 4
         assert list(res["A"]) == [1, 2, 3, 4]
@@ -675,7 +675,7 @@ class TestWriteCsvAppend:
         path = str(tmp_path / "test_schema_mismatch.csv")
         frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}))
         frame3 = ar.from_pandas(pd.DataFrame({"A": [5], "C": ["diff"]}))
-        
+
         ar.write_csv(frame1, path)
         with pytest.raises(ValueError, match="Schema mismatch"):
             ar.write_csv(frame3, path, append=True)
@@ -683,7 +683,7 @@ class TestWriteCsvAppend:
     def test_append_missing_newline(self, tmp_path):
         path = tmp_path / "test_missing_newline.csv"
         path.write_bytes(b"A,B\n1,x\n2,y")  # No trailing newline
-        
+
         frame2 = ar.from_pandas(pd.DataFrame({"A": [3], "B": ["z"]}))
         with pytest.raises(ValueError, match="lacks a final line terminator"):
             ar.write_csv(frame2, str(path), append=True)
@@ -692,10 +692,10 @@ class TestWriteCsvAppend:
         path = str(tmp_path / "test_append_non_utf8.csv")
         frame1 = ar.from_pandas(pd.DataFrame({"city": ["München"]}))
         frame2 = ar.from_pandas(pd.DataFrame({"city": ["Zürich"]}))
-        
+
         ar.write_csv(frame1, path, encoding="latin-1")
         ar.write_csv(frame2, path, encoding="latin-1", append=True)
-        
+
         res = ar.to_pandas(ar.read_csv(path, encoding="latin-1"))
         assert len(res) == 2
         assert list(res["city"]) == ["München", "Zürich"]
@@ -704,10 +704,10 @@ class TestWriteCsvAppend:
         path = str(tmp_path / "test_append_false.csv")
         frame1 = ar.from_pandas(pd.DataFrame({"A": [1, 2]}))
         frame2 = ar.from_pandas(pd.DataFrame({"A": [3, 4]}))
-        
+
         ar.write_csv(frame1, path)
         ar.write_csv(frame2, path, append=False)  # default is False
-        
+
         res = ar.to_pandas(ar.read_csv(path))
         assert len(res) == 2
         assert list(res["A"]) == [3, 4]


### PR DESCRIPTION
## Summary

Fixes #644

### Problem
Currently, `write_csv` always overwrites existing files, making it impossible to append data incrementally to a CSV. Users have to read the existing file, concatenate, and write the whole file, which is memory-inefficient and slow.

### Solution
- Added an `append: bool = False` flag to `write_csv` in both Python and C++ writer config.
- When `append=True` and the file exists and is non-empty, `write_csv` validates the schema against the existing file using `scan_csv` to avoid silent data corruption.
- If the file is non-empty, headers are automatically omitted to prevent duplicated headers.
- The C++ `CsvWriter` was updated to open the file stream with `std::ios::app` when appending.