### PR TITLE
test: add unit tests for _version module

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -25,9 +25,9 @@ def test_version_matches_pyproject_pattern():
     from arnio._version import __version__
 
     pattern = r"^\d+\.\d+\.\d+"
-    assert re.match(pattern, __version__), (
-        f"Version '{__version__}' does not match expected pattern"
-    )
+    assert re.match(
+        pattern, __version__
+    ), f"Version '{__version__}' does not match expected pattern"
 
 
 def test_resolve_version_returns_string():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,44 @@
+"""Tests for _version module."""
+
+import re
+
+
+def test_version_is_string():
+    from arnio._version import __version__
+
+    assert isinstance(__version__, str)
+
+
+def test_version_not_empty():
+    from arnio._version import __version__
+
+    assert len(__version__) > 0
+
+
+def test_version_not_unknown_by_default():
+    from arnio._version import __version__
+
+    assert __version__ != "unknown"
+
+
+def test_version_matches_pyproject_pattern():
+    from arnio._version import __version__
+
+    pattern = r"^\d+\.\d+\.\d+"
+    assert re.match(pattern, __version__), (
+        f"Version '{__version__}' does not match expected pattern"
+    )
+
+
+def test_resolve_version_returns_string():
+    from arnio._version import _resolve_version
+
+    result = _resolve_version()
+    assert isinstance(result, str)
+
+
+def test_resolve_version_not_empty():
+    from arnio._version import _resolve_version
+
+    result = _resolve_version()
+    assert len(result) > 0


### PR DESCRIPTION
Reopens #2234

Added tests/test_version.py with 6 tests for arnio._version module covering __version__ string format and _resolve_version function.

Note: Maintainer indicated #2234 is blocked until issue #1374 is resolved. PR #2571 (sanitize_column_names) closes #1374.