### PR TITLE
Bug: dismissed docs search results can still be activated with Enter (#2465)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: dismissed docs search results can still be activated with enter (#2465)


### PR DESCRIPTION
Fixes #2465