### PR TITLE
Bug: published 1.19.0 schema export helpers miss path and metadata validation (#2395)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: published 1.19.0 schema export helpers miss path and metadata validation (#2395)


### PR DESCRIPTION
Fixes #2395