### PR TITLE
Bug: report to_json methods accept string indent and emit invalid JSON (#2411)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: report to_json methods accept string indent and emit invalid json (#2411)


### PR DESCRIPTION
Fixes #2411