### PR TITLE
fix: normalize data quality suggestion kwargs for JSON

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -3184,7 +3184,7 @@ def _json_safe_suggestion_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {str(k): _json_safe_suggestion_value(v) for k, v in value.items()}
 
-    if isinstance(value, set):
+    if isinstance(value, Set) and not isinstance(value, (str, bytes, bytearray)):
         try:
             ordered = sorted(value)
         except TypeError:
@@ -3226,7 +3226,7 @@ def _filtered_suggestion_kwargs(
         raw_value = value
 
         if key in {"subset", "columns"} and isinstance(
-            value, (list, tuple, set, np.ndarray)
+            value, (list, tuple, Set, np.ndarray)
         ):
             raw_value = [item for item in value if item not in exclude_columns]
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -5,7 +5,6 @@ Data quality profiling and safe automatic cleaning helpers.
 
 from __future__ import annotations
 
-import decimal
 import html
 import json
 import math
@@ -3175,7 +3174,13 @@ def _approx_top_values(
 
 
 def _json_safe_suggestion_value(value: Any) -> Any:
-    """Normalize suggestion kwargs values after redaction/filtering only."""
+    """Normalize cleaning-suggestion kwargs values for json.dumps without default=."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+
     if isinstance(value, dict):
         return {str(k): _json_safe_suggestion_value(v) for k, v in value.items()}
 
@@ -3195,10 +3200,17 @@ def _json_safe_suggestion_value(value: Any) -> Any:
     if isinstance(value, date):
         return value.isoformat()
 
-    if isinstance(value, decimal.Decimal):
-        return str(value)
+    if hasattr(value, "item"):
+        try:
+            return _json_safe_suggestion_value(value.item())
+        except Exception:
+            return str(value)
 
-    return _clean_scalar(value)
+    cleaned = _clean_scalar(value)
+    if cleaned is not value:
+        return _json_safe_suggestion_value(cleaned)
+
+    return str(value)
 
 
 def _filtered_suggestion_kwargs(

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -5,6 +5,7 @@ Data quality profiling and safe automatic cleaning helpers.
 
 from __future__ import annotations
 
+import decimal
 import html
 import json
 import math
@@ -12,6 +13,7 @@ import os
 import re
 from collections.abc import Sequence, Set
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Any
 
 import numpy as np
@@ -423,23 +425,7 @@ class DataQualityReport:
             "suggestions": [
                 {
                     "step": s[0],
-                    "kwargs": {
-                        key: (
-                            [item for item in value if item not in exclude_columns]
-                            if key in {"subset", "columns"} and isinstance(value, list)
-                            else (
-                                {
-                                    col_name: col_type
-                                    for col_name, col_type in value.items()
-                                    if col_name not in exclude_columns
-                                }
-                                if key == "cast_types" and isinstance(value, dict)
-                                else value
-                            )
-                        )
-                        for key, value in sorted(dict(s[1]).items())
-                        if key not in exclude_columns
-                    },
+                    "kwargs": _filtered_suggestion_kwargs(s[1], exclude_columns),
                     "confidence_score": getattr(s, "confidence_score", None),
                     "confidence_reason": _redact_reason(
                         getattr(s, "confidence_reason", None)
@@ -3186,6 +3172,62 @@ def _approx_top_values(
         sample_n,
         _ratio(sample_n, len(series)),
     )
+
+
+def _json_safe_suggestion_value(value: Any) -> Any:
+    """Normalize suggestion kwargs values after redaction/filtering only."""
+    if isinstance(value, dict):
+        return {str(k): _json_safe_suggestion_value(v) for k, v in value.items()}
+
+    if isinstance(value, set):
+        try:
+            ordered = sorted(value)
+        except TypeError:
+            ordered = sorted(value, key=lambda x: (type(x).__name__, repr(x)))
+        return [_json_safe_suggestion_value(x) for x in ordered]
+
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_suggestion_value(x) for x in value]
+
+    if isinstance(value, np.ndarray):
+        return [_json_safe_suggestion_value(x) for x in value.tolist()]
+
+    if isinstance(value, date):
+        return value.isoformat()
+
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+
+    return _clean_scalar(value)
+
+
+def _filtered_suggestion_kwargs(
+    kwargs: dict[str, Any],
+    exclude_columns: set[str],
+) -> dict[str, Any]:
+    filtered: dict[str, Any] = {}
+
+    for key, value in sorted(dict(kwargs).items()):
+        if key in exclude_columns:
+            continue
+
+        raw_value = value
+
+        if key in {"subset", "columns"} and isinstance(
+            value, (list, tuple, set, np.ndarray)
+        ):
+            raw_value = [item for item in value if item not in exclude_columns]
+
+        elif key == "cast_types" and isinstance(value, dict):
+            raw_value = {
+                col_name: col_type
+                for col_name, col_type in value.items()
+                if col_name not in exclude_columns
+            }
+
+        filtered[key] = _json_safe_suggestion_value(raw_value)
+
+    return filtered
 
 
 _EMAIL_PATTERN = r"[^@\s]+@[^@\s]+\.[^@\s]+"

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -91,6 +91,64 @@ def test_data_quality_report_to_json_round_trips_through_to_dict_options():
     assert actual == expected
 
 
+def test_data_quality_report_suggestion_kwargs_stringifies_unsupported_leaf():
+    from pathlib import Path
+
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[
+            (
+                "custom_step",
+                {
+                    "path": Path("data/input.csv"),
+                    "nested": {"complex": complex(1, 2)},
+                },
+            )
+        ],
+    )
+
+    payload = report.to_dict()
+    json.dumps(payload)
+
+    kwargs = payload["suggestions"][0]["kwargs"]
+    assert kwargs["path"] == "data/input.csv"
+    assert kwargs["nested"]["complex"] == "(1+2j)"
+    assert json.loads(report.to_json()) == payload
+
+
+def test_data_quality_report_suggestion_kwargs_recurses_numpy_item_result():
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[
+            (
+                "custom_step",
+                {
+                    "timestamp": np.datetime64("2024-01-02T03:04:05"),
+                    "non_finite": np.float64(float("inf")),
+                },
+            )
+        ],
+    )
+
+    payload = report.to_dict()
+    json.dumps(payload)
+
+    kwargs = payload["suggestions"][0]["kwargs"]
+    assert kwargs["timestamp"].startswith("2024-01-02")
+    assert kwargs["non_finite"] is None
+    assert json.loads(report.to_json()) == payload
+
+
 def test_data_quality_report_to_dict_normalizes_suggestions_after_exclusions():
     columns = ar.profile(
         ar.from_pandas(

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -6,6 +6,7 @@ import io
 import json
 import math
 import warnings
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -92,7 +93,6 @@ def test_data_quality_report_to_json_round_trips_through_to_dict_options():
 
 
 def test_data_quality_report_suggestion_kwargs_stringifies_unsupported_leaf():
-    from pathlib import Path
 
     report = ar.DataQualityReport(
         row_count=1,
@@ -116,8 +116,68 @@ def test_data_quality_report_suggestion_kwargs_stringifies_unsupported_leaf():
     json.dumps(payload)
 
     kwargs = payload["suggestions"][0]["kwargs"]
-    assert kwargs["path"] == "data/input.csv"
+    assert kwargs["path"] == str(Path("data/input.csv"))
     assert kwargs["nested"]["complex"] == "(1+2j)"
+    assert json.loads(report.to_json()) == payload
+
+
+def test_data_quality_report_suggestion_kwargs_normalizes_frozenset():
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[
+            (
+                "custom_step",
+                {
+                    "values": frozenset(["beta", "alpha"]),
+                    "nested": {
+                        "ids": frozenset([np.int64(2), np.int64(1)]),
+                    },
+                },
+            )
+        ],
+    )
+
+    payload = report.to_dict()
+    json.dumps(payload)
+
+    kwargs = payload["suggestions"][0]["kwargs"]
+
+    assert kwargs["values"] == ["alpha", "beta"]
+    assert kwargs["nested"]["ids"] == [1, 2]
+
+
+def test_data_quality_report_suggestion_kwargs_normalizes_frozenset_nested_values():
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[
+            (
+                "custom_step",
+                {
+                    "values": frozenset(["beta", "alpha"]),
+                    "nested": {
+                        "values": frozenset([np.int64(2), np.int64(1)]),
+                    },
+                },
+            )
+        ],
+    )
+
+    payload = report.to_dict()
+    json.dumps(payload)
+
+    kwargs = payload["suggestions"][0]["kwargs"]
+    assert kwargs["values"] == ["alpha", "beta"]
+    assert kwargs["nested"]["values"] == [1, 2]
     assert json.loads(report.to_json()) == payload
 
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,11 +1,14 @@
 """Tests for data quality profiling and smart cleaning."""
 
+import datetime as dt
+import decimal
 import io
 import json
 import math
 import warnings
 from typing import Any
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -20,6 +23,123 @@ from arnio.quality import (
     _validate_gate_ratio_threshold,
     _validate_gate_threshold,
 )
+
+
+def test_data_quality_report_suggestion_kwargs_are_json_serializable():
+    report = ar.DataQualityReport(
+        row_count=1,
+        column_count=0,
+        memory_usage=0,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns={},
+        suggestions=[
+            (
+                "custom_step",
+                {
+                    "created_at": dt.datetime(2024, 1, 2, 3, 4, 5),
+                    "amount": decimal.Decimal("12.34"),
+                    "metadata": {"count": np.int64(1)},
+                    "columns": ("name", "age"),
+                    "tags": {"beta", "alpha"},
+                },
+            )
+        ],
+    )
+
+    payload = report.to_dict()
+    json.dumps(payload)
+
+    json_output = report.to_json()
+    assert isinstance(json_output, str)
+    assert json.loads(json_output) == payload
+
+    kwargs = payload["suggestions"][0]["kwargs"]
+    assert kwargs["created_at"] == "2024-01-02T03:04:05"
+    assert kwargs["amount"] == "12.34"
+    assert kwargs["metadata"] == {"count": 1}
+    assert kwargs["columns"] == ["name", "age"]
+    assert kwargs["tags"] == ["alpha", "beta"]
+
+
+def test_data_quality_report_to_json_round_trips_through_to_dict_options():
+    report = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": ["Alice", "Bob"],
+                    "age": [30, 40],
+                    "secret": ["token-a", "token-b"],
+                }
+            )
+        ),
+        sample_size=2,
+    )
+
+    expected = report.to_dict(
+        redact_sample_values=True,
+        exclude_columns=["secret"],
+    )
+
+    actual = json.loads(
+        report.to_json(
+            redact_sample_values=True,
+            exclude_columns=["secret"],
+        )
+    )
+
+    assert actual == expected
+
+
+def test_data_quality_report_to_dict_normalizes_suggestions_after_exclusions():
+    columns = ar.profile(
+        ar.from_pandas(
+            pd.DataFrame(
+                {
+                    "name": [" Alice ", "Bob"],
+                    "secret": ["token-a", "token-b"],
+                }
+            )
+        )
+    ).columns
+
+    report = ar.DataQualityReport(
+        row_count=2,
+        column_count=2,
+        memory_usage=100,
+        duplicate_rows=0,
+        duplicate_ratio=0.0,
+        columns=columns,
+        suggestions=[
+            (
+                "custom_step",
+                {
+                    "subset": np.array(["name", "secret"]),
+                    "columns": ("name", "secret"),
+                    "cast_types": {
+                        "name": np.str_("string"),
+                        "secret": np.str_("string"),
+                    },
+                    "metadata": {"kept_count": np.int64(1)},
+                },
+            )
+        ],
+    )
+
+    result = report.to_dict(
+        redact_sample_values=True,
+        exclude_columns=["secret"],
+    )
+    json.dumps(result)
+
+    kwargs = result["suggestions"][0]["kwargs"]
+
+    assert kwargs["subset"] == ["name"]
+    assert kwargs["columns"] == ["name"]
+    assert kwargs["cast_types"] == {"name": "string"}
+    assert kwargs["metadata"] == {"kept_count": 1}
+    assert "secret" not in json.dumps(result)
+    assert result["columns"]["name"]["sample_values"] == ["[REDACTED]", "[REDACTED]"]
 
 
 def test_profile_reports_quality_signals(tmp_path):


### PR DESCRIPTION
Fixes #186

## Summary

This PR keeps `DataQualityReport.to_dict()` as the canonical JSON-oriented payload and normalizes cleaning suggestion kwargs there, after existing `exclude_columns`, `cast_types`, and `subset` filtering.

`DataQualityReport.to_json()` remains a thin wrapper over `to_dict()` plus `json.dumps()`. This avoids adding a parallel export API or changing the report shape.

## Scope

* Normalize suggestion kwargs to JSON-safe values inside `DataQualityReport.to_dict()`
* Preserve existing redaction and exclusion semantics
* Keep suggestion sorting deterministic
* Keep `to_json()` API behavior unchanged
* Do not add `ValidationResult.to_json()` in this PR
* Avoid README churn unless docstrings are insufficient

## Why

The current export path is already the right shape. The gap is that suggestion kwargs can contain values that are not directly JSON-serializable, while other render paths tolerate them through `default=str`.

Normalizing in `to_dict()` fixes the contract at the source, so callers can safely use:

```python
json.dumps(report.to_dict())
```

for CI artifacts and integrations.

## Tests

Added focused coverage for:

* non-JSON-native suggestion kwargs becoming JSON-safe through `to_dict()`
* `to_json()` round-tripping consistently with `to_dict()`
* redaction and `exclude_columns` continuing to prevent leakage after kwargs normalization
