### PR TITLE
feat: add title and camel case_types to clean_column_names (#2541)

### DIFF
--- a/arnio/cleaning.py
+++ b/arnio/cleaning.py
@@ -2568,7 +2568,7 @@ def clean_column_names(
     frame : ArFrame
         Input data frame.
     case_type : str, default "lower"
-        Case to normalize to. Options: "lower", "upper", "none".
+        Case to normalize to. Options: "lower", "upper", "title", "camel", "none".
 
     Returns
     -------
@@ -2585,8 +2585,10 @@ def clean_column_names(
     _validate_arframe(frame)
     if not isinstance(case_type, str):
         raise TypeError("case_type must be a string")
-    if case_type not in {"lower", "upper", "none"}:
-        raise ValueError("case_type must be one of 'lower', 'upper', or 'none'")
+    if case_type not in {"lower", "upper", "title", "camel", "none"}:
+        raise ValueError(
+            "case_type must be one of 'lower', 'upper', 'title', 'camel' or 'none'"
+        )
 
     import re
 
@@ -2603,6 +2605,14 @@ def clean_column_names(
             name = name.lower()
         elif case_type == "upper":
             name = name.upper()
+        elif case_type == "camel":
+            name = name.lower()
+            parts = name.split("_")
+            name = parts[0] + "".join(el.title() for el in parts[1:])
+        elif case_type == "title":
+            name = name.lower()
+            parts = name.split("_")
+            name = "_".join(el.title() for el in parts)
 
         if not name:
             name = "column"

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -4930,6 +4930,66 @@ class TestCleanColumnNames:
         result = ar.pipeline(frame, [("clean_column_names", {"case_type": "upper"})])
         assert to_pandas(result).columns.tolist() == ["MY_NAME", "AGE"]
 
+    def test_clean_column_names_case_type_title(self):
+        df = pd.DataFrame({"My-NaMe!!": [1]})
+        frame = from_pandas(df)
+        result = ar.clean_column_names(frame, case_type="title")
+        assert to_pandas(result).columns.tolist() == ["My_Name"]
+
+    def test_clean_column_names_case_type_camel(self):
+        df = pd.DataFrame({"My-Name!!": [1]})
+        frame = from_pandas(df)
+        result = ar.clean_column_names(frame, case_type="camel")
+        assert to_pandas(result).columns.tolist() == ["myName"]
+
+    def test_clean_column_names_case_type_title_acronyms(self):
+        df = pd.DataFrame({"HTTP_status": [1]})
+        frame = from_pandas(df)
+        result = ar.clean_column_names(frame, case_type="title")
+        assert to_pandas(result).columns.tolist() == ["Http_Status"]
+
+    def test_clean_column_names_case_type_camel_acronyms(self):
+        df = pd.DataFrame({"HTTP_status": [1]})
+        frame = from_pandas(df)
+        result = ar.clean_column_names(frame, case_type="camel")
+        assert to_pandas(result).columns.tolist() == ["httpStatus"]
+
+    def test_clean_column_names_case_type_title_leading_digits(self):
+        df = pd.DataFrame({"123_status": [1]})
+        frame = from_pandas(df)
+        result = ar.clean_column_names(frame, case_type="title")
+        assert to_pandas(result).columns.tolist() == ["123_Status"]
+
+    def test_clean_column_names_case_type_camel_leading_digits(self):
+        df = pd.DataFrame({"123_status": [1]})
+        frame = from_pandas(df)
+        result = ar.clean_column_names(frame, case_type="camel")
+        assert to_pandas(result).columns.tolist() == ["123Status"]
+
+    def test_clean_column_names_title_pipeline(self):
+        df = pd.DataFrame({"My-Name!!": [1], "age##": [2]})
+        frame = from_pandas(df)
+        result = ar.pipeline(frame, [("clean_column_names", {"case_type": "title"})])
+        assert to_pandas(result).columns.tolist() == ["My_Name", "Age"]
+
+    def test_clean_column_names_camel_pipeline(self):
+        df = pd.DataFrame({"My-Name!!": [1], "age##": [2]})
+        frame = from_pandas(df)
+        result = ar.pipeline(frame, [("clean_column_names", {"case_type": "camel"})])
+        assert to_pandas(result).columns.tolist() == ["myName", "age"]
+
+    def test_clean_column_names_title_duplicate_raises(self):
+        df = pd.DataFrame({"My_Name": [1], "my_name": [2]})
+        frame = from_pandas(df)
+        with pytest.raises(ValueError, match="duplicates"):
+            ar.clean_column_names(frame, case_type="title")
+
+    def test_clean_column_names_camel_duplicate_raises(self):
+        df = pd.DataFrame({"My_Name": [1], "my_name": [2]})
+        frame = from_pandas(df)
+        with pytest.raises(ValueError, match="duplicates"):
+            ar.clean_column_names(frame, case_type="camel")
+
 
 class TestSlugifyColumnNames:
     def test_spaces_become_underscores(self):


### PR DESCRIPTION
## Summary
Adds `"camel"` and `"title"` as supported `case_type` options in `clean_column_names`. Both modes lowercase tokens before transformation so acronyms are normalized deterministically, and preserve leading digits. Updated docstring, error message, and added regression tests covering ordinary names, acronyms, leading digits, pipeline usage, and collisions.

## Linked issue
Fixes #2541

## Type of change
- [x] Feature
- [x] Tests
- [x] Documentation

## Area
- [x] Python API / ArFrame

## Testing
- [x] `make test` — 3719 passed including 10 new tests in `tests/cleanng.py`

1. `test_clean_column_names_case_type_title`
2. `test_clean_column_names_case_type_camel`
3. `test_clean_column_names_case_type_title_acronyms`
4. `test_clean_column_names_case_type_camel_acronyms`
5. `test_clean_column_names_case_type_title_leading_digits`
6. `test_clean_column_names_case_type_camel_leading_digits`
7. `test_clean_column_names_title_pipeline`
8. `test_clean_column_names_camel_pipeline`
9. `test_clean_column_names_title_duplicate_raises`
10. `test_clean_column_names_camel_duplicate_raises`

- [x] `make lint`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
`snake` was intentionally not added per maintainer's narrowed contract — it would be functionally identical to the existing `lower`.