### PR TITLE
Bug: published 1.19.0 validate(max_errors=0) reports invalid data as passed (#2405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2405


### PR DESCRIPTION
Fixes #2405