### PR TITLE
Docs: null_values pages incorrectly describe custom tokens as additive (#2447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2447


### PR DESCRIPTION
Fixes #2447