### PR TITLE
Docs: null_values pages incorrectly describe custom tokens as additive (#2447)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: docs: null_values pages incorrectly describe custom tokens as additive (#2447)


### PR DESCRIPTION
Fixes #2447