### PR TITLE
test: add coverage for object dtype mapping validation

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1326,6 +1326,20 @@ def test_astype_rejects_object_dtype_aliases(invalid_dtype):
         frame.astype(invalid_dtype)
 
 
+def test_astype_rejects_object_dtype_in_mapping():
+    frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}])
+
+    with pytest.raises(TypeError, match="dtype must"):
+        frame.astype({"a": object})
+
+
+def test_astype_rejects_object_string_dtype_in_mapping():
+    frame = ar.ArFrame.from_records([{"a": 1}, {"a": 2}])
+
+    with pytest.raises(TypeError, match="dtype must"):
+        frame.astype({"a": "object"})
+
+
 # ── drop_columns ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Adds regression coverage for unsupported object dtype mappings in `ArFrame.astype()`.

Added tests for:

- `frame.astype({"a": object})`
- `frame.astype({"a": "object"})`

These tests ensure unsupported object dtype mappings continue to raise `TypeError`.

## Linked issue
Fixes #1818 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] CI / packaging

## Area
- [ ] CSV parser / I/O
- [ ] C++ cleaning engine
- [x] Python API / ArFrame
- [ ] Pipeline / custom steps
- [ ] Data quality / profiling
- [ ] Schema validation
- [ ] pandas interoperability
- [ ] Docs / website
- [ ] Developer tooling

## Testing
<!-- Paste commands you ran and summarize the result. -->
- [ ] `make test` (or `python -m pytest tests -v --cov=arnio`)
- [ ] `make lint` (or run separately):
```bash
  python scripts/check_docs_utf8.py
  python -m black --check --diff .
  python -m ruff check . --extend-exclude "*.ipynb"
  python -m mypy --config-file mypy.ini
  find cpp/ bindings/ -type f \( -name '*.cpp' -o -name '*.h' \) | xargs clang-format --dry-run --Werror
  ```
- [ ] optionally `python -m pytest tests -v --tb=short -x`
- [x] Other:
pytest tests/test_frame.py -k astype -v

Result:
16 passed, 177 deselected

## Screenshots / Media
N/A

## Performance Impact
<!-- If this PR affects speed or memory, paste a snippet from `make benchmark` or other tools. -->

## GSSoC labels
<!-- Maintainers only: use exact scoring labels where applicable, for example `gssoc:approved`, `level:beginner`, `quality:clean`, and `type:bug`. Do not add labels only to increase points. -->

## Contributor checklist
- [x] I read the contributing guide.
- [x] I kept the PR focused on one issue or one logical change.
- [x] I added or updated tests for behavior changes.
- [ ] I added or updated docs/examples for public API changes.
- [x] I checked that generated files, logs, and local build artifacts are not committed.
- [x] My PR title uses Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).

## Maintainer notes
N/A
