### PR TITLE
Bug: remote sampled and row-limited CSV reads download the entire response (#2501)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: remote sampled and row-limited csv reads download the entire response (#2501)


### PR DESCRIPTION
Fixes #2501