### PR TITLE
Bug: published wheel rejects .csv.gz inputs as binary (#2428)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: published wheel rejects .csv.gz inputs as binary (#2428)


### PR DESCRIPTION
Fixes #2428