### PR TITLE
Bug: python -m arnio.cli --help requires the C++ extension in source checkouts (#2462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2462


### PR DESCRIPTION
Fixes #2462