### PR TITLE
docs: remove noisy PR template comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
 ## Summary
 <!-- What changed and why? Keep this short but specific. -->
 
-<!-- Need quick setup or contribution help? Join Discord: https://discord.gg/xsEw7r78M -->
-
 ## Linked issue
 <!-- Use "Fixes #123" when the PR fully resolves an issue. Use "Refs #123" for partial work. -->
 


### PR DESCRIPTION
## Summary
- remove the standalone Discord helper comment from the PR template body
- keep the template focused on the contributor-provided PR content
- leave existing Discord onboarding links in CONTRIBUTING/README intact

Closes #2579

## Validation
- uv run ruff check .
- uv run pytest -q
- git diff --check

Known existing environment/project issues:
- uv run ruff format --check . reports pre-existing formatting changes in 34 unrelated files
- uv run pyright fails because the pyright executable is not installed in the uv environment