### PR TITLE
Security: published 1.19.0 Markdown reports lack exclude_columns privacy control (#2414)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: security: published 1.19.0 markdown reports lack exclude_columns privacy control (#2414)


### PR DESCRIPTION
Fixes #2414