### PR TITLE
Bug: write_csv writes directly to the destination path without atomic write semantics, leaving a truncated file on partial failure (#2069)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,3 +2161,4 @@ loaded_steps = ar.load_pipeline("my_pipeline.json")
 ## Security
 
 Please review our [Security Policy](SECURITY.md) for responsible vulnerability reporting guidelines.
+# TODO: bug: write_csv writes directly to the destination path without atomic write semantics, leaving a truncated file on partial failure (#2069)


### PR DESCRIPTION
Fixes #2069