### PR TITLE
Bug: nested recipe examples fail when launched outside their data directory (#2439)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: nested recipe examples fail when launched outside their data directory (#2439)


### PR DESCRIPTION
Fixes #2439