### PR TITLE
fix: close docs search dropdown after result selection

### DIFF
--- a/website/js/search.js
+++ b/website/js/search.js
@@ -2,7 +2,6 @@ const searchInput = document.getElementById("docs-search");
 const resultsBox = document.getElementById("search-results");
 
 if (searchInput && resultsBox) {
-
   const searchIndex = [
     { title: "Installation", page: "docs.html#install" },
     { title: "Quickstart", page: "docs.html#quickstart" },
@@ -30,11 +29,22 @@ if (searchInput && resultsBox) {
 
   let selectedIndex = -1;
 
+  function closeResults() {
+    selectedIndex = -1;
+    resultsBox.classList.remove("show");
+
+    resultsBox
+      .querySelectorAll(".search-result.active")
+      .forEach((result) => {
+        result.classList.remove("active");
+      });
+  }
+
   function render(items) {
     resultsBox.innerHTML = "";
 
     if (!items.length) {
-      resultsBox.classList.remove("show");
+      closeResults();
       return;
     }
 
@@ -44,6 +54,7 @@ if (searchInput && resultsBox) {
       div.textContent = item.title;
 
       div.addEventListener("click", () => {
+        closeResults();
         window.location.href = item.page;
       });
 
@@ -57,11 +68,11 @@ if (searchInput && resultsBox) {
     const q = e.target.value.toLowerCase();
 
     if (!q) {
-      resultsBox.classList.remove("show");
+      closeResults();
       return;
     }
 
-    const matches = searchIndex.filter(item =>
+    const matches = searchIndex.filter((item) =>
       item.title.toLowerCase().includes(q)
     );
 
@@ -70,15 +81,18 @@ if (searchInput && resultsBox) {
   });
 
   document.addEventListener("keydown", (e) => {
-
     if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
       e.preventDefault();
       searchInput.focus();
     }
 
-    const results = [...document.querySelectorAll(".search-result")];
+    const results = [
+      ...resultsBox.querySelectorAll(".search-result")
+    ];
 
-    if (!results.length) return;
+    if (!resultsBox.classList.contains("show") || !results.length) {
+      return;
+    }
 
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -91,18 +105,21 @@ if (searchInput && resultsBox) {
         (selectedIndex - 1 + results.length) % results.length;
     }
 
-    results.forEach(r => r.classList.remove("active"));
+    results.forEach((result) => {
+      result.classList.remove("active");
+    });
 
     if (selectedIndex >= 0) {
       results[selectedIndex].classList.add("active");
     }
 
     if (e.key === "Enter" && selectedIndex >= 0) {
+      e.preventDefault();
       results[selectedIndex].click();
     }
 
     if (e.key === "Escape") {
-      resultsBox.classList.remove("show");
+      closeResults();
     }
   });
 }


### PR DESCRIPTION
## Summary

Fixes the documentation search dropdown remaining visible after selecting a result.

This update introduces a shared `closeResults()` helper that:
- Closes the search results dropdown.
- Resets the keyboard selection index.
- Removes the active state from the selected result.
- Runs consistently for mouse selection, keyboard selection, empty queries, empty results, and Escape.

Keyboard navigation is also restricted to visible results within the documentation search container.

## Linked issue

Fixes #2450

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [x] Docs / website
- [ ] Developer tooling

## Testing
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately):

```bash
python scripts/check_docs_utf8.py
python -m black --check --diff .
python -m ruff check . --extend-exclude "*.ipynb"
python -m mypy --config-file mypy.ini
find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
```

- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
```bash
node --check website/js/search.js
git diff --check
```
Both commands completed successfully without errors.
Manual browser testing was performed using:

```bash
python -m http.server 8000 --directory website
```

Verified:
- Clicking a search result closes the dropdown before navigation.
- Selecting a result using `ArrowDown` and `Enter` closes the dropdown.
- Navigation to `docs.html#jsonl-parquet` works correctly.
- Pressing Escape closes the dropdown and resets the active selection.
- Clearing the query closes the dropdown.
- The search results container no longer has the `show` class after selection.
- No search result retains the `active` class after navigation.

Browser console verification after keyboard selection:

```javascript
document
  .getElementById("search-results")
  .classList.contains("show")
```

Result:

```text
false
```

```javascript
document.querySelectorAll(
  "#search-results .search-result.active"
).length
```

Result:
```text
0
```

## Screenshots / Media

### Keyboard result selection verification

The screenshot below demonstrates successful navigation to `docs.html#jsonl-parquet` and confirms through the browser console that:
- The results dropdown is no longer shown.
- The number of active search results is `0`.

<img width="1908" height="957" alt="Screenshot 2026-06-11 135100" src="https://github.com/user-attachments/assets/63ab71d8-6f38-429c-8b7c-a10b02df6787" />


## Performance Impact

No measurable performance impact is expected. The change only performs a small DOM cleanup when the search dropdown is closed.

## GSSoC labels

Maintainers may apply the appropriate labels after review, such as:
- `gssoc:approved`
- `level:beginner`
- `quality:clean`
- `type:bug`

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [ ] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
This is a focused frontend-only change limited to `website/js/search.js`. It does not modify the public Python API, documentation content, or backend behaviour.
