### PR TITLE
Bug: Field datetime min/max bounds are silently ignored (#2424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2424


### PR DESCRIPTION
Fixes #2424