### PR TITLE
Security: published 1.19.0 wheel is missing documented CSV formula escaping option (#2362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,3 +883,5 @@
 ## [0.1.2] - 2026-05-03
 ### Fixed
 - Stability improvements and initial PyPI release
+
+# TODO: issue #2362


### PR DESCRIPTION
Fixes #2362