### PR TITLE
fix: prevent invalid column references after add_column

### DIFF
--- a/bindings/bind_arnio.cpp
+++ b/bindings/bind_arnio.cpp
@@ -154,13 +154,12 @@ PYBIND11_MODULE(_arnio_cpp, m) {
         .def("memory_usage", &Frame::memory_usage)
         .def("has_column", &Frame::has_column)
         .def(
-            "column_by_index",
-            [](const Frame& f, size_t idx) -> const Column& { return f.column(idx); },
-            py::return_value_policy::reference_internal)
+            "column_by_index", [](const Frame& f, size_t idx) { return f.column(idx); },
+            py::return_value_policy::copy)
         .def(
             "column_by_name",
-            [](const Frame& f, const std::string& name) -> const Column& { return f.column(name); },
-            py::return_value_policy::reference_internal)
+            [](const Frame& f, const std::string& name) { return f.column(name); },
+            py::return_value_policy::copy)
         .def("add_column", &Frame::add_column)
         .def("clone", &Frame::clone)
         .def("describe",

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -989,6 +989,7 @@ def test_named_column_reference_survives_add_column_reallocation():
     assert col.size() == 1
     assert col.at(0) == 1
 
+
 # ArFrame.describe() Tests
 
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -947,7 +947,7 @@ def test_add_column_rejects_duplicate_name():
     with pytest.raises(ValueError, match="already exists"):
         frame.add_column(c2)
 
-        
+
 def test_column_reference_survives_add_column_reallocation():
     from arnio._arnio_cpp import Column, DType, Frame
 
@@ -968,6 +968,26 @@ def test_column_reference_survives_add_column_reallocation():
     assert col.size() == 1
     assert col.at(0) == 1
 
+
+def test_named_column_reference_survives_add_column_reallocation():
+    from arnio._arnio_cpp import Column, DType, Frame
+
+    frame = Frame()
+
+    c1 = Column("a", DType.INT64)
+    c1.push_back(1)
+
+    frame.add_column(c1)
+
+    col = frame.column_by_name("a")
+
+    for i in range(100):
+        extra = Column(f"c{i}", DType.INT64)
+        extra.push_back(i)
+        frame.add_column(extra)
+
+    assert col.size() == 1
+    assert col.at(0) == 1
 # ArFrame.describe() Tests
 
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -988,6 +988,7 @@ def test_named_column_reference_survives_add_column_reallocation():
 
     assert col.size() == 1
     assert col.at(0) == 1
+
 # ArFrame.describe() Tests
 
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -947,6 +947,26 @@ def test_add_column_rejects_duplicate_name():
     with pytest.raises(ValueError, match="already exists"):
         frame.add_column(c2)
 
+        
+def test_column_reference_survives_add_column_reallocation():
+    from arnio._arnio_cpp import Column, DType, Frame
+
+    frame = Frame()
+
+    c1 = Column("a", DType.INT64)
+    c1.push_back(1)
+
+    frame.add_column(c1)
+
+    col = frame.column_by_index(0)
+
+    for i in range(100):
+        extra = Column(f"c{i}", DType.INT64)
+        extra.push_back(i)
+        frame.add_column(extra)
+
+    assert col.size() == 1
+    assert col.at(0) == 1
 
 # ArFrame.describe() Tests
 


### PR DESCRIPTION
## Summary

Fix invalid Python column references after `Frame::add_column()` reallocation.

`column_by_index()` and `column_by_name()` previously returned references using `py::return_value_policy::reference_internal`. Since `Frame` stores columns in a `std::vector`, calling `add_column()` can trigger vector reallocation and invalidate previously returned references.

This change returns copies instead of references and adds a regression test covering repeated `add_column()` growth after obtaining a column handle.

## Linked issue

Fixes  #1986 

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Performance improvement
* [ ] Documentation
* [x] Tests
* [ ] Refactor
* [ ] CI / packaging

## Area

* [ ] CSV parser / I/O
* [ ] C++ cleaning engine
* [x] Python API / ArFrame
* [ ] Pipeline / custom steps
* [ ] Data quality / profiling
* [ ] Schema validation
* [ ] pandas interoperability
* [ ] Docs / website
* [ ] Developer tooling

## Testing

* [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
* [ ] `make lint`
* [x] Other:

Added a regression test (`test_column_reference_survives_add_column_reallocation`) that verifies a column handle remains valid after repeated `add_column()` calls.


## Performance Impact

Negligible. This change prioritizes safety by preventing invalid references from being exposed to Python.

## Contributor checklist

* [x] I read the contributing guide.
* [x] I kept the PR focused on one issue or one logical change.
* [x] I added or updated tests for behavior changes.
* [ ] I added or updated docs/examples for public API changes.
* [x] I checked that generated files, logs, and local build artifacts are not committed.
* [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes

The fix changes `column_by_index()` and `column_by_name()` from `reference_internal` to `copy` to avoid exposing dangling references when vector-backed column storage is reallocated by `add_column()`.
