### PR TITLE
Bug: published 1.19.0 ArFrame.to_dict is missing orient support (#2410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2410


### PR DESCRIPTION
Fixes #2410