### PR TITLE
feat : added exclude_columns parameter to pandas profile accessor

### DIFF
--- a/arnio/integrations/pandas.py
+++ b/arnio/integrations/pandas.py
@@ -110,6 +110,7 @@ class ArnioPandasAccessor:
     def profile(
         self,
         *,
+        exclude_columns: Sequence[str] | None = None,
         sample_size: int = 5,
         approx_top_values: bool = False,
         approx_top_values_min_unique: int = 1000,
@@ -119,6 +120,7 @@ class ArnioPandasAccessor:
         """Profile DataFrame quality with Arnio."""
         return profile(
             self.to_arframe(),
+            exclude_columns=exclude_columns,
             sample_size=sample_size,
             approx_top_values=approx_top_values,
             approx_top_values_min_unique=approx_top_values_min_unique,

--- a/tests/test_pandas_accessor.py
+++ b/tests/test_pandas_accessor.py
@@ -82,6 +82,17 @@ def test_pandas_accessor_profiles_dataframe_quality():
     assert report.columns["score"].null_count == 1
 
 
+def test_pandas_accessor_profiles_dataframe_quality_exclude_columns():
+    df = pd.DataFrame({"name": [" Alice ", "Bob"], "score": [1.5, None]})
+
+    report = df.arnio.profile(exclude_columns=["score"])
+
+    assert isinstance(report, ar.DataQualityReport)
+    assert report.row_count == 2
+    assert "name" in report.columns
+    assert "score" not in report.columns
+
+
 def test_pandas_accessor_auto_clean_returns_dataframe_and_report():
     df = pd.DataFrame({"name": [" Alice ", "Bob"]})
 


### PR DESCRIPTION
Closes #1374.

Summary of What Has Been Done:
Exposed the exclude_columns option on the pandas DataFrame accessor profile method.

Changes Made:
- Added exclude_columns parameter to ArnioPandasAccessor.profile in arnio/integrations/pandas.py.
- Forwarded the exclude_columns argument to the underlying quality.profile call.
- Added a unit test test_pandas_accessor_profiles_dataframe_quality_exclude_columns in tests/test_pandas_accessor.py to verify that columns specified in exclude_columns are excluded from the output DataQualityReport.

Impact it Made:
Enables pandas users to exclude sensitive or irrelevant columns when profiling directly through the pandas accessor API, aligning it with the native ar.profile API.