### PR TITLE
Bug: published 1.19.0 writers fail bytes paths with raw suffix errors (#2445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2445


### PR DESCRIPTION
Fixes #2445