### PR TITLE
fix : reject directory paths in sniff_delimiter

### DIFF
--- a/arnio/io.py
+++ b/arnio/io.py
@@ -1991,6 +1991,8 @@ def sniff_delimiter(
         raise ValueError("sample_size must be a positive integer greater than 0")
 
     # 2. Check File Exists and Check for Binary Content
+    if os.path.isdir(path):
+        raise IsADirectoryError(f"Path is a directory, not a file: {path!r}")
     try:
         if os.path.getsize(path) == 0:
             raise CsvReadError(f"CSV file is empty: {path!r}")


### PR DESCRIPTION
Fixes #2415

## Summary

Added a check in `sniff_delimiter` to reject directory paths with `IsADirectoryError`.

## Changes

- `arnio/io.py`: Added `os.path.isdir(path)` check before reading the file. If the path is a directory, raises `IsADirectoryError`.