### PR TITLE
Bug: dismissed docs search results can still be activated with Enter (#2465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2465


### PR DESCRIPTION
Fixes #2465