### PR TITLE
Security: published 1.19.0 wheel is missing documented CSV formula escaping option (#2362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: security: published 1.19.0 wheel is missing documented csv formula escaping option (#2362)


### PR DESCRIPTION
Fixes #2362