### PR TITLE
DX: check_env reports ready even when the build toolchain is blocked (#2393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2393


### PR DESCRIPTION
Fixes #2393