### PR TITLE
fix: change 404 heading from h2 to h1 for accessibility

### DIFF
--- a/website/404.html
+++ b/website/404.html
@@ -35,7 +35,7 @@
 
 <main id="main-content" class="main-content">
   <div class="container">
-    <article class="docs-content" style="max-width: 800px; margin: 0 auto; text-align: center; padding: 0;">      <h2 style="font-size: 4rem; margin-bottom: 1rem;">404</h2>
+    <article class="docs-content" style="max-width: 800px; margin: 0 auto; text-align: center; padding: 0;">      <h1 style="font-size: 4rem; margin-bottom: 1rem;">404</h1>
 
       <p style="margin-top: 1rem; font-size: 1.25rem; font-weight: 600;">Page not found</p>
 


### PR DESCRIPTION
Closes #2437

### Changes
- Changed `<h2>404</h2>` to `<h1>404</h1>` on 404 page to ensure proper heading hierarchy (WCAG)

### Files changed
- website/404.html