### PR TITLE
Bug: sniff_delimiter reports directory paths as empty CSV files (#2415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: sniff_delimiter reports directory paths as empty csv files (#2415)


### PR DESCRIPTION
Fixes #2415