### PR TITLE
Docs: normalize API_REFERENCE.md to valid UTF-8 (#1386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: docs: normalize api_reference.md to valid utf-8 (#1386)


### PR DESCRIPTION
Fixes #1386