### PR TITLE
ci: run benchmark workflow on push to main for binding changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,16 @@ on:
       - "benchmarks/**"
       - ".github/workflows/benchmark.yml"
 
+  push:
+    branches:
+      - main
+    paths:
+      - "arnio/**"
+      - "bindings/**"
+      - "cpp/**"
+      - "benchmarks/**"
+      - ".github/workflows/benchmark.yml"
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Closes #1898

## Context
`bindings/**` is already present in the `pull_request.paths` filters (landed in 555c9ec7, Jul 22), so the literal first step of the issue is satisfied on main. The remaining gap from the issue's 'Why it matters' is that binding changes merged to `main` still skip the benchmark workflow entirely — performance regressions or benchmark breakage from the Python/native bridge (`bindings/bind_arnio.cpp`) go unnoticed until a later scheduled/manual run.

## Change
- Add a `push` trigger on `main`, filtered to the same paths as the pull_request trigger (`arnio/**`, `bindings/**`, `cpp/**`, `benchmarks/**`, the workflow file itself).
- `pull_request` triggers, benchmark jobs, and commands unchanged.

## Validation
- `git diff --check` clean
- YAML parses cleanly (ruby yaml + pyyaml)

## Verification
1. Merge a binding-only change to main.
2. The Benchmark workflow now runs on the merge commit.