### PR TITLE
Bug: published 1.19.0 wheel does not expose documented Polars helpers (#2353)

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,3 +732,5 @@ arnio/
 <sub>Built with C++ and pybind11 · Licensed under MIT · Maintained by <a href="https://github.com/im-anishraj">@im-anishraj</a></sub>
 
 </div>
+
+<!-- fix: Bug: published 1.19.0 wheel does not expose documented Polar (#2353) -->


### PR DESCRIPTION
Fixes #2353