### PR TITLE
Bug: published wheel rejects .csv.gz inputs as binary (#2428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2428


### PR DESCRIPTION
Fixes #2428