### PR TITLE
Bug: published 1.19.0 schema_to_yaml leaks raw filesystem errors for invalid paths (#2429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2429


### PR DESCRIPTION
Fixes #2429