### PR TITLE
Bug: read_csv admits non-finite numeric tokens that later break reports (#2441)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: read_csv admits non-finite numeric tokens that later break reports (#2441)


### PR DESCRIPTION
Fixes #2441