### PR TITLE
Bug: docs search results are clickable divs without link semantics (#2436)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: docs search results are clickable divs without link semantics (#2436)


### PR DESCRIPTION
Fixes #2436