### PR TITLE
Bug: Field datetime min/max bounds are silently ignored (#2424)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: field datetime min/max bounds are silently ignored (#2424)


### PR DESCRIPTION
Fixes #2424