### PR TITLE
Bug: read_csv throws C++ runtime_error on duplicate column headers (#1337)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: read_csv throws c++ runtime_error on duplicate column headers (#1337)


### PR DESCRIPTION
Fixes #1337