### PR TITLE
Bug: published 1.19.0 wheel is missing the arnio CLI entry point (#2352)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: published 1.19.0 wheel is missing the arnio cli entry point (#2352)


### PR DESCRIPTION
Fixes #2352