### PR TITLE
Bug: python -m arnio.cli --help requires the C++ extension in source checkouts (#2462)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: python -m arnio.cli --help requires the c++ extension in source checkouts (#2462)


### PR DESCRIPTION
Fixes #2462