### PR TITLE
Bug: Field accepts non-numeric min/max that crash schema validation (#2423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2423


### PR DESCRIPTION
Fixes #2423