### PR TITLE
Docs: API reference documents unsupported read_csv mode="lax" (#2396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2396


### PR DESCRIPTION
Fixes #2396