### PR TITLE
Docs: API reference documents unsupported read_csv mode="lax" (#2396)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: docs: api reference documents unsupported read_csv mode="lax" (#2396)


### PR DESCRIPTION
Fixes #2396