### PR TITLE
test : add edge case tests for sniff_delimiter

### DIFF
--- a/tests/test_sniff_delimiter.py
+++ b/tests/test_sniff_delimiter.py
@@ -273,3 +273,12 @@ class TestSniffDelimiterPublicAPI:
         assert delim == ";"
         frame = ar.read_csv(str(path), delimiter=delim, decimal_separator=",")
         assert frame.columns == ["a", "b"]
+
+    def test_raises_on_mixed_delimiters_consistent_counts(self, tmp_path):
+        """sniff_delimiter raises ValueError when delimiter is ambiguous (mixed delimiters, consistent counts)."""
+        path = tmp_path / "ambiguous.csv"
+        path.write_text("a,b\nc;d\ne,f\n")
+        with pytest.raises(
+            ValueError, match="Could not determine CSV delimiter|ambiguous"
+        ):
+            ar.sniff_delimiter(str(path))

--- a/tests/test_sniff_delimiter.py
+++ b/tests/test_sniff_delimiter.py
@@ -278,7 +278,5 @@ class TestSniffDelimiterPublicAPI:
         """sniff_delimiter raises ValueError when delimiter is ambiguous (mixed delimiters, consistent counts)."""
         path = tmp_path / "ambiguous.csv"
         path.write_text("a,b,c\nd;e;f\n")
-        with pytest.raises(
-            ValueError, match="Could not determine CSV delimiter"
-        ):
+        with pytest.raises(ValueError, match="Could not determine CSV delimiter"):
             ar.sniff_delimiter(str(path))

--- a/tests/test_sniff_delimiter.py
+++ b/tests/test_sniff_delimiter.py
@@ -277,8 +277,8 @@ class TestSniffDelimiterPublicAPI:
     def test_raises_on_mixed_delimiters_consistent_counts(self, tmp_path):
         """sniff_delimiter raises ValueError when delimiter is ambiguous (mixed delimiters, consistent counts)."""
         path = tmp_path / "ambiguous.csv"
-        path.write_text("a,b\nc;d\ne,f\n")
+        path.write_text("a,b,c\nd;e;f\n")
         with pytest.raises(
-            ValueError, match="Could not determine CSV delimiter|ambiguous"
+            ValueError, match="Could not determine CSV delimiter"
         ):
             ar.sniff_delimiter(str(path))


### PR DESCRIPTION
Reopens #1834

Added test_raises_on_mixed_delimiters_consistent_counts to tests/test_sniff_delimiter.py. The test uses truly mixed delimiters (comma and semicolon) to verify sniff_delimiter raises ValueError when the delimiter is ambiguous.