### PR TITLE
Bug: published 1.19.0 from_pandas silently stringifies unsupported scalar values (#2388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2388


### PR DESCRIPTION
Fixes #2388