### PR TITLE
test: add coalesce_columns tests for default output, unrelated column…

### DIFF
--- a/tests/test_coalesce_columns.py
+++ b/tests/test_coalesce_columns.py
@@ -117,3 +117,43 @@ def test_coalesce_columns_pandas_index() -> None:
     expected["result"] = [10.0, 2.0, 40.0]
 
     pd.testing.assert_frame_equal(res_df, expected, check_dtype=False)
+
+
+def test_coalesce_columns_default_output_column() -> None:
+    # output_column defaults to "coalesced" when not specified
+    df = pd.DataFrame({"a": [None, 2.0], "b": [1.0, None]})
+    res_df = ar.coalesce_columns(df, subset=["a", "b"])
+
+    assert "coalesced" in res_df.columns
+    assert list(res_df["coalesced"]) == [1.0, 2.0]
+
+
+def test_coalesce_columns_preserves_unrelated_columns() -> None:
+    # Columns not in subset must survive unchanged
+    df = pd.DataFrame(
+        {
+            "keep_me": ["x", "y", "z"],
+            "a": [None, 2.0, None],
+            "b": [1.0, None, None],
+        }
+    )
+    res_df = ar.coalesce_columns(df, subset=["a", "b"], output_column="result")
+
+    pd.testing.assert_series_equal(res_df["keep_me"], df["keep_me"])
+    assert list(res_df.columns) == ["keep_me", "a", "b", "result"]
+
+
+def test_coalesce_columns_single_column_subset() -> None:
+    # Single-column subset: output equals that column's values
+    df = pd.DataFrame({"a": [1.0, None, 3.0], "b": [10.0, 20.0, 30.0]})
+    res_df = ar.coalesce_columns(df, subset=["a"], output_column="result")
+
+    expected = df.copy()
+    expected["result"] = [1.0, None, 3.0]
+    pd.testing.assert_frame_equal(res_df, expected, check_dtype=False)
+
+
+def test_coalesce_columns_invalid_frame_type() -> None:
+    # Non-ArFrame / non-DataFrame input must raise TypeError
+    with pytest.raises(TypeError):
+        ar.coalesce_columns({"a": [1, 2]}, subset=["a"], output_column="result")  # type: ignore


### PR DESCRIPTION
## Summary

Adds 4 tests to `tests/test_coalesce_columns.py` covering untested paths:
- Default `output_column="coalesced"` when not specified
- Unrelated columns are preserved unchanged in output
- Single-column subset produces correct output
- Invalid frame type (dict) raises TypeError

<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->

## Linked issue
fixes #1822 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [x] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [x] `make lint` (or run separately):
```bash
  python scripts/check_docs_utf8.py
  python -m black --check --diff .
  python -m ruff check . --extend-exclude "*.ipynb"
  python -m mypy --config-file mypy.ini
  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
  ```
- [x] optionally `python -m pytest tests -v --tb=short -x`
- [ ] Other:

## Screenshots / Media
<img width="2524" height="520" alt="image" src="https://github.com/user-attachments/assets/788de035-96d7-4c21-99a2-651481027d06" />

**Performance Impact**
N/A — tests only, no runtime code changed.

---

**GSSoC labels**
Leave blank — maintainers fill this.

---

**Contributor checklist**
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes. *(no public API changes)*
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`test: add coalesce_columns edge case tests`)

---

**Maintainer notes**
N/A — adds 4 tests to the existing `tests/test_coalesce_columns.py` covering previously untested paths: default `output_column`, preservation of unrelated columns, single-column subset, and invalid frame type. No implementation changes.
