### PR TITLE
Bug: published 1.19.0 wheel is missing documented Parquet attrs opt-out (#2363)

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,3 +732,5 @@ arnio/
 <sub>Built with C++ and pybind11 · Licensed under MIT · Maintained by <a href="https://github.com/im-anishraj">@im-anishraj</a></sub>
 
 </div>
+
+<!-- fix: Bug: published 1.19.0 wheel is missing documented Parquet at (#2363) -->


### PR DESCRIPTION
Fixes #2363