### PR TITLE
fix: DataQualityReport.to_html leaks filesystem errors for invalid file_path

### DIFF
--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -691,29 +691,29 @@ class DataQualityReport:
             names raise ``KeyError``.
         """
         if file_path is not None:
-        if isinstance(file_path, bool) or not isinstance(
-            file_path, (str, bytes, os.PathLike)
-        ):
-            raise TypeError(
-                f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
-            )
+            if isinstance(file_path, bool) or not isinstance(
+                file_path, (str, bytes, os.PathLike)
+            ):
+                raise TypeError(
+                    f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
+                )
 
-        norm_path = os.fspath(file_path)
+            norm_path = os.fspath(file_path)
 
-        # Handle empty path validation for both bytes and strings securely
-        if isinstance(norm_path, bytes) and norm_path == b"":
-            raise ValueError("Report path cannot be empty")
-        if isinstance(norm_path, str) and norm_path == "":
-            raise ValueError("Report path cannot be empty")
+            # Handle empty path validation for both bytes and strings securely
+            if isinstance(norm_path, bytes) and norm_path == b"":
+                raise ValueError("Report path cannot be empty")
+            if isinstance(norm_path, str) and norm_path == "":
+                raise ValueError("Report path cannot be empty")
 
-        # Reject paths that point to a directory instead of a file
-        if os.path.isdir(norm_path):
-            raise ValueError("file_path must point to a file, not a directory")
+            # Reject paths that point to a directory instead of a file
+            if os.path.isdir(norm_path):
+                raise ValueError("file_path must point to a file, not a directory")
 
-        # Reject missing parent directories without breaking simple relative filenames
-        parent_dir = os.path.dirname(norm_path)
-        if parent_dir and not os.path.exists(parent_dir):
-            raise ValueError("parent_dir does not exist")
+            # Reject missing parent directories without breaking simple relative filenames
+            parent_dir = os.path.dirname(norm_path)
+            if parent_dir and not os.path.exists(parent_dir):
+                raise ValueError("parent_dir does not exist")
 
         redact_top_values = _validate_bool_option(
             redact_top_values, "redact_top_values"

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -702,9 +702,9 @@ class DataQualityReport:
 
             # Handle empty path validation for both bytes and strings securely
             if isinstance(norm_path, bytes) and norm_path == b"":
-                raise ValueError("Report path cannot be empty")
+                raise ValueError("file_path must not be empty")
             if isinstance(norm_path, str) and norm_path == "":
-                raise ValueError("Report path cannot be empty")
+                raise ValueError("file_path must not be empty")
 
             # Reject paths that point to a directory instead of a file
             if os.path.isdir(norm_path):
@@ -713,7 +713,7 @@ class DataQualityReport:
             # Reject missing parent directories without breaking simple relative filenames
             parent_dir = os.path.dirname(norm_path)
             if parent_dir and not os.path.exists(parent_dir):
-                raise ValueError("parent_dir does not exist")
+                raise ValueError("parent directory does not exist")
 
         redact_top_values = _validate_bool_option(
             redact_top_values, "redact_top_values"

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -697,8 +697,22 @@ class DataQualityReport:
                 raise TypeError(
                     f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
                 )
-            if file_path == "":
+
+            # Normalize the input path to handle strings, bytes, and os.PathLike objects uniformly
+            norm_path = os.fspath(file_path)
+
+            # Reject empty string and empty bytes paths explicitly
+            if norm_path == "" or norm_path == b"":
                 raise ValueError("file_path must not be empty")
+
+            # Reject paths that point to a directory instead of a file
+            if os.path.isdir(norm_path):
+                raise ValueError("file_path must point to a file, not a directory")
+
+            # Reject missing parent directories without breaking simple relative filenames
+            parent_dir = os.path.dirname(norm_path)
+            if parent_dir and not os.path.exists(parent_dir):
+                raise ValueError("parent directory does not exist")
 
         redact_top_values = _validate_bool_option(
             redact_top_values, "redact_top_values"
@@ -729,7 +743,7 @@ class DataQualityReport:
             exclude_columns=validated_exclude,
         )
         if file_path is not None:
-            with open(file_path, "w", encoding="utf-8") as f:
+            with open(norm_path, "w", encoding="utf-8") as f:
                 f.write(html_out)
 
         if output is None:

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -691,32 +691,31 @@ class DataQualityReport:
             names raise ``KeyError``.
         """
         if file_path is not None:
-            if isinstance(file_path, bool) or not isinstance(
-                file_path, (str, bytes, os.PathLike)
-            ):
-                raise TypeError(
-                    f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
-                )
+        if isinstance(file_path, bool) or not isinstance(
+            file_path, (str, bytes, os.PathLike)
+        ):
+            raise TypeError(
+                f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
+            )
 
-            # Normalize the input path to handle strings, bytes, and os.PathLike objects uniformly
-            norm_path = os.fspath(file_path)
+        # 1. Check for empty paths BEFORE calling os.fspath to avoid premature crashes
+        if isinstance(file_path, bytes) and file_path == b"":
+            raise ValueError("Report path cannot be empty")
 
-            # Check if the path is provided as bytes and handle empty check via exception
-            if isinstance(file_path, bytes) and file_path == b"":
-                raise ValueError("Report path cannot be empty")
+        if isinstance(file_path, str) and file_path == "":
+            raise ValueError("Report path cannot be empty")
 
-            # Check if the path is provided as string and handle empty check via exception
-            if isinstance(file_path, str) and file_path == "":
-                raise ValueError("Report path cannot be empty")
+        # 2. Normalize the input path once we are sure it is not empty
+        norm_path = os.fspath(file_path)
 
-            # NOW the rest of the code will run perfectly for valid paths below...
-            if os.path.isdir(norm_path):
-                raise ValueError("file_path must point to a file, not a directory")
+        # Reject paths that point to a directory instead of a file
+        if os.path.isdir(norm_path):
+            raise ValueError("file_path must point to a file, not a directory")
 
-            # Reject missing parent directories without breaking simple relative filenames
-            parent_dir = os.path.dirname(norm_path)
-            if parent_dir and not os.path.exists(parent_dir):
-                raise ValueError("parent directory does not exist")
+        # Reject missing parent directories without breaking simple relative filenames
+        parent_dir = os.path.dirname(norm_path)
+        if parent_dir and not os.path.exists(parent_dir):
+            raise ValueError("parent_dir does not exist")
 
         redact_top_values = _validate_bool_option(
             redact_top_values, "redact_top_values"

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -701,13 +701,13 @@ class DataQualityReport:
             # Normalize the input path to handle strings, bytes, and os.PathLike objects uniformly
             norm_path = os.fspath(file_path)
 
-            # Check if the path is provided as bytes and handle empty check
+            # Check if the path is provided as bytes and handle empty check via exception
             if isinstance(file_path, bytes) and file_path == b"":
-                return False, "Report path cannot be empty"
+                raise ValueError("Report path cannot be empty")
 
-            # Check if the path is provided as string and handle empty check
+            # Check if the path is provided as string and handle empty check via exception
             if isinstance(file_path, str) and file_path == "":
-                return False, "Report path cannot be empty"
+                raise ValueError("Report path cannot be empty")
 
             # NOW the rest of the code will run perfectly for valid paths below...
             if os.path.isdir(norm_path):

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -698,15 +698,13 @@ class DataQualityReport:
                 f"file_path must be a string, bytes, or os.PathLike object, got {type(file_path).__name__}"
             )
 
-        # 1. Check for empty paths BEFORE calling os.fspath to avoid premature crashes
-        if isinstance(file_path, bytes) and file_path == b"":
-            raise ValueError("Report path cannot be empty")
-
-        if isinstance(file_path, str) and file_path == "":
-            raise ValueError("Report path cannot be empty")
-
-        # 2. Normalize the input path once we are sure it is not empty
         norm_path = os.fspath(file_path)
+
+        # Handle empty path validation for both bytes and strings securely
+        if isinstance(norm_path, bytes) and norm_path == b"":
+            raise ValueError("Report path cannot be empty")
+        if isinstance(norm_path, str) and norm_path == "":
+            raise ValueError("Report path cannot be empty")
 
         # Reject paths that point to a directory instead of a file
         if os.path.isdir(norm_path):

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -702,15 +702,14 @@ class DataQualityReport:
             norm_path = os.fspath(file_path)
 
             # Check if the path is provided as bytes and handle empty check
-            if isinstance(file_path, bytes):
-                if file_path == b"":
-                    return False, "Report path cannot be empty"
-            # Handle the path if it is a standard string
-            else:
-                if file_path == "":
-                    return False, "Report path cannot be empty"
+            if isinstance(file_path, bytes) and file_path == b"":
+                return False, "Report path cannot be empty"
 
-            # Reject paths that point to a directory instead of a file
+            # Check if the path is provided as string and handle empty check
+            if isinstance(file_path, str) and file_path == "":
+                return False, "Report path cannot be empty"
+
+            # NOW the rest of the code will run perfectly for valid paths below...
             if os.path.isdir(norm_path):
                 raise ValueError("file_path must point to a file, not a directory")
 

--- a/arnio/quality.py
+++ b/arnio/quality.py
@@ -701,9 +701,14 @@ class DataQualityReport:
             # Normalize the input path to handle strings, bytes, and os.PathLike objects uniformly
             norm_path = os.fspath(file_path)
 
-            # Reject empty string and empty bytes paths explicitly
-            if norm_path == "" or norm_path == b"":
-                raise ValueError("file_path must not be empty")
+            # Check if the path is provided as bytes and handle empty check
+            if isinstance(file_path, bytes):
+                if file_path == b"":
+                    return False, "Report path cannot be empty"
+            # Handle the path if it is a standard string
+            else:
+                if file_path == "":
+                    return False, "Report path cannot be empty"
 
             # Reject paths that point to a directory instead of a file
             if os.path.isdir(norm_path):

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -5067,3 +5067,62 @@ def test_score_breakdown_with_real_values():
     for key in expected_keys:
         assert key in result, f"Missing key: {key}"
         assert isinstance(result[key], (int, float)), f"{key} must be numeric"
+
+
+def test_to_html_rejects_empty_bytes():
+    import pytest
+
+    import arnio as ar
+
+    # Create a dummy report to test with
+    report = ar.profile(ar.from_pandas(pd.DataFrame({"x": [1, 2]})))
+
+    # 1. Test empty bytes path
+    with pytest.raises(ValueError, match="file_path must not be empty"):
+        report.to_html(file_path=b"")
+
+
+def test_to_html_rejects_directory_path(tmp_path):
+    import pytest
+
+    import arnio as ar
+
+    report = ar.profile(ar.from_pandas(pd.DataFrame({"x": [1, 2]})))
+
+    # 2. Test path pointing to an actual directory
+    with pytest.raises(
+        ValueError, match="file_path must point to a file, not a directory"
+    ):
+        report.to_html(file_path=tmp_path)
+
+
+def test_to_html_rejects_missing_parent(tmp_path):
+    import pytest
+
+    import arnio as ar
+
+    report = ar.profile(ar.from_pandas(pd.DataFrame({"x": [1, 2]})))
+    invalid_path = tmp_path / "missing_folder" / "report.html"
+
+    # 3. Test path where parent directory does not exist
+    with pytest.raises(ValueError, match="parent directory does not exist"):
+        report.to_html(file_path=invalid_path)
+
+
+def test_to_html_accepts_valid_relative_and_pathlike(tmp_path, monkeypatch):
+    import os
+
+    import arnio as ar
+
+    report = ar.profile(ar.from_pandas(pd.DataFrame({"x": [1, 2]})))
+
+    # 4. Test that a normal relative filename works fine (parent dir is empty string)
+    monkeypatch.chdir(tmp_path)
+    relative_file = "test_report.html"
+    report.to_html(file_path=relative_file)
+    assert os.path.exists(relative_file)
+
+    # Test that a valid PathLike object works fine too
+    pathlike_file = tmp_path / "another_report.html"
+    report.to_html(file_path=pathlike_file)
+    assert os.path.exists(pathlike_file)


### PR DESCRIPTION
## Summary
Fixed a validation bug in `DataQualityReport.to_html()` where passing invalid path types or structures (like empty bytes `b""`, directory paths, or missing parent directories) leaked platform-specific raw filesystem errors. Normalized the `file_path` handling using `os.fspath()` and added strict validation preflight guards before opening the file.

## Linked issue
Fixes #2454

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [ ] Python API / ArFrame
- [ ] Pipeline / custom steps
- [x] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
Ran focused pytest suite locally within the feature branch:
- [x] `python -m pytest tests/test_quality.py -k "test_to_html"`

Result: All 12 focused test cases passed successfully, confirming the three invalid path regressions throw custom Arnio `ValueError` messages, while valid relative-file strings and `PathLike` objects write successfully without regression.

## Screenshots / Media
N/A

## Performance Impact
N/A

## GSSoC labels
## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [x] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`fix: DataQualityReport.to_html leaks filesystem errors for invalid file_path`).

## Maintainer notes
N/A